### PR TITLE
use const_cast to cast away const, and don't cast away const when unnecessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 /autom4te.cache/
 /babelweb/
+/compile_commands.json
 /config.h
 /config.log
 /config.status
 /cscope.out
 /gpsbabel
 /gpsbabel-debug
+/gpsbabel_coverage.xml
 /gpsbabel.exe
 /gpsbabel.fo
 /gpsbabel.html
@@ -14,6 +16,9 @@
 /.qmake.cache
 /.qmake.stash
 /GPSBabel
+/*.gcda
+/*.gcno
+/*.gcov
 *.o
 /GPSBabel[0-9]*.[0-9]*.[0-9]*/
 /GPSBabel[0-9]*.[0-9]*.[0-9]*.tar.bz2

--- a/an1sym.h
+++ b/an1sym.h
@@ -725,7 +725,7 @@ static int FindIconByGuid(GUID* guid, char** name)
   unsigned int i = 0;
   for (i = 0; i < (sizeof(default_guids)/sizeof(struct defguid)); i++) {
     if (!memcmp(guid, &default_guids[i].guid, sizeof(GUID))) {
-      *name = (char*) default_guids[i].name;
+      *name = const_cast<char*>(default_guids[i].name);
       return 1;
     }
   }

--- a/arcdist.cc
+++ b/arcdist.cc
@@ -87,14 +87,14 @@ void ArcDistanceFilter::arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2)
             ed->prjlongitude = prjlon;
             ed->frac = frac;
             ed->arcpt1 = arcpt1;
-            ed->arcpt2 = (Waypoint*) arcpt2;
+            ed->arcpt2 = const_cast<Waypoint*>(arcpt2);
           }
         }
         waypointp->extra_data = ed;
       }
     }
   }
-  arcpt1 = (Waypoint*) arcpt2;
+  arcpt1 = const_cast<Waypoint*>(arcpt2);
 }
 
 void ArcDistanceFilter::arcdist_arc_disp_hdr_cb(const route_head*)

--- a/cet.cc
+++ b/cet.cc
@@ -163,7 +163,7 @@ cet_utf8_to_ucs4(const char* str, int* bytes, int* value)
           if ((*cp & 0xc0) != 0x80) {
             break;  /* invalid 	*/
           } else if (i == 0) {		/* all valid 	*/
-            char* c = (char*)str;		/* found valid sequence, now storing value */
+            char* c = const_cast<char*>(str);		/* found valid sequence, now storing value */
             int res = *c++ & (mask ^ 0xFF);
             i = len;
             while (i-- > 0) {
@@ -205,7 +205,7 @@ cet_ucs4_to_char(const int value, const cet_cs_vec_t* vec)
 {
   cet_ucs4_link_t* link;
 
-  if ((link = (cet_ucs4_link_t*)vec->ucs4_link)) {
+  if ((link = const_cast<cet_ucs4_link_t*>(vec->ucs4_link))) {
     int i = 0;
     int j = vec->ucs4_links - 1;			/* validate ucs value against vec */
     while (i <= j) {
@@ -222,7 +222,7 @@ cet_ucs4_to_char(const int value, const cet_cs_vec_t* vec)
     }
   }
 
-  if ((link = (cet_ucs4_link_t*)vec->ucs4_extra)) {	/* can be NULL */
+  if ((link = const_cast<cet_ucs4_link_t*>(vec->ucs4_extra))) {	/* can be NULL */
     int i = 0;
     int j = vec->ucs4_extras - 1;
     while (i <= j) {
@@ -362,7 +362,7 @@ cet_utf8_strndup(const char* str, const int maxlen)
 char*
 cet_str_utf8_to_any(const char* src, const cet_cs_vec_t* vec)
 {
-  char* c = (char*)src;
+  char* c = const_cast<char*>(src);
   int len;
   char* res, *dest, *cend;
 
@@ -400,7 +400,7 @@ cet_str_any_to_utf8(const char* src, const cet_cs_vec_t* vec)
   char* result, *cin, *cout;
   char temp = CET_NOT_CONVERTABLE_DEFAULT;
 
-  cin = (char*)src;
+  cin = const_cast<char*>(src);
   if (cin == nullptr) {
     return nullptr;
   }
@@ -417,7 +417,7 @@ cet_str_any_to_utf8(const char* src, const cet_cs_vec_t* vec)
   }
 
   result = cout = (char*) xmalloc(len + 1);
-  cin = (char*)src;
+  cin = const_cast<char*>(src);
 
   while (*cin != '\0') {
     if (CET_ERROR == cet_char_to_ucs4(*cin++, vec, &value)) {

--- a/cet.cc
+++ b/cet.cc
@@ -163,7 +163,7 @@ cet_utf8_to_ucs4(const char* str, int* bytes, int* value)
           if ((*cp & 0xc0) != 0x80) {
             break;  /* invalid 	*/
           } else if (i == 0) {		/* all valid 	*/
-            char* c = const_cast<char*>(str);		/* found valid sequence, now storing value */
+            const char* c = str;		/* found valid sequence, now storing value */
             int res = *c++ & (mask ^ 0xFF);
             i = len;
             while (i-- > 0) {
@@ -203,9 +203,9 @@ cet_utf8_to_ucs4(const char* str, int* bytes, int* value)
 short
 cet_ucs4_to_char(const int value, const cet_cs_vec_t* vec)
 {
-  cet_ucs4_link_t* link;
+  const cet_ucs4_link_t* link;
 
-  if ((link = const_cast<cet_ucs4_link_t*>(vec->ucs4_link))) {
+  if ((link = vec->ucs4_link)) {
     int i = 0;
     int j = vec->ucs4_links - 1;			/* validate ucs value against vec */
     while (i <= j) {
@@ -222,7 +222,7 @@ cet_ucs4_to_char(const int value, const cet_cs_vec_t* vec)
     }
   }
 
-  if ((link = const_cast<cet_ucs4_link_t*>(vec->ucs4_extra))) {	/* can be NULL */
+  if ((link = vec->ucs4_extra)) {	/* can be NULL */
     int i = 0;
     int j = vec->ucs4_extras - 1;
     while (i <= j) {
@@ -362,9 +362,10 @@ cet_utf8_strndup(const char* str, const int maxlen)
 char*
 cet_str_utf8_to_any(const char* src, const cet_cs_vec_t* vec)
 {
-  char* c = const_cast<char*>(src);
+  const char* c = src;
   int len;
-  char* res, *dest, *cend;
+  char* res, *dest;
+  const char* cend;
 
   if (c == nullptr) {
     return nullptr;
@@ -397,10 +398,11 @@ char*
 cet_str_any_to_utf8(const char* src, const cet_cs_vec_t* vec)
 {
   int len, value;
-  char* result, *cin, *cout;
+  char* result, *cout;
+  const char* cin;
   char temp = CET_NOT_CONVERTABLE_DEFAULT;
 
-  cin = const_cast<char*>(src);
+  cin = src;
   if (cin == nullptr) {
     return nullptr;
   }
@@ -417,7 +419,7 @@ cet_str_any_to_utf8(const char* src, const cet_cs_vec_t* vec)
   }
 
   result = cout = (char*) xmalloc(len + 1);
-  cin = const_cast<char*>(src);
+  cin = src;
 
   while (*cin != '\0') {
     if (CET_ERROR == cet_char_to_ucs4(*cin++, vec, &value)) {

--- a/cet_util.cc
+++ b/cet_util.cc
@@ -155,7 +155,7 @@ cet_register()
     for (p = cet_cs_vec_root; p != nullptr; p = p->next) {
       c++;
       if (p->alias != nullptr) {
-        char** a = const_cast<char**>(p->alias);
+        const char** a = p->alias;
         while ((*a) != nullptr) {
           a++;
           c++;
@@ -168,7 +168,7 @@ cet_register()
     i = 0;
     for (p = cet_cs_vec_root; p != nullptr; p = p->next) {
       if (p->alias != nullptr) {
-        char** a = const_cast<char**>(p->alias);
+        const char** a = p->alias;
 
         list[i].name = xstrdup(p->name);
         list[i].vec = p;
@@ -440,7 +440,7 @@ cet_convert_route_tlr(const route_head* route)
 void
 cet_convert_strings(const cet_cs_vec_t* source, const cet_cs_vec_t* target, const char* format)
 {
-  char* cs_name_from, *cs_name_to;
+  const char* cs_name_from, *cs_name_to;
   (void)format;
 
   converter = nullptr;
@@ -454,8 +454,8 @@ cet_convert_strings(const cet_cs_vec_t* source, const cet_cs_vec_t* target, cons
     cet_output = 1;
 
     converter = cet_convert_from_utf8;
-    cs_name_from = const_cast<char*>(cet_cs_vec_utf8.name);
-    cs_name_to = const_cast<char*>(target->name);
+    cs_name_from = cet_cs_vec_utf8.name;
+    cs_name_to = target->name;
   } else {
     if ((target != nullptr) && (target != &cet_cs_vec_utf8)) {
       fatal(MYNAME ": Internal error!\n");
@@ -464,8 +464,8 @@ cet_convert_strings(const cet_cs_vec_t* source, const cet_cs_vec_t* target, cons
     cet_output = 0;
 
     converter = cet_convert_to_utf8;
-    cs_name_to = const_cast<char*>(cet_cs_vec_utf8.name);
-    cs_name_from = const_cast<char*>(source->name);
+    cs_name_to = cet_cs_vec_utf8.name;
+    cs_name_from = source->name;
   }
 
   if (global_opts.debug_level > 0) {

--- a/cet_util.cc
+++ b/cet_util.cc
@@ -155,7 +155,7 @@ cet_register()
     for (p = cet_cs_vec_root; p != nullptr; p = p->next) {
       c++;
       if (p->alias != nullptr) {
-        char** a = (char**)p->alias;
+        char** a = const_cast<char**>(p->alias);
         while ((*a) != nullptr) {
           a++;
           c++;
@@ -168,7 +168,7 @@ cet_register()
     i = 0;
     for (p = cet_cs_vec_root; p != nullptr; p = p->next) {
       if (p->alias != nullptr) {
-        char** a = (char**)p->alias;
+        char** a = const_cast<char**>(p->alias);
 
         list[i].name = xstrdup(p->name);
         list[i].vec = p;
@@ -322,13 +322,13 @@ cet_convert_init(const QString& cs_name, const int force)
 static void
 cet_flag_waypt(const Waypoint* wpt)
 {
-  ((Waypoint*)(wpt))->wpt_flags.cet_converted = 1;
+  (const_cast<Waypoint*>(wpt))->wpt_flags.cet_converted = 1;
 }
 
 static void
 cet_flag_route(const route_head* rte)
 {
-  ((route_head*)(rte))->cet_converted = 1;
+  (const_cast<route_head*>(rte))->cet_converted = 1;
 }
 
 static void
@@ -391,7 +391,7 @@ cet_convert_string(const QString& str)
 static void
 cet_convert_waypt(const Waypoint* wpt)
 {
-  Waypoint* w = (Waypoint*)wpt;
+  Waypoint* w = const_cast<Waypoint*>(wpt);
   format_specific_data* fs;
 
   if ((cet_output == 0) && (w->wpt_flags.cet_converted != 0)) {
@@ -414,7 +414,7 @@ cet_convert_waypt(const Waypoint* wpt)
 static void
 cet_convert_route_hdr(const route_head* route)
 {
-  route_head* rte = (route_head*)route;
+  route_head* rte = const_cast<route_head*>(route);
 
   if ((cet_output == 0) && (rte->cet_converted != 0)) {
     return;
@@ -454,8 +454,8 @@ cet_convert_strings(const cet_cs_vec_t* source, const cet_cs_vec_t* target, cons
     cet_output = 1;
 
     converter = cet_convert_from_utf8;
-    cs_name_from = (char*)cet_cs_vec_utf8.name;
-    cs_name_to = (char*)target->name;
+    cs_name_from = const_cast<char*>(cet_cs_vec_utf8.name);
+    cs_name_to = const_cast<char*>(target->name);
   } else {
     if ((target != nullptr) && (target != &cet_cs_vec_utf8)) {
       fatal(MYNAME ": Internal error!\n");
@@ -464,8 +464,8 @@ cet_convert_strings(const cet_cs_vec_t* source, const cet_cs_vec_t* target, cons
     cet_output = 0;
 
     converter = cet_convert_to_utf8;
-    cs_name_to = (char*)cet_cs_vec_utf8.name;
-    cs_name_from = (char*)source->name;
+    cs_name_to = const_cast<char*>(cet_cs_vec_utf8.name);
+    cs_name_from = const_cast<char*>(source->name);
   }
 
   if (global_opts.debug_level > 0) {

--- a/compegps.cc
+++ b/compegps.cc
@@ -78,8 +78,8 @@ static int snlen;
 static int radius;
 static int input_datum;
 
-static route_head* curr_track;
-static route_head* curr_route;
+static const route_head* curr_track;
+static const route_head* curr_route;
 
 /* placeholders for options */
 
@@ -514,7 +514,7 @@ write_waypt_cb(const Waypoint* wpt)
 static void
 write_route_hdr_cb(const route_head* rte)
 {
-  curr_route = const_cast<route_head*>(rte);
+  curr_route = rte;
   curr_index++;
   if (curr_index != target_index) {
     return;
@@ -540,7 +540,7 @@ static void
 write_track_hdr_cb(const route_head* trk)
 {
   track_info_flag = 0;
-  curr_track = const_cast<route_head*>(trk);
+  curr_track = trk;
 
   curr_index++;
   if (curr_index != target_index) {

--- a/compegps.cc
+++ b/compegps.cc
@@ -514,7 +514,7 @@ write_waypt_cb(const Waypoint* wpt)
 static void
 write_route_hdr_cb(const route_head* rte)
 {
-  curr_route = (route_head*) rte;
+  curr_route = const_cast<route_head*>(rte);
   curr_index++;
   if (curr_index != target_index) {
     return;
@@ -540,7 +540,7 @@ static void
 write_track_hdr_cb(const route_head* trk)
 {
   track_info_flag = 0;
-  curr_track = (route_head*) trk;
+  curr_track = const_cast<route_head*>(trk);
 
   curr_index++;
   if (curr_index != target_index) {

--- a/cst.cc
+++ b/cst.cc
@@ -69,7 +69,7 @@ cst_add_wpt(const route_head* track, Waypoint* wpt)
     }
     route_add_wpt(temp_route, new Waypoint(*wpt));
   }
-  track_add_wpt((route_head*)track, wpt);
+  track_add_wpt(const_cast<route_head*>(track), wpt);
 }
 
 static char*

--- a/cst.cc
+++ b/cst.cc
@@ -50,7 +50,7 @@ arglist_t cst_args[] = {
 /* helpers */
 
 static void
-cst_add_wpt(const route_head* track, Waypoint* wpt)
+cst_add_wpt(route_head* track, Waypoint* wpt)
 {
   if ((wpt == nullptr) || (track == nullptr)) {
     return;
@@ -69,7 +69,7 @@ cst_add_wpt(const route_head* track, Waypoint* wpt)
     }
     route_add_wpt(temp_route, new Waypoint(*wpt));
   }
-  track_add_wpt(const_cast<route_head*>(track), wpt);
+  track_add_wpt(track, wpt);
 }
 
 static char*

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -489,7 +489,7 @@ human_to_dec(const char* instr, double* outlat, double* outlon, int which)
       *c = '.';
     }
   } else {
-    buff = (char*)instr;
+    buff = const_cast<char*>(instr);
   }
 
   cur = buff;
@@ -1566,10 +1566,10 @@ xcsv_resetpathlen(const route_head* head)
   csv_route = csv_track = nullptr;
   switch (xcsv_file.datatype) {
   case trkdata:
-    csv_track = (route_head*) head;
+    csv_track = const_cast<route_head*>(head);
     break;
   case rtedata:
-    csv_route = (route_head*) head;
+    csv_route = const_cast<route_head*>(head);
     break;
   default:
     break;

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -480,7 +480,7 @@ human_to_dec(const char* instr, double* outlat, double* outlon, int which)
   const char* cur;
   double* numres = unk;
   int numind = 0;
-  char* buff;
+  char* buff = nullptr;
 
   if (strchr(instr, ',') != nullptr) {
     char* c;
@@ -488,11 +488,10 @@ human_to_dec(const char* instr, double* outlat, double* outlon, int which)
     while ((c = strchr(buff, ','))) {
       *c = '.';
     }
+    cur = buff;
   } else {
-    buff = const_cast<char*>(instr);
+    cur = instr;
   }
-
-  cur = buff;
 
   while (cur && *cur) {
     switch (*cur) {
@@ -626,7 +625,7 @@ human_to_dec(const char* instr, double* outlat, double* outlon, int which)
       *outlon *= lonsign;
     }
   }
-  if (buff != instr) {
+  if (buff) {
     xfree(buff);
   }
 }

--- a/discard.cc
+++ b/discard.cc
@@ -39,7 +39,7 @@ void DiscardFilter::fix_process_wpt(const Waypoint* wpt)
   int delh = 0;
   int delv = 0;
 
-  Waypoint* waypointp = (Waypoint*) wpt;
+  Waypoint* waypointp = const_cast<Waypoint*>(wpt);
 
   if ((hdopf >= 0.0) && (waypointp->hdop > hdopf)) {
     delh = 1;
@@ -107,7 +107,7 @@ void DiscardFilter::fix_process_wpt(const Waypoint* wpt)
 
 void DiscardFilter::fix_process_head(const route_head* trk)
 {
-  head = (route_head*)trk;
+  head = const_cast<route_head*>(trk);
 }
 
 void DiscardFilter::process()

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -212,13 +212,13 @@ enum_waypt_cb(const Waypoint* wpt)
     for (i = 0; i < wpt_a_ct; i++) {		/* check for duplicates */
       Waypoint* tmp = wpt_a[i];
       if (case_ignore_strcmp(tmp->shortname, wpt->shortname) == 0) {
-        wpt_a[i] = (Waypoint*)wpt;
+        wpt_a[i] = const_cast<Waypoint*>(wpt);
         waypoints--;
         return;
 
       }
     }
-    wpt_a[wpt_a_ct++] = (Waypoint*)wpt;
+    wpt_a[wpt_a_ct++] = const_cast<Waypoint*>(wpt);
   }
 
 }
@@ -259,10 +259,10 @@ prework_wpt_cb(const Waypoint* wpt)
     cur_info->time += (wpt->GetCreationTime().toTime_t() - prev->GetCreationTime().toTime_t());
     cur_info->length += waypt_distance_ex(prev, wpt);
   } else {
-    cur_info->first_wpt = (Waypoint*)wpt;
+    cur_info->first_wpt = const_cast<Waypoint*>(wpt);
     cur_info->start = wpt->GetCreationTime().toTime_t();
   }
-  cur_info->prev_wpt = (Waypoint*)wpt;
+  cur_info->prev_wpt = const_cast<Waypoint*>(wpt);
   cur_info->count++;
   routepoints++;
 }
@@ -628,7 +628,7 @@ write_waypt(const Waypoint* wpt)
 static void
 route_disp_hdr_cb(const route_head* rte)
 {
-  current_trk = (route_head*)rte;
+  current_trk = const_cast<route_head*>(rte);
   cur_info = &route_info[route_idx];
   cur_info->prev_wpt = nullptr;
   cur_info->total = 0;
@@ -674,7 +674,7 @@ route_disp_wpt_cb(const Waypoint* wpt)
 
   gbfprintf(fout, "\r\n");
 
-  cur_info->prev_wpt = (Waypoint*)wpt;
+  cur_info->prev_wpt = const_cast<Waypoint*>(wpt);
 }
 
 static void
@@ -683,7 +683,7 @@ track_disp_hdr_cb(const route_head* track)
   cur_info = &route_info[route_idx];
   cur_info->prev_wpt = nullptr;
   cur_info->total = 0;
-  current_trk = (route_head*)track;
+  current_trk = const_cast<route_head*>(track);
   if (track->rte_waypt_ct <= 0) {
     return;
   }
@@ -745,7 +745,7 @@ track_disp_wpt_cb(const Waypoint* wpt)
   }
   gbfprintf(fout, "\r\n");
 
-  cur_info->prev_wpt = (Waypoint*)wpt;
+  cur_info->prev_wpt = const_cast<Waypoint*>(wpt);
 }
 
 /*******************************************************************************

--- a/gdb.cc
+++ b/gdb.cc
@@ -1631,7 +1631,7 @@ write_waypoint_cb(const Waypoint* refpt)
 // but, but, casting away the const here is wrong...
   (const_cast<Waypoint*>(refpt))->shortname = refpt->shortname.trimmed();
 #else
-  rtrim(((Waypoint*)refpt)->shortname);
+  rtrim(const_cast<Waypoint*>(refpt))->shortname);
 #endif
   test = gdb_find_wayptq(&wayptq_out, refpt, 1);
 

--- a/gdb.cc
+++ b/gdb.cc
@@ -1629,7 +1629,7 @@ write_waypoint_cb(const Waypoint* refpt)
   /* do this when backup always happens in main */
 #if NEW_STRINGS
 // but, but, casting away the const here is wrong...
-  ((Waypoint*)refpt)->shortname = refpt->shortname.trimmed();
+  (const_cast<Waypoint*>(refpt))->shortname = refpt->shortname.trimmed();
 #else
   rtrim(((Waypoint*)refpt)->shortname);
 #endif

--- a/height.cc
+++ b/height.cc
@@ -87,7 +87,7 @@ double HeightFilter::wgs84_separation(double lat, double lon)
 
 void HeightFilter::correct_height(const Waypoint* wpt)
 {
-  Waypoint* waypointp = (Waypoint*) wpt;
+  Waypoint* waypointp = const_cast<Waypoint*>(wpt);
 
   if (waypointp->altitude != unknown_alt) {
     if (addopt) {

--- a/humminbird.cc
+++ b/humminbird.cc
@@ -953,13 +953,13 @@ humminbird_write_waypoint_wrapper(const Waypoint* wpt)
 
   xasprintf(&key, "%s\01%.9f\01%.9f", CSTRc(wpt->shortname), wpt->latitude, wpt->longitude);
   if (!(tmpwpt = map[key])) {
-    tmpwpt = (Waypoint*)wpt;
-    map[key] = (Waypoint*) wpt;
+    tmpwpt = const_cast<Waypoint*>(wpt);
+    map[key] = const_cast<Waypoint*>(wpt);
     tmpwpt->extra_data = gb_int2ptr(waypoint_num + 1);	/* NOT NULL */
     humminbird_write_waypoint(wpt);
   } else {
     void* p = tmpwpt->extra_data;
-    tmpwpt = (Waypoint*)wpt;
+    tmpwpt = const_cast<Waypoint*>(wpt);
     tmpwpt->extra_data = p;
   }
 

--- a/lowranceusr4.cc
+++ b/lowranceusr4.cc
@@ -300,7 +300,7 @@ static void
 register_waypt(const Waypoint* ref)
 {
   int i;
-  Waypoint* wpt = (Waypoint*) ref;
+  Waypoint* wpt = const_cast<Waypoint*>(ref);
 
   for (i = 0; i < waypt_table_ct; i++) {
     Waypoint* cmp = waypt_table[i];

--- a/mmo.cc
+++ b/mmo.cc
@@ -250,7 +250,7 @@ mmo_register_object(const int objid, const void* ptr, const gpsdata_type type)
   mmo_data_t* data;
 
   data = (mmo_data_t*) xcalloc(1, sizeof(*data));
-  data->data = (void*)ptr;
+  data->data = const_cast<void*>(ptr);
   data->visible = 1;
   data->locked = 0;
   data->type = type;
@@ -956,7 +956,7 @@ mmo_read_object()
 static void
 mmo_finalize_rtept_cb(const Waypoint* wptref)
 {
-  Waypoint* wpt = (Waypoint*)wptref;
+  Waypoint* wpt = const_cast<Waypoint*>(wptref);
 
   if ((wpt->shortname[0] == 1) && (wpt->latitude == 0) && (wpt->longitude == 0)) {
     mmo_data_t* data;
@@ -1340,7 +1340,7 @@ mmo_write_rte_head_cb(const route_head* rte)
     return;
   }
 
-  mmo_rte = (route_head*)rte;
+  mmo_rte = const_cast<route_head*>(rte);
 
   QUEUE_FOR_EACH(&rte->waypoint_list, elem, tmp) {
     Waypoint* wpt = (Waypoint*)elem;

--- a/mmo.cc
+++ b/mmo.cc
@@ -78,7 +78,7 @@ static uint16_t ico_object_id;
 static uint16_t pos_object_id;
 static uint16_t txt_object_id;
 static gpsdata_type mmo_datatype;
-static route_head* mmo_rte;
+static const route_head* mmo_rte;
 
 static QHash<QString, int> category_names;
 static QHash<int, QString> icons;
@@ -1337,7 +1337,7 @@ mmo_write_rte_head_cb(const route_head* rte)
     return;
   }
 
-  mmo_rte = const_cast<route_head*>(rte);
+  mmo_rte = rte;
 
   QUEUE_FOR_EACH(&rte->waypoint_list, elem, tmp) {
     Waypoint* wpt = (Waypoint*)elem;

--- a/osm.cc
+++ b/osm.cc
@@ -459,10 +459,7 @@ osm_feature_symbol(const int ikey, const char* value)
 static char*
 osm_strip_html(const char* str)
 {
-  utf_string utf;
-  utf.is_html = true;
-  utf.utfstring = const_cast<char*>(str);
-
+  utf_string utf(true, str);
   return strip_html(&utf);	// util.cc
 }
 

--- a/osm.cc
+++ b/osm.cc
@@ -461,7 +461,7 @@ osm_strip_html(const char* str)
 {
   utf_string utf;
   utf.is_html = true;
-  utf.utfstring = (char*)str;
+  utf.utfstring = const_cast<char*>(str);
 
   return strip_html(&utf);	// util.cc
 }
@@ -775,7 +775,7 @@ static void
 osm_release_ids(const Waypoint* wpt)
 {
   if (wpt && wpt->extra_data) {
-    Waypoint* tmp = (Waypoint*)wpt;
+    Waypoint* tmp = const_cast<Waypoint*>(wpt);
     xfree(tmp->extra_data);
     tmp->extra_data = nullptr;
   }
@@ -806,7 +806,7 @@ osm_waypt_disp(const Waypoint* wpt)
 
   id = (int*) xmalloc(sizeof(*id));
   *id = --node_id;
-  ((Waypoint*)(wpt))->extra_data = id;
+  (const_cast<Waypoint*>(wpt))->extra_data = id;
 
   gbfprintf(fout, "  <node id='%d' visible='true' lat='%0.7f' lon='%0.7f'", *id, wpt->latitude, wpt->longitude);
   if (wpt->creation_time.isValid()) {

--- a/position.cc
+++ b/position.cc
@@ -134,8 +134,8 @@ void PositionFilter::position_process_any_route(const route_head* rh, int type)
   int i = rh->rte_waypt_ct;
 
   if (i) {
-    cur_rte = (route_head*)rh;
-    position_runqueue((queue*)&rh->waypoint_list, i, type);
+    cur_rte = const_cast<route_head*>(rh);
+    position_runqueue(const_cast<queue*>(&rh->waypoint_list), i, type);
     cur_rte = nullptr;
   }
 

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -317,13 +317,13 @@ register_waypt(const Waypoint* ref, const char)
 static void
 enum_waypt_cb(const Waypoint* wpt)
 {
-  register_waypt(const_cast<Waypoint*>(wpt), 0);
+  register_waypt(wpt, 0);
 }
 
 static void
 enum_rtept_cb(const Waypoint* wpt)
 {
-  register_waypt(const_cast<Waypoint*>(wpt), 1);
+  register_waypt(wpt, 1);
 }
 
 static int

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -288,7 +288,7 @@ static void
 register_waypt(const Waypoint* ref, const char)
 {
   int i;
-  Waypoint* wpt = (Waypoint*) ref;
+  Waypoint* wpt = const_cast<Waypoint*>(ref);
 
   for (i = 0; i < waypt_table_ct; i++) {
     Waypoint* cmp = waypt_table[i];
@@ -317,13 +317,13 @@ register_waypt(const Waypoint* ref, const char)
 static void
 enum_waypt_cb(const Waypoint* wpt)
 {
-  register_waypt((Waypoint*) wpt, 0);
+  register_waypt(const_cast<Waypoint*>(wpt), 0);
 }
 
 static void
 enum_rtept_cb(const Waypoint* wpt)
 {
-  register_waypt((Waypoint*) wpt, 1);
+  register_waypt(const_cast<Waypoint*>(wpt), 1);
 }
 
 static int

--- a/reverse_route.cc
+++ b/reverse_route.cc
@@ -33,7 +33,7 @@ void ReverseRouteFilter::reverse_route_wpt(const Waypoint* waypointp)
 {
 
   /* Cast away const-ness */
-  Waypoint* wpp = (Waypoint*) waypointp;
+  Waypoint* wpp = const_cast<Waypoint*>(waypointp);
 
   int curr_new_trkseg;
 

--- a/route.cc
+++ b/route.cc
@@ -263,7 +263,7 @@ void
 route_reverse(const route_head* rte_hd)
 {
   /* Cast away const-ness */
-  route_head* rh = (route_head*) rte_hd;
+  route_head* rh = const_cast<route_head*>(rte_hd);
   queue* elem, *tmp;
   QUEUE_FOR_EACH(&rh->waypoint_list, elem, tmp) {
     ENQUEUE_HEAD(&rh->waypoint_list, dequeue(elem));

--- a/stmsdf.cc
+++ b/stmsdf.cc
@@ -509,7 +509,7 @@ any_hdr_calc_cb(const route_head* trk)
     rte_desc = trk->rte_desc;
   }
 
-  trk_out = (route_head*)trk;
+  trk_out = const_cast<route_head*>(trk);
 }
 
 static void
@@ -544,7 +544,7 @@ any_waypt_calc_cb(const Waypoint* wpt)
     this_time += (wpt->GetCreationTime().toTime_t() - trkpt_out->GetCreationTime().toTime_t());
   }
 
-  trkpt_out = (Waypoint*)wpt;
+  trkpt_out = const_cast<Waypoint*>(wpt);
 }
 
 static void
@@ -566,7 +566,7 @@ track_disp_hdr_cb(const route_head* trk)
 {
   track_index++;
   track_points = 0;
-  trk_out = (route_head*)trk;
+  trk_out = const_cast<route_head*>(trk);
   trkpt_out = nullptr;
 }
 
@@ -630,7 +630,7 @@ track_disp_wpt_cb(const Waypoint* wpt)
     gbfprintf(fout, ",0\n");
   }
 
-  trkpt_out = (Waypoint*)wpt;
+  trkpt_out = const_cast<Waypoint*>(wpt);
 }
 
 static void

--- a/stmsdf.cc
+++ b/stmsdf.cc
@@ -61,8 +61,8 @@ static queue trackpts;
 static QString rte_name;
 static QString rte_desc;
 
-static Waypoint* trkpt_out;
-static route_head* trk_out;
+static const Waypoint* trkpt_out;
+static const route_head* trk_out;
 
 static double trkpt_dist;
 static double minalt, maxalt, maxspeed;
@@ -509,7 +509,7 @@ any_hdr_calc_cb(const route_head* trk)
     rte_desc = trk->rte_desc;
   }
 
-  trk_out = const_cast<route_head*>(trk);
+  trk_out = trk;
 }
 
 static void
@@ -544,7 +544,7 @@ any_waypt_calc_cb(const Waypoint* wpt)
     this_time += (wpt->GetCreationTime().toTime_t() - trkpt_out->GetCreationTime().toTime_t());
   }
 
-  trkpt_out = const_cast<Waypoint*>(wpt);
+  trkpt_out = wpt;
 }
 
 static void
@@ -566,7 +566,7 @@ track_disp_hdr_cb(const route_head* trk)
 {
   track_index++;
   track_points = 0;
-  trk_out = const_cast<route_head*>(trk);
+  trk_out = trk;
   trkpt_out = nullptr;
 }
 
@@ -630,7 +630,7 @@ track_disp_wpt_cb(const Waypoint* wpt)
     gbfprintf(fout, ",0\n");
   }
 
-  trkpt_out = const_cast<Waypoint*>(wpt);
+  trkpt_out = wpt;
 }
 
 static void

--- a/swapdata.cc
+++ b/swapdata.cc
@@ -30,7 +30,7 @@
 
 void SwapDataFilter::swapdata_cb(const Waypoint* ref)
 {
-  Waypoint* wpt = (Waypoint*)ref;
+  Waypoint* wpt = const_cast<Waypoint*>(ref);
   double x;
 
   x = wpt->latitude;

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -60,7 +60,7 @@ int TrackFilter::trackfilter_parse_time_opt(const char* arg)
 {
   time_t t0, t1;
   int sign = 1;
-  char* cin = (char*)arg;
+  char* cin = const_cast<char*>(arg);
   char c;
 
   t0 = t1 = 0;
@@ -178,7 +178,7 @@ void TrackFilter::trackfilter_fill_track_list_cb(const route_head* track) 	/* ca
   queue* elem, *tmp;
 
   if (track->rte_waypt_ct == 0) {
-    track_del_head((route_head*)track);
+    track_del_head(const_cast<route_head*>(track));
     return;
   }
 
@@ -186,15 +186,15 @@ void TrackFilter::trackfilter_fill_track_list_cb(const route_head* track) 	/* ca
     if (!QRegExp(opt_name, Qt::CaseInsensitive, QRegExp::WildcardUnix).exactMatch(track->rte_name)) {
       QUEUE_FOR_EACH((queue*)&track->waypoint_list, elem, tmp) {
         Waypoint* wpt = (Waypoint*)elem;
-        track_del_wpt((route_head*)track, wpt);
+        track_del_wpt(const_cast<route_head*>(track), wpt);
         delete wpt;
       }
-      track_del_head((route_head*)track);
+      track_del_head(const_cast<route_head*>(track));
       return;
     }
   }
 
-  track_list[track_ct].track = (route_head*)track;
+  track_list[track_ct].track = const_cast<route_head*>(track);
 
   i = 0;
   prev = nullptr;
@@ -234,7 +234,7 @@ void TrackFilter::trackfilter_minpoint_list_cb(const route_head* track)
 {
   int minimum_points = atoi(opt_minpoints);
   if (track->rte_waypt_ct < minimum_points) {
-    track_del_head((route_head*)track);
+    track_del_head(const_cast<route_head*>(track));
     return;
   }
 }
@@ -747,7 +747,7 @@ time_t TrackFilter::trackfilter_range_check(const char* timestr)
 
   i = 0;
   strncpy(fmt, "00000101000000", sizeof(fmt));
-  cin = (char*)timestr;
+  cin = const_cast<char*>(timestr);
 
   while ((c = *cin++)) {
     if (fmt[i] == '\0') {
@@ -1044,7 +1044,7 @@ void TrackFilter::trackfilter_segment_head(const route_head* rte)
           Waypoint* next_wpt = (Waypoint*) QUEUE_NEXT(&wpt->Q);
           if (trackfilter_points_are_same(prev_wpt, wpt) &&
               trackfilter_points_are_same(wpt, next_wpt)) {
-            track_del_wpt((route_head*)rte, wpt);
+            track_del_wpt(const_cast<route_head*>(rte), wpt);
             continue;
           }
         }

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -60,7 +60,7 @@ int TrackFilter::trackfilter_parse_time_opt(const char* arg)
 {
   time_t t0, t1;
   int sign = 1;
-  char* cin = const_cast<char*>(arg);
+  const char* cin = arg;
   char c;
 
   t0 = t1 = 0;
@@ -741,13 +741,13 @@ time_t TrackFilter::trackfilter_range_check(const char* timestr)
   int i;
   char fmt[20];
   char c;
-  char* cin;
+  const char* cin;
   struct tm time;
 
 
   i = 0;
   strncpy(fmt, "00000101000000", sizeof(fmt));
-  cin = const_cast<char*>(timestr);
+  cin = timestr;
 
   while ((c = *cin++)) {
     if (fmt[i] == '\0') {

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -462,7 +462,7 @@ unicsv_adjust_time(const time_t time, time_t* date)
 static char
 unicsv_compare_fields(const char* s, const field_t* f)
 {
-  char* name = (char*)f->name;
+  char* name = const_cast<char*>(f->name);
   const char* test = s;
   char result;
 

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -462,7 +462,7 @@ unicsv_adjust_time(const time_t time, time_t* date)
 static char
 unicsv_compare_fields(const char* s, const field_t* f)
 {
-  char* name = const_cast<char*>(f->name);
+  const char* name = f->name;
   const char* test = s;
   char result;
 

--- a/util.cc
+++ b/util.cc
@@ -1120,7 +1120,8 @@ char*
 gstrsub(const char* s, const char* search, const char* replace)
 {
   int ooffs = 0;
-  char* o, *c;
+  char* o;
+  const char* c;
   const char* src = s;
   int olen = strlen(src);
   int slen = strlen(search);

--- a/util.cc
+++ b/util.cc
@@ -124,7 +124,7 @@ XFREE(const void* mem, DEBUG_PARAMS)
 xfree(const void* mem)
 #endif
 {
-  free((void*) mem);
+  free(const_cast<void*>(mem));
 #ifdef DEBUG_MEM
   debug_mem_output("free, %x, %s, %d\n",
                    mem, file, line);
@@ -167,7 +167,7 @@ xstrndup(const char* str, size_t sz)
 #endif
 {
   size_t newlen = 0;
-  char* cin = (char*)str;
+  char* cin = const_cast<char*>(str);
   char* newstr;
 
   while ((newlen < sz) && (*cin != '\0')) {
@@ -484,8 +484,8 @@ str_match(const char* str, const char* match)
 {
   char* m, *s;
 
-  s = (char*)str;
-  m = (char*)match;
+  s = const_cast<char*>(str);
+  m = const_cast<char*>(match);
 
   while (*m || *s) {
     switch (*m) {
@@ -1121,7 +1121,7 @@ gstrsub(const char* s, const char* search, const char* replace)
 {
   int ooffs = 0;
   char* o, *c;
-  char* src = (char*)s;
+  char* src = const_cast<char*>(s);
   int olen = strlen(src);
   int slen = strlen(search);
   int rlen = strlen(replace);
@@ -1212,7 +1212,7 @@ convert_human_date_format(const char* human_datef)
   prev = '\0';
   ylen = 0;
 
-  for (cin = (char*)human_datef; *cin; cin++) {
+  for (cin = const_cast<char*>(human_datef); *cin; cin++) {
     char okay = 1;
 
     if (toupper(*cin) != 'Y') {
@@ -1278,7 +1278,7 @@ convert_human_time_format(const char* human_timef)
   cout = result;
   prev = '\0';
 
-  for (cin = (char*)human_timef; *cin; cin++) {
+  for (cin = const_cast<char*>(human_timef); *cin; cin++) {
     int okay = 1;
 
     if (isalpha(*cin)) {

--- a/util.cc
+++ b/util.cc
@@ -167,7 +167,7 @@ xstrndup(const char* str, size_t sz)
 #endif
 {
   size_t newlen = 0;
-  char* cin = const_cast<char*>(str);
+  const char* cin = str;
   char* newstr;
 
   while ((newlen < sz) && (*cin != '\0')) {
@@ -482,10 +482,10 @@ lrtrim(char* buff)
 int
 str_match(const char* str, const char* match)
 {
-  char* m, *s;
+  const char* m, *s;
 
-  s = const_cast<char*>(str);
-  m = const_cast<char*>(match);
+  s = str;
+  m = match;
 
   while (*m || *s) {
     switch (*m) {
@@ -511,7 +511,7 @@ str_match(const char* str, const char* match)
       }
 
       do {
-        char* mx, *sx;
+        const char* mx, *sx;
 
         while (*s && (*s != *m)) {
           s++;
@@ -1121,7 +1121,7 @@ gstrsub(const char* s, const char* search, const char* replace)
 {
   int ooffs = 0;
   char* o, *c;
-  char* src = const_cast<char*>(s);
+  const char* src = s;
   int olen = strlen(src);
   int slen = strlen(search);
   int rlen = strlen(replace);
@@ -1203,7 +1203,7 @@ rot13(const QString& s)
 char*
 convert_human_date_format(const char* human_datef)
 {
-  char* result, *cin, *cout;
+  char* result, *cout;
   char prev;
   int ylen;
 
@@ -1212,7 +1212,7 @@ convert_human_date_format(const char* human_datef)
   prev = '\0';
   ylen = 0;
 
-  for (cin = const_cast<char*>(human_datef); *cin; cin++) {
+  for (const char* cin = human_datef; *cin; cin++) {
     char okay = 1;
 
     if (toupper(*cin) != 'Y') {
@@ -1271,14 +1271,14 @@ convert_human_date_format(const char* human_datef)
 char*
 convert_human_time_format(const char* human_timef)
 {
-  char* result, *cin, *cout;
+  char* result, *cout;
   char prev;
 
   result = (char*) xcalloc((2*strlen(human_timef)) + 1, 1);
   cout = result;
   prev = '\0';
 
-  for (cin = const_cast<char*>(human_timef); *cin; cin++) {
+  for (const char* cin = human_timef; *cin; cin++) {
     int okay = 1;
 
     if (isalpha(*cin)) {

--- a/vecs.cc
+++ b/vecs.cc
@@ -1179,7 +1179,7 @@ assign_option(const char* module, arglist_t* ap, const char* val)
   if (case_ignore_strcmp(val, ap->argstring) == 0) {
     c = "";
   } else {
-    c = const_cast<char*>(val);
+    c = val;
   }
 
   switch (ap->argtype & ARGTYPE_TYPEMASK) {
@@ -1290,7 +1290,7 @@ find_vec(const char* vecname, const char** opts)
           if (opt) {
             found = 1;
             assign_option(svecname, ap, opt);
-            xfree(const_cast<char*>(opt));
+            xfree(opt);
             continue;
           }
         }
@@ -1347,7 +1347,7 @@ find_vec(const char* vecname, const char** opts)
           if (opt) {
             found = 1;
             assign_option(svecname, ap, opt);
-            xfree(const_cast<char*>(opt));
+            xfree(opt);
             continue;
           }
         }

--- a/vecs.cc
+++ b/vecs.cc
@@ -1179,7 +1179,7 @@ assign_option(const char* module, arglist_t* ap, const char* val)
   if (case_ignore_strcmp(val, ap->argstring) == 0) {
     c = "";
   } else {
-    c = (char*)val;
+    c = const_cast<char*>(val);
   }
 
   switch (ap->argtype & ARGTYPE_TYPEMASK) {
@@ -1290,7 +1290,7 @@ find_vec(const char* vecname, const char** opts)
           if (opt) {
             found = 1;
             assign_option(svecname, ap, opt);
-            xfree((char*)opt);
+            xfree(const_cast<char*>(opt));
             continue;
           }
         }
@@ -1347,7 +1347,7 @@ find_vec(const char* vecname, const char** opts)
           if (opt) {
             found = 1;
             assign_option(svecname, ap, opt);
-            xfree((char*)opt);
+            xfree(const_cast<char*>(opt));
             continue;
           }
         }


### PR DESCRIPTION
In the first commit clang-tidy is used to convert c style cast to const_cast using the google-readability-casting check, but only accepting fixes corresponding to message "C-style casts are discouraged; use const_cast".

In subsequent steps files using const_cast are manually reviewed to see if it is necessary to cast away const, and then possibly edited to remove the casting away of const.