### PR TITLE
VS2010 compilation issue (va_copy); Bug in the NMEA parser

### DIFF
--- a/gpsbabel/GPSBabel.pro
+++ b/gpsbabel/GPSBabel.pro
@@ -1,4 +1,4 @@
-QT -= gui
+6QT -= gui
 
 TARGET = GPSBabel
 CONFIG += console
@@ -258,7 +258,7 @@ win32 {
   }
   SOURCES += gbser_win.cc
   JEEPS += jeeps/gpsusbwin.cc
-  LIBS += "C:/Program Files/Windows Kits/8.0/Lib/win8/um/x86/setupapi.lib" "C:/Program Files/Windows Kits/8.0/Lib/win8/um/x86/hid.lib"
+  LIBS += "setupapi.lib"
 }
 
 win32-msvc*{

--- a/gpsbabel/gbfile.cc
+++ b/gpsbabel/gbfile.cc
@@ -36,6 +36,10 @@
 #  define SET_BINARY_MODE(file)
 #endif
 
+#if _MSC_VER
+#  define va_copy(dest, src) (dest = src)
+#endif // _MSC_VER
+
 #define MYNAME "gbfile"
 #define NO_ZLIB MYNAME ": No zlib support.\n"
 

--- a/gpsbabel/nmea.cc
+++ b/gpsbabel/nmea.cc
@@ -976,7 +976,7 @@ nmea_parse_one_line(char* ibuf)
      for that field.  Rather than change all the parse routines, we first
      substitute a default value of zero for any missing field.
   */
-  if (strstr(tbuf, ",,")) {
+  while(strstr(tbuf, ",,")) {
     tbuf = gstrsub(tbuf, ",,", ",0,");
   }
 

--- a/gpsbabel/util.cc
+++ b/gpsbabel/util.cc
@@ -43,6 +43,10 @@
 #endif
 #endif
 
+#if _MSC_VER
+#  define va_copy(dest, src) (dest = src)
+#endif // _MSC_VER
+
 #ifdef DEBUG_MEM
 #define DEBUG_FILENAME "/tmp/gpsbabel.debug"
 


### PR DESCRIPTION
Following string cannot be parsed by official GPSBabel:
$GPGGA,092252,5004.6498,N,01958.1196,E,1,,,337,,,,,*6d

After parsing, altitude parameter is zero. My fix solves this issue.
