### PR TITLE
track-discard test to use testo gpsbabel()

### DIFF
--- a/testo.d/track-discard.test
+++ b/testo.d/track-discard.test
@@ -17,7 +17,7 @@ gpsbabel -t -i gpx -f ${REFERENCE}/track/trackfilter_discard.gpx -x track,merge,
 compare ${REFERENCE}/track/trackfilter_discard_out.gpx ${TMPDIR}/discard.gpx
 
 # This file has ONLY names starting with GC; verify we toss all.
-./gpsbabel -i geo -f geocaching.loc  -x discard,matchname=GC* -o csv -F ${TMPDIR}/discardgc.geo
+gpsbabel -i geo -f geocaching.loc  -x discard,matchname=GC* -o csv -F ${TMPDIR}/discardgc.geo
 compare ${TMPDIR}/discardgc.geo /dev/null
 
 # Throw out all caches from Joe


### PR DESCRIPTION
track-discard.test was using ./gpsbabel instead of gpsbabel for one test.  In a *.test file gpsbabel is a shell function defined in testo.  Using ./gpsbabel undesirably avoids the testo function.