### PR TITLE
eliminate superfluous casting "redundant cast to the same type"

### DIFF
--- a/bcr.cc
+++ b/bcr.cc
@@ -225,7 +225,7 @@ bcr_wgs84_to_mercator(const double lat, const double lon, int* north, int* east)
   double N, E;
 
   N = log(tan(lat * M_PI / 360 + M_PI / 4)) * radius;
-  E = lon * radius * M_PI / (double)180;
+  E = lon * radius * M_PI / 180.0;
 
   if (lat > 0) {
     N += 0.500000000001;  /* we go from double to integer */
@@ -245,8 +245,8 @@ bcr_wgs84_to_mercator(const double lat, const double lon, int* north, int* east)
 static void
 bcr_mercator_to_wgs84(const int north, const int east, double* lat, double* lon)
 {
-  *lat = 2 * (atan(exp(north / radius)) - M_PI / 4) / M_PI * (double)180;
-  *lon = (double)east * (double)180 / (radius * M_PI);
+  *lat = 2 * (atan(exp(north / radius)) - M_PI / 4) / M_PI * 180.0;
+  *lon = (double)east * 180.0 / (radius * M_PI);
 }
 
 /* ------------------------------------------------------------- */

--- a/cst.cc
+++ b/cst.cc
@@ -69,7 +69,7 @@ cst_add_wpt(const route_head* track, Waypoint* wpt)
     }
     route_add_wpt(temp_route, new Waypoint(*wpt));
   }
-  track_add_wpt((route_head*)track, (Waypoint*)wpt);
+  track_add_wpt((route_head*)track, wpt);
 }
 
 static char*

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -399,9 +399,9 @@ intdeg_to_dec(const int ideg)
   double d;
 
   if (ideg >= 0) {
-    d = ((2147483647) - ideg) / (double)8388608;
+    d = ((2147483647) - ideg) / 8388608.0;
   } else {
-    d = ((-2147483647-1) + ideg) / (double)8388608;
+    d = ((-2147483647-1) + ideg) / 8388608.0;
   }
 
   return(d);
@@ -1390,9 +1390,9 @@ xcsv_parse_val(const char* s, Waypoint* wpt, const field_map_t* fmp,
   break;
   case -1:
     if (strncmp(fmp->key, "LON_10E", 7) == 0) {
-      wpt->longitude = atof(s) / pow((double)10, atof(fmp->key+7));
+      wpt->longitude = atof(s) / pow(10.0, atof(fmp->key+7));
     } else if (strncmp(fmp->key, "LAT_10E", 7) == 0) {
-      wpt->latitude = atof(s) / pow((double)10, atof(fmp->key+7));
+      wpt->latitude = atof(s) / pow(10.0, atof(fmp->key+7));
     } else {
       warning(MYNAME ": Unknown style directive: %s\n", fmp->key);
     }
@@ -2150,9 +2150,9 @@ xcsv_waypt_pr(const Waypoint* wpt)
       break;
     case -1:
       if (strncmp(fmp->key, "LON_10E", 7) == 0) {
-        buff = QString().sprintf(fmp->printfc, lon * pow((double)10, atof(fmp->key+7)));
+        buff = QString().sprintf(fmp->printfc, lon * pow(10.0, atof(fmp->key+7)));
       } else if (strncmp(fmp->key, "LAT_10E", 7) == 0) {
-        buff = QString().sprintf(fmp->printfc, lat * pow((double)10, atof(fmp->key+7)));
+        buff = QString().sprintf(fmp->printfc, lat * pow(10.0, atof(fmp->key+7)));
       }
       break;
     default:

--- a/destinator.cc
+++ b/destinator.cc
@@ -435,10 +435,10 @@ destinator_trkpt_disp(const Waypoint* wpt)
     tm = *gmtime(&ct);
     tm.tm_mon += 1;
     tm.tm_year -= 100;
-    date = ((int)tm.tm_mday * 10000) + ((int)tm.tm_mon * 100) + tm.tm_year;
+    date = (tm.tm_mday * 10000) + (tm.tm_mon * 100) + tm.tm_year;
     gbfputint32(date, fout);
-    milliseconds = ((int)tm.tm_hour * 10000) +
-                   ((int)tm.tm_min * 100) + tm.tm_sec;
+    milliseconds = (tm.tm_hour * 10000) +
+                   (tm.tm_min * 100) + tm.tm_sec;
     milliseconds = (milliseconds * 1000) + (wpt->GetCreationTime().time().msec());
 
     gbfputflt(milliseconds, fout);

--- a/energympro.cc
+++ b/energympro.cc
@@ -158,8 +158,8 @@ read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime)
 
   Waypoint* waypt;
   waypt = new Waypoint;
-  waypt->latitude = (point.Latitude / (double)1000000);
-  waypt->longitude = (point.Longitude / (double)1000000);
+  waypt->latitude = (point.Latitude / 1000000.0);
+  waypt->longitude = (point.Longitude / 1000000.0);
   waypt->altitude = point.Altitude;
 
   if (global_opts.debug_level > 1) {

--- a/exif.cc
+++ b/exif.cc
@@ -1081,8 +1081,8 @@ exif_put_coord(const int ifd_nr, const int tag_id, const double val)
   vmin = floor(vmin);
 
   exif_put_double(ifd_nr, tag_id, 0, (double)vint);
-  exif_put_double(ifd_nr, tag_id, 1, (double)vmin);
-  exif_put_double(ifd_nr, tag_id, 2, (double)vsec);
+  exif_put_double(ifd_nr, tag_id, 1, vmin);
+  exif_put_double(ifd_nr, tag_id, 2, vsec);
 }
 
 static void

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -1390,7 +1390,7 @@ load_bitmap_from_file(const char* fname, unsigned char** data, int* data_sz)
 
   /* calculate line-size for source and destination */
   src_line_sz = (src_h.width * src_h.bpp) / 8;
-  src_line_sz = ((int)((src_line_sz + 3) / 4)) * 4;
+  src_line_sz = (((src_line_sz + 3) / 4)) * 4;
 
   if (src_h.bpp == 24) {
     dest_bpp = 32;
@@ -1399,7 +1399,7 @@ load_bitmap_from_file(const char* fname, unsigned char** data, int* data_sz)
   }
 
   dest_line_sz = (src_h.width * dest_bpp) / 8;
-  dest_line_sz = ((int)((dest_line_sz + 3) / 4)) * 4;
+  dest_line_sz = (((dest_line_sz + 3) / 4)) * 4;
 
   sz = sizeof(*dest_h) + (src_h.height * dest_line_sz);
   if (src_h.used_colors) {

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -442,7 +442,7 @@ print_distance(const double distance, const int no_scale, const int with_tab, co
       gbfprintf(fout, "%.*f ft", decis, dist);
     } else {
       dist = METERS_TO_MILES(distance);
-      if (dist < (double)100) {
+      if (dist < 100.0) {
         gbfprintf(fout, "%.1f mi", dist);
       } else {
         gbfprintf(fout, "%d mi", si_round(dist));
@@ -453,7 +453,7 @@ print_distance(const double distance, const int no_scale, const int with_tab, co
       gbfprintf(fout, "%.*f m", decis, dist);
     } else {
       dist = dist / 1000.0;
-      if (dist < (double)100) {
+      if (dist < 100.0) {
         gbfprintf(fout, "%.1f km", dist);
       } else {
         gbfprintf(fout, "%d km", si_round(dist));

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -452,7 +452,7 @@ print_distance(const double distance, const int no_scale, const int with_tab, co
     if ((dist < 1000) || no_scale) {
       gbfprintf(fout, "%.*f m", decis, dist);
     } else {
-      dist = dist / (double)1000.0;
+      dist = dist / 1000.0;
       if (dist < (double)100) {
         gbfprintf(fout, "%.1f km", dist);
       } else {
@@ -484,7 +484,7 @@ print_speed(double* distance, time_t* time)
     double speed = MPS_TO_KPH(dist / (double)*time);
     int ispeed = si_round(speed);
 
-    if (speed < (double)0.01) {
+    if (speed < 0.01) {
       gbfprintf(fout, "0 %s", unit);
     } else if (ispeed < 2) {
       gbfprintf(fout, "%.1f %s", speed, unit);

--- a/ggv_log.cc
+++ b/ggv_log.cc
@@ -130,13 +130,13 @@ ggv_log_read()
     deg = (int16_t) le_read16(&buf[0]);
     min = le_read16(&buf[2]);
     sec = le_read_float(&buf[4]);
-    xlat = (double)deg + ((double)min / (double)60) + (sec / (double)3600.0);
+    xlat = (double)deg + ((double)min / 60.0) + (sec / 3600.0);
     wpt->latitude = xlat;
 
     deg = (int16_t) le_read16(&buf[8]);
     min = le_read16(&buf[10]);
     sec = le_read_float(&buf[12]);
-    xlon = (double)deg + ((double)min / (double)60) + (sec / (double)3600.0);
+    xlon = (double)deg + ((double)min / 60.0) + (sec / 3600.0);
     wpt->longitude = xlon;
 
     WAYPT_SET(wpt, course, le_read16(&buf[16 + 0]));

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -522,12 +522,12 @@ track_read()
     //payload is packed with a number of trainingheaders with the size of 29bytes each
     number_headers = length / 29;	//29=packed sizeof(gh_trainheader)
     if (global_opts.debug_level > 1) {
-      printf("length=%d sizeof(gh_trainheader)=%d number_headers=%d\n", (int) length, (int) 29, (int) number_headers);
+      printf("length=%d sizeof(gh_trainheader)=%d number_headers=%d\n", length, 29, number_headers);
     }
 
     for (int i = 0; i < number_headers; i++) {
       int pos = i * 29; //29=packed sizeof(gh_trainheader)
-      uint8_t* hdr = (uint8_t*) & (payload[pos]);
+      uint8_t* hdr = & (payload[pos]);
       gh_trainheader header;
       header.dateStart.Year = hdr[0];
       header.dateStart.Month = hdr[1];
@@ -582,7 +582,7 @@ track_read()
         is_fatal(((track_length == 0) || (track_payload == nullptr)) , "tracklength in 0 bytes or payload nonexistant");
         //      printf("Got track package!!! Train data\n");
 
-        uint8_t* dbtrain = (uint8_t*) track_payload;
+        uint8_t* dbtrain = track_payload;
         gh_db_train db_train;
         db_train.dateStart.Year = dbtrain[0];
         db_train.dateStart.Month = dbtrain[1];
@@ -637,7 +637,7 @@ track_read()
           is_fatal(((track_length == 0) || (track_payload == nullptr)), "tracklength in 0 bytes or payload nonexistant");
           //	printf("Got track package!!! Laps data\n");
 
-          uint8_t* hdr = (uint8_t*) track_payload;
+          uint8_t* hdr = track_payload;
           gh_trainheader header;
           header.dateStart.Year = hdr[0];
           header.dateStart.Month = hdr[1];
@@ -678,7 +678,7 @@ track_read()
           uint8_t* lap_start_pos = track_payload + 29;	//29=packed sizeof(gh_trainheader)
           int lap;
           for (lap = 0; lap < laps_in_package; lap++) {
-            uint8_t* dblap = (uint8_t*)(lap_start_pos) + lap * 41;	//  packed sizeof(gh_db_lap)=41
+            uint8_t* dblap = (lap_start_pos) + lap * 41;	//  packed sizeof(gh_db_lap)=41
             gh_db_lap db_lap;
 
             db_lap.AccruedTime = be_read32(dblap+0);
@@ -725,7 +725,7 @@ track_read()
           track_payload = globalsat_read_package(&track_length, &trackDeviceCommand);
           if ((track_length > 0) && (track_payload != nullptr)) {
             //	  printf("Got track package!!! Train data\n");
-            uint8_t* hdr = (uint8_t*) track_payload;
+            uint8_t* hdr = track_payload;
             gh_trainheader header;
             header.dateStart.Year = hdr[0];
             header.dateStart.Month = hdr[1];
@@ -756,7 +756,7 @@ track_read()
             uint8_t* recpoints_start_pos = track_payload + 29;	//29=packed sizeof(gh_trainheader)
             int recpoint;
             for (recpoint = 0; recpoint < recpoints_in_package; recpoint++) {
-              uint8_t* ghpoint = (uint8_t*)(recpoints_start_pos + recpoint * 25);	//  packed sizeof(gh_recpoint)=25
+              uint8_t* ghpoint = (recpoints_start_pos + recpoint * 25);	//  packed sizeof(gh_recpoint)=25
               gh_recpoint point;
               point.Latitude = be_read32(ghpoint);
               point.Longitude = be_read32(ghpoint+4);

--- a/gopal.cc
+++ b/gopal.cc
@@ -130,7 +130,7 @@ gopal_rd_init(const QString& fname)
   if (optdate) {
     memset(&opt_tm, 0, sizeof(opt_tm));
 
-    ck = (char*)strptime(optdate, "%Y%m%d", &opt_tm);
+    ck = strptime(optdate, "%Y%m%d", &opt_tm);
     if ((ck == nullptr) || (*ck != '\0') || (strlen(optdate) != 8)) {
       fatal(MYNAME ": Invalid date \"%s\"!\n", optdate);
     } else if (opt_tm.tm_year < 70) {

--- a/holux.cc
+++ b/holux.cc
@@ -190,8 +190,8 @@ static void holux_disp(const Waypoint* wpt)
   short sIndex;
   WPT* pWptHxTmp;
 
-  lon =(double)wpt->longitude * 36000;
-  lat =(double)wpt->latitude * -36000;
+  lon =wpt->longitude * 36000.0;
+  lat =wpt->latitude * -36000.0;
 
 
   /* round it to increase the accuracy */

--- a/igo8.cc
+++ b/igo8.cc
@@ -335,13 +335,13 @@ static void write_header()
   if (igo8_option_title) {
     title = igo8_option_title;
   }
-  current_position += ascii_to_unicode_2((char*)(header+current_position), IGO8_HEADER_SIZE - current_position - 2, title);
+  current_position += ascii_to_unicode_2((header+current_position), IGO8_HEADER_SIZE - current_position - 2, title);
 
   // Set the description of the track
   if (igo8_option_description) {
     description = igo8_option_description;
   }
-  current_position += ascii_to_unicode_2((char*)(header+current_position), IGO8_HEADER_SIZE - current_position, description);
+  current_position += ascii_to_unicode_2((header+current_position), IGO8_HEADER_SIZE - current_position, description);
 
   gbfwrite(&header, IGO8_HEADER_SIZE, 1, igo8_file_out);
 }

--- a/jeeps/gpsapp.cc
+++ b/jeeps/gpsapp.cc
@@ -231,7 +231,7 @@ static int32 GPS_A000(const char* port)
 
   (void) strcpy(gps_save_string,(char*)rec.data+4);
   gps_save_id = id;
-  gps_save_version = (double)((double)version/(double)100.);
+  gps_save_version = ((double)version/100.);
 
   GPS_User("Unit:\t%s\nID:\t%d\nVersion:\t%.2f",
            gps_save_string, gps_save_id, gps_save_version);
@@ -2057,9 +2057,9 @@ static void GPS_D100_Send(UC* data, GPS_PWay way, int32* len)
   p = data;
 
   copy_char_array(&p, way->ident, 6, UpperYes);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2088,9 +2088,9 @@ static void GPS_D101_Send(UC* data, GPS_PWay way, int32* len)
   p = data;
 
   copy_char_array(&p, way->ident, 6, UpperYes);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2125,9 +2125,9 @@ static void GPS_D102_Send(UC* data, GPS_PWay way, int32* len)
   p = data;
 
   copy_char_array(&p, way->ident, 6, UpperYes);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2162,9 +2162,9 @@ static void GPS_D103_Send(UC* data, GPS_PWay way, int32* len)
 
   copy_char_array(&p, way->ident, 6, UpperYes);
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2196,9 +2196,9 @@ static void GPS_D104_Send(UC* data, GPS_PWay way, int32* len)
   p = data;
 
   copy_char_array(&p, way->ident, 6, UpperYes);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2239,9 +2239,9 @@ static void GPS_D105_Send(UC* data, GPS_PWay way, int32* len)
 
   p = data;
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
 
   GPS_Util_Put_Short(p, (int16) way->smbl);
@@ -2279,9 +2279,9 @@ static void GPS_D106_Send(UC* data, GPS_PWay way, int32* len)
   for (i=0; i<13; ++i) {
     *p++ = way->subclass[i];
   }
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
 
   GPS_Util_Put_Short(p, (int16) way->smbl);
@@ -2315,9 +2315,9 @@ static void GPS_D107_Send(UC* data, GPS_PWay way, int32* len)
   p = data;
 
   copy_char_array(&p, way->ident, 6, UpperYes);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2366,9 +2366,9 @@ static void GPS_D108_Send(UC* data, GPS_PWay way, int32* len)
   for (i=0; i<18; ++i) {
     *p++ = way->subclass[i];
   }
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
 
   if (way->alt_is_unknown) {
@@ -2452,9 +2452,9 @@ static void GPS_D109_Send(UC* data, GPS_PWay way, int32* len, int protoid)
   for (i=0; i<18; ++i) {
     *p++ = way->subclass[i];
   }
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   if (way->alt_is_unknown) {
     GPS_Util_Put_Float(p,(const float) 1.0e25);
@@ -2545,9 +2545,9 @@ static void GPS_D150_Send(UC* data, GPS_PWay way, int32* len)
   }
   *p++ = way->wpt_class;
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
 
   GPS_Util_Put_Short(p,(US) way->alt);
@@ -2583,9 +2583,9 @@ static void GPS_D151_Send(UC* data, GPS_PWay way, int32* len)
 
   copy_char_array(&p, way->ident, 6, UpperYes);
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2636,9 +2636,9 @@ static void GPS_D152_Send(UC* data, GPS_PWay way, int32* len)
 
   copy_char_array(&p, way->ident, 6, UpperYes);
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2688,9 +2688,9 @@ static void GPS_D154_Send(UC* data, GPS_PWay way, int32* len)
 
   copy_char_array(&p, way->ident, 6, UpperYes);
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -2743,9 +2743,9 @@ static void GPS_D155_Send(UC* data, GPS_PWay way, int32* len)
 
   copy_char_array(&p, way->ident, 6, UpperYes);
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -5163,9 +5163,9 @@ static void GPS_D400_Send(UC* data, GPS_PWay way, int32* len)
   for (i=0; i<6; ++i) {
     *p++ = way->ident[i];
   }
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -5201,9 +5201,9 @@ static void GPS_D403_Send(UC* data, GPS_PWay way, int32* len)
   for (i=0; i<6; ++i) {
     *p++ = way->ident[i];
   }
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
   GPS_Util_Put_Uint(p,0);
   p+=sizeof(int32);
@@ -5250,9 +5250,9 @@ static void GPS_D450_Send(UC* data, GPS_PWay way, int32* len)
   }
   *p++ = way->wpt_class;
 
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lat));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lat));
   p+=sizeof(int32);
-  GPS_Util_Put_Int(p,(int32)GPS_Math_Deg_To_Semi(way->lon));
+  GPS_Util_Put_Int(p,GPS_Math_Deg_To_Semi(way->lon));
   p+=sizeof(int32);
 
   GPS_Util_Put_Short(p,(US) way->alt);

--- a/jeeps/gpsmath.cc
+++ b/jeeps/gpsmath.cc
@@ -47,7 +47,7 @@ static int32 GPS_Math_UTM_Param_To_Mc(int32 zone, char zc, double* Mc,
 
 double GPS_Math_Deg_To_Rad(double v)
 {
-  return v*(double)((double)GPS_PI/(double)180.);
+  return v*(GPS_PI/180.);
 }
 
 
@@ -63,7 +63,7 @@ double GPS_Math_Deg_To_Rad(double v)
 
 double GPS_Math_Rad_To_Deg(double v)
 {
-  return v*(double)((double)180./(double)GPS_PI);
+  return v*(180./GPS_PI);
 }
 
 
@@ -83,18 +83,18 @@ void GPS_Math_Deg_To_DegMin(double v, int32* d, double* m)
 {
   int32 sign;
 
-  if (v<(double)0.) {
-    v *= (double)-1.;
+  if (v<0.) {
+    v *= -1.;
     sign = 1;
   } else {
     sign = 0;
   }
 
   *d = (int32)v;
-  *m = (v-(double)*d) * (double)60.0;
-  if (*m>(double)59.999) {
+  *m = (v-(double)*d) * 60.0;
+  if (*m>59.999) {
     ++*d;
-    *m = (double)0.0;
+    *m = 0.0;
   }
 
   if (sign) {
@@ -120,7 +120,7 @@ void GPS_Math_Deg_To_DegMin(double v, int32* d, double* m)
 void GPS_Math_DegMin_To_Deg(int32 d, double m, double* deg)
 {
 
-  *deg = ((double)abs(d)) + m / (double)60.0;
+  *deg = ((double)abs(d)) + m / 60.0;
   if (d<0) {
     *deg = -*deg;
   }
@@ -147,25 +147,25 @@ void GPS_Math_Deg_To_DegMinSec(double v, int32* d, int32* m, double* s)
   int32 sign;
   double t;
 
-  if (v<(double)0.) {
-    v *= (double)-1.;
+  if (v<0.) {
+    v *= -1.;
     sign = 1;
   } else {
     sign = 0;
   }
 
   *d = (int32)v;
-  t  = (v -(double)*d) * (double)60.0;
-  *m = (v-(double)*d) * (double)60.0;
-  *s = (t - (int32)t) * (double)60.0;
+  t  = (v -(double)*d) * 60.0;
+  *m = (v-(double)*d) * 60.0;
+  *s = (t - (int32)t) * 60.0;
 
-  if (*s>(double)59.999) {
+  if (*s>59.999) {
     ++t;
-    *s = (double)0.0;
+    *s = 0.0;
   }
 
 
-  if (t>(double)59.999) {
+  if (t>59.999) {
     ++*d;
     t = 0;
   }
@@ -196,7 +196,7 @@ void GPS_Math_Deg_To_DegMinSec(double v, int32* d, int32* m, double* s)
 void GPS_Math_DegMinSec_To_Deg(int32 d, int32 m, double s, double* deg)
 {
 
-  *deg = ((double)abs(d)) + ((double)m + s / (double)60.0) / (double)60.0;
+  *deg = ((double)abs(d)) + ((double)m + s / 60.0) / 60.0;
   if (d<0) {
     *deg = -*deg;
   }
@@ -249,7 +249,7 @@ double GPS_Math_Feet_To_Metres(double v)
 
 int32 GPS_Math_Deg_To_Semi(double v)
 {
-  return ((double)(1U<<31) / (double)180) * v;
+  return ((double)(1U<<31) / 180.0) * v;
 }
 
 
@@ -265,7 +265,7 @@ int32 GPS_Math_Deg_To_Semi(double v)
 
 double GPS_Math_Semi_To_Deg(int32 v)
 {
-  return (double)(((double)v / (double)(1U<<31)) * (double)180);
+  return (((double)v / (double)(1U<<31)) * 180.0);
 }
 
 
@@ -332,10 +332,10 @@ void GPS_Math_LatLonH_To_XYZ(double phi, double lambda, double H,
 
   esq   = ((a*a)-(b*b)) / (a*a);
 
-  nu    = a / pow(((double)1.0-esq*sin(phi)*sin(phi)),(double)0.5);
+  nu    = a / pow((1.0-esq*sin(phi)*sin(phi)),0.5);
   *x    = (nu+H) * cos(phi) * cos(lambda);
   *y    = (nu+H) * cos(phi) * sin(lambda);
-  *z    = (((double)1.0-esq)*nu+H) * sin(phi);
+  *z    = ((1.0-esq)*nu+H) * sin(phi);
 
   return;
 }
@@ -370,21 +370,21 @@ void GPS_Math_XYZ_To_LatLonH(double* phi, double* lambda, double* H,
   int32    t1=0;
   int32    t2=0;
 
-  if (x<(double)0 && y>=(double)0) {
+  if (x<0.0 && y>=0.0) {
     t1=1;
   }
-  if (x<(double)0 && y<(double)0) {
+  if (x<0.0 && y<0.0) {
     t2=1;
   }
 
-  rho  = pow(((x*x)+(y*y)),(double)0.5);
+  rho  = pow(((x*x)+(y*y)),0.5);
   esq  = ((a*a)-(b*b)) / (a*a);
-  phix = atan(z/(((double)1.0 - esq) * rho));
-  nphi = (double)1e20;
+  phix = atan(z/((1.0 - esq) * rho));
+  nphi = 1e20;
 
-  while (fabs(phix-nphi)>(double)0.00000000001) {
+  while (fabs(phix-nphi)>0.00000000001) {
     nphi  = phix;
-    nu    = a / pow(((double)1.0-esq*sin(nphi)*sin(nphi)),(double)0.5);
+    nu    = a / pow((1.0-esq*sin(nphi)*sin(nphi)),0.5);
     phix  = atan((z+esq*nu*sin(nphi))/rho);
   }
 
@@ -393,10 +393,10 @@ void GPS_Math_XYZ_To_LatLonH(double* phi, double* lambda, double* H,
   *lambda = GPS_Math_Rad_To_Deg(atan(y/x));
 
   if (t1) {
-    *lambda += (double)180.0;
+    *lambda += 180.0;
   }
   if (t2) {
-    *lambda -= (double)180.0;
+    *lambda -= 180.0;
   }
 
   return;
@@ -561,54 +561,54 @@ void GPS_Math_LatLon_To_EN(double* E, double* N, double phi,
   esq = ((a*a)-(b*b)) / (a*a);
   n   = (a-b) / (a+b);
 
-  tmp  = (double)1.0 - (esq * sin(phi) * sin(phi));
-  nu   = a * F0 * pow(tmp,(double)-0.5);
-  rho  = a * F0 * ((double)1.0 - esq) * pow(tmp,(double)-1.5);
-  etasq = (nu / rho) - (double)1.0;
+  tmp  = 1.0 - (esq * sin(phi) * sin(phi));
+  nu   = a * F0 * pow(tmp,-0.5);
+  rho  = a * F0 * (1.0 - esq) * pow(tmp,-1.5);
+  etasq = (nu / rho) - 1.0;
 
-  fdf   = (double)5.0 / (double)4.0;
-  tmp   = (double)1.0 + n + (fdf * n * n) + (fdf * n * n * n);
+  fdf   = 5.0 / 4.0;
+  tmp   = 1.0 + n + (fdf * n * n) + (fdf * n * n * n);
   tmp  *= (phi - phi0);
-  tmp2  = (double)3.0*n + (double)3.0*n*n + ((double)21./(double)8.)*n*n*n;
+  tmp2  = 3.0*n + 3.0*n*n + (21./8.)*n*n*n;
   tmp2 *= (sin(phi-phi0) * cos(phi+phi0));
   tmp  -= tmp2;
 
-  fde   = ((double)15.0 / (double)8.0);
-  tmp2  = ((fde*n*n) + (fde*n*n*n)) * sin((double)2.0 * (phi-phi0));
-  tmp2 *= cos((double)2.0 * (phi+phi0));
+  fde   = (15.0 / 8.0);
+  tmp2  = ((fde*n*n) + (fde*n*n*n)) * sin(2.0 * (phi-phi0));
+  tmp2 *= cos(2.0 * (phi+phi0));
   tmp  += tmp2;
 
-  tmp2  = ((double)35.0/(double)24.0) * n * n * n;
-  tmp2 *= sin((double)3.0 * (phi-phi0));
-  tmp2 *= cos((double)3.0 * (phi+phi0));
+  tmp2  = (35.0/24.0) * n * n * n;
+  tmp2 *= sin(3.0 * (phi-phi0));
+  tmp2 *= cos(3.0 * (phi+phi0));
   tmp  -= tmp2;
 
   M     = b * F0 * tmp;
   I     = M + N0;
-  II    = (nu / (double)2.0) * sin(phi) * cos(phi);
-  III   = (nu / (double)24.0) * sin(phi) * cos(phi) * cos(phi) * cos(phi);
-  III  *= ((double)5.0 - (tan(phi) * tan(phi)) + ((double)9.0 * etasq));
-  IIIA  = (nu / (double)720.0) * sin(phi) * pow(cos(phi),(double)5.0);
-  IIIA *= ((double)61.0 - ((double)58.0*tan(phi)*tan(phi)) +
-           pow(tan(phi),(double)4.0));
+  II    = (nu / 2.0) * sin(phi) * cos(phi);
+  III   = (nu / 24.0) * sin(phi) * cos(phi) * cos(phi) * cos(phi);
+  III  *= (5.0 - (tan(phi) * tan(phi)) + (9.0 * etasq));
+  IIIA  = (nu / 720.0) * sin(phi) * pow(cos(phi),5.0);
+  IIIA *= (61.0 - (58.0*tan(phi)*tan(phi)) +
+           pow(tan(phi),4.0));
   IV    = nu * cos(phi);
 
-  tmp   = pow(cos(phi),(double)3.0);
+  tmp   = pow(cos(phi),3.0);
   tmp  *= ((nu/rho) - tan(phi) * tan(phi));
-  V     = (nu/(double)6.0) * tmp;
+  V     = (nu/6.0) * tmp;
 
-  tmp   = (double)5.0 - ((double)18.0 * tan(phi) * tan(phi));
-  tmp  += tan(phi)*tan(phi)*tan(phi)*tan(phi) + ((double)14.0 * etasq);
-  tmp  -= ((double)58.0 * tan(phi) * tan(phi) * etasq);
+  tmp   = 5.0 - (18.0 * tan(phi) * tan(phi));
+  tmp  += tan(phi)*tan(phi)*tan(phi)*tan(phi) + (14.0 * etasq);
+  tmp  -= (58.0 * tan(phi) * tan(phi) * etasq);
   tmp2  = cos(phi)*cos(phi)*cos(phi)*cos(phi)*cos(phi) * tmp;
-  VI    = (nu / (double)120.0) * tmp2;
+  VI    = (nu / 120.0) * tmp2;
 
   *N = I + II*(lambda-lambda0)*(lambda-lambda0) +
-       III*pow((lambda-lambda0),(double)4.0) +
-       IIIA*pow((lambda-lambda0),(double)6.0);
+       III*pow((lambda-lambda0),4.0) +
+       IIIA*pow((lambda-lambda0),6.0);
 
-  *E = E0 + IV*(lambda-lambda0) + V*pow((lambda-lambda0),(double)3.0) +
-       VI * pow((lambda-lambda0),(double)5.0);
+  *E = E0 + IV*(lambda-lambda0) + V*pow((lambda-lambda0),3.0) +
+       VI * pow((lambda-lambda0),5.0);
 
   return;
 }
@@ -822,7 +822,7 @@ void GPS_Math_Cassini_LatLon_To_EN(double phi, double lambda, double* E,
   M0     = GPS_Math_Deg_To_Rad(M0);
 
 
-  p2 = (double)GPS_PI * (double)2.;
+  p2 = GPS_PI * 2.;
 
   a2 = a*a;
   b2 = b*b;
@@ -830,20 +830,20 @@ void GPS_Math_Cassini_LatLon_To_EN(double phi, double lambda, double* E,
   e4 = e2*e2;
   e6 = e2*e4;
 
-  te4 = (double)3.0 * e4;
-  j   = (double)45. * e6 / (double)1024.;
-  c0 = (double)1.0-e2/(double)4.-te4/(double)64.-(double)5.*e6/(double)256.;
-  c1 = (double)3.*e2/(double)8.+te4/(double)32.+j;
-  c2 = (double)15.*e4/(double)256.+j;
-  c3 = (double)35.*e6/(double)3072.;
+  te4 = 3.0 * e4;
+  j   = 45. * e6 / 1024.;
+  c0 = 1.0-e2/4.-te4/64.-5.*e6/256.;
+  c1 = 3.*e2/8.+te4/32.+j;
+  c2 = 15.*e4/256.+j;
+  c3 = 35.*e6/3072.;
 
   lat = c0*phi0;
-  phi0s2 = c1 * sin((double)2.*phi0);
-  phi0s4 = c2 * sin((double)4.*phi0);
-  phi0s6 = c3 * sin((double)6.*phi0);
+  phi0s2 = c1 * sin(2.*phi0);
+  phi0s4 = c2 * sin(4.*phi0);
+  phi0s6 = c3 * sin(6.*phi0);
   AM0 = a * (lat-phi0s2+phi0s4-phi0s6);
 
-  om0 = (double)1.0 - e2;
+  om0 = 1.0 - e2;
 #if 0
   // None of this is used -- is there a reason to keep it?
   x = pow(om0,(double)0.5);
@@ -869,7 +869,7 @@ void GPS_Math_Cassini_LatLon_To_EN(double phi, double lambda, double* E,
   phis = sin(phi);
   phic = cos(phi);
   phit = tan(phi);
-  RD = pow((double)1.-e2*phis*phis,(double).5);
+  RD = pow(1.-e2*phis*phis,.5);
   NN = a/RD;
   TT = phit*phit;
   WW = dlam*phic;
@@ -879,15 +879,15 @@ void GPS_Math_Cassini_LatLon_To_EN(double phi, double lambda, double* E,
   WW5 = WW*WW4;
   CC = e2*phic*phic/om0;
   lat = c0*phi;
-  phis2 = c1 * sin((double)2.*phi);
-  phis4 = c2 * sin((double)4.*phi);
-  phis6 = c3 * sin((double)6.*phi);
+  phis2 = c1 * sin(2.*phi);
+  phis4 = c2 * sin(4.*phi);
+  phis6 = c3 * sin(6.*phi);
   MM = a * (lat-phis2+phis4-phis6);
 
-  *E = NN*(WW-(TT*WW3/(double)6.)-((double)8.-TT+(double)8.*CC)*
-           (TT*WW5/(double)120.)) + E0;
-  *N = MM-AM0+NN*phit*((WW2/(double)2.)+((double)5.-TT+(double)6.*CC) *
-                       WW4/(double)24.) + N0;
+  *E = NN*(WW-(TT*WW3/6.)-(8.-TT+8.*CC)*
+           (TT*WW5/120.)) + E0;
+  *N = MM-AM0+NN*phit*((WW2/2.)+(5.-TT+6.*CC) *
+                       WW4/24.) + N0;
   return;
 }
 
@@ -973,8 +973,8 @@ void GPS_Math_Cassini_EN_To_LatLon(double E, double N, double* phi,
   M0 = GPS_Math_Deg_To_Rad(M0);
   phi0 = GPS_Math_Deg_To_Rad(phi0);
 
-  p2 = (double)GPS_PI * (double)2.;
-  po2 = (double)GPS_PI / (double)2.;
+  p2 = GPS_PI * 2.;
+  po2 = GPS_PI / 2.;
 
   a2 = a*a;
   b2 = b*b;
@@ -982,42 +982,42 @@ void GPS_Math_Cassini_EN_To_LatLon(double E, double N, double* phi,
   e4 = e2*e2;
   e6 = e2*e4;
 
-  te4 = (double)3.0 * e4;
-  j   = (double)45. * e6 / (double)1024.;
-  c0 = (double)1.0-e2/(double)4.-te4/(double)64.-(double)5.*e6/(double)256.;
-  c1 = (double)3.*e2/(double)8.+te4/(double)32.+j;
-  c2 = (double)15.*e4/(double)256.+j;
-  c3 = (double)35.*e6/(double)3072.;
+  te4 = 3.0 * e4;
+  j   = 45. * e6 / 1024.;
+  c0 = 1.0-e2/4.-te4/64.-5.*e6/256.;
+  c1 = 3.*e2/8.+te4/32.+j;
+  c2 = 15.*e4/256.+j;
+  c3 = 35.*e6/3072.;
 
   lat = c0*phi0;
-  phi0s2 = c1 * sin((double)2.*phi0);
-  phi0s4 = c2 * sin((double)4.*phi0);
-  phi0s6 = c3 * sin((double)6.*phi0);
+  phi0s2 = c1 * sin(2.*phi0);
+  phi0s4 = c2 * sin(4.*phi0);
+  phi0s6 = c3 * sin(6.*phi0);
   AM0 = a * (lat-phi0s2+phi0s4-phi0s6);
 
-  om0 = (double)1.0 - e2;
-  x = pow(om0,(double)0.5);
-  E1 = ((double)1.0 - x) / ((double)1.0 + x);
+  om0 = 1.0 - e2;
+  x = pow(om0,0.5);
+  E1 = (1.0 - x) / (1.0 + x);
   E2 = E1*E1;
   E3 = E1*E2;
   E4 = E1*E3;
-  A0 = (double)3.*E1/(double)2.-(double)27.*E3/(double)32.;
-  A1 = (double)21.*E2/(double)16.-(double)55.*E4/(double)32.;
-  A2 = (double)151.*E3/(double)96.;
-  A3 = (double)1097.*E4/(double)512.;
+  A0 = 3.*E1/2.-27.*E3/32.;
+  A1 = 21.*E2/16.-55.*E4/32.;
+  A2 = 151.*E3/96.;
+  A3 = 1097.*E4/512.;
 
 
 
-  tol = (double)1.e-5;
+  tol = 1.e-5;
 
   dx = E - E0;
   dy = N - N0;
   M1 = AM0 + dy;
   mu = M1 / (a*c0);
-  mus2 = A0 * sin((double)2.*mu);
-  mus4 = A1 * sin((double)4.*mu);
-  mus6 = A2 * sin((double)6.*mu);
-  mus8 = A3 * sin((double)8.*mu);
+  mus2 = A0 * sin(2.*mu);
+  mus4 = A1 * sin(4.*mu);
+  mus6 = A2 * sin(6.*mu);
+  mus8 = A3 * sin(8.*mu);
   phi1 = mu + mus2 + mus4 + mus6 + mus8;
 
   if ((((po2-tol)<phi1)&&(phi1<(po2+tol)))) {
@@ -1031,7 +1031,7 @@ void GPS_Math_Cassini_EN_To_LatLon(double E, double N, double* phi,
     phi1c = cos(phi1);
     phi1t = tan(phi1);
     T1 = phi1t*phi1t;
-    RD = pow((double)1.-e2*phi1s*phi1s,(double).5);
+    RD = pow(1.-e2*phi1s*phi1s,.5);
     N1 = a/RD;
     R1 = N1 * om0 / (RD*RD);
     DD = dx/N1;
@@ -1039,9 +1039,9 @@ void GPS_Math_Cassini_EN_To_LatLon(double E, double N, double* phi,
     D3 = DD*D2;
     D4 = DD*D3;
     D5 = DD*D4;
-    T = (double)1. + (double)3.*T1;
-    *phi = phi1-(N1*phi1t/R1)*(D2/(double)2.-T*D4/(double)24.);
-    *lambda = M0+(DD-T1*D3/(double)3.+T*T1*D5/(double)15.)/phi1c;
+    T = 1. + 3.*T1;
+    *phi = phi1-(N1*phi1t/R1)*(D2/2.-T*D4/24.);
+    *lambda = M0+(DD-T1*D3/3.+T*T1*D5/15.)/phi1c;
 
     if (*phi>po2) {
       *phi=po2;
@@ -1195,80 +1195,80 @@ void GPS_Math_EN_To_LatLon(double E, double N, double* phi,
   lambda0 = GPS_Math_Deg_To_Rad(lambda0);
 
   n     = (a-b) / (a+b);
-  fdf   = (double)5.0 / (double)4.0;
-  fde   = ((double)15.0 / (double)8.0);
+  fdf   = 5.0 / 4.0;
+  fde   = (15.0 / 8.0);
 
   esq = ((a*a)-(b*b)) / (a*a);
 
 
   phix = ((N-N0)/(a*F0)) + phi0;
 
-  tmp  = (double)1.0 - (esq * sin(phix) * sin(phix));
-  nu   = a * F0 * pow(tmp,(double)-0.5);
-  rho  = a * F0 * ((double)1.0 - esq) * pow(tmp,(double)-1.5);
-  etasq = (nu / rho) - (double)1.0;
+  tmp  = 1.0 - (esq * sin(phix) * sin(phix));
+  nu   = a * F0 * pow(tmp,-0.5);
+  rho  = a * F0 * (1.0 - esq) * pow(tmp,-1.5);
+  etasq = (nu / rho) - 1.0;
 
-  M = (double)-1e20;
+  M = -1e20;
 
-  while (N-N0-M > (double)0.000001) {
+  while (N-N0-M > 0.000001) {
     nphi = phix;
 
-    tmp   = (double)1.0 + n + (fdf * n * n) + (fdf * n * n * n);
+    tmp   = 1.0 + n + (fdf * n * n) + (fdf * n * n * n);
     tmp  *= (nphi - phi0);
-    tmp2  = (double)3.0*n + (double)3.0*n*n +
-            ((double)21./(double)8.)*n*n*n;
+    tmp2  = 3.0*n + 3.0*n*n +
+            (21./8.)*n*n*n;
     tmp2 *= (sin(nphi-phi0) * cos(nphi+phi0));
     tmp  -= tmp2;
 
 
-    tmp2  = ((fde*n*n) + (fde*n*n*n)) * sin((double)2.0 * (nphi-phi0));
-    tmp2 *= cos((double)2.0 * (nphi+phi0));
+    tmp2  = ((fde*n*n) + (fde*n*n*n)) * sin(2.0 * (nphi-phi0));
+    tmp2 *= cos(2.0 * (nphi+phi0));
     tmp  += tmp2;
 
-    tmp2  = ((double)35.0/(double)24.0) * n * n * n;
-    tmp2 *= sin((double)3.0 * (nphi-phi0));
-    tmp2 *= cos((double)3.0 * (nphi+phi0));
+    tmp2  = (35.0/24.0) * n * n * n;
+    tmp2 *= sin(3.0 * (nphi-phi0));
+    tmp2 *= cos(3.0 * (nphi+phi0));
     tmp  -= tmp2;
 
     M     = b * F0 * tmp;
 
-    if (N-N0-M > (double)0.000001) {
+    if (N-N0-M > 0.000001) {
       phix = ((N-N0-M)/(a*F0)) + nphi;
     }
   }
 
 
-  VII  = tan(nphi) / ((double)2.0 * rho * nu);
+  VII  = tan(nphi) / (2.0 * rho * nu);
 
-  tmp  = (double)5.0 + (double)3.0 * tan(nphi) * tan(nphi) + etasq;
-  tmp -= (double)9.0 * tan(nphi) * tan(nphi) * etasq;
-  VIII = (tan(nphi)*tmp) / ((double)24.0 * rho * nu*nu*nu);
+  tmp  = 5.0 + 3.0 * tan(nphi) * tan(nphi) + etasq;
+  tmp -= 9.0 * tan(nphi) * tan(nphi) * etasq;
+  VIII = (tan(nphi)*tmp) / (24.0 * rho * nu*nu*nu);
 
-  tmp  = (double)61.0 + (double)90.0 * tan(nphi) * tan(nphi);
-  tmp += (double)45.0 * pow(tan(nphi),(double)4.0);
-  IX   = tan(nphi) / ((double)720.0 * rho * pow(nu,(double)5.0)) * tmp;
+  tmp  = 61.0 + 90.0 * tan(nphi) * tan(nphi);
+  tmp += 45.0 * pow(tan(nphi),4.0);
+  IX   = tan(nphi) / (720.0 * rho * pow(nu,5.0)) * tmp;
 
-  X    = (double)1.0 / (cos(nphi) * nu);
+  X    = 1.0 / (cos(nphi) * nu);
 
-  tmp  = (nu / rho) + (double)2.0 * tan(nphi) * tan(nphi);
-  XI   = ((double)1.0 / (cos(nphi) * (double)6.0 * nu*nu*nu)) * tmp;
+  tmp  = (nu / rho) + 2.0 * tan(nphi) * tan(nphi);
+  XI   = (1.0 / (cos(nphi) * 6.0 * nu*nu*nu)) * tmp;
 
-  tmp  = (double)5.0 + (double)28.0 * tan(nphi)*tan(nphi);
-  tmp += (double)24.0 * pow(tan(nphi),(double)4.0);
-  XII  = ((double)1.0 / ((double)120.0 * pow(nu,(double)5.0) * cos(nphi)))
+  tmp  = 5.0 + 28.0 * tan(nphi)*tan(nphi);
+  tmp += 24.0 * pow(tan(nphi),4.0);
+  XII  = (1.0 / (120.0 * pow(nu,5.0) * cos(nphi)))
          * tmp;
 
-  tmp  = (double)61.0 + (double)662.0 * tan(nphi) * tan(nphi);
-  tmp += (double)1320.0 * pow(tan(nphi),(double)4.0);
-  tmp += (double)720.0  * pow(tan(nphi),(double)6.0);
-  XIIA = ((double)1.0 / (cos(nphi) * (double)5040.0 * pow(nu,(double)7.0)))
+  tmp  = 61.0 + 662.0 * tan(nphi) * tan(nphi);
+  tmp += 1320.0 * pow(tan(nphi),4.0);
+  tmp += 720.0  * pow(tan(nphi),6.0);
+  XIIA = (1.0 / (cos(nphi) * 5040.0 * pow(nu,7.0)))
          * tmp;
 
-  *phi = nphi - VII*pow((E-E0),(double)2.0) + VIII*pow((E-E0),(double)4.0) -
-         IX*pow((E-E0),(double)6.0);
+  *phi = nphi - VII*pow((E-E0),2.0) + VIII*pow((E-E0),4.0) -
+         IX*pow((E-E0),6.0);
 
-  *lambda = lambda0 + X*(E-E0) - XI*pow((E-E0),(double)3.0) +
-            XII*pow((E-E0),(double)5.0) - XIIA*pow((E-E0),(double)7.0);
+  *lambda = lambda0 + X*(E-E0) - XI*pow((E-E0),3.0) +
+            XII*pow((E-E0),5.0) - XIIA*pow((E-E0),7.0);
 
   *phi    = GPS_Math_Rad_To_Deg(*phi);
   *lambda = GPS_Math_Rad_To_Deg(*lambda);
@@ -1358,8 +1358,8 @@ int32 GPS_Math_EN_To_UKOSNG_Map(double E, double N, double* mE,
   int32  t;
   int32  idx;
 
-  if (E>=(double)700000. || E<(double)0.0 || N<(double)0.0 ||
-      N>=(double)1300000.0) {
+  if (E>=700000. || E<0.0 || N<0.0 ||
+      N>=1300000.0) {
     return 0;
   }
 
@@ -1397,8 +1397,8 @@ int32 GPS_Math_UKOSNG_Map_To_EN(char* map, double mapE, double mapN, double* E,
   int32  t;
   int32  idx;
 
-  if (mapE>=(double)100000.0 || mapE<(double)0.0 || mapN<(double)0.0 ||
-      mapN>(double)100000.0) {
+  if (mapE>=100000.0 || mapE<0.0 || mapN<0.0 ||
+      mapN>100000.0) {
     return 0;
   }
 
@@ -1468,11 +1468,11 @@ void GPS_Math_Molodensky(double Sphi, double Slam, double SH, double Sa,
   double lams;
   double lamc;
 
-  Sf = (double)1.0 / Sif;
-  Df = (double)1.0 / Dif;
+  Sf = 1.0 / Sif;
+  Df = 1.0 / Dif;
 
-  esq = (double)2.0*Sf - pow(Sf,(double)2.0);
-  bda = (double)1.0 - Sf;
+  esq = 2.0*Sf - pow(Sf,2.0);
+  bda = 1.0 - Sf;
   Sphi = GPS_Math_Deg_To_Rad(Sphi);
   Slam = GPS_Math_Deg_To_Rad(Slam);
 
@@ -1484,9 +1484,9 @@ void GPS_Math_Molodensky(double Sphi, double Slam, double SH, double Sa,
   lams = sin(Slam);
   lamc = cos(Slam);
 
-  N = Sa /  sqrt((double)1.0 - esq*pow(phis,(double)2.0));
+  N = Sa /  sqrt(1.0 - esq*pow(phis,2.0));
 
-  tmp = ((double)1.0-esq) /pow(((double)1.0-esq*pow(phis,(double)2.0)),1.5);
+  tmp = (1.0-esq) /pow((1.0-esq*pow(phis,2.0)),1.5);
   M   = Sa * tmp;
 
   tmp  = df * ((M/bda)+N*bda) * phis * phic;
@@ -1538,8 +1538,8 @@ void GPS_Math_Known_Datum_To_WGS84_M(double Sphi, double Slam, double SH,
   double z;
   int32    idx;
 
-  Da  = (double) 6378137.0;
-  Dif = (double) 298.257223563;
+  Da  = 6378137.0;
+  Dif = 298.257223563;
 
   idx  = GPS_Datum[n].ellipse;
   Sa   = GPS_Ellipse[idx].a;
@@ -1582,8 +1582,8 @@ void GPS_Math_WGS84_To_Known_Datum_M(double Sphi, double Slam, double SH,
   double z;
   int32    idx;
 
-  Sa  = (double) 6378137.0;
-  Sif = (double) 298.257223563;
+  Sa  = 6378137.0;
+  Sif = 298.257223563;
 
   idx  = GPS_Datum[n].ellipse;
   Da   = GPS_Ellipse[idx].a;
@@ -1631,8 +1631,8 @@ void GPS_Math_Known_Datum_To_WGS84_C(double Sphi, double Slam, double SH,
   double sy;
   double sz;
 
-  Da  = (double) 6378137.0;
-  Dif = (double) 298.257223563;
+  Da  = 6378137.0;
+  Dif = 298.257223563;
   Db  = Da - (Da / Dif);
 
   idx  = GPS_Datum[n].ellipse;
@@ -1688,8 +1688,8 @@ void GPS_Math_WGS84_To_Known_Datum_C(double Sphi, double Slam, double SH,
   double dy;
   double dz;
 
-  Sa  = (double) 6378137.0;
-  Sif = (double) 298.257223563;
+  Sa  = 6378137.0;
+  Sif = 298.257223563;
   Sb   = Sa - (Sa / Sif);
 
   idx  = GPS_Datum[n].ellipse;
@@ -2009,15 +2009,15 @@ static int32 GPS_Math_LatLon_To_UTM_Param(double lat, double lon, int32* zone,
   int32 psign;
   int32 lsign;
 
-  if (lat >= (double)84.0 || lat < (double)-80.0) {
+  if (lat >= 84.0 || lat < -80.0) {
     return 0;
   }
 
   psign = lsign = 0;
-  if (lon < (double)0.0) {
+  if (lon < 0.0) {
     lsign=1;
   }
-  if (lat < (double)0.0) {
+  if (lat < 0.0) {
     psign=1;
   }
 
@@ -2045,37 +2045,37 @@ static int32 GPS_Math_LatLon_To_UTM_Param(double lat, double lon, int32* zone,
   }
 
 
-  if (lat>=(double)56.0 && lat<(double)64.0 && lon>=(double)3.0 &&
-      lon<(double)12.0) {
+  if (lat>=56.0 && lat<64.0 && lon>=3.0 &&
+      lon<12.0) {
     *zone = 32;
     *zc   = 'V';
-    *Mc   = (double)9.0;
+    *Mc   = 9.0;
   }
 
-  if (*zc=='X' && lon>=(double)0.0 && lon<(double)42.0) {
-    if (lon<(double)9.0) {
+  if (*zc=='X' && lon>=0.0 && lon<42.0) {
+    if (lon<9.0) {
       *zone = 31;
-      *Mc   = (double)3.0;
-    } else if (lon<(double)21.0) {
+      *Mc   = 3.0;
+    } else if (lon<21.0) {
       *zone = 33;
-      *Mc   = (double)15.0;
-    } else if (lon<(double)33.0) {
+      *Mc   = 15.0;
+    } else if (lon<33.0) {
       *zone = 35;
-      *Mc   = (double)27.0;
+      *Mc   = 27.0;
     } else {
       *zone = 37;
-      *Mc   = (double)39.0;
+      *Mc   = 39.0;
     }
   }
 
   if (!psign) {
-    *N0 = (double)0.0;
+    *N0 = 0.0;
   } else {
-    *N0 = (double)10000000;
+    *N0 = 10000000.0;
   }
 
-  *E0 = (double)500000;
-  *F0 = (double)0.9996;
+  *E0 = 500000.0;
+  *F0 = 0.9996;
 
   return 1;
 }
@@ -2111,9 +2111,9 @@ int32 GPS_Math_NAD83_To_UTM_EN(double lat, double lon, double* E,
     return 0;
   }
 
-  phi0 = (double)0.0;
+  phi0 = 0.0;
 
-  a = (double) GPS_Ellipse[21].a;
+  a = GPS_Ellipse[21].a;
   b = a - (a/GPS_Ellipse[21].invf);
 
   GPS_Math_LatLon_To_EN(E,N,lat,lon,N0,E0,phi0,lambda0,F0,a,b);
@@ -2176,36 +2176,36 @@ static int32 GPS_Math_UTM_Param_To_Mc(int32 zone, char zc, double* Mc,
   }
 
   if (zone > 30) {
-    *Mc = (double)((zone-31)*6) + (double)3.0;
+    *Mc = (double)((zone-31)*6) + 3.0;
   } else {
     *Mc = (double) -(((30-zone)*6)+3);
   }
 
   if (zone==32 && zc=='V') {
-    *Mc = (double)9.0;
+    *Mc = 9.0;
   }
 
   if (zone==31 && zc=='X') {
-    *Mc = (double)3.0;
+    *Mc = 3.0;
   }
   if (zone==33 && zc=='X') {
-    *Mc = (double)15.0;
+    *Mc = 15.0;
   }
   if (zone==35 && zc=='X') {
-    *Mc = (double)27.0;
+    *Mc = 27.0;
   }
   if (zone==37 && zc=='X') {
-    *Mc = (double)39.0;
+    *Mc = 39.0;
   }
 
   if (zc>'M') {
-    *N0 = (double)0.0;
+    *N0 = 0.0;
   } else {
-    *N0 = (double)10000000;
+    *N0 = 10000000.0;
   }
 
-  *E0 = (double)500000;
-  *F0 = (double)0.9996;
+  *E0 = 500000.0;
+  *F0 = 0.9996;
 
   return 1;
 }
@@ -2294,10 +2294,10 @@ int32 GPS_Math_Known_Datum_To_UTM_EN(double lat, double lon, double* E,
     return 0;
   }
 
-  phi0 = (double)0.0;
+  phi0 = 0.0;
 
   idx  = GPS_Datum[n].ellipse;
-  a = (double) GPS_Ellipse[idx].a;
+  a = GPS_Ellipse[idx].a;
   b = a - (a/GPS_Ellipse[idx].invf);
 
   GPS_Math_LatLon_To_EN(E,N,lat,lon,N0,E0,phi0,lambda0,F0,a,b);
@@ -2381,26 +2381,26 @@ void GPS_Math_Swiss_LatLon_To_EN(double phi, double lambda, double* E,
   lambda  = GPS_Math_Deg_To_Rad(lambda);
   phi     = GPS_Math_Deg_To_Rad(phi);
 
-  po4=GPS_PI/(double)4.0;
+  po4=GPS_PI/4.0;
 
   a2 = a*a;
   b2 = b*b;
   esq = (a2-b2)/a2;
-  e   = pow(esq,(double)0.5);
+  e   = pow(esq,0.5);
 
-  c = sqrt(1+((esq*pow(cos(phi0),(double)4.))/((double)1.-esq)));
+  c = sqrt(1+((esq*pow(cos(phi0),4.))/(1.-esq)));
 
   ephi0p = asin(sin(phi0)/c);
 
-  K = log(tan(po4+ephi0p/(double)2.)) - c*(log(tan(po4+phi0/(double)2.)) -
-      e/(double)2. * log(((double)1.+e*sin(phi0)) /
-                         ((double)1.-e*sin(phi0))));
+  K = log(tan(po4+ephi0p/2.)) - c*(log(tan(po4+phi0/2.)) -
+      e/2. * log((1.+e*sin(phi0)) /
+                         (1.-e*sin(phi0))));
   lambda1 = c*(lambda-lambda0);
-  w = c*(log(tan(po4+phi/(double)2.)) - e/(double)2. *
-         log(((double)1.+e*sin(phi)) / ((double)1.-e*sin(phi)))) + K;
+  w = c*(log(tan(po4+phi/2.)) - e/2. *
+         log((1.+e*sin(phi)) / (1.-e*sin(phi)))) + K;
 
 
-  phip = (double)2. * (atan(exp(w)) - po4);
+  phip = 2. * (atan(exp(w)) - po4);
 
   sphip = cos(ephi0p) * sin(phip) - sin(ephi0p) * cos(phip) * cos(lambda1);
   phid  = asin(sphip);
@@ -2408,9 +2408,9 @@ void GPS_Math_Swiss_LatLon_To_EN(double phi, double lambda, double* E,
   slambda2 = cos(phip)*sin(lambda1) / cos(phid);
   lambda2  = asin(slambda2);
 
-  R = a*sqrt((double)1.-esq) / ((double)1.-esq*sin(phi0) * sin(phi0));
+  R = a*sqrt(1.-esq) / (1.-esq*sin(phi0) * sin(phi0));
 
-  *N = R*log(tan(po4 + phid/(double)2.)) + N0;
+  *N = R*log(tan(po4 + phid/2.)) + N0;
   *E = R*lambda2 + E0;
   return;
 }
@@ -2461,21 +2461,21 @@ void GPS_Math_Swiss_EN_To_LatLon(double E, double N, double* phi,
   lambda0 = GPS_Math_Deg_To_Rad(lambda0);
   phi0    = GPS_Math_Deg_To_Rad(phi0);
 
-  po4=GPS_PI/(double)4.0;
-  tol=(double)0.00001;
+  po4=GPS_PI/4.0;
+  tol=0.00001;
 
   a2 = a*a;
   b2 = b*b;
   esq = (a2-b2)/a2;
-  e   = pow(esq,(double)0.5);
+  e   = pow(esq,0.5);
 
-  R = a*sqrt((double)1.-esq) / ((double)1.-esq*sin(phi0) * sin(phi0));
+  R = a*sqrt(1.-esq) / (1.-esq*sin(phi0) * sin(phi0));
 
-  phid = (double)2.*(atan(exp((N - N0)/R)) - po4);
+  phid = 2.*(atan(exp((N - N0)/R)) - po4);
   lambdad = (E - E0)/R;
 
-  c = sqrt((double)1.+((esq * pow(cos(phi0), (double)4.)) /
-                       ((double)1.-esq)));
+  c = sqrt(1.+((esq * pow(cos(phi0), 4.)) /
+                       (1.-esq)));
   ephi0p = asin(sin(phi0) / c);
 
   sphip = cos(ephi0p)*sin(phid) + sin(ephi0p)*cos(phid)*cos(lambdad);
@@ -2486,16 +2486,16 @@ void GPS_Math_Swiss_EN_To_LatLon(double E, double N, double* phi,
 
   *lambda = GPS_Math_Rad_To_Deg((lambda1/c + lambda0));
 
-  K = log(tan(po4 + ephi0p/(double)2.)) -c*(log(tan(po4 + phi0/(double)2.))
-      - e/(double)2. * log(((double)1.+e*sin(phi0)) /
-                           ((double)1.-e*sin(phi0))));
-  C = (K - log(tan(po4 + phi1/(double)2.)))/c;
+  K = log(tan(po4 + ephi0p/2.)) -c*(log(tan(po4 + phi0/2.))
+      - e/2. * log((1.+e*sin(phi0)) /
+                           (1.-e*sin(phi0))));
+  C = (K - log(tan(po4 + phi1/2.)))/c;
 
   do {
-    cr = (C + log(tan(po4 + phi1/(double)2.)) - e/(double)2. *
-          log(((double)1.+e*sin(phi1)) / ((double)1.-e*sin(phi1)))) *
-         ((((double)1.-esq*sin(phi1)*sin(phi1)) * cos(phi1)) /
-          ((double)1.-esq));
+    cr = (C + log(tan(po4 + phi1/2.)) - e/2. *
+          log((1.+e*sin(phi1)) / (1.-e*sin(phi1)))) *
+         (((1.-esq*sin(phi1)*sin(phi1)) * cos(phi1)) /
+          (1.-esq));
     phi1 -= cr;
   } while (fabs(cr) > tol);
 

--- a/lowranceusr4.cc
+++ b/lowranceusr4.cc
@@ -324,7 +324,7 @@ register_waypt(const Waypoint* ref)
            qPrintable(wpt->shortname), qPrintable(wpt->description), waypt_table_ct);
   }
 
-  waypt_table[waypt_table_ct] = (Waypoint*)wpt;
+  waypt_table[waypt_table_ct] = wpt;
   waypt_table_ct++;
 }
 
@@ -769,7 +769,7 @@ data_read()
 
   serial_num = gbfgetint32(file_in);
   if (global_opts.debug_level >= 1) {
-    printf(MYNAME " device serial number %u\n", (unsigned int)serial_num);
+    printf(MYNAME " device serial number %u\n", serial_num);
   }
 
   text_len = lowranceusr4_readstr(&buff[0], MAXUSRSTRINGSIZE, file_in, 1);

--- a/navilink.cc
+++ b/navilink.cc
@@ -845,7 +845,7 @@ navilink_decode_logpoint(const unsigned char* buffer)
   Waypoint* waypt = nullptr;
   waypt = new Waypoint;
 
-  waypt->hdop = ((unsigned char)buffer[0]) * 0.2f;
+  waypt->hdop = (buffer[0]) * 0.2f;
   waypt->sat = buffer[1];
   waypt->SetCreationTime(decode_sbp_datetime_packed(buffer + 4),
                          decode_sbp_msec(buffer + 2));

--- a/nmea.cc
+++ b/nmea.cc
@@ -1037,7 +1037,7 @@ nmea_read()
   if (optdate) {
     memset(&opt_tm, 0, sizeof(opt_tm));
 
-    ck = (char*)strptime(optdate, "%Y%m%d", &opt_tm);
+    ck = strptime(optdate, "%Y%m%d", &opt_tm);
     if ((ck == nullptr) || (*ck != '\0') || (strlen(optdate) != 8)) {
       fatal(MYNAME ": Invalid date \"%s\"!\n", optdate);
     } else if (opt_tm.tm_year < 70) {

--- a/parse.cc
+++ b/parse.cc
@@ -200,8 +200,8 @@ parse_coordinates(const char* str, int datum, const grid_type grid,
                 &result);
     valid = (ct == 8);
     if (valid) {
-      lat = (double)deg_lat + ((double)min_lat / (double)60) + (lat / (double)3600.0);
-      lon = (double)deg_lon + ((double)min_lon / (double)60) + (lon / (double)3600.0);
+      lat = (double)deg_lat + ((double)min_lat / (double)60) + (lat / 3600.0);
+      lon = (double)deg_lon + ((double)min_lon / (double)60) + (lon / 3600.0);
     }
     break;
 
@@ -266,7 +266,7 @@ parse_coordinates(const char* str, int datum, const grid_type grid,
 
   if (datum != DATUM_WGS84) {
     double alt;
-    GPS_Math_Known_Datum_To_WGS84_M(lat, lon, (double) 0.0,
+    GPS_Math_Known_Datum_To_WGS84_M(lat, lon, 0.0,
                                     &lat, &lon, &alt, datum);
   }
 

--- a/parse.cc
+++ b/parse.cc
@@ -188,8 +188,8 @@ parse_coordinates(const char* str, int datum, const grid_type grid,
                 &lathemi, &deg_lat, &lat, &lonhemi, &deg_lon, &lon, &result);
     valid = (ct == 6);
     if (valid) {
-      lat = (double)deg_lat + (lat / (double)60);
-      lon = (double)deg_lon + (lon / (double)60);
+      lat = (double)deg_lat + (lat / 60.0);
+      lon = (double)deg_lon + (lon / 60.0);
     }
     break;
 
@@ -200,8 +200,8 @@ parse_coordinates(const char* str, int datum, const grid_type grid,
                 &result);
     valid = (ct == 8);
     if (valid) {
-      lat = (double)deg_lat + ((double)min_lat / (double)60) + (lat / 3600.0);
-      lon = (double)deg_lon + ((double)min_lon / (double)60) + (lon / 3600.0);
+      lat = (double)deg_lat + ((double)min_lat / 60.0) + (lat / 3600.0);
+      lon = (double)deg_lon + ((double)min_lon / 60.0) + (lon / 3600.0);
     }
     break;
 

--- a/polygon.cc
+++ b/polygon.cc
@@ -261,7 +261,7 @@ void PolygonFilter::process()
           ed = (extra_data*) xcalloc(1, sizeof(*ed));
           ed->state = OUTSIDE;
           ed->override = 0;
-          waypointp->extra_data = (extra_data*) ed;
+          waypointp->extra_data = ed;
         }
         if (lat2 == waypointp->latitude &&
             lon2 == waypointp->longitude) {

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -310,7 +310,7 @@ register_waypt(const Waypoint* ref, const char)
 
   wpt->extra_data = (void*)mkshort(hshort_wpt, CSTRc(wpt->shortname));
 
-  waypt_table[waypt_table_ct] = (Waypoint*)wpt;
+  waypt_table[waypt_table_ct] = wpt;
   waypt_table_ct++;
 }
 

--- a/tpo.cc
+++ b/tpo.cc
@@ -545,7 +545,7 @@ static void tpo_process_tracks()
     // next three bytes are RGB color, fourth is unknown
     // Topo and web uses rrggbb, also need line_color.bbggrr for KML
     for (xx = 0; xx < 3; xx++) {
-      int col = (int)gbfgetc(tpo_file_in);
+      int col = gbfgetc(tpo_file_in);
       if ((col < 0) || (col >255)) {
         col = 0; // assign black if out of range 0x00 to 0xff
       }
@@ -572,11 +572,11 @@ static void tpo_process_tracks()
     }
     //TBD: Should this be TRACKNAMELENGTH?
     for (xx = 0; xx < 3; xx++) {
-      if (styles[ii].name[xx] == (char) ',') {
-        styles[ii].name[xx] = (char) '_';
+      if (styles[ii].name[xx] == ',') {
+        styles[ii].name[xx] = '_';
       }
-      if (styles[ii].name[xx] == (char) '=') {
-        styles[ii].name[xx] = (char) '_';
+      if (styles[ii].name[xx] == '=') {
+        styles[ii].name[xx] = '_';
       }
     }
 

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -607,7 +607,7 @@ void TrackFilter::trackfilter_split()
 #ifdef TRACKF_DBG
       printf(MYNAME ": splitting new track\n");
 #endif
-      curr = (route_head*) route_head_alloc();
+      curr = route_head_alloc();
       trackfilter_split_init_rte_name(curr, buff[j]->GetCreationTime());
       track_add_head(curr);
     }

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -418,7 +418,7 @@ unicsv_parse_time(const char* str, int* usec, time_t* date)
     *usec = 0;
   }
 
-  return ((hour * SECONDS_PER_HOUR) + (min * 60) + (int)sec);
+  return ((hour * SECONDS_PER_HOUR) + (min * 60) + sec);
 }
 
 static time_t
@@ -1188,7 +1188,7 @@ unicsv_parse_one_line(char* ibuf)
   if ((src_datum != DATUM_WGS84) &&
       (wpt->latitude != unicsv_unknown) && (wpt->longitude != unicsv_unknown)) {
     double alt;
-    GPS_Math_Known_Datum_To_WGS84_M(wpt->latitude, wpt->longitude, (double) 0.0,
+    GPS_Math_Known_Datum_To_WGS84_M(wpt->latitude, wpt->longitude, 0.0,
                                     &wpt->latitude, &wpt->longitude, &alt, src_datum);
   }
 

--- a/units.cc
+++ b/units.cc
@@ -63,7 +63,7 @@ fmt_distance(const double distance_meters, const char** tag)
     if (d < 1000) {
       *tag = "meters";
     } else {
-      d = d / (double) 1000.0;
+      d = d / 1000.0;
       *tag = "km";
     }
     break;

--- a/util.cc
+++ b/util.cc
@@ -1076,7 +1076,7 @@ double degrees2ddmm(double deg_val)
 {
   signed int deg;
   deg = (signed int) deg_val;
-  return (double)(deg * 100.0) + ((deg_val - deg) * 60.0);
+  return (deg * 100.0) + ((deg_val - deg) * 60.0);
 }
 
 /*

--- a/vpl.cc
+++ b/vpl.cc
@@ -205,8 +205,8 @@ vpl_parse_75_sentence(const char* ibuf)
   // Speed comes in (MPH x 0x10) which we have to convert to m/s
   WAYPT_SET(waypt, speed, (speed_raw / (double) 0x10) * 0.44704);
   waypt->course    = hdg_raw * (double)(360/65535);
-  waypt->hdop      = hdop_raw / (double) 8;
-  waypt->vdop      = vdop_raw / (double) 8;
+  waypt->hdop      = hdop_raw / 8.0;
+  waypt->vdop      = vdop_raw / 8.0;
 
   waypt->SetCreationTime(mkgmtime(&tm));
 

--- a/waypt.cc
+++ b/waypt.cc
@@ -414,7 +414,7 @@ double
 waypt_time(const Waypoint* wpt)
 {
   if (!wpt->creation_time.isValid()) {
-    return (double) 0;
+    return 0.0;
   } else {
     return ((double)wpt->creation_time.toMSecsSinceEpoch()) / 1000.0;
   }


### PR DESCRIPTION
this was based on clang-tidy google-readability-casting check,
but only for the Message redundant cast to the same type.
Some hand manipulation of literals was done before clang-tidy.
Some fixes were rejected for portability.