### PR TITLE
Support v2 of the Garmin FIT format

### DIFF
--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -26,6 +26,38 @@
 
 #define MYNAME "fit"
 
+// constants for global IDs
+const int kIdDeviceSettings = 0;
+const int kIdLap = 19;
+const int kIdRecord = 20;
+
+// constants for message fields
+// for all global IDs
+const int kFieldTimestamp = 253;
+// for global ID: device settings
+const int kFieldGlobalUtcOffset = 4;
+// for global ID: lap
+const int kFieldStartTime = 2;
+const int kFieldStartLatitude = 3;
+const int kFieldStartLongitude = 4;
+const int kFieldEndLatitude = 5;
+const int kFieldEndLongitude = 6;
+const int kFieldElapsedTime = 7;
+const int kFieldTotalDistance = 9;
+// for global ID: record
+const int kFieldLatitude = 0;
+const int kFieldLongitude = 1;
+const int kFieldAltitude = 2;
+const int kFieldHeartRate = 3;
+const int kFieldCadence = 4;
+const int kFieldDistance = 5;
+const int kFieldSpeed = 6;
+const int kFieldPower = 7;
+const int kFieldTemperature = 13;
+const int kFieldEnhancedSpeed = 73;
+const int kFieldEnhancedAltitude = 78;
+
+
 static char* opt_allpoints = NULL;
 static int lap_ct = 0;
 
@@ -351,7 +383,7 @@ fit_parse_data(fit_message_def* def, int time_offset)
     }
     f = &def->fields[i];
     val = fit_read_field(f);
-    if (f->id == 253) {
+    if (f->id == kFieldTimestamp) {
       if (global_opts.debug_level >= 7) {
         debug_print(7,"%s: parsing fit data: timestamp=%d\n", MYNAME, val);
       }
@@ -363,9 +395,9 @@ fit_parse_data(fit_message_def* def, int time_offset)
       fit_data.last_timestamp = timestamp;
     } else {
       switch (def->global_id) {
-      case 0: // device settings message
+      case kIdDeviceSettings: // device settings message
         switch (f->id) {
-        case 4:
+        case kFieldGlobalUtcOffset:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: global utc_offset=%d\n", MYNAME, val);
           }
@@ -377,72 +409,72 @@ fit_parse_data(fit_message_def* def, int time_offset)
           }
           break;
         } // switch (f->id)
-        // end of case def->global_id = 0
+        // end of case def->global_id = kIdDeviceSettings
         break;
 
-      case 20: // record message - trkType is a track
+      case kIdRecord: // record message - trkType is a track
         switch (f->id) {
-        case 0:
+        case kFieldLatitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: lat=%d\n", MYNAME, val);
           }
           lat = val;
           break;
-        case 1:
+        case kFieldLongitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: lon=%d\n", MYNAME, val);
           }
           lon = val;
           break;
-        case 2:
+        case kFieldAltitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: alt=%d\n", MYNAME, val);
           }
           alt = val;
           break;
-        case 3:
+        case kFieldHeartRate:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: heartrate=%d\n", MYNAME, val);
           }
           heartrate = val;
           break;
-        case 4:
+        case kFieldCadence:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: cadence=%d\n", MYNAME, val);
           }
           cadence = val;
           break;
-        case 5:
+        case kFieldDistance:
           // NOTE: 5 is DISTANCE in cm ... unused.
           if (global_opts.debug_level >= 7) {
             debug_print(7, "%s: unrecognized data type in GARMIN FIT record: f->id=%d\n", MYNAME, f->id);
           }
           break;
-        case 6:
+        case kFieldSpeed:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: speed=%d\n", MYNAME, val);
           }
           speed = val;
           break;
-        case 7:
+        case kFieldPower:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: power=%d\n", MYNAME, val);
           }
           power = val;
           break;
-        case 13:
+        case kFieldTemperature:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: temperature=%d\n", MYNAME, val);
           }
           temperature = val;
           break;
-        case 73:
+        case kFieldEnhancedSpeed:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: enhanced_speed=%d\n", MYNAME, val);
           }
           speed = val;
           break;
-        case 78:
+        case kFieldEnhancedAltitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: enhanced_altitude=%d\n", MYNAME, val);
           }
@@ -454,48 +486,48 @@ fit_parse_data(fit_message_def* def, int time_offset)
           }
           break;
         } // switch (f->id)
-        // end of case def->global_id = 20
+        // end of case def->global_id = kIdRecord
         break;
 
-      case 19: // lap wptType , endlat+lon is wpt
+      case kIdLap: // lap wptType , endlat+lon is wpt
         switch (f->id) {
-        case 2:
+        case kFieldStartTime:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: starttime=%d\n", MYNAME, val);
           }
           starttime = val;
           break;
-        case 3:
+        case kFieldStartLatitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: startlat=%d\n", MYNAME, val);
           }
           startlat = val;
           break;
-        case 4:
+        case kFieldStartLongitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: startlon=%d\n", MYNAME, val);
           }
           startlon = val;
           break;
-        case 5:
+        case kFieldEndLatitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: endlat=%d\n", MYNAME, val);
           }
           endlat = val;
           break;
-        case 6:
+        case kFieldEndLongitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: endlon=%d\n", MYNAME, val);
           }
           endlon = val;
           break;
-        case 7:
+        case kFieldElapsedTime:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: elapsedtime=%d\n", MYNAME, val);
           }
           //elapsedtime = val;
           break;
-        case 9:
+        case kFieldTotalDistance:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: totaldistance=%d\n", MYNAME, val);
           }
@@ -507,7 +539,7 @@ fit_parse_data(fit_message_def* def, int time_offset)
           }
           break;
         } // switch (f->id)
-        // end of case def->global_id = 19
+        // end of case def->global_id = kIdLap
         break;
 
       default:
@@ -523,7 +555,7 @@ fit_parse_data(fit_message_def* def, int time_offset)
     debug_print(7,"%s: storing fit data with num_fields=%d\n", MYNAME, def->num_fields);
   }
   switch (def->global_id) {
-  case 19: // lap message
+  case kIdLap: // lap message
     if (endlat == 0x7fffffff || endlon == 0x7fffffff) {
       break;
     }
@@ -538,7 +570,7 @@ fit_parse_data(fit_message_def* def, int time_offset)
     lappt->shortname = cbuf;
     waypt_add(lappt);
     break;
-  case 20: // record message
+  case kIdRecord: // record message
     if ((lat == 0x7fffffff || lon == 0x7fffffff) && !opt_allpoints) {
       break;
     }

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -411,6 +411,18 @@ fit_parse_data(fit_message_def* def, int time_offset)
           }
           temperature = val;
           break;
+        case 73:
+          if (global_opts.debug_level >= 7) {
+            debug_print(7,"%s: parsing fit data: enhanced_speed=%d\n", MYNAME, val);
+          }
+          speed = val;
+          break;
+        case 78:
+          if (global_opts.debug_level >= 7) {
+            debug_print(7,"%s: parsing fit data: enhanced_altitude=%d\n", MYNAME, val);
+          }
+          alt = val;
+          break;
         default:
           if (global_opts.debug_level >= 1) {
             debug_print(1, "%s: unrecognized data type in GARMIN FIT record: f->id=%d\n", MYNAME, f->id);

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -411,6 +411,15 @@ fit_parse_data(fit_message_def* def, int time_offset)
           }
           temperature = val;
           break;
+        default:
+          if (global_opts.debug_level >= 1) {
+            debug_print(1, "%s: unrecognized data type in GARMIN FIT record: f->id=%d\n", MYNAME, f->id);
+          }
+          break;
+        } // switch (f->id)
+        // end of case def->global_id = 20
+        break;
+
       case 19: // lap wptType , endlat+lon is wpt
         switch (f->id) {
         case 2:
@@ -461,14 +470,15 @@ fit_parse_data(fit_message_def* def, int time_offset)
           }
           break;
         } // switch (f->id)
+        // end of case def->global_id = 19
         break;
-        default:
-          if (global_opts.debug_level >= 1) {
-            debug_print(1, "%s: unrecognized data type in GARMIN FIT record: f->id=%d\n", MYNAME, f->id);
-          }
-          break;
+
+      default:
+        if (global_opts.debug_level >= 1) {
+          debug_print(1, "%s: unrecognized/unhandled global ID for GARMIN FIT: %d\n", MYNAME, def->global_id);
         }
-      }
+        break;
+      } // switch (def->global_id)
     }
   }
 

--- a/reference/track/fit-sample.gpx
+++ b/reference/track/fit-sample.gpx
@@ -1,7 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="GPSBabel - http://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
   <time>1970-01-01T00:00:00Z</time>
-  <bounds minlat="53.726060537" minlon="-1.449245141" maxlat="53.744836335" maxlon="-1.411503945"/>
+  <bounds minlat="53.726060537" minlon="-1.449245141" maxlat="53.744839017" maxlon="-1.411503945"/>
+  <wpt lat="53.741919600" lon="-1.425495605">
+    <name>LAP001</name>
+    <cmt>LAP001</cmt>
+    <desc>LAP001</desc>
+  </wpt>
+  <wpt lat="53.734134070" lon="-1.417237418">
+    <name>LAP002</name>
+    <cmt>LAP002</cmt>
+    <desc>LAP002</desc>
+  </wpt>
+  <wpt lat="53.726707200" lon="-1.434524591">
+    <name>LAP003</name>
+    <cmt>LAP003</cmt>
+    <desc>LAP003</desc>
+  </wpt>
+  <wpt lat="53.731990901" lon="-1.420505522">
+    <name>LAP004</name>
+    <cmt>LAP004</cmt>
+    <desc>LAP004</desc>
+  </wpt>
+  <wpt lat="53.740844873" lon="-1.420731247">
+    <name>LAP005</name>
+    <cmt>LAP005</cmt>
+    <desc>LAP005</desc>
+  </wpt>
+  <wpt lat="53.744306263" lon="-1.444196469">
+    <name>LAP006</name>
+    <cmt>LAP006</cmt>
+    <desc>LAP006</desc>
+  </wpt>
+  <wpt lat="53.744839017" lon="-1.449086890">
+    <name>LAP007</name>
+    <cmt>LAP007</cmt>
+    <desc>LAP007</desc>
+  </wpt>
   <trk>
     <trkseg>
       <trkpt lat="53.744833401" lon="-1.449245141">

--- a/reference/track/garmin-edge-200-output.gpx
+++ b/reference/track/garmin-edge-200-output.gpx
@@ -2,6 +2,11 @@
 <gpx version="1.0" creator="GPSBabel - http://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
   <time>1970-01-01T00:00:00Z</time>
   <bounds minlat="50.874917028" minlon="4.361335395" maxlat="50.881270678" maxlon="4.373297963"/>
+  <wpt lat="50.881270678" lon="4.373297963">
+    <name>LAP001</name>
+    <cmt>LAP001</cmt>
+    <desc>LAP001</desc>
+  </wpt>
   <trk>
     <trkseg>
       <trkpt lat="50.874994141" lon="4.361335395">

--- a/reference/track/garmin-edge-800-output.gpx
+++ b/reference/track/garmin-edge-800-output.gpx
@@ -2,6 +2,11 @@
 <gpx version="1.0" creator="GPSBabel - http://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
   <time>1970-01-01T00:00:00Z</time>
   <bounds minlat="48.154215127" minlon="11.807058943" maxlat="48.198396474" maxlon="11.895890353"/>
+  <wpt lat="48.186895413" lon="11.858545873">
+    <name>LAP001</name>
+    <cmt>LAP001</cmt>
+    <desc>LAP001</desc>
+  </wpt>
   <trk>
     <trkseg>
       <trkpt lat="48.189526493" lon="11.858895315">

--- a/reference/track/garmin-forerunner-10-output.gpx
+++ b/reference/track/garmin-forerunner-10-output.gpx
@@ -2,6 +2,61 @@
 <gpx version="1.0" creator="GPSBabel - http://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
   <time>1970-01-01T00:00:00Z</time>
   <bounds minlat="52.402762795" minlon="13.313763036" maxlat="52.429130670" maxlon="13.419362946"/>
+  <wpt lat="52.405359257" lon="13.411235518">
+    <name>LAP001</name>
+    <cmt>LAP001</cmt>
+    <desc>LAP001</desc>
+  </wpt>
+  <wpt lat="52.410497029" lon="13.403836309">
+    <name>LAP002</name>
+    <cmt>LAP002</cmt>
+    <desc>LAP002</desc>
+  </wpt>
+  <wpt lat="52.413102543" lon="13.394398621">
+    <name>LAP003</name>
+    <cmt>LAP003</cmt>
+    <desc>LAP003</desc>
+  </wpt>
+  <wpt lat="52.410614962" lon="13.380171598">
+    <name>LAP004</name>
+    <cmt>LAP004</cmt>
+    <desc>LAP004</desc>
+  </wpt>
+  <wpt lat="52.410783354" lon="13.366606074">
+    <name>LAP005</name>
+    <cmt>LAP005</cmt>
+    <desc>LAP005</desc>
+  </wpt>
+  <wpt lat="52.413863369" lon="13.352951954">
+    <name>LAP006</name>
+    <cmt>LAP006</cmt>
+    <desc>LAP006</desc>
+  </wpt>
+  <wpt lat="52.417012869" lon="13.339746265">
+    <name>LAP007</name>
+    <cmt>LAP007</cmt>
+    <desc>LAP007</desc>
+  </wpt>
+  <wpt lat="52.424533615" lon="13.332924989">
+    <name>LAP008</name>
+    <cmt>LAP008</cmt>
+    <desc>LAP008</desc>
+  </wpt>
+  <wpt lat="52.427703316" lon="13.324095240">
+    <name>LAP009</name>
+    <cmt>LAP009</cmt>
+    <desc>LAP009</desc>
+  </wpt>
+  <wpt lat="52.425872121" lon="13.313921789">
+    <name>LAP010</name>
+    <cmt>LAP010</cmt>
+    <desc>LAP010</desc>
+  </wpt>
+  <wpt lat="52.427264607" lon="13.313978702">
+    <name>LAP011</name>
+    <cmt>LAP011</cmt>
+    <desc>LAP011</desc>
+  </wpt>
   <trk>
     <trkseg>
       <trkpt lat="52.403174095" lon="13.419362946">


### PR DESCRIPTION
As briefly mentioned in #65, there have been recent updates to the Garmin FIT format. One of those (#54) breaks the correct interpretation of data point timestamps by gpsbabel.

This patchset includes several fixes to support the most recent version of Garmin FIT, while maintaining backwards compatibility. These changes have been tested against FIT files created by a Garmin VIRB Ultra 30.

* Fix a pre-existing bug in the switch logic (+ fix tests)
* Add support for two new fields: enhanced speed and enhanced altitude
* Fix handling of timestamp fields (#54)
* Use constants rather than magic numbers for better code readablity