### PR TITLE
Shapefile doc and reader fixes.

### DIFF
--- a/xmldoc/formats/shape.xml
+++ b/xmldoc/formats/shape.xml
@@ -11,6 +11,8 @@ When passing a file name for a set of shape files the name of any of the files f
 </para>
 <para>
 On read any projection format in a .prj file will be ignored.  This may or may not result in a misinterpretation of the data.
+GPSBabel expects the coordinate system used in the shapefile to be a Geographic Coordinate System with units in decimal degrees measuring degrees of longitude (x-coordinates) and degrees of latitude (y-coordinates), e.g. WGS 84.
+To transform from the spatial reference system described in the .prj file to the Geographic Coordinate System WGS 84 you can use the GDAL utility ogr2ogr, e.g. "ogr2ogr -t_srs EPSG:4326 output.shp input.shp".
 </para>
 <para>
 On read an attempt will be made to check the code page used by the .dbf file and


### PR DESCRIPTION
Don't cram different parts of polylines into one route, they
may not be connected.
Add documentation on transformation of coordinate systems that
may be required for GPSBabel usage of shapefiles.