### PR TITLE
Incorporate improvements found by Qt oriented code checker clazy

### DIFF
--- a/bcr.cc
+++ b/bcr.cc
@@ -447,9 +447,9 @@ bcr_route_header(const route_head* route)
     }
 
     if (sout.isEmpty()) {
-      sout = QString("%1,%2,@,0").arg(s1).arg(s1);
+      sout = QString("%1,%2,@,0").arg(s1, s1);
     } else {
-      sout = QString("%1,%2,@,0").arg(s1).arg(s2);
+      sout = QString("%1,%2,@,0").arg(s1, s2);
     }
 
     bcr_write_line(fout, "STATION", &i, sout);

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -1593,7 +1593,7 @@ xcsv_waypt_pr(const Waypoint* wpt)
   }
 
   int i = 0;
-  for (const auto& fmp : xcsv_file.ofields) {
+  for (const auto& fmp : qAsConst(xcsv_file.ofields)) {
     double lat = latitude;
     double lon = longitude;
     /*
@@ -2183,7 +2183,7 @@ xcsv_data_write(void)
   waypt_out_count = 0;
 
   /* output prologue lines, if any. */
-  for (const auto& line : xcsv_file.prologue) {
+  for (const auto& line : qAsConst(xcsv_file.prologue)) {
    QString line_to_write = xcsv_replace_tokens(line);
     *xcsv_file.stream << line_to_write <<  xcsv_file.record_delimiter;
   }
@@ -2199,7 +2199,7 @@ xcsv_data_write(void)
   }
 
   /* output epilogue lines, if any. */
-  for (const auto& line : xcsv_file.epilogue) {
+  for (const auto& line : qAsConst(xcsv_file.epilogue)) {
     QString line_to_write = xcsv_replace_tokens(line);
     *xcsv_file.stream << line_to_write << xcsv_file.record_delimiter;
   }

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -894,7 +894,6 @@ writetime(const char* format, time_t t, bool gmt)
 
   char tbuff[1024];
   strftime(tbuff, sizeof tbuff, format, stmp);
-  QDateTime dt = QDateTime::fromTime_t(t);
   return QString(tbuff);
 }
 

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -24,7 +24,7 @@
 #include <QtCore/QDateTime>        // for QDateTime, QDate
 #include <QtCore/QString>          // for QString, QCharRef
 #include <QtCore/QTextStream>      // for QTextStream
-#include <QtCore/QtGlobal>         // for foreach
+#include <QtCore/QtGlobal>         // for qAsConst
 
 #include "csv_util.h"
 #include "defs.h"
@@ -1421,7 +1421,7 @@ xcsv_data_read(void)
      * pre-read the file to know how many data lines we should be seeing,
      * we take this cheap shot at the data and cross our fingers.
      */
-    foreach(const QString& ogp, xcsv_file.epilogue) {
+    for(const auto& ogp : qAsConst(xcsv_file.epilogue)) {
        if (ogp.startsWith(buff)) {
          buff.clear();
          break;

--- a/defs.h
+++ b/defs.h
@@ -1062,7 +1062,7 @@ case_ignore_strcmp(const QString& s1, const QString& s2)
 // In 95% of the callers, this could be s1.startsWith(s2)...
 inline int case_ignore_strncmp(const QString& s1, const QString& s2, int n)
 {
-  return s1.left(n).compare(s2.left(n), Qt::CaseInsensitive);
+  return s1.leftRef(n).compare(s2.left(n), Qt::CaseInsensitive);
 }
 
 int str_match(const char* str, const char* match);

--- a/garmin_tables.cc
+++ b/garmin_tables.cc
@@ -798,7 +798,7 @@ int gt_find_icon_number_from_desc(const QString& desc, garmin_formats_e garmin_f
       base = 7680;
     }
     if (base) {
-      n = desc.mid(7).toInt();
+      n = desc.midRef(7).toInt();
       return n + base;
     }
   }

--- a/gdb.cc
+++ b/gdb.cc
@@ -603,7 +603,7 @@ read_waypoint(gt_waypt_classes_e* waypt_class_out)
       FREAD(buf, 2);
     }
 
-    QString junk = FREAD_CSTR_AS_QSTR;				/* undocumented & unused string */
+    (void) FREAD_CSTR_AS_QSTR;				/* undocumented & unused string */
 #if GDB_DEBUG
     DBG(GDB_DBG_WPTe, temp)
     printf(MYNAME "-wpt \"%s\" (%d): Unknown string = %s\n",

--- a/ggv_bin.cc
+++ b/ggv_bin.cc
@@ -397,7 +397,6 @@ static void
 ggv_bin_read_v34(QDataStream& stream)
 {
   QByteArray buf;
-  QString track_name;
   quint32 label_count;
   quint32 record_count;
 

--- a/gpssim.cc
+++ b/gpssim.cc
@@ -146,7 +146,7 @@ gpssim_trk_hdr(const route_head* rh)
       fatal(MYNAME ": output file already open.\n");
     }
 
-    QString ofname = QString("%1%2%3.gpssim").arg(fnamestr).arg(doing_tracks ? "-track" : "-route").arg(trk_count++, 4, 10, QChar('0'));
+    QString ofname = QString("%1%2%3.gpssim").arg(fnamestr, doing_tracks ? "-track" : "-route").arg(trk_count++, 4, 10, QChar('0'));
     fout = gbfopen(ofname, "wb", MYNAME);
   }
   (void) track_recompute(rh);

--- a/gpx.cc
+++ b/gpx.cc
@@ -20,20 +20,28 @@
  */
 
 #include "defs.h"
-#include "cet_util.h"
 #include "garmin_fs.h"
 #include "garmin_tables.h"
+#include "src/core/datetime.h"
 #include "src/core/file.h"
 #include "src/core/logging.h"
 #include "src/core/xmlstreamwriter.h"
 #include "src/core/xmltag.h"
 
-#include <QtCore/QDateTime>
-#include <QtCore/QDebug>
-#include <QtCore/QRegExp>
-#include <QtCore/QXmlStreamReader>
+#include <QtCore/QDateTime>            // for QDateTime, QDate, QTime
+#include <QtCore/QHash>                // for QHash
+#include <QtCore/QList>                // for QList
+#include <QtCore/QString>              // for QString, QStringLiteral, QStringRef, QStaticStringData, QLatin1String, operator+
+#include <QtCore/QStringList>          // for QStringList
+#include <QtCore/QXmlStreamAttributes> // for QXmlStreamAttributes
+#include <QtCore/QXmlStreamNamespaceDeclarations> // for QXmlStreamNamespaceDeclarations
+#include <QtCore/QXmlStreamReader>     // for QXmlStreamReader, QXmlStreamReader::TokenType::Characters, QXmlStreamReader::TokenType::EndDocument, QXmlStreamReader::TokenType::EndElement, QXmlStreamReader::TokenType::Invalid, QXmlStreamReader::TokenType::StartElement
+#include <QtCore/QtGlobal>             // for qAsConst
 
-#include <cmath>
+#include <cmath>                       // for lround
+#include <cstdio>                      // for sscanf
+#include <cstdlib>                     // for atoi, strtod
+#include <cstring>                     // for strchr
 
 
 static QXmlStreamReader* reader;
@@ -1302,7 +1310,7 @@ gpx_wr_init(const QString& fname)
   } else {
     if (gpx_global) {
       // TODO: gpx 1.1 copyright goes here
-      for (const auto& l : gpx_global->link) {
+      for (const auto& l : qAsConst(gpx_global->link)) {
         writer->writeStartElement(QStringLiteral("link"));
         writer->writeAttribute(QStringLiteral("href"), l.url_);
         writer->writeOptionalTextElement(QStringLiteral("text"), l.url_link_text_);

--- a/kml.cc
+++ b/kml.cc
@@ -792,33 +792,33 @@ void kml_output_trkdescription(const route_head* header, const computed_trkdata*
   }
   const char* distance_units;
   double distance = fmt_distance(td->distance_meters, &distance_units);
-  kml_td(hwriter, QStringLiteral("Distance"), QStringLiteral(" %1 %2 ").arg(QString::number(distance, 'f', 1)).arg(distance_units));
+  kml_td(hwriter, QStringLiteral("Distance"), QStringLiteral(" %1 %2 ").arg(QString::number(distance, 'f', 1), distance_units));
   if (td->min_alt) {
     const char* min_alt_units;
     double min_alt = fmt_altitude(*td->min_alt, &min_alt_units);
-    kml_td(hwriter, QStringLiteral("Min Alt"), QStringLiteral(" %1 %2 ").arg(QString::number(min_alt, 'f', 3)).arg(min_alt_units));
+    kml_td(hwriter, QStringLiteral("Min Alt"), QStringLiteral(" %1 %2 ").arg(QString::number(min_alt, 'f', 3), min_alt_units));
   }
   if (td->max_alt) {
     const char* max_alt_units;
     double max_alt = fmt_altitude(*td->max_alt, &max_alt_units);
-    kml_td(hwriter, QStringLiteral("Max Alt"), QStringLiteral(" %1 %2 ").arg(QString::number(max_alt, 'f', 3)).arg(max_alt_units));
+    kml_td(hwriter, QStringLiteral("Max Alt"), QStringLiteral(" %1 %2 ").arg(QString::number(max_alt, 'f', 3), max_alt_units));
   }
   if (td->min_spd) {
     const char* spd_units;
     double spd = fmt_speed(*td->min_spd, &spd_units);
-    kml_td(hwriter, QStringLiteral("Min Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1)).arg(spd_units));
+    kml_td(hwriter, QStringLiteral("Min Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
   }
   if (td->max_spd) {
     const char* spd_units;
     double spd = fmt_speed(*td->max_spd, &spd_units);
-    kml_td(hwriter, QStringLiteral("Max Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1)).arg(spd_units));
+    kml_td(hwriter, QStringLiteral("Max Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
   }
   if (td->max_spd && td->start.isValid() && td->end.isValid()) {
     const char* spd_units;
     double elapsed = td->start.msecsTo(td->end)/1000.0;
     double spd = fmt_speed(td->distance_meters / elapsed, &spd_units);
     if (spd > 1.0)  {
-      kml_td(hwriter, QStringLiteral("Avg Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1)).arg(spd_units));
+      kml_td(hwriter, QStringLiteral("Avg Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
     }
   }
   if (td->avg_hrt) {
@@ -957,7 +957,7 @@ static void kml_output_description(const Waypoint* pt)
   kml_td(hwriter, QStringLiteral("Latitude: %1 ").arg(QString::number(pt->latitude, 'f', precision)));
 
   if (kml_altitude_known(pt)) {
-    kml_td(hwriter, QStringLiteral("Altitude: %1 %2 ").arg(QString::number(alt, 'f', 3)).arg(alt_units));
+    kml_td(hwriter, QStringLiteral("Altitude: %1 %2 ").arg(QString::number(alt, 'f', 3), alt_units));
   }
 
   if (pt->heartrate) {
@@ -976,13 +976,13 @@ static void kml_output_description(const Waypoint* pt)
   if WAYPT_HAS(pt, depth) {
     const char* depth_units;
     double depth = fmt_distance(pt->depth, &depth_units);
-    kml_td(hwriter, QStringLiteral("Depth: %1 %2 ").arg(QString::number(depth, 'f', 1)).arg(depth_units));
+    kml_td(hwriter, QStringLiteral("Depth: %1 %2 ").arg(QString::number(depth, 'f', 1), depth_units));
   }
 
   if WAYPT_HAS(pt, speed) {
     const char* spd_units;
     double spd = fmt_speed(pt->speed, &spd_units);
-    kml_td(hwriter, QStringLiteral("Speed: %1 %2 ").arg(QString::number(spd, 'f', 1)).arg(spd_units));
+    kml_td(hwriter, QStringLiteral("Speed: %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
   }
 
   if WAYPT_HAS(pt, course) {

--- a/maggeo.cc
+++ b/maggeo.cc
@@ -192,9 +192,9 @@ maggeo_fmtdate(const QDateTime& dt)
 static QDateTime maggeo_parsedate(char* dmy)
 {
   QString date(dmy);
-  int d = date.mid(0,2).toInt();
-  int m = date.mid(2,2).toInt();
-  int y = date.mid(4,3).toInt();
+  int d = date.midRef(0,2).toInt();
+  int m = date.midRef(2,2).toInt();
+  int y = date.midRef(4,3).toInt();
   QDateTime r(QDate(y + 1900, m, d));
   return r;
 }

--- a/main.cc
+++ b/main.cc
@@ -598,7 +598,7 @@ main(int argc, char* argv[])
   }
   if (qargs.size() > 2) {
     fatal("Extra arguments on command line\n");
-  } else if (qargs.size() && ivecs) {
+  } else if ((!qargs.isEmpty()) && ivecs) {
     did_something = 1;
     /* simulates the default behaviour of waypoints */
     if (doing_nothing) {
@@ -632,7 +632,7 @@ main(int argc, char* argv[])
 
       cet_convert_deinit();
     }
-  } else if (qargs.size()) {
+  } else if (!qargs.isEmpty()) {
     usage(prog_name,0);
     exit(0);
   }

--- a/mmo.cc
+++ b/mmo.cc
@@ -22,6 +22,7 @@
 
 #include "defs.h"
 #include <QtCore/QHash>
+#include <QtCore/QtGlobal>
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
@@ -259,9 +260,9 @@ mmo_register_object(const int objid, const void* ptr, const gpsdata_type type)
 static int
 mmo_get_objid(const void* ptr)
 {
-  foreach(int key, objects.keys()) {
-    if (objects.value(key)->data == ptr) {
-      return key;
+  for (auto o = objects.constBegin(); o != objects.constEnd(); ++o) {
+    if (o.value()->data == ptr) {
+      return o.key();
     }
   }
   return 0;
@@ -305,7 +306,7 @@ mmo_free_object(mmo_data_t* data)
     xfree(data->name);
   }
   if ((data->type == wptdata) && (data->refct == 0)) {
-    delete(Waypoint*)data->data;
+    delete (Waypoint*)data->data;
   }
   xfree(data);
 }
@@ -973,8 +974,8 @@ mmo_rd_deinit()
 
   icons.clear();
 
-  foreach(int k, objects.keys()) {
-    mmo_free_object(objects.value(k));
+  for (auto value : qAsConst(objects)) {
+    mmo_free_object(value);
   }
   objects.clear();
 
@@ -1279,7 +1280,7 @@ mmo_write_rte_head_cb(const route_head* rte)
   mmo_rte = rte;
 
   QUEUE_FOR_EACH(&rte->waypoint_list, elem, tmp) {
-    Waypoint* wpt = reinterpret_cast<Waypoint *>(elem);
+    Waypoint* wpt = reinterpret_cast<Waypoint*>(elem);
     QDateTime t = wpt->GetCreationTime();
     if ((t.isValid()) && (t.toTime_t() < time)) {
       time = t.toTime_t();
@@ -1323,7 +1324,7 @@ mmo_write_rte_tail_cb(const route_head* rte)
   }
 
   QUEUE_FOR_EACH(&rte->waypoint_list, elem, tmp) {
-    Waypoint* wpt = reinterpret_cast<Waypoint *>(elem);
+    Waypoint* wpt = reinterpret_cast<Waypoint*>(elem);
     int objid = mmo_get_objid(wpt);
     gbfputuint16(objid & 0x7FFF, fout);
   }
@@ -1409,8 +1410,8 @@ mmo_wr_deinit()
   mmobjects.clear();
   category_names.clear();
 
-  foreach(int k, objects.keys()) {
-    mmo_free_object(objects.value(k));
+  for (auto value : qAsConst(objects)) {
+    mmo_free_object(value);
   }
   objects.clear();
 

--- a/osm.cc
+++ b/osm.cc
@@ -449,7 +449,7 @@ osm_feature_symbol(const int ikey, const char* value)
   if (values.contains(key)) {
     result = values.value(key)->icon;
   } else {
-    result = QString("%1:%2").arg(osm_features[ikey]).arg(value);
+    result = QString("%1:%2").arg(osm_features[ikey], value);
   }
   return result;
 }

--- a/ozi.cc
+++ b/ozi.cc
@@ -216,7 +216,7 @@ ozi_openfile(const QString& fname)
     sname.chop(suffix_len + 1);
   }
 
-  QString tmpname = QString("%1%2.%3").arg(sname).arg(buff).arg(ozi_extensions[ozi_objective]);
+  QString tmpname = QString("%1%2.%3").arg(sname, buff, ozi_extensions[ozi_objective]);
 
   /* re-open file_out with the new filename */
   if (file_out) {

--- a/pcx.cc
+++ b/pcx.cc
@@ -168,8 +168,8 @@ static void data_read() {
           wpt_tmp->longitude = lon;
           wpt_tmp->latitude = lat;
         } else {
-          lat = tbuf.mid(1, -1).toDouble();
-          lon = nbuf.mid(1, -1).toDouble();
+          lat = tbuf.midRef(1, -1).toDouble();
+          lon = nbuf.midRef(1, -1).toDouble();
           if (tbuf[0] == 'S') {
             lat = -lat;
           }
@@ -241,8 +241,8 @@ static void data_read() {
           wpt_tmp->longitude = lon;
           wpt_tmp->latitude = lat;
         } else {
-          lat = tbuf.mid(1, -1).toDouble();
-          lon = nbuf.mid(1, -1).toDouble();
+          lat = tbuf.midRef(1, -1).toDouble();
+          lon = nbuf.midRef(1, -1).toDouble();
           if (tbuf[0] == 'S') {
             lat = -lat;
           }

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -245,7 +245,6 @@ tef_item_start(xg_string, const QXmlStreamAttributes* attrv)
 
   foreach(QXmlStreamAttribute attr, *attrv) {
     QString attrstr = attr.value().toString();
-    QByteArray attrtext = attrstr.toUtf8();
 
     if (attr.name().compare(QLatin1String("SegDescription"), Qt::CaseInsensitive) == 0) {
       wpt_tmp->shortname = attrstr.trimmed();

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -263,10 +263,10 @@ void TrackFilter::trackfilter_split_init_rte_name(route_head* track, const QDate
       strftime(buff, sizeof(buff), opt_title, &tm);
       track->rte_name = buff;
     } else {
-      track->rte_name = QString("%1-%2").arg(opt_title).arg(datetimestring);
+      track->rte_name = QString("%1-%2").arg(opt_title, datetimestring);
     }
   } else if (!track->rte_name.isEmpty()) {
-    track->rte_name = QString("%1-%2").arg(track->rte_name).arg(datetimestring);
+    track->rte_name = QString("%1-%2").arg(track->rte_name, datetimestring);
   } else {
     track->rte_name = datetimestring;
   }


### PR DESCRIPTION
https://github.com/KDE/clazy tag v1.4 was used to build clazy.

Fixes are manual except for clazy-qstring-ref.

When a for loop was flagged, I followed the recommendations on
http://doc.qt.io/qt-5/qtglobal.html#Q_FOREACH
regarding qforeach vs. c++11 range-for.
I note that these recommendations seem to be a bit different than those on
http://doc.qt.io/qt-5/containers.html#the-foreach-keyword