### PR TITLE
Formal

### DIFF
--- a/enigma.cc
+++ b/enigma.cc
@@ -180,11 +180,11 @@ enigma_waypt_disp(const Waypoint* wpt)
     le_write32(&ewpt.data.wp_altitude, METERS_TO_FEET(wpt->altitude) + 1000);
   }
   if (wpt->shortname != nullptr) {
-    ewpt.shortname_len = min(6, strlen(CSTRc(wpt->shortname)));
+    ewpt.shortname_len = (uint8_t) min(6, strlen(CSTRc(wpt->shortname)));
     strncpy(ewpt.shortname, CSTRc(wpt->shortname), 6);
   }
   if (wpt->description != nullptr) {
-    ewpt.longname_len = min(27, strlen(CSTRc(wpt->description)));
+    ewpt.longname_len = (uint8_t) min(27, strlen(CSTRc(wpt->description)));
     strncpy(ewpt.longname, CSTRc(wpt->description), 27);
   }
   gbfwrite(&ewpt, sizeof(ewpt), 1, file_out);

--- a/enigma.cc
+++ b/enigma.cc
@@ -160,10 +160,10 @@ wr_init(const QString& fname)
 }
 
 #ifndef min
-#define min(a,b) ((a) < (b)) ? (a) : (b)
+#define min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 #ifndef max
-#define max(a,b) ((a) > (b)) ? (a) : (b)
+#define max(a,b) (((a) > (b)) ? (a) : (b))
 #endif
 
 static void

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -244,7 +244,7 @@ gpi_gmsd_init(Waypoint* wpt)
 }
 
 static char*
-gpi_read_lc_string_old(const char* field, char* languagecode, short* length)
+gpi_read_lc_string_old(char* languagecode, short* length)
 {
   char lc[3];
   short len;
@@ -291,9 +291,9 @@ gpi_read_string_old(const char* field)
       is_fatal((gbfgetc(fin) != 0),
                MYNAME ": Error reading field '%s'!", field);
 
-      res1 = gpi_read_lc_string_old(field, lc1,  &l1);
+      res1 = gpi_read_lc_string_old(lc1,  &l1);
       if ((l1 + 4) < l0) { // dual language?
-        res2 = gpi_read_lc_string_old(field, lc2,  &l2);
+        res2 = gpi_read_lc_string_old(lc2,  &l2);
         is_fatal((l1 + 4 + l2 + 4 != l0),
                  MYNAME ": Error out of sync (wrong size %d/%d/%d) on field '%s'!", l0, l1, l2, field);
         if (opt_lang && (strcmp(opt_lang, lc1) == 0)) {

--- a/jeeps/gpscom.cc
+++ b/jeeps/gpscom.cc
@@ -1308,22 +1308,22 @@ int32 GPS_Command_Send_Track_As_Course(const char* port, GPS_PTrack* trk, int32 
 }
 
 /*Stubs for unimplemented stuff*/
-int32  GPS_Command_Get_Workout(const char*, void**, int (*cb)(int, struct GPS_SWay**))
+int32  GPS_Command_Get_Workout(const char* /* port */, void** /* lap */, int (* /* cb */)(int, struct GPS_SWay**))
 {
   return 0;
 }
 
-int32  GPS_Command_Get_Fitness_User_Profile(const char* port, void** lap, int (*cb)(int, struct GPS_SWay**))
+int32  GPS_Command_Get_Fitness_User_Profile(const char* /* port */, void**  /* lap */, int (* /* cb */)(int, struct GPS_SWay**))
 {
   return 0;
 }
 
-int32  GPS_Command_Get_Workout_Limits(const char* port, void** lap, int (*cb)(int, struct GPS_SWay**))
+int32  GPS_Command_Get_Workout_Limits(const char* /* port */, void** /* lap */, int (* /* cb */)(int, struct GPS_SWay**))
 {
   return 0;
 }
 
-int32  GPS_Command_Get_Course_Limits(const char* port, void** lap, int (*cb)(int, struct GPS_SWay**))
+int32  GPS_Command_Get_Course_Limits(const char* /* port */, void** /* lap */, int (* /* cb */)(int, struct GPS_SWay**))
 {
   return 0;
 }

--- a/jeeps/gpsserial.cc
+++ b/jeeps/gpsserial.cc
@@ -191,7 +191,7 @@ int32 GPS_Serial_Wait(gpsdevh* fd)
   return GPS_Serial_Chars_Ready(fd);
 }
 
-int32 GPS_Serial_Flush(gpsdevh* fd)
+int32 GPS_Serial_Flush(gpsdevh* /* fd */)
 {
   return 1;
 }

--- a/jeeps/gpsusbwin.cc
+++ b/jeeps/gpsusbwin.cc
@@ -58,7 +58,7 @@ static int usb_tx_packet_size ;
 static const gdx_info* gdx;
 
 static int
-gusb_win_close(gpsdevh* handle)
+gusb_win_close(gpsdevh* /* handle */)
 {
   if (usb_handle != INVALID_HANDLE_VALUE) {
     CloseHandle(usb_handle);

--- a/magproto.cc
+++ b/magproto.cc
@@ -1612,21 +1612,25 @@ const char** os_get_magellan_mountpoints()
 
 // My kingdom for container classes and portable tree-walking...
 // Returns a pointer to a static vector that's valid until the next call.
+#if HAVE_GLOB
 static char**
 os_gpx_files(const char* dirname)
 {
-#if HAVE_GLOB
   static glob_t g;
   char* path;
   xasprintf(&path, "%s/*.gpx", dirname);
   glob(path, 0, nullptr, &g);
   xfree(path);
   return g.gl_pathv;
+}
 #else
+static char**
+os_gpx_files(const char* /* dirname */)
+{
   fatal("Not implemented");
   return NULL;
-#endif
 }
+#endif
 
 /*
  *  This is repeated just so it shows up as separate menu options


### PR DESCRIPTION
clean up some MSVC warnings.

- C4100: '*': unreferenced formal parameter 
  all instances fixed by eliminated unused function parameters or commenting  the name of the parameter out in the definition.
- C4267: '=': conversion from 'size_t' to 'uint8_t', possible loss of data
  one instance fixed when demotion is safe following setting the maximum value.
