### PR TITLE
Fix default values for targetlocation and configlog flags.

### DIFF
--- a/skytraq.cc
+++ b/skytraq.cc
@@ -77,11 +77,11 @@ arglist_t skytraq_args[] = {
   },
   {
     "targetlocation", &opt_set_location, "Set location finder target location as lat,lng",
-    "", ARGTYPE_STRING, "", ""
+    NULL, ARGTYPE_STRING, "", ""
   },
   {
     "configlog", &opt_configure_logging, "Configure logging parameter as tmin:tmax:dmin:dmax",
-    "", ARGTYPE_STRING, "", ""
+    NULL, ARGTYPE_STRING, "", ""
   },
   {
     "baud", &opt_dlbaud, "Baud rate used for download",


### PR DESCRIPTION
The previous default value "" was considered as TRUE in the IF condition. The targetlocation and configlog flags took effect even if users didn't specify it. There were no workarounds. It prevented users to reach to the main function skytraq_read_tracks.

Those should be NULL by default so that the IF condition should be FALSE if a user doesn't specify it.
