### PR TITLE
Start new track segments on timer events (start/stop/...)

### DIFF
--- a/reference/track/garmin-edge-800-output.gpx
+++ b/reference/track/garmin-edge-800-output.gpx
@@ -244,6 +244,8 @@
         <time>2012-04-12T12:56:05Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="48.187666381" lon="11.854188457">
         <ele>517.200</ele>
         <time>2012-04-12T12:56:31Z</time>
@@ -2434,6 +2436,8 @@
         <time>2012-04-12T13:15:45Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="48.186057223" lon="11.822205210">
         <ele>542.000</ele>
         <time>2012-04-12T13:15:48Z</time>
@@ -2499,6 +2503,8 @@
         <time>2012-04-12T13:16:51Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="48.186576817" lon="11.821112377">
         <ele>544.000</ele>
         <time>2012-04-12T13:17:16Z</time>
@@ -3479,6 +3485,8 @@
         <time>2012-04-12T13:26:29Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="48.174140671" lon="11.811101954">
         <ele>526.400</ele>
         <time>2012-04-12T13:26:45Z</time>
@@ -3499,6 +3507,8 @@
         <time>2012-04-12T13:26:57Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="48.173926598" lon="11.811192227">
         <ele>526.400</ele>
         <time>2012-04-12T13:27:38Z</time>
@@ -3659,6 +3669,8 @@
         <time>2012-04-12T13:29:06Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="48.171076583" lon="11.816465199">
         <ele>528.400</ele>
         <time>2012-04-12T13:29:17Z</time>
@@ -3674,6 +3686,8 @@
         <time>2012-04-12T13:29:21Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="48.171064345" lon="11.816544240">
         <ele>528.400</ele>
         <time>2012-04-12T13:29:26Z</time>

--- a/reference/track/garmin-forerunner-10-output.gpx
+++ b/reference/track/garmin-forerunner-10-output.gpx
@@ -67,6 +67,8 @@
         <time>2013-06-13T03:56:36Z</time>
         <speed>0.376000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="52.403139059" lon="13.419341572">
         <time>2013-06-13T03:56:40Z</time>
         <speed>1.953000</speed>
@@ -571,6 +573,8 @@
         <time>2013-06-13T04:03:00Z</time>
         <speed>0.091000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="52.414478684" lon="13.401474540">
         <time>2013-06-13T04:03:20Z</time>
         <speed>3.568000</speed>
@@ -591,6 +595,8 @@
         <time>2013-06-13T04:03:34Z</time>
         <speed>0.123000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="52.414743552" lon="13.401259963">
         <time>2013-06-13T04:04:05Z</time>
         <speed>2.382000</speed>
@@ -711,6 +717,8 @@
         <time>2013-06-13T04:05:38Z</time>
         <speed>0.164000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="52.412753772" lon="13.392770772">
         <time>2013-06-13T04:06:06Z</time>
         <speed>3.186000</speed>
@@ -859,6 +867,8 @@
         <time>2013-06-13T04:07:52Z</time>
         <speed>0.177000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="52.411193397" lon="13.382592794">
         <time>2013-06-13T04:09:23Z</time>
         <speed>2.474000</speed>
@@ -1143,6 +1153,8 @@
         <time>2013-06-13T04:13:00Z</time>
         <speed>0.079000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="52.412378598" lon="13.362509922">
         <time>2013-06-13T04:13:22Z</time>
         <speed>3.287000</speed>

--- a/reference/track/wahoo-element-bolt.gpx
+++ b/reference/track/wahoo-element-bolt.gpx
@@ -1578,6 +1578,8 @@
         <time>2018-03-20T07:13:58Z</time>
         <speed>1.151000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="51.705748370" lon="8.721013353">
         <ele>116.400</ele>
         <time>2018-03-20T07:14:11Z</time>
@@ -1608,6 +1610,8 @@
         <time>2018-03-20T07:14:16Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="51.705778126" lon="8.721019555">
         <ele>117.000</ele>
         <time>2018-03-20T07:14:19Z</time>
@@ -5483,6 +5487,8 @@
         <time>2018-03-20T07:27:13Z</time>
         <speed>0.000000</speed>
       </trkpt>
+    </trkseg>
+    <trkseg>
       <trkpt lat="51.704860056" lon="8.755921632">
         <ele>168.200</ele>
         <time>2018-03-20T07:27:26Z</time>


### PR DESCRIPTION
Insert track segment separators when encountering a timer start event in a
FIT file (usually caused by manually pushing the start button). This way,
pauses in a FIT file don't appear as continuous tracks.

Also adapt reference tracks by adding suitable <trkseg> tags to please "make
check"/testo.