### PR TITLE
miscellaneous cleanups & bug fixes.

### DIFF
--- a/easygps.cc
+++ b/easygps.cc
@@ -48,7 +48,7 @@ rd_init(const QString& fname)
   sz = gbfread(ibuf, 1, 52, file_in);
 
   if ((sz < 52) ||
-      strncmp(ibuf, ezsig, sizeof(ezsig)-1) ||
+      strncmp(ibuf, ezsig, strlen(ezsig)) ||
       (ibuf[51] != 'W')) {
     fatal(MYNAME ": %s is not an EasyGPS file.\n", qPrintable(fname));
   }

--- a/garmin_fs.cc
+++ b/garmin_fs.cc
@@ -27,6 +27,7 @@
 #include "inifile.h"
 
 #include <QtCore/QXmlStreamWriter>
+#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 
@@ -388,6 +389,9 @@ garmin_fs_convert_category(const char* category_name, uint16_t* category)
       char* c;
       char key[3];
 
+      // use assertion to silence gcc 7.3 warning
+      // warning: ‘%d’ directive output may be truncated writing between 1 and 11 bytes into a region of size 3 [-Wformat-truncation=]
+      assert((i>=0) && (i<16));
       snprintf(key, sizeof(key), "%d", i + 1);
       c = inifile_readstr(global_opts.inifile, GMSD_SECTION_CATEGORIES, key);
       if ((c != nullptr) && (case_ignore_strcmp(c, category_name) == 0)) {

--- a/mapsource.cc
+++ b/mapsource.cc
@@ -609,7 +609,7 @@ mps_waypoint_r(gbfile* mps_file, int mps_ver, Waypoint** wpt, unsigned int* mpsc
  * MRCB
  */
 static void
-mps_waypoint_w(gbfile* mps_file, int mps_ver, const Waypoint* wpt, const int isRouteWpt)
+mps_waypoint_w(gbfile* mps_file, int mps_ver, const Waypoint* wpt, const bool isRouteWpt)
 {
   int reclen;
   int lat, lon;
@@ -768,7 +768,7 @@ mps_waypoint_w_unique_wrapper(const Waypoint* wpt)
 
   /* if this waypoint hasn't been written then it is okay to do so */
   if (wptfound == nullptr) {
-    mps_waypoint_w(mps_file_out, mps_ver_out, wpt, (1==0));
+    mps_waypoint_w(mps_file_out, mps_ver_out, wpt, false);
 
     /* ensure we record in our "private" queue what has been
     written so that we don't write it again */
@@ -807,10 +807,10 @@ mps_route_wpt_w_unique_wrapper(const Waypoint* wpt)
 
     if (wptfound == nullptr) {
       /* well, we tried to find: it wasn't written and isn't a real waypoint */
-      mps_waypoint_w(mps_file_out, mps_ver_out, wpt, (1==1));
+      mps_waypoint_w(mps_file_out, mps_ver_out, wpt, true);
       mps_wpt_q_add(&written_route_wpt_head, wpt);
     } else {
-      mps_waypoint_w(mps_file_out, mps_ver_out, wpt, (1==0));
+      mps_waypoint_w(mps_file_out, mps_ver_out, wpt, false);
       /* Simulated real user waypoint */
       mps_wpt_q_add(&written_wpt_head, wpt);
     }
@@ -849,11 +849,11 @@ mps_waypoint_w_uniqloc_wrapper(Waypoint* wpt)
       wptfound = new Waypoint(*wpt);
       xfree(wptfound->shortname);
       wptfound->shortname = newName;
-      mps_waypoint_w(mps_file_out, mps_ver_out, wptfound, (1==0));
+      mps_waypoint_w(mps_file_out, mps_ver_out, wptfound, false);
       mps_wpt_q_add(&written_wpt_head, wpt);
     }
   } else {
-    mps_waypoint_w(mps_file_out, mps_ver_out, wpt, (1==0));
+    mps_waypoint_w(mps_file_out, mps_ver_out, wpt, false);
     /* ensure we record in out "private" queue what has been
     written so that we don't write it again */
     mps_wpt_q_add(&written_wpt_head, wpt);

--- a/random.cc
+++ b/random.cc
@@ -183,7 +183,7 @@ random_read()
 
     wpt->SetCreationTime(time);
     if RND(3) {
-      wpt->creation_time = wpt->creation_time.addMSecs(rand_int(1000) * 1000);
+      wpt->creation_time = wpt->creation_time.addMSecs(rand_int(1000));
     }
     time += rand_int(10) + 1;
 

--- a/tpo.cc
+++ b/tpo.cc
@@ -74,6 +74,7 @@
 #include "defs.h"
 #include "jeeps/gpsmath.h" /* for datum conversions */
 #include <QtCore/QScopedArrayPointer> // Wish we could use c++11...
+#include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -1453,6 +1454,10 @@ tpo_read()
 static void
 tpo_write_file_header()
 {
+  // this assertion will quiet gcc 7.3 warnings about output_state in the strncmp calls
+  // warning: argument 2 null where non-null expected [-Wnonnull]
+  assert(output_state != nullptr);
+
   /* force upper-case state name */
   strupper(output_state);
 

--- a/xmlgeneric.cc
+++ b/xmlgeneric.cc
@@ -35,7 +35,6 @@
 #include <QtCore/QDebug>
 #endif
 
-static QString current_tag;
 static xg_tag_mapping* xg_tag_tbl;
 static QSet<QString> xg_ignore_taglist;
 
@@ -100,9 +99,10 @@ xml_consider_ignoring(const QStringRef& name)
 }
 
 static void
-xml_run_parser(QXmlStreamReader& reader, QString& current_tag)
+xml_run_parser(QXmlStreamReader& reader)
 {
   xg_callback* cb;
+  QString current_tag;
 
   while (!reader.atEnd()) {
     switch (reader.tokenType()) {
@@ -175,13 +175,12 @@ readnext:
 void xml_read()
 {
   gpsbabel::File file(rd_fname);
-  QString current_tag;
 
   file.open(QIODevice::ReadOnly);
 
   QXmlStreamReader reader(&file);
 
-  xml_run_parser(reader, current_tag);
+  xml_run_parser(reader);
   if (reader.hasError())  {
     fatal(MYNAME ":Read error: %s (%s, line %ld, col %ld)\n",
           qPrintable(reader.errorString()),
@@ -209,13 +208,11 @@ void xml_readprefixstring(const char* str)
 // determine file encoding, falls back to UTF-8 if unspecified.
 void xml_readstring(const char* str)
 {
-  QString current_tag;
-
   reader_data.append(str);
 
   QXmlStreamReader reader(reader_data);
 
-  xml_run_parser(reader, current_tag);
+  xml_run_parser(reader);
   if (reader.hasError())  {
     fatal(MYNAME ":Read error: %s (%s, line %ld, col %ld)\n",
           qPrintable(reader.errorString()),
@@ -229,10 +226,9 @@ void xml_readstring(const char* str)
 // encoding because the source is already Qt's internal UTF-16.
 void xml_readunicode(const QString& str)
 {
-  QString current_tag;
   QXmlStreamReader reader(str);
 
-  xml_run_parser(reader, current_tag);
+  xml_run_parser(reader);
 }
 
 /******************************************/


### PR DESCRIPTION
easygps.cc: bugfix - clang-tidy check misc-sizeof-expression

garmin_fs.cc: warning cleanup - gcc warning: warning: ‘%d’ directive output may be truncated writing between 1 and 11 bytes into a region of size 3 [-Wformat-truncation=]

jtr.cc: warning cleanup - gcc warning: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
jtr.cc: bugfix - the jtr writter could incorrecly print the msec portion of the creationtime by dropping the most significant digit when it was zero.

mapsource.cc: warning cleanup - binary operator acts on identical operands

random.cc: bugfix - fractional seconds were always zero.

tpo.cc: warning cleanup - gcc warning: argument 2 null where non-null expected [-Wnonnull]

xmlgeneric.cc: warning cleanup - Declarator is never used