### PR TITLE
configure.in: Link minizip when using system zlib

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -132,6 +132,7 @@ AC_ARG_WITH(zlib, [  --with-zlib=[(included)|system|no]])
   case $with_zlib in 
     "system") 
 	AC_CHECK_LIB([z], [gzopen])
+	AC_CHECK_LIB([minizip], [zipOpen64])
 	;;
     "no") 
         AC_DEFINE(ZLIB_INHIBITED, 1, [1 to inhibit our use of zlib.])


### PR DESCRIPTION
When using system libz minizip is not added to the linker commandline causing the following error:

src/core/ziparchive.o: In function `ZipArchive::Open(QString)':
ziparchive.cc:(.text+0x2f): undefined reference to`zipOpen64'
src/core/ziparchive.o: In function `ZipArchive::Close()':
ziparchive.cc:(.text+0x17b): undefined reference to`zipClose'
src/core/ziparchive.o: In function `ZipArchive::Add(QString)':
ziparchive.cc:(.text+0x253): undefined reference to`zipOpenNewFileInZip64'
ziparchive.cc:(.text+0x64f): undefined reference to `zipWriteInFileInZip'
ziparchive.cc:(.text+0x866): undefined reference to`zipCloseFileInZip'
collect2: error: ld returned 1 exit status
