### PR TITLE
Remove leftover code from 'adding class' change

### DIFF
--- a/xcsv.cc
+++ b/xcsv.cc
@@ -142,10 +142,6 @@ xcsv_destroy_style(void)
   if (xcsv_file.mkshort_handle) {
     mkshort_del_handle(&xcsv_file.mkshort_handle);
   }
-
-  /* return everything to zeros */
-  int internal = xcsv_file.is_internal;
-  xcsv_file.is_internal = internal;
 }
 
 // Given a keyword of "COMMASPACE", return ", ".


### PR DESCRIPTION
As tsteven4 points out, No reason to move is_internal to local and back