### PR TITLE
remove obsolete msvc workarounds.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -112,15 +112,6 @@
 #  define strdup _strdup
 #endif
 
-/* Workaround for lack of va_copy in Visual Studio 2012 and earlier */
-#if __WIN32__
-#  if _MSC_VER
-#    if _MSC_VER < 1700
-#      define va_copy(dest, src) ((dest) = (src))
-#    endif
-#  endif
-#endif
-
 /* Turn off numeric conversion warning */
 #if __WIN32__
 #  if _MSC_VER
@@ -1125,14 +1116,6 @@ QString rot13(const QString& s);
  */
 
 signed int si_round(double d);
-
-#if _MSC_VER
-//These functions are not included in the MS pre C99 implementation, use internal implementation
-//This asssumes that non-_MSC_VER includes math.h (all should include defs.h)
-#define round si_round
-#define lround si_round
-#endif
-
 
 /*
  * Protypes for Endianness helpers.

--- a/v900.cc
+++ b/v900.cc
@@ -76,10 +76,6 @@ for a little more info, see structures:
 #include <cstdio>
 #include <cstdlib> // atoi
 
-#if _MSC_VER
-#define __func__ __FUNCTION__
-#endif
-
 /* the start of each record (line) is common to both advanced and basic mode.
    it will be parsed by a single common code. hence, it will be easier and clearer
    to have a common structure for it.


### PR DESCRIPTION
msvc 2012 and earlier are not supported.
They didn't support c++14 anyway which we currently require.