### PR TITLE
update travis for xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,37 @@ matrix:
       sudo: required
       services: docker
       compiler: gcc
+      env:
+        - BUILD_TYPE="docker"
     - os: linux
       dist: trusty
       sudo: required
       services: docker
       compiler: clang
+      env:
+        - BUILD_TYPE="docker"
+    - os: linux
+      dist: xenial
+      sudo: required
+      compiler: gcc
+      env:
+        - BUILD_TYPE="local"
+      addons:
+        apt:
+          packages:
+            - expat
+            - fop
+            - valgrind
+            - xsltproc
+            - libxml2-utils
+            - libusb-dev
+            - docbook-xml
+            - docbook-xsl
+            - libgl1-mesa-dev
+      cache:
+        directories:
+          - $HOME/Qt
+        timeout: 600
     - os: osx
       compiler: clang
       cache:
@@ -19,11 +45,11 @@ matrix:
           - $HOME/Qt
         timeout: 600
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       compiler: gcc
       env:
-        - GEN_COVERAGE="true"
+        - BUILD_TYPE="coverage"
       addons:
         apt:
           packages:
@@ -34,12 +60,14 @@ matrix:
           - $HOME/Qt
 
 install:
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "coverage" ]; then ./tools/travis_install_linux_coverage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "local" ]; then source ./tools/travis_install_linux_local; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then source ./tools/travis_install_osx; fi
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${GEN_COVERAGE}" = "true" ]; then ./tools/travis_install_linux_coverage; fi 
 
 script:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${GEN_COVERAGE}" != "true" ]; then ./tools/travis_script_linux_docker; fi 
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${GEN_COVERAGE}" = "true" ]; then ./tools/travis_script_linux_coverage; fi 
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "coverage" ]; then ./tools/travis_script_linux_coverage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "docker" ]; then ./tools/travis_script_linux_docker; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "local" ]; then echo $PATH; ./build_and_test; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./tools/travis_script_osx; fi
 
 after_success:

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -262,7 +262,7 @@ linux{
   coverage.commands += ln -sf GPSBabel gpsbabel;
   coverage.commands += $(MAKE) CFLAGS=\"$(CFLAGS) -fprofile-arcs -ftest-coverage\" CXXFLAGS=\"$(CXXFLAGS) -fprofile-arcs -ftest-coverage\" LFLAGS=\"$(LFLAGS) --coverage\" &&
   coverage.commands += ./testo &&
-  coverage.commands += gcov -r $(SOURCES) &&
+  coverage.commands += gcov -r -o . $(SOURCES) &&
   coverage.commands += gcovr -r . --xml --exclude='zlib/*' --exclude='shapelib/*' -o gpsbabel_coverage.xml;
   QMAKE_EXTRA_TARGETS += coverage
 }

--- a/tools/travis_install_linux_local
+++ b/tools/travis_install_linux_local
@@ -1,0 +1,30 @@
+#!/bin/bash -ex
+#
+# This script is run on travis for the install stage of mac builds.
+# Note the script must be sourced if you want the modified PATH to
+# be used outside this script.
+#
+
+# our expectation is that install-qt creates $QTDIR, $QTDIR/bin.
+QTDIR=${HOME}/Qt/5.9.7/gcc_64
+
+if [ -d "${QTDIR}/bin" ]; then
+  echo "Using cached Qt."
+  echo "If you need to clear the cache see"
+  echo "https://docs.travis-ci.com/user/caching/#Fetching-and-storing-caches."
+else
+  pushd ${HOME};
+  rm -fr Qt
+  # install_qt creates the install at $PWD/Qt.
+  QT_CI_PACKAGES=qt.qt5.597.gcc_64,qt.qt5.597.qtwebengine PATH=${TRAVIS_BUILD_DIR}/tools/qtci:${PATH} install-qt 5.9.7
+  popd;
+fi
+# note that qt-5.9.7.env created by install-qt is not cached!
+export PATH=${QTDIR}/bin:${PATH}
+unset -v QTDIR
+
+# prepare locale for test_encoding_latin1, requires locales package.
+sudo rm -rf /var/lib/apt/lists/* \
+  && sudo sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+  && sudo locale-gen \
+  && locale -a

--- a/tools/travis_script_linux_coverage
+++ b/tools/travis_script_linux_coverage
@@ -20,9 +20,8 @@ make coverage
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 if [ -v CODACY_PROJECT_TOKEN ] ; then
   # upload coverate report to codacy.
-  wget -nv -c https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/4.0.1/codacy-coverage-reporter-4.0.1-assembly.jar
-  java -jar codacy-coverage-reporter-4.0.1-assembly.jar report -l cpp -f -r gpsbabel_coverage.xml
+  wget -nv -c https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/4.0.3/codacy-coverage-reporter-4.0.3-assembly.jar
+  java -jar codacy-coverage-reporter-4.0.3-assembly.jar report -l cpp -f -r gpsbabel_coverage.xml
 else
   echo "Skipping codacy coverage upload as CODACY_PROJECT_TOKEN is not set."
 fi
-


### PR DESCRIPTION
add a travis build on xenial.
move coverage generation on travis from trusty to xenial.

update codacy-coverage-reporter for newer java virtual machines.
fix gcov issues with "cannot open notes file" 

note that travis docker builds are still done from trusty.