### PR TITLE
update appveyor for Qt 5.12.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,10 +37,10 @@ build_script:
       echo "qt: $env:qt"
       qmake -query
       Get-Location
-      if (($env:arch -eq "x86") -and ($env:qt -eq "5.9\msvc2015"))
+      if ($env:flow -eq "nmake") -and ($env:arch -eq "x86") -and ($env:qt -eq "5.12\msvc2017"))
       {
         # full build and deploy of our release configuration
-        & ".\tools\make_windows_release.ps1" -gpsbabel_build_dir_name "build-GPSBabel-Desktop_Qt_5_9_MSVC2015_32bit-Release" -gui_build_dir_name "build-app-Desktop_Qt_5_9_MSVC2015_32bit-Release" -flow $env:flow -buildinstaller "true"
+        & ".\tools\make_windows_release.ps1" -flow $env:flow -buildinstaller "true"
         $verid=(Get-Date -UFormat "%Y%m%dT%H%MZ" -Date (Get-Date -Date (git show -s --format="%aI" HEAD)).toUniversalTime()) `
                + '-' + (git rev-parse --short=7 HEAD)
         Get-ChildItem .\gui\release\GPSBabel-*-Setup.exe | % { Push-AppveyorArtifact $_.FullName -FileName "GPSBabel-$($verid)-Setup.exe" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: 1.0.{build}
 
+# msvc arch decode is host_target
+
 environment:
   matrix:
   - arch: x86
@@ -10,13 +12,17 @@ environment:
     qt: 5.9\msvc2015_64
     flow: nmake
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  - arch: x86_amd64
-    qt: 5.9\msvc2017_64
+  - arch: x86
+    qt: 5.12\msvc2017
     flow: nmake
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  - arch: x86_amd64
-    qt: 5.9\msvc2017_64
+  - arch: x86
+    qt: 5.12\msvc2017
     flow: msbuild
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - arch: x86_amd64
+    qt: 5.12\msvc2017_64
+    flow: nmake
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 init:
@@ -65,7 +71,7 @@ deploy_script:
   - ps: |
       $env:projdir=(C:\msys64\usr\bin\bash.exe -c "pwd")
       C:\msys64\usr\bin\bash.exe -lc "cd $env:projdir; ./tools/ci_tokens"
-      if (($env:arch -eq "x86") -and ($env:qt -eq "5.9\msvc2015") -and ($env:APPVEYOR_REPO_BRANCH -eq "master"))
+      if (($env:flow -eq "nmake") -and ($env:arch -eq "x86") -and ($env:qt -eq "5.12\msvc2017") -and ($env:APPVEYOR_REPO_BRANCH -eq "master"))
       {
         $verid=(Get-Date -UFormat "%Y%m%dT%H%MZ" -Date (Get-Date -Date (git show -s --format="%aI" HEAD)).toUniversalTime()) `
                + '-' + (git rev-parse --short=7 HEAD)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,6 @@ version: 1.0.{build}
 environment:
   matrix:
   - arch: x86
-    qt: 5.9\msvc2015
-    flow: nmake
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  - arch: amd64
-    qt: 5.9\msvc2015_64
-    flow: nmake
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  - arch: x86
     qt: 5.12\msvc2017
     flow: nmake
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -24,6 +16,14 @@ environment:
     qt: 5.12\msvc2017_64
     flow: nmake
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - arch: x86
+    qt: 5.9\msvc2015
+    flow: nmake
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #- arch: amd64
+  #  qt: 5.9\msvc2015_64
+  #  flow: nmake
+  #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 init:
   - set PATH=C:\Qt\%qt%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ build_script:
       echo "qt: $env:qt"
       qmake -query
       Get-Location
-      if ($env:flow -eq "nmake") -and ($env:arch -eq "x86") -and ($env:qt -eq "5.12\msvc2017"))
+      if (($env:flow -eq "nmake") -and ($env:arch -eq "x86") -and ($env:qt -eq "5.12\msvc2017"))
       {
         # full build and deploy of our release configuration
         & ".\tools\make_windows_release.ps1" -flow $env:flow -buildinstaller "true"

--- a/tools/make_windows_release.ps1
+++ b/tools/make_windows_release.ps1
@@ -31,7 +31,12 @@ New-Item "$($gpsbabel_build_dir)" -type directory -force | Out-Null
 Set-Location "$($gpsbabel_build_dir)"
 switch ($flow) {
   "mingw"   { qmake "$($gpsbabel_src_dir)\GPSBabel.pro" -spec "win32-g++" }
-  "msbuild" { qmake -tp vc "$($gpsbabel_src_dir)\GPSBabel.pro"}
+  # work around Qt 5.12.1 qmake bug.
+  #C:\Qt\5.12.1\msvc2017\bin\qmake.exe -tp vc GPSBabel.pro
+  #WARNING: Could not parse Compiler option '-std:c++14'; added to AdditionalOptions.
+  #WARNING: You can suppress these warnings with CONFIG+=suppress_vcproj_warnings.
+  #WARNING: Could not parse Compiler option '-std:c++14'; added to AdditionalOptions.
+  "msbuild" { $ErrorActionPreference = "Continue"; qmake -tp vc "$($gpsbabel_src_dir)\GPSBabel.pro"; $ErrorActionPreference = "Stop" }
   "nmake"   { qmake "$($gpsbabel_src_dir)\GPSBabel.pro" -spec "win32-msvc" }
 }
 if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }


### PR DESCRIPTION
Update appveyor build to use Qt 5.12.1 with MSVC 2017.

Also use Qt 5.12.1 and MSVC 2017 for the pre-release version.