### PR TITLE
fix irrelevant booboo in 23cb08f17.

### DIFF
--- a/gdb.cc
+++ b/gdb.cc
@@ -1623,7 +1623,7 @@ write_waypoint_cb(const Waypoint* refpt)
 // but, but, casting away the const here is wrong...
   (const_cast<Waypoint*>(refpt))->shortname = refpt->shortname.trimmed();
 #else
-  rtrim(const_cast<Waypoint*>(refpt))->shortname);
+  rtrim((const_cast<Waypoint*>(refpt))->shortname);
 #endif
   Waypoint* test = gdb_find_wayptq(&wayptq_out, refpt, 1);
 


### PR DESCRIPTION
This only mattered if NEW_STRINGS wasn't defined,
and it always is, except if running cppcheck.