### PR TITLE
Fix compilation on OpenBSD

### DIFF
--- a/zlib/contrib/minizip/ioapi.h
+++ b/zlib/contrib/minizip/ioapi.h
@@ -50,7 +50,7 @@
 #define ftello64 ftell
 #define fseeko64 fseek
 #else
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #define fopen64 fopen
 #define ftello64 ftello
 #define fseeko64 fseeko


### PR DESCRIPTION
OpenBSD doesn't provide fopen64 and similar functions.
