### PR TITLE
restore fiddling with -e in kml test.

### DIFF
--- a/testo.d/kml.test
+++ b/testo.d/kml.test
@@ -80,3 +80,4 @@ then
 else
   echo "Skipping KML validation phase."
 fi
+set +e


### PR DESCRIPTION
this allows subsequent test errors to be counted.