### PR TITLE
build using msvc x64 on AppVeyor.

### DIFF
--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -152,11 +152,9 @@ win32 {
   LIBS += "-lsetupapi" 
 }
 
-win32-msvc*{
+win32-msvc* {
   DEFINES += _CRT_SECURE_NO_DEPRECATE
-  INCLUDEPATH += ../../src/core src/core
   QMAKE_CXXFLAGS += /MP -wd4100
-  TEMPLATE=vcapp
 }
 
 linux {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
     platform: mingw
     qt: 5.9\mingw53_32
   # MSVC x64
-  #- name: win64
-  #  platform: amd64
-  #  qt: 5.9\msvc2015_64
+  - name: win64
+    platform: amd64
+    qt: 5.9\msvc2015_64
 
 init:
   - if %platform%==mingw set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
@@ -20,4 +20,4 @@ init:
 # Flesh out with amd64/msvc cases later.
 build_script:
   - qmake GPSBabel.pro
-  - mingw32-make
+  - if not %platform%==mingw (nmake) else (mingw32-make)


### PR DESCRIPTION
Changing the platform variable win32-mcsv* to use the default TEMPLATE (app) creates a Makefile we can run nmake on.  This is an alternative to a TEMPLATE of vcapp which creates a Visual Studio project file to build the app.