### PR TITLE
add config tests in GPSBabel.pro.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /gpsbabel.html
 /gpsbabel.pdf
 /Makefile
+/.qmake.cache
+/.qmake.stash
+/GPSBabel
 *.o
 /GPSBabel[0-9]*.[0-9]*.[0-9]*/
 /GPSBabel[0-9]*.[0-9]*.[0-9]*.tar.bz2

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -134,8 +134,18 @@ HEADERS =  \
 
 INCLUDEPATH += zlib
 
+load(configure)
+
 macx|linux {
-  DEFINES += HAVE_NANOSLEEP HAVE_LIBUSB HAVE_GLOB HAVE_UNISTD_H
+  qtCompileTest(unistd) {
+    # this is used by zlib
+    DEFINES += HAVE_UNISTD_H
+  }
+  qtCompileTest(stdarg) {
+    # this is used by zlib
+    DEFINES += HAVE_STDARG_H
+  }
+  DEFINES += HAVE_NANOSLEEP HAVE_LIBUSB HAVE_GLOB
   SOURCES += gbser_posix.cc
   JEEPS += jeeps/gpslibusb.cc
   INCLUDEPATH += jeeps

--- a/config.tests/stdarg/.gitignore
+++ b/config.tests/stdarg/.gitignore
@@ -1,0 +1,2 @@
+/Makefile
+/stdarg

--- a/config.tests/stdarg/main.cpp
+++ b/config.tests/stdarg/main.cpp
@@ -1,0 +1,2 @@
+#include <stdarg.h>
+int main() { return 0; }

--- a/config.tests/stdarg/stdarg.pro
+++ b/config.tests/stdarg/stdarg.pro
@@ -1,0 +1,1 @@
+SOURCES = main.cpp

--- a/config.tests/unistd/.gitignore
+++ b/config.tests/unistd/.gitignore
@@ -1,0 +1,2 @@
+/Makefile
+/unistd

--- a/config.tests/unistd/main.cpp
+++ b/config.tests/unistd/main.cpp
@@ -1,0 +1,2 @@
+#include <unistd.h>
+int main() { return 0; }

--- a/config.tests/unistd/unistd.pro
+++ b/config.tests/unistd/unistd.pro
@@ -1,0 +1,1 @@
+SOURCES = main.cpp


### PR DESCRIPTION
specifically, we look for stdarg.h and unistd.h for zlib.

In #168 a warning was fixed related to unistd.h by assuming HAVE_UNISTD_H.  This PR actually tests for unistd.h and conditionally sets HAVE_UNISTD_H. It also tests for stdarg.h, and conditionally sets HAVE_STDARG_H.  Both of these macros are used by zlib.