### PR TITLE
Declare the xstrdup(const char*) variant of xstrdup.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -902,6 +902,7 @@ char* xstrappend(char* src, const char* addon);
 #define xxrealloc(p, s, file, line) xrealloc(p,s)
 #define xxfree(mem, file, line) xfree(mem)
 #define xxstrdup(s, file, line) xstrdup(s)
+char *xstrdup(const char* s);
 #define xxstrappend(src, addon, file, line) xstrappend(src, addon)
 #else /* DEBUG_MEM */
 void* XCALLOC(size_t nmemb, size_t size, DEBUG_PARAMS);


### PR DESCRIPTION
Previously, only the xstrdup(const Qstring&) version was known, which led
to incorrect encoding conversions.
https://sourceforge.net/p/gpsbabel/mailman/gpsbabel-misc/thread/22100.54710.435238.946764%40mimmi.uddeborg/#msg34645421
