### PR TITLE
clang tidy optimizes to use parameter passing by const reference.

### DIFF
--- a/csv_util.cc
+++ b/csv_util.cc
@@ -958,7 +958,7 @@ writehms(const char* format, const gpsbabel::DateTime& t, int gmt)
 
 static
 long
-time_to_yyyymmdd(QDateTime t)
+time_to_yyyymmdd(const QDateTime& t)
 {
   QDate d = t.date();
   return d.year() * 10000 + d.month() * 100 + d.day();

--- a/csv_util.h
+++ b/csv_util.h
@@ -40,7 +40,7 @@ csv_lineparse(const char* stringstart, const char* delimited_by, const char* enc
 void
 human_to_dec(const char* instr, double* outlat, double* outlon, int which);
 inline void
-human_to_dec(const QString instr, double* outlat, double* outlon, int which) {
+human_to_dec(const QString& instr, double* outlat, double* outlon, int which) {
   human_to_dec(CSTR(instr), outlat, outlon, which);
 }
 

--- a/defs.h
+++ b/defs.h
@@ -341,17 +341,17 @@ class UrlLink
 {
 public:
   UrlLink() { }
-  UrlLink(const QString url) :
+  UrlLink(const QString& url) :
     url_(url)
   { }
   UrlLink(const char* url) :
     url_(url)
   { }
-  UrlLink(const QString url, const QString url_link_text) :
+  UrlLink(const QString& url, const QString& url_link_text) :
     url_(url),
     url_link_text_(url_link_text)
   { }
-  UrlLink(const QString url, const QString url_link_text, const QString url_link_type) :
+  UrlLink(const QString& url, const QString& url_link_text, const QString& url_link_type) :
     url_(url),
     url_link_text_(url_link_text),
     url_link_type_(url_link_type)
@@ -547,7 +547,7 @@ public:
   bool HasUrlLink() const;
   const UrlLink& GetUrlLink() const;
   const QList<UrlLink> GetUrlLinks() const;
-  void AddUrlLink(const UrlLink l);
+  void AddUrlLink(const UrlLink& l);
   QString CreationTimeXML() const;
   gpsbabel::DateTime  GetCreationTime() const;
   void SetCreationTime(gpsbabel::DateTime t);

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -501,7 +501,7 @@ memapi_error(gbfile* self)
  */
 
 gbfile*
-gbfopen(const QString filename, const char* mode, const char* module)
+gbfopen(const QString& filename, const char* mode, const char* module)
 {
   gbfile* file;
   const char* m;
@@ -609,7 +609,7 @@ gbfopen(const QString filename, const char* mode, const char* module)
  */
 
 gbfile*
-gbfopen_be(const QString filename, const char* mode, const char* module)
+gbfopen_be(const QString& filename, const char* mode, const char* module)
 {
   gbfile* result;
 

--- a/gbfile.h
+++ b/gbfile.h
@@ -86,8 +86,8 @@ typedef struct gbfile_s {
 } gbfile_t;
 
 
-gbfile* gbfopen(const QString filename, const char* mode, const char* module);
-gbfile* gbfopen_be(const QString filename, const char* mode, const char* module);
+gbfile* gbfopen(const QString& filename, const char* mode, const char* module);
+gbfile* gbfopen_be(const QString& filename, const char* mode, const char* module);
 #define gbfopen_le gbfopen
 void gbfclose(gbfile* file);
 

--- a/gdb.cc
+++ b/gdb.cc
@@ -361,7 +361,7 @@ gdb_add_route_waypt(route_head* rte, Waypoint* ref, const int wpt_class)
 /*******************************************************************************/
 /* TOOLS AND MACROS FOR THE WRITER */
 /*-----------------------------------------------------------------------------*/
-static void FWRITE_CSTR(QString a)  {
+static void FWRITE_CSTR(const QString& a)  {
   if (a.isEmpty()) {
     gbfputc(0, fout);
     return;

--- a/gpx.cc
+++ b/gpx.cc
@@ -527,7 +527,7 @@ tag_gs_cache(const QXmlStreamAttributes& attr)
 }
 
 static void
-start_something_else(const QString el, const QXmlStreamAttributes& attr)
+start_something_else(const QString& el, const QXmlStreamAttributes& attr)
 {
   char** avcp;
   int attr_count;
@@ -1652,7 +1652,7 @@ gpx_write_common_extensions(const Waypoint* waypointp, const gpx_point_type poin
 }
 
 static void
-gpx_write_common_description(const Waypoint* waypointp, QString oname)
+gpx_write_common_description(const Waypoint* waypointp, const QString& oname)
 {
   writer->writeOptionalTextElement(QStringLiteral("name"), oname);
 

--- a/gtrnctr.cc
+++ b/gtrnctr.cc
@@ -234,7 +234,7 @@ gtc_write_xml(int indent, const char* fmt, ...)
 }
 
 static void
-gtc_write_xml(int indent, const QString s)
+gtc_write_xml(int indent, const QString& s)
 {
   if (indent < 0) {
     gtc_indent_level--;

--- a/maggeo.cc
+++ b/maggeo.cc
@@ -176,7 +176,7 @@ maggeo_read()
 
 static
 QString
-maggeo_fmtdate(QDateTime dt)
+maggeo_fmtdate(const QDateTime& dt)
 {
   QDate date = dt.date();
   int y = date.year() - 1900;

--- a/mynav.cc
+++ b/mynav.cc
@@ -52,7 +52,7 @@ static gbfile* fin;
 //           local helper functions
 //***************************************************************************
 static void
-mynav_rd_line(QString line)
+mynav_rd_line(const QString& line)
 {
   QStringList fields = line.split("|");
 

--- a/pcx.cc
+++ b/pcx.cc
@@ -70,13 +70,13 @@ static void wr_deinit() {
 
 // Find the first token in string |in| when there may be leading whitespace.
 // These files have weird mixtures of spaces and tabs.
-static QString FirstTokenAt(QString in, int index) {
+static QString FirstTokenAt(const QString& in, int index) {
   static const QRegExp sep("\\s+");
   return in.mid(index, -1).section(sep, 0, 0, QString::SectionSkipEmpty);
 }
 
 // Centralize Date/Time parsing between Waypoint and Trackpoint readers.
-static void  SetWaypointTime(Waypoint* wpt, QString date, QString time) {
+static void  SetWaypointTime(Waypoint* wpt, const QString& date, const QString& time) {
   QDate qdate = QDate::fromString(date, "dd-MMM-yy");
   QTime qtime = QTime::fromString(time, "hh:mm:ss");
   if (qdate.isValid() && qtime.isValid()) {

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -52,7 +52,7 @@ class Warning {
   inline Warning& operator << (float d) { fileStream_ << d; return optionalSpace(); }
   inline Warning& operator << (double d) { fileStream_ << d; return optionalSpace(); }
   inline Warning& operator << (const char* d) { fileStream_ << QString::fromUtf8(d); return optionalSpace(); }
-  inline Warning& operator << (QString d) { fileStream_ << '\"' << d << '\"'; return optionalSpace(); }
+  inline Warning& operator << (const QString& d) { fileStream_ << '\"' << d << '\"'; return optionalSpace(); }
   inline Warning& operator << (const void* d) { fileStream_ << '\"' << d << '\"'; return optionalSpace(); }
 
   inline Warning& optionalSpace() {

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -394,7 +394,7 @@ trackfilter_minpoint_list_cb(const route_head* track)
 *******************************************************************************/
 
 static void
-trackfilter_split_init_rte_name(route_head* track, const QDateTime dt)
+trackfilter_split_init_rte_name(route_head* track, const QDateTime& dt)
 {
   QString datetimestring;
 

--- a/waypt.cc
+++ b/waypt.cc
@@ -707,7 +707,7 @@ Waypoint::GetUrlLinks() const
 }
 
 void
-Waypoint::AddUrlLink(const UrlLink l)
+Waypoint::AddUrlLink(const UrlLink& l)
 {
   url_link_list_.push_back(l);
 }


### PR DESCRIPTION
RUN_CLANG_TIDY_FLAGS="-header-filter=.*\\\.h -checks=-*,performance-unnecessary-value-param -fix

The suggestion "parameter '*' is passed by value and only copied once; consider moving
it to avoid unnecessary copies" was not accepted.

The suggestion "the const qualified parameter '*' is copied for each invocation;
consider making it a reference" was accepted.

The suggestion "the parameter '*' is copied for each invocation but only used as a const
reference; consider making it a const reference" was accepted.