### PR TITLE
tweak endian routines for consistency.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -1007,9 +1007,8 @@ void* xmalloc(size_t size);
 void* xrealloc(void* p, size_t s);
 void xfree(const void* mem);
 char* xstrdup(const QString& s);
-char* xstrndup(const char* s, size_t n);
-char* xstrndupt(const char* s, size_t n);
-char* xstrappend(char* src, const char* addon);
+char* xstrndup(const char* str, size_t sz);
+char* xstrappend(char* src, const char* newd);
 #define xxcalloc(nmemb, size, file, line) xcalloc(nmemb, size)
 #define xxmalloc(size, file, line) xmalloc(size)
 #define xxrealloc(p, s, file, line) xrealloc(p,s)
@@ -1024,7 +1023,6 @@ void* XREALLOC(void* p, size_t s, DEBUG_PARAMS);
 void XFREE(void* mem, DEBUG_PARAMS);
 char* XSTRDUP(const char* s, DEBUG_PARAMS);
 char* XSTRNDUP(const char* src, size_t size, DEBUG_PARAMS);
-char* XSTRNDUPT(const char* src, size_t size, DEBUG_PARAMS);
 char* XSTRAPPEND(char* src, const char* addon, DEBUG_PARAMS);
 void debug_mem_open();
 void debug_mem_output(char* format, ...);
@@ -1035,14 +1033,12 @@ void debug_mem_close();
 #define xfree(mem) XFREE(mem, __FILE__, __LINE__)
 #define xstrdup(s) XSTRDUP(s, __FILE__, __LINE__)
 #define xstrndup(s, z) XSTRNDUP(s, z, __FILE__, __LINE__)
-#define xstrndupt(s, z) XSTRNDUPT(s, z, __FILE__, __LINE__)
 #define xstrappend(src,addon) XSTRAPPEND(src, addon, __FILE__, __LINE__)
 #define xxcalloc XCALLOC
 #define xxmalloc XMALLOC
 #define xxrealloc XREALLOC
 #define xxfree XFREE
 #define xxstrdup XSTRDUP
-#define xxstrndupt XSTRNDUPT
 #define xxstrappend XSTRAPPEND
 #endif /* DEBUG_MEM */
 
@@ -1075,7 +1071,7 @@ char* strsub(const char* s, const char* search, const char* replace);
 char* gstrsub(const char* s, const char* search, const char* replace);
 const char* xstrrstr(const char* s1, const char* s2);
 void rtrim(char* s);
-char* lrtrim(char* s);
+char* lrtrim(char* buff);
 int xasprintf(char** strp, const char* fmt, ...) PRINTFLIKE(2, 3);
 int xasprintf(QString* strp, const char* fmt, ...) PRINTFLIKE(2, 3);
 int xvasprintf(char** strp, const char* fmt, va_list ap);
@@ -1085,7 +1081,7 @@ signed int get_tz_offset(void);
 time_t mklocaltime(struct tm* t);
 time_t mkgmtime(struct tm* t);
 gpsbabel::DateTime current_time(void);
-void dotnet_time_to_time_t(double dotnet, time_t* t, int* ms);
+void dotnet_time_to_time_t(double dotnet, time_t* t, int* millisecs);
 signed int month_lookup(const char* m);
 const char* get_cache_icon(const Waypoint* waypointp);
 const char* gs_get_cachetype(geocache_type t);
@@ -1120,7 +1116,7 @@ const QString get_filename(const QString& fname);			/* extract the filename port
 /* this lives in gpx.c */
 gpsbabel::DateTime xml_parse_time(const QString& cdatastr);
 
-QString rot13(const QString& str);
+QString rot13(const QString& s);
 
 /*
  * PalmOS records like fixed-point numbers, which should be rounded
@@ -1141,39 +1137,39 @@ signed int si_round(double d);
  * Protypes for Endianness helpers.
  */
 
-signed int be_read16(const void* p);
-unsigned int be_readu16(const void* p);
-signed int be_read32(const void* p);
-signed int le_read16(const void* p);
-unsigned int le_readu16(const void* p);
-signed int le_read32(const void* p);
-unsigned int le_readu32(const void* p);
+signed int be_read16(const void* ptr);
+unsigned int be_readu16(const void* ptr);
+signed int be_read32(const void* ptr);
+signed int le_read16(const void* ptr);
+unsigned int le_readu16(const void* ptr);
+signed int le_read32(const void* ptr);
+unsigned int le_readu32(const void* ptr);
 void le_read64(void* dest, const void* src);
-void be_write16(void* pp, const unsigned i);
-void be_write32(void* pp, const unsigned i);
-void le_write16(void* pp, const unsigned i);
-void le_write32(void* pp, const unsigned i);
+void be_write16(void* ptr, const unsigned value);
+void be_write32(void* ptr, const unsigned value);
+void le_write16(void* ptr, const unsigned value);
+void le_write32(void* ptr, const unsigned value);
 
 double endian_read_double(const void* ptr, int read_le);
 float  endian_read_float(const void* ptr, int read_le);
-void   endian_write_double(void* ptr, double d, int write_le);
-void   endian_write_float(void* ptr, float f, int write_le);
+void   endian_write_double(void* ptr, double value, int write_le);
+void   endian_write_float(void* ptr, float value, int write_le);
 
-float  be_read_float(void* p);
-double be_read_double(void* p);
-void   be_write_float(void* pp, float d);
-void   be_write_double(void* pp, double d);
+float  be_read_float(void* ptr);
+double be_read_double(void* ptr);
+void   be_write_float(void* ptr, float value);
+void   be_write_double(void* ptr, double value);
 
-float  le_read_float(const void* p);
-double le_read_double(const void* p);
-void   le_write_float(void* ptr, float f);
-void   le_write_double(void* p, double d);
+float  le_read_float(const void* ptr);
+double le_read_double(const void* ptr);
+void   le_write_float(void* ptr, float value);
+void   le_write_double(void* ptr, double value);
 
 /*
  * Prototypes for generic conversion routines (util.c).
  */
 
-double ddmm2degrees(double ddmm_val);
+double ddmm2degrees(double pcx_val);
 double degrees2ddmm(double deg_val);
 
 typedef enum {

--- a/util.cc
+++ b/util.cc
@@ -188,7 +188,7 @@ XREALLOC(void* p, size_t s, DEBUG_PARAMS)
 xrealloc(void* p, size_t s)
 #endif
 {
-  char* o = (char*) realloc(p,s);
+  char* o = (char*) realloc(p, s);
 #ifdef DEBUG_MEM
   if (p != NULL) {
     debug_mem_output("realloc, %x, %x, %x, %s, %d\n", o, p, s, file, line);
@@ -623,71 +623,70 @@ is_fatal(const int condition, const char* fmt, ...)
  * Read 4 bytes in big-endian.   Return as "int" in native endianness.
  */
 signed int
-be_read32(const void* p)
+be_read32(const void* ptr)
 {
-  unsigned char* i = (unsigned char*) p;
+  const unsigned char* i = (const unsigned char*) ptr;
   return i[0] << 24 | i[1] << 16  | i[2] << 8 | i[3];
 }
 
 signed int
-be_read16(const void* p)
+be_read16(const void* ptr)
 {
-  unsigned char* i = (unsigned char*) p;
+  const unsigned char* i = (const unsigned char*) ptr;
   return i[0] << 8 | i[1];
 }
 
 unsigned int
-be_readu16(const void* p)
+be_readu16(const void* ptr)
 {
-  const unsigned char* i = (unsigned char*) p;
+  const unsigned char* i = (const unsigned char*) ptr;
   return i[0] << 8 | i[1];
 }
 
 void
-be_write16(void* addr, const unsigned value)
+be_write16(void* ptr, const unsigned value)
 {
-  unsigned char* p = (unsigned char*) addr;
+  unsigned char* p = (unsigned char*) ptr;
   p[0] = value >> 8;
   p[1] = value;
-
 }
 
 void
-be_write32(void* pp, const unsigned i)
+be_write32(void* ptr, const unsigned value)
 {
-  char* p = (char*)pp;
+  unsigned char* p = (unsigned char*) ptr;
 
-  p[0] = (i >> 24) & 0xff;
-  p[1] = (i >> 16) & 0xff;
-  p[2] = (i >> 8) & 0xff;
-  p[3] = i & 0xff;
+  p[0] = value >> 24;
+  p[1] = value >> 16;
+  p[2] = value >> 8;
+  p[3] = value;
 }
 
 signed int
-le_read16(const void* addr)
+le_read16(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) addr;
+  const unsigned char* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8);
 }
 
 unsigned int
-le_readu16(const void* addr)
+le_readu16(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) addr;
+  const unsigned char* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8);
 }
 
 signed int
-le_read32(const void* addr)
+le_read32(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) addr;
+  const unsigned char* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
 }
 
 unsigned int
-le_readu32(const void* addr)
+le_readu32(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) addr;
+  const unsigned char* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
 }
 
@@ -712,18 +711,17 @@ le_read64(void* dest, const void* src)
 }
 
 void
-le_write16(void* addr, const unsigned value)
+le_write16(void* ptr, const unsigned value)
 {
-  unsigned char* p = (unsigned char*) addr;
+  unsigned char* p = (unsigned char*) ptr;
   p[0] = value;
   p[1] = value >> 8;
-
 }
 
 void
-le_write32(void* addr, const unsigned value)
+le_write32(void* ptr, const unsigned value)
 {
-  unsigned char* p = (unsigned char*) addr;
+  unsigned char* p = (unsigned char*) ptr;
   p[0] = value;
   p[1] = value >> 8;
   p[2] = value >> 16;
@@ -960,16 +958,16 @@ endian_read_float(const void* ptr, int read_le)
 }
 
 void
-endian_write_double(void* ptr, double d, int write_le)
+endian_write_double(void* ptr, double value, int write_le)
 {
   char* optr = (char*) ptr;
 // Word order is different on arm, but not on arm-eabi.
 #if defined(__arm__) && !defined(__ARM_EABI__)
   char r[8];
-  memcpy(r + 4, &d, 4);
-  memcpy(r, ((void*)&d) + 4, 4);
+  memcpy(r + 4, &value, 4);
+  memcpy(r, ((void*)&value) + 4, 4);
 #else
-  char* r = (char*)(void*)&d;
+  char* r = (char*)(void*)&value;
 #endif
 
 
@@ -983,13 +981,13 @@ endian_write_double(void* ptr, double d, int write_le)
 }
 
 void
-endian_write_float(void* ptr, float f, int write_le)
+endian_write_float(void* ptr, float value, int write_le)
 {
-  char* r = (char*)(void*)&f;
+  char* r = (char*)(void*)&value;
   char* optr = (char*) ptr;
 
   if (i_am_little_endian == write_le) {
-    memcpy(ptr, &f, 4);
+    memcpy(ptr, &value, 4);
   } else {
     for (int i = 0; i < 4; i++) {
       *optr++ = r[3-i];
@@ -1004,9 +1002,9 @@ le_read_float(const void* ptr)
 }
 
 void
-le_write_float(void* ptr, float f)
+le_write_float(void* ptr, float value)
 {
-  endian_write_float(ptr,f,1);
+  endian_write_float(ptr, value, 1);
 }
 
 float
@@ -1016,33 +1014,33 @@ be_read_float(void* ptr)
 }
 
 void
-be_write_float(void* ptr, float f)
+be_write_float(void* ptr, float value)
 {
-  endian_write_float(ptr,f,0);
+  endian_write_float(ptr, value, 0);
 }
 
 double
 le_read_double(const void* ptr)
 {
-  return endian_read_double(ptr,1);
+  return endian_read_double(ptr, 1);
 }
 
 void
-le_write_double(void* ptr, double d)
+le_write_double(void* ptr, double value)
 {
-  endian_write_double(ptr,d,1);
+  endian_write_double(ptr, value, 1);
 }
 
 double
 be_read_double(void* ptr)
 {
-  return endian_read_double(ptr,0);
+  return endian_read_double(ptr, 0);
 }
 
 void
-be_write_double(void* ptr, double d)
+be_write_double(void* ptr, double value)
 {
-  endian_write_double(ptr,d,0);
+  endian_write_double(ptr, value, 0);
 }
 
 
@@ -1514,7 +1512,7 @@ strip_html(const utf_string* in)
 
     if (((tag[0] == '<') && (*instr == '>')) ||
         ((tag[0] == '&') && (*instr == ';'))) {
-      if (! strcmp(tag,"&amp;")) {
+      if (! strcmp(tag, "&amp;")) {
         *out++ = '&';
       } else if (! strcmp(tag, "&lt;")) {
         *out++ = '<';
@@ -1565,7 +1563,7 @@ typedef struct {
 static
 entity_types stdentities[] =  {
   { "&",	"&amp;", 0 },
-  { "'", 	"&apos;", 1 },
+  { "'",	"&apos;", 1 },
   { "<",	"&lt;", 0 },
   { ">",	"&gt;", 0 },
   { "\"",	"&quot;", 0 },


### PR DESCRIPTION
and align util routines with prototypes using readability-inconsistent-declaration-parameter-name.