### PR TITLE
fix up style file OFIELD option processing.

### DIFF
--- a/xcsv.cc
+++ b/xcsv.cc
@@ -333,8 +333,10 @@ xcsv_parse_style_line(QString line)
 
     // This is pretty lazy way to parse write options.
     // They've very rarely used, so we'll go for simple.
-    if (tokens.size() > 4) {
-      QString options_string = tokens[3].simplified();
+    // We may have split the optional fourth and final field which can contain
+    // option[s], so look at all the remaining tokens.
+    for (int token_idx = 3; token_idx < tokens.size(); ++token_idx) {
+      QString options_string = tokens[token_idx].simplified();
       if (options_string.contains("no_delim_before")) {
         options |= OPTIONS_NODELIM;
       }


### PR DESCRIPTION
The fourth field of a OFIELD line in the style file, which represent options, may or may not be split into multiple tokens.
Note that there were two issues here:
1) we only looked for options when we had 5 or more tokens, not 4.
2) we only looked at the fourth token.
