### PR TITLE
add missing Qt libs for gui on linux.

### DIFF
--- a/gui/makelinuxdist.sh.in
+++ b/gui/makelinuxdist.sh.in
@@ -11,7 +11,8 @@ mkdir $DISTDIR/plugins
 mkdir $DISTDIR/translations
 mkdir $DISTDIR/help
 
-QT_LIBS=`ldd objects/gpsbabelfe-bin | grep libQt | awk '{print $3}'`
+QT_LIBS="`ldd objects/gpsbabelfe-bin | grep libQt | awk '{print $3}'`"
+QT_LIBS="$QT_LIBS `ldd $QT_INSTALL_PLUGINS/platforms/libqxcb.so | grep libQt | awk '{print $3}'`"
 for lib in $QT_LIBS
 do
 	cp $lib $DISTDIR


### PR DESCRIPTION
The required plugin platforms/libqxcb.so needs
libQt5DBus and libQt5XcbQpa.

This was tested on Ubuntu 16.0.3 with Qt 5.5.1.
