### PR TITLE
cleanup defs.h orgainizing route and waypt elemements.

### DIFF
--- a/route.cc
+++ b/route.cc
@@ -519,6 +519,7 @@ track_restore(queue* head_bak)
   common_restore_finish();
 }
 
+#ifdef DEAD_CODE_IS_REBORN
 /*
  * Move the entire track queue onto the route queue making no attempt
  * at all to "fix" anything in the process.
@@ -534,7 +535,9 @@ routes_to_tracks()
     ENQUEUE_TAIL(&my_track_head, &trk->Q);
   }
 }
+#endif
 
+#ifdef DEAD_CODE_IS_REBORN
 /*
  * Same, but in opposite direction.
  */
@@ -549,6 +552,7 @@ tracks_to_routes()
     ENQUEUE_TAIL(&my_route_head, &trk->Q);
   }
 }
+#endif
 
 
 /*


### PR DESCRIPTION
The following prototypes were deleted, they had no definitions:
waypt_free
waypt_dupe
waypt_new
route_add
waypt_alloc_gc_data
waypt_empty_gc_data

The following functions were never used, and they had no prototypes:
void routes_to_tracks();
void tracks_to_routes();

The following function had a repeated prototype:
route_flush

The following function is missing a prototype but is explictly listed by the using file:
update_common_traits

In addition to resolving the above issues, some sections of defs.h
were moved based on if they came from waypt.cc or route.cc,
when they were required, and grouping of similar elements.