### PR TITLE
Input redirection can fail with gpx reader on windows

### DIFF
--- a/gpx.cc
+++ b/gpx.cc
@@ -1382,6 +1382,8 @@ gpx_read()
 //  sent to stdin has dos line endings.
 //  This does NOT occur with Qt 5.9.2 on windows when the file being
 //  sent to stdin has unix line endings.
+//  This does NOT occur with Qt 5.9.2 on windows with either line
+//  endings if the file is read directly, i.e. not sent through stdin.
 //  An example of a problematic file is reference/basecamp.gpx,
 //  which fails on windows with this invocation from a command prompt:
 //  .\GPSBabel.exe -i gpx -f - < reference\basecamp.gpx

--- a/gpx.cc
+++ b/gpx.cc
@@ -1375,6 +1375,22 @@ gpx_read()
       gpx_cdata(reader->text().toString());
       break;
 
+//  On windows with input redirection we can read an Invalid token
+//  after the EndDocument token.  This also will set an error
+//  "Premature end of document." that we will fatal on below.
+//  This occurs with Qt 5.9.2 on windows when the file being
+//  sent to stdin has dos line endings.
+//  This does NOT occur with Qt 5.9.2 on windows when the file being
+//  sent to stdin has unix line endings.
+//  An example of a problematic file is reference/basecamp.gpx,
+//  which fails on windows with this invocation from a command prompt:
+//  .\GPSBabel.exe -i gpx -f - < reference\basecamp.gpx
+//  This was demonstrated on 64 bit windows 10.  Other versions of
+//  windows and Qt likely fail as well.
+//  To avoid this we quit reading when we see the EndDocument.
+//  This does not prevent us from correctly detecting the error
+//  "Extra content at end of document."
+    case QXmlStreamReader::EndDocument:
     case QXmlStreamReader::Invalid:
       atEnd = true;
       break;


### PR DESCRIPTION
Our gpx.test is failing on windows.  This is due to:
//  On windows with input redirection we can read an Invalid token
//  after the EndDocument token.  This also will set an error
//  "Premature end of document." that we will fatal on below.
//  This occurs with Qt 5.9.2 on windows when the file being
//  sent to stdin has dos line endings.
//  This does NOT occur with Qt 5.9.2 on windows when the file being
//  sent to stdin has unix line endings.
//  This does NOT occur with Qt 5.9.2 on windows with either line
//  endings if the file is read directly, i.e. not sent through stdin.
//  An example of a problematic file is reference/basecamp.gpx,
//  which fails on windows with this invocation from a command prompt:
//  .\GPSBabel.exe -i gpx -f - < reference\basecamp.gpx
//  This was demonstrated on 64 bit windows 10.  Other versions of
//  windows and Qt likely fail as well.

I have a simple test program that demonstrates this without involving gpsbabel.  The read loop is identical to that described in the QXmlStreamReader documentation as "A typical loop with QXmlStreamReader".  If someone has a Qt Account I will share the test case so a bug report can be opened.