### PR TITLE
support kml 2.3 track element.

### DIFF
--- a/kml.cc
+++ b/kml.cc
@@ -26,15 +26,23 @@
 
 #include "defs.h"
 #include "grtcirc.h"
+#include "queue.h"
+#include "src/core/datetime.h"
 #include "src/core/file.h"
 #include "src/core/xmlstreamwriter.h"
 #include "src/core/xmltag.h"
 #include "xmlgeneric.h"
-#include <QtCore/QRegExp>
-#include <QtCore/QXmlStreamAttributes>
+#include <QtCore/QXmlStreamAttributes> // for QXmlStreamAttributes
+#include <QtCore/QDateTime>            // for QDateTime
+#include <QtCore/QFile>                // for QFile
+#include <QtCore/QList>                // for QList
+#include <QtCore/QString>              // for QString, QStringLiteral, QStat...
+#include <QtCore/QtGlobal>             // for qint64, qPrintable
+#include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <tuple>
 
 // options
@@ -485,9 +493,9 @@ void gx_trk_e(xg_string, const QXmlStreamAttributes*)
     // It is not clear that coord elements without altitude are allowed, but our
     // writer produces them.
     if (n >= 2) {
-    trkpt->latitude = lat;
-    trkpt->longitude = lon;
-    if (n >= 3) {
+      trkpt->latitude = lat;
+      trkpt->longitude = lon;
+      if (n >= 3) {
         trkpt->altitude = alt;
       }
       track_add_wpt(gx_trk_head, trkpt);

--- a/reference/track/Placemark-Track-1.kml
+++ b/reference/track/Placemark-Track-1.kml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" version="2.3">
+	<Placemark id="PM005">
+		<Track>
+			<when>2010-05-28T02:02:09Z</when>
+			<when>2010-05-28T02:02:35Z</when>
+			<when>2010-05-28T02:02:44Z</when>
+			<when>2010-05-28T02:02:53Z</when>
+			<when>2010-05-28T02:02:54Z</when>
+			<when>2010-05-28T02:02:55Z</when>
+			<when>2010-05-28T02:02:56Z</when>
+			<coord>-122.207881 37.371915 156.000000</coord>
+			<coord>-122.205712 37.373288 152.000000</coord>
+			<coord>-122.204678 37.373939 147.000000</coord>
+			<coord>-122.203572 37.374630 142.199997</coord>
+			<coord>-122.203451 37.374706 141.800003</coord>
+			<coord>-122.203329 37.374780 141.199997</coord>
+			<coord>-122.203207 37.374857 140.199997</coord>
+		</Track>
+	</Placemark>
+</kml>

--- a/reference/track/Placemark-Track-1~kml.gpx
+++ b/reference/track/Placemark-Track-1~kml.gpx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="GPSBabel - http://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
+  <time>1970-01-01T00:00:00Z</time>
+  <bounds minlat="37.371915000" minlon="-122.207881000" maxlat="37.374857000" maxlon="-122.203207000"/>
+  <trk>
+    <trkseg>
+      <trkpt lat="37.371915000" lon="-122.207881000">
+        <ele>156.000</ele>
+        <time>2010-05-28T02:02:09Z</time>
+      </trkpt>
+      <trkpt lat="37.373288000" lon="-122.205712000">
+        <ele>152.000</ele>
+        <time>2010-05-28T02:02:35Z</time>
+      </trkpt>
+      <trkpt lat="37.373939000" lon="-122.204678000">
+        <ele>147.000</ele>
+        <time>2010-05-28T02:02:44Z</time>
+      </trkpt>
+      <trkpt lat="37.374630000" lon="-122.203572000">
+        <ele>142.200</ele>
+        <time>2010-05-28T02:02:53Z</time>
+      </trkpt>
+      <trkpt lat="37.374706000" lon="-122.203451000">
+        <ele>141.800</ele>
+        <time>2010-05-28T02:02:54Z</time>
+      </trkpt>
+      <trkpt lat="37.374780000" lon="-122.203329000">
+        <ele>141.200</ele>
+        <time>2010-05-28T02:02:55Z</time>
+      </trkpt>
+      <trkpt lat="37.374857000" lon="-122.203207000">
+        <ele>140.200</ele>
+        <time>2010-05-28T02:02:56Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/testo.d/kml.test
+++ b/testo.d/kml.test
@@ -61,6 +61,10 @@ compare ${REFERENCE}/bounds-test.kml ${TMPDIR}/bnds_so.kml
 gpsbabel -i gpx -f ${REFERENCE}/track/tracks.gpx -o kml,track=1,trackdirection=1,units='m' -F ${TMPDIR}/tracks~gpx.kml
 compare ${REFERENCE}/track/tracks~gpx.kml ${TMPDIR}/tracks~gpx.kml
 
+# kml 2.3
+gpsbabel -i kml -f ${REFERENCE}/track/Placemark-Track-1.kml -o gpx -F ${TMPDIR}/Placemark-Track-1~kml.gpx
+compare ${REFERENCE}/track/Placemark-Track-1~kml.gpx ${TMPDIR}/Placemark-Track-1~kml.gpx
+
 set -e
 if which xmllint > /dev/null;
 then


### PR DESCRIPTION
Also relax ordering requirement for gx:Track kml:when and
gx:coord children.  This allows gx:Track elements that violate
the schema as far as the sequencing of coord and when
children to be processed.  Note that the number of coord and when
elements still must be equal.