### PR TITLE
Use Latin1 when converting from Garmin device.

### DIFF
--- a/garmin.cc
+++ b/garmin.cc
@@ -394,8 +394,8 @@ waypt_read(void)
   for (i = 0; i < n; i++) {
     Waypoint* wpt_tmp = new Waypoint;
 
-    wpt_tmp->shortname = way[i]->ident;
-    wpt_tmp->description = QString(way[i]->cmnt).simplified();
+    wpt_tmp->shortname = QString::fromLatin1(way[i]->ident);
+    wpt_tmp->description = QString::fromLatin1(way[i]->cmnt);
     wpt_tmp->shortname = wpt_tmp->shortname.simplified();
     wpt_tmp->description = wpt_tmp->description.simplified();
     wpt_tmp->longitude = way[i]->lon;


### PR DESCRIPTION
When copying waypoints from my Garmin eTrex Legend HCx any non-ASCII characters showed up as the Unicode _replacement character_.  I'm not sure when exactly this started, but when digging into it I found in garmin.cc it was converted to QString using assignments.  In Qt5, such assignments assume the C string is in UTF-8, but the string from the device is in Latin-1.  This patch should fix the problem.

While staring at the code, I realized _simplified_ was called twoce on the description string.  As that operation is idempotent that is harmless, but also pretty pointless.