### PR TITLE
correct header file list in GPSBabel.pro, and a warning fix.

### DIFF
--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -120,13 +120,13 @@ HEADERS =  \
 	xmlgeneric.h \
 	zlib/crc32.h \
 	zlib/deflate.h \
+	zlib/gzguts.h \
 	zlib/inffast.h \
 	zlib/inffixed.h \
 	zlib/inflate.h \
 	zlib/inftrees.h \
 	zlib/trees.h \
 	zlib/zconf.h \
-	zlib/zconf.in.h \
 	zlib/zlib.h \
 	zlib/zutil.h \
 	src/core/xmlstreamwriter.h \

--- a/energympro.cc
+++ b/energympro.cc
@@ -240,7 +240,7 @@ track_read()
   }
 
   gbfseek(file_in, 0L, SEEK_END);
-  gbfseek(file_in, (int32_t) -(sizeof(tw_workout)), SEEK_CUR);
+  gbfseek(file_in, -(int32_t)(sizeof(tw_workout)), SEEK_CUR);
   tw_workout workout;
   workout.dateStart.Year = gbfgetc(file_in);
   workout.dateStart.Month = gbfgetc(file_in);


### PR DESCRIPTION
C4146: unary minus operator applied to unsigned type, result still unsigned