### PR TITLE
Prefer QLatin1String for conversion from char strings

### DIFF
--- a/garmin_device_xml.cc
+++ b/garmin_device_xml.cc
@@ -42,7 +42,7 @@ jmp_buf gdx_jmp_buf;
 
 void type_s(xg_string args, const QXmlStreamAttributes*)
 {
-  type = args.compare("GPSData");
+  type = args.compare(QLatin1String("GPSData"));
 }
 
 void device_s(xg_string args, const QXmlStreamAttributes*)

--- a/gpx.cc
+++ b/gpx.cc
@@ -496,7 +496,7 @@ tag_cache_desc(const QXmlStreamAttributes& attr)
 {
   cache_descr_is_html = false;
   if (attr.hasAttribute("html")) {
-    if (attr.value("html").toString() == QStringLiteral("True")) {
+    if (attr.value("html").compare(QLatin1String("True"), Qt::CaseInsensitive) == 0) {
       cache_descr_is_html = true;
     }
   }
@@ -511,16 +511,16 @@ tag_gs_cache(const QXmlStreamAttributes& attr)
     gc_data->id = attr.value("id").toString().toInt();
   }
   if (attr.hasAttribute("available")) {
-    if (attr.value("available").toString().compare(QStringLiteral("True"), Qt::CaseInsensitive) == 0) {
+    if (attr.value("available").compare(QLatin1String("True"), Qt::CaseInsensitive) == 0) {
       gc_data->is_available = status_true;
-    } else if (attr.value("available").toString().compare(QStringLiteral("False"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.value("available").compare(QLatin1String("False"), Qt::CaseInsensitive) == 0) {
       gc_data->is_available = status_false;
     }
   }
   if (attr.hasAttribute("archived")) {
-    if (attr.value("archived").toString().compare(QStringLiteral("True"), Qt::CaseInsensitive) == 0) {
+    if (attr.value("archived").compare(QLatin1String("True"), Qt::CaseInsensitive) == 0) {
       gc_data->is_archived = status_true;
-    } else if (attr.value("archived").toString().compare(QStringLiteral("False"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.value("archived").compare(QLatin1String("False"), Qt::CaseInsensitive) == 0) {
       gc_data->is_archived = status_false;
     }
   }
@@ -974,7 +974,7 @@ gpx_end(const QString&)
      * last date we saw in this log.
      */
   case tt_cache_log_type:
-    if ((cdatastr.compare(QStringLiteral("Found it")) == 0) &&
+    if ((cdatastr.compare(QLatin1String("Found it")) == 0) &&
         (0 == wpt_tmp->gc_data->last_found.toTime_t())) {
       wpt_tmp->AllocGCData()->last_found = gc_log_date;
     }
@@ -1443,7 +1443,7 @@ fprint_xml_chain(xml_tag* tag, const Waypoint* wpt)
         fprint_xml_chain(tag->child, wpt);
       }
       if (wpt && wpt->gc_data->exported.isValid() &&
-          tag->tagname.compare(QStringLiteral("groundspeak:cache")) == 0) {
+          tag->tagname.compare(QLatin1String("groundspeak:cache")) == 0) {
         writer->writeTextElement("time",
                                  wpt->gc_data->exported.toPrettyString());
       }

--- a/gpx.cc
+++ b/gpx.cc
@@ -496,7 +496,7 @@ tag_cache_desc(const QXmlStreamAttributes& attr)
 {
   cache_descr_is_html = false;
   if (attr.hasAttribute("html")) {
-    if (attr.value("html").compare(QLatin1String("True"), Qt::CaseInsensitive) == 0) {
+    if (attr.value("html").compare(QLatin1String("True")) == 0) {
       cache_descr_is_html = true;
     }
   }

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -767,7 +767,7 @@ lowranceusr_waypt_disp(const Waypoint* wpt)
 
   gbfputint32(Time, file_out);
 
-  if (get_cache_icon(wpt) && wpt->icon_descr.compare("Geocache Found") == 0) {
+  if (get_cache_icon(wpt) && wpt->icon_descr.compare(QLatin1String("Geocache Found")) == 0) {
     SymbolId = lowranceusr_find_icon_number_from_desc(get_cache_icon(wpt));
   } else {
     SymbolId = lowranceusr_find_icon_number_from_desc(wpt->icon_descr);

--- a/magproto.cc
+++ b/magproto.cc
@@ -819,11 +819,11 @@ mag_rd_init_common(const QString& portname)
    */
   QString exten = QFileInfo(curfname).suffix();
   if (exten.length() > 0) {
-    if (0 == exten.compare(QStringLiteral("upt"), Qt::CaseInsensitive)) {
+    if (0 == exten.compare(QLatin1String("upt"), Qt::CaseInsensitive)) {
       extension_hint = WPTDATAMASK;
-    } else if (0 == exten.compare(QStringLiteral("log"), Qt::CaseInsensitive)) {
+    } else if (0 == exten.compare(QLatin1String("log"), Qt::CaseInsensitive)) {
       extension_hint = TRKDATAMASK;
-    } else if (0 == exten.compare(QStringLiteral("rte"), Qt::CaseInsensitive)) {
+    } else if (0 == exten.compare(QLatin1String("rte"), Qt::CaseInsensitive)) {
       extension_hint = RTEDATAMASK;
     }
   }

--- a/psitrex.cc
+++ b/psitrex.cc
@@ -363,7 +363,7 @@ psit_waypoint_w(gbfile* psit_file, const Waypoint* wpt)
 
   icon = gt_find_icon_number_from_desc(wpt->icon_descr, PCX);
 
-  if (get_cache_icon(wpt) && wpt->icon_descr.compare("Geocache Found") != 0) {
+  if (get_cache_icon(wpt) && wpt->icon_descr.compare(QLatin1String("Geocache Found")) != 0) {
     icon = gt_find_icon_number_from_desc(get_cache_icon(wpt), PCX);
   }
 

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -72,11 +72,11 @@ tef_start(xg_string, const QXmlStreamAttributes* attrv)
   bool valid = false;
 
   foreach(QXmlStreamAttribute attr, *attrv) {
-    if (attr.name().compare(QString("Comment"), Qt::CaseInsensitive) == 0) {
-      if (attr.value().compare(QString("TourExchangeFormat"), Qt::CaseInsensitive) == 0) {
+    if (attr.name().compare(QLatin1String("Comment"), Qt::CaseInsensitive) == 0) {
+      if (attr.value().compare(QLatin1String("TourExchangeFormat"), Qt::CaseInsensitive) == 0) {
         valid = true;
       }
-    } else if (attr.name().compare(QString("Version"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.name().compare(QLatin1String("Version"), Qt::CaseInsensitive) == 0) {
       version = attr.value().toString().toDouble();
     }
   }
@@ -95,9 +95,9 @@ tef_header(xg_string, const QXmlStreamAttributes* attrv)
 {
   route = route_head_alloc();
   foreach(QXmlStreamAttribute attr, *attrv) {
-    if (attr.name().compare(QString("Name"), Qt::CaseInsensitive) == 0) {
+    if (attr.name().compare(QLatin1String("Name"), Qt::CaseInsensitive) == 0) {
       route->rte_name = attr.value().toString().trimmed();
-    } else if (attr.name().compare(QString("Software"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.name().compare(QLatin1String("Software"), Qt::CaseInsensitive) == 0) {
       route->rte_desc = attr.value().toString().trimmed();
     }
   }
@@ -248,20 +248,20 @@ tef_item_start(xg_string, const QXmlStreamAttributes* attrv)
     QString attrstr = attr.value().toString();
     QByteArray attrtext = attrstr.toUtf8();
 
-    if (attr.name().compare(QString("SegDescription"), Qt::CaseInsensitive) == 0) {
+    if (attr.name().compare(QLatin1String("SegDescription"), Qt::CaseInsensitive) == 0) {
       wpt_tmp->shortname = attrstr.trimmed();
-    } else if (attr.name().compare(QString("PointDescription"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.name().compare(QLatin1String("PointDescription"), Qt::CaseInsensitive) == 0) {
       wpt_tmp->description = attrstr.trimmed();
-    } else if (attr.name().compare(QString("ViaStation"), Qt::CaseInsensitive) == 0 &&
-               attr.value().compare(QString("true"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.name().compare(QLatin1String("ViaStation"), Qt::CaseInsensitive) == 0 &&
+               attr.value().compare(QLatin1String("true"), Qt::CaseInsensitive) == 0) {
       wpt_tmp->wpt_flags.fmt_use = 1;  /* only a flag */
 
       /* new in TEF V2 */
-    } else if (attr.name().compare(QString("Instruction"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.name().compare(QLatin1String("Instruction"), Qt::CaseInsensitive) == 0) {
       wpt_tmp->description = attrstr.trimmed();
-    } else if (attr.name().compare(QString("Altitude"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.name().compare(QLatin1String("Altitude"), Qt::CaseInsensitive) == 0) {
       wpt_tmp->altitude = attrstr.toDouble();
-    } else if (attr.name().compare(QString("TimeStamp"), Qt::CaseInsensitive) == 0) {
+    } else if (attr.name().compare(QLatin1String("TimeStamp"), Qt::CaseInsensitive) == 0) {
       /* nothing for the moment */
     }
   }

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -430,13 +430,13 @@ unicsv_parse_time(const QString& str, int* msec, time_t* date)
 static status_type
 unicsv_parse_status(const QString& str)
 {
-  if (str.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0 ||
-      str.compare(QStringLiteral("yes"), Qt::CaseInsensitive) == 0 ||
+  if (str.compare(QLatin1String("true"), Qt::CaseInsensitive) == 0 ||
+      str.compare(QLatin1String("yes"), Qt::CaseInsensitive) == 0 ||
       str == "1") {
     return status_true;
   }
-  if (str.compare(QStringLiteral("false"), Qt::CaseInsensitive) == 0 ||
-      str.compare(QStringLiteral("no"), Qt::CaseInsensitive) == 0 ||
+  if (str.compare(QLatin1String("false"), Qt::CaseInsensitive) == 0 ||
+      str.compare(QLatin1String("no"), Qt::CaseInsensitive) == 0 ||
       str == "0") {
     return status_false;
   }


### PR DESCRIPTION
as opposed to QStringLiteral or QString when used with
QString::compare or QStringRef::compare.