### PR TITLE
Qt 5.12.1 and valgrind on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       compiler: gcc
       env:
         - BUILD_TYPE="local"
-        - QT_VERSION="5.12.1"
+        - QT_VERSION="5.9.7" # 5.12.1 vtesto stmsdf fails with valgrind 3.11.0 which is on xenial
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       compiler: gcc
       env:
         - BUILD_TYPE="docker"
+        - DOCKER_IMG="qtio"
     - os: linux
       dist: xenial
       sudo: required
@@ -16,6 +17,15 @@ matrix:
       compiler: clang
       env:
         - BUILD_TYPE="docker"
+        - DOCKER_IMG="qtio"
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      compiler: gcc
+      env:
+        - BUILD_TYPE="docker"
+        - DOCKER_IMG=""
     - os: linux
       dist: xenial
       sudo: required
@@ -77,7 +87,7 @@ install:
 
 script:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "coverage" ]; then ./tools/travis_script_linux_coverage; fi
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "docker" ]; then ./tools/travis_script_linux_docker; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "docker" ]; then ./tools/travis_script_linux_docker ${DOCKER_IMG}; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "local" ]; then echo $PATH; ./build_and_test; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./tools/travis_script_osx; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       compiler: gcc
       env:
         - BUILD_TYPE="local"
-        - QT_VERSION="5.9.7" # 5.12.1 vtesto stmsdf fails differently on xenial & bionic
+        - QT_VERSION="5.12.1"
       addons:
         apt:
           packages:

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,9 +1,32 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
+FROM ubuntu:bionic as qt_install
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed to install Qt
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libdbus-1-3 \
+  libfreetype6 \
+  libfontconfig1 \
+  libx11-6 \
+  libx11-xcb1 \
+  ca-cacert \
+  wget \
+ && rm -rf /var/lib/apt/lists/*
+
+# basic build and test tools
+COPY ./qtci/install-qt ./qtci/extract-qt-installer /app/
+RUN QT_CI_PACKAGES=qt.qt5.5121.gcc_64,qt.qt5.5121.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=/app:${PATH} ./install-qt 5.12.1 /opt
+
 FROM ubuntu:bionic
-
 LABEL maintainer="https://github.com/tsteven4"
-
 WORKDIR /app
 
 # update environment.
@@ -27,10 +50,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     expat \
     libxml2-utils \
  && rm -rf /var/lib/apt/lists/*
+
 # alternative compiler
 RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
  && rm -rf /var/lib/apt/lists/*
+
 # pkgs needed to build document
 RUN apt-get update && apt-get install -y --no-install-recommends \
     fop \
@@ -38,17 +63,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     docbook-xml \
     docbook-xsl \
  && rm -rf /var/lib/apt/lists/*
+
 # pkgs with libraries needed by gpsbabel
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-dev \
  && rm -rf /var/lib/apt/lists/*
-# pkgs with qt used by gpsbabel
+
+# dependencies of Qt
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    qt5-default \
-    libqt5webkit5-dev \
-    qttools5-dev-tools \
-    qttranslations5-l10n \
+    libglib2.0-0 \
+    libx11-xcb-dev \
+    libglu1-mesa-dev \
+    libasound2 \
+    libxcomposite1 \
+    libxcursor1 \
  && rm -rf /var/lib/apt/lists/*
+
+# Qt
+COPY --from=qt_install /opt/qt-5.12.1.env /opt/qt-5.12.1.env
+COPY --from=qt_install /opt/Qt/5.12.1 /opt/Qt/5.12.1
+COPY --from=qt_install /opt/Qt/Licenses /opt/Qt/Licenses
+
 # pkgs needed to generate coverage report:
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcovr \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 # Qt
-COPY --from=qt_install /opt/qt-5.12.1.env /opt/qt-5.12.1.env
+COPY --from=qt_install /opt/qt-5.12.1.env /opt/qtio.env
 COPY --from=qt_install /opt/Qt/5.12.1 /opt/Qt/5.12.1
 COPY --from=qt_install /opt/Qt/Licenses /opt/Qt/Licenses
 

--- a/tools/Dockerfile_qtio
+++ b/tools/Dockerfile_qtio
@@ -1,9 +1,32 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
+FROM ubuntu:bionic as qt_install
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed to install Qt
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libdbus-1-3 \
+  libfreetype6 \
+  libfontconfig1 \
+  libx11-6 \
+  libx11-xcb1 \
+  ca-cacert \
+  wget \
+ && rm -rf /var/lib/apt/lists/*
+
+# basic build and test tools
+COPY ./qtci/install-qt ./qtci/extract-qt-installer /app/
+RUN QT_CI_PACKAGES=qt.qt5.5121.gcc_64,qt.qt5.5121.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=/app:${PATH} ./install-qt 5.12.1 /opt
+
 FROM ubuntu:bionic
-
 LABEL maintainer="https://github.com/tsteven4"
-
 WORKDIR /app
 
 # update environment.
@@ -46,13 +69,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-dev \
  && rm -rf /var/lib/apt/lists/*
 
-# pkgs with qt used by gpsbabel
+# dependencies of Qt
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    qt5-default \
-    libqt5webkit5-dev \
-    qttools5-dev-tools \
-    qttranslations5-l10n \
+    libglib2.0-0 \
+    libx11-xcb-dev \
+    libglu1-mesa-dev \
+    libasound2 \
+    libxcomposite1 \
+    libxcursor1 \
  && rm -rf /var/lib/apt/lists/*
+
+# Qt
+COPY --from=qt_install /opt/qt-5.12.1.env /opt/qtio.env
+COPY --from=qt_install /opt/Qt/5.12.1 /opt/Qt/5.12.1
+COPY --from=qt_install /opt/Qt/Licenses /opt/Qt/Licenses
 
 # pkgs needed to generate coverage report:
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tools/make_docker_image
+++ b/tools/make_docker_image
@@ -1,11 +1,11 @@
 #!/bin/bash -ex
 # you must be logged into docker for the push to succeed.
-ver=bionic_qt_5_12_1 # tag name must be lower case
+ver=_qtio # tag name must be lower case
 tag=$(date -u +%Y%m%dT%H%M%SZ)
-docker build --pull --tag gpsbabel_build_environment_${ver}:latest .
-docker tag gpsbabel_build_environment_${ver}:latest gpsbabel_build_environment_${ver}:$tag
-docker tag gpsbabel_build_environment_${ver}:latest tsteven4/gpsbabel_build_environment_${ver}:latest 
-docker tag gpsbabel_build_environment_${ver}:latest tsteven4/gpsbabel_build_environment_${ver}:$tag
-docker push tsteven4/gpsbabel_build_environment_${ver}:$tag
-docker push tsteven4/gpsbabel_build_environment_${ver}:latest
+docker build --pull --tag gpsbabel_build_environment${ver}:latest .
+docker tag gpsbabel_build_environment${ver}:latest gpsbabel_build_environment${ver}:$tag
+docker tag gpsbabel_build_environment${ver}:latest tsteven4/gpsbabel_build_environment${ver}:latest 
+docker tag gpsbabel_build_environment${ver}:latest tsteven4/gpsbabel_build_environment${ver}:$tag
+docker push tsteven4/gpsbabel_build_environment${ver}:$tag
+docker push tsteven4/gpsbabel_build_environment${ver}:latest
 docker image ls

--- a/tools/make_docker_image
+++ b/tools/make_docker_image
@@ -1,10 +1,11 @@
 #!/bin/bash -ex
 # you must be logged into docker for the push to succeed.
+ver=bionic_qt_5_12_1 # tag name must be lower case
 tag=$(date -u +%Y%m%dT%H%M%SZ)
-docker build --pull --tag gpsbabel_build_environment:latest .
-docker tag gpsbabel_build_environment:latest gpsbabel_build_environment:$tag
-docker tag gpsbabel_build_environment:latest tsteven4/gpsbabel_build_environment:latest 
-docker tag gpsbabel_build_environment:latest tsteven4/gpsbabel_build_environment:$tag
-docker push tsteven4/gpsbabel_build_environment:$tag
-docker push tsteven4/gpsbabel_build_environment:latest
+docker build --pull --tag gpsbabel_build_environment_${ver}:latest .
+docker tag gpsbabel_build_environment_${ver}:latest gpsbabel_build_environment_${ver}:$tag
+docker tag gpsbabel_build_environment_${ver}:latest tsteven4/gpsbabel_build_environment_${ver}:latest 
+docker tag gpsbabel_build_environment_${ver}:latest tsteven4/gpsbabel_build_environment_${ver}:$tag
+docker push tsteven4/gpsbabel_build_environment_${ver}:$tag
+docker push tsteven4/gpsbabel_build_environment_${ver}:latest
 docker image ls

--- a/tools/make_docker_image
+++ b/tools/make_docker_image
@@ -1,11 +1,12 @@
 #!/bin/bash -ex
 # you must be logged into docker for the push to succeed.
-ver=_qtio # tag name must be lower case
+
+versuffix=${1:+_$1} # tag name must be lower case
 tag=$(date -u +%Y%m%dT%H%M%SZ)
-docker build --pull --tag gpsbabel_build_environment${ver}:latest .
-docker tag gpsbabel_build_environment${ver}:latest gpsbabel_build_environment${ver}:$tag
-docker tag gpsbabel_build_environment${ver}:latest tsteven4/gpsbabel_build_environment${ver}:latest 
-docker tag gpsbabel_build_environment${ver}:latest tsteven4/gpsbabel_build_environment${ver}:$tag
-docker push tsteven4/gpsbabel_build_environment${ver}:$tag
-docker push tsteven4/gpsbabel_build_environment${ver}:latest
+docker build --pull --file Dockerfile${versuffix} --tag gpsbabel_build_environment${versuffix}:latest .
+docker tag gpsbabel_build_environment${versuffix}:latest gpsbabel_build_environment${versuffix}:$tag
+docker tag gpsbabel_build_environment${versuffix}:latest tsteven4/gpsbabel_build_environment${versuffix}:latest 
+docker tag gpsbabel_build_environment${versuffix}:latest tsteven4/gpsbabel_build_environment${versuffix}:$tag
+docker push tsteven4/gpsbabel_build_environment${versuffix}:$tag
+docker push tsteven4/gpsbabel_build_environment${versuffix}:latest
 docker image ls

--- a/tools/travis_script_linux_docker
+++ b/tools/travis_script_linux_docker
@@ -16,5 +16,5 @@ docker run \
 --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
 --mount type=bind,source=/etc/group,target=/etc/group,readonly \
 --user "$(id -u):$(id -g)" \
-tsteven4/gpsbabel_build_environment_test \
+tsteven4/gpsbabel_build_environment_bionic_qt_5_12_1 \
 bash -c ". /opt/qt-5.12.1.env; ./build_and_test"

--- a/tools/travis_script_linux_docker
+++ b/tools/travis_script_linux_docker
@@ -16,5 +16,5 @@ docker run \
 --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
 --mount type=bind,source=/etc/group,target=/etc/group,readonly \
 --user "$(id -u):$(id -g)" \
-tsteven4/gpsbabel_build_environment \
+tsteven4/gpsbabel_build_environment_test \
 bash -c "./build_and_test"

--- a/tools/travis_script_linux_docker
+++ b/tools/travis_script_linux_docker
@@ -17,4 +17,4 @@ docker run \
 --mount type=bind,source=/etc/group,target=/etc/group,readonly \
 --user "$(id -u):$(id -g)" \
 tsteven4/gpsbabel_build_environment_test \
-bash -c "./build_and_test"
+bash -c ". /opt/qt-5.12.1.env; ./build_and_test"

--- a/tools/travis_script_linux_docker
+++ b/tools/travis_script_linux_docker
@@ -7,6 +7,9 @@
 # pass the compiler from the travis matrix through CC, CXX.
 # we need the default charmap to be UTF-8 for test_encoding_utf8, explicit set it here through LC_ALL.
 # travis has got the code to test in the pwd.
+
+ver=${1}
+versuffix=${ver:+_$1}
 docker run \
 --rm \
 --mount type=bind,source="$(pwd)",target=/app \
@@ -16,5 +19,5 @@ docker run \
 --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
 --mount type=bind,source=/etc/group,target=/etc/group,readonly \
 --user "$(id -u):$(id -g)" \
-tsteven4/gpsbabel_build_environment_qtio \
-bash -c ". /opt/qtio.env; ./build_and_test"
+tsteven4/gpsbabel_build_environment${versuffix} \
+bash -c "if [ -n ${ver} ]; then if [ -e /opt/${ver}.env ]; then . /opt/${ver}.env; fi; fi; ./build_and_test"

--- a/tools/travis_script_linux_docker
+++ b/tools/travis_script_linux_docker
@@ -16,5 +16,5 @@ docker run \
 --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
 --mount type=bind,source=/etc/group,target=/etc/group,readonly \
 --user "$(id -u):$(id -g)" \
-tsteven4/gpsbabel_build_environment_bionic_qt_5_12_1 \
-bash -c ". /opt/qt-5.12.1.env; ./build_and_test"
+tsteven4/gpsbabel_build_environment_qtio \
+bash -c ". /opt/qtio.env; ./build_and_test"

--- a/vtesto
+++ b/vtesto
@@ -9,6 +9,9 @@
 QUIET="-q"
 BASEPATH=`dirname $0`
 
+# https://doc.qt.io/qt-5/qregularexpression.html#debugging-code-that-uses-qregularexpression
+export QT_ENABLE_REGEXP_JIT=0
+
 while getopts "lj:" opt; do
   case $opt in
     l) OPTS="--leak-check=full --show-reachable=yes --num-callers=24 --suppressions=${BASEPATH}/gpsbabel.supp" ; QUIET="";;

--- a/vtesto
+++ b/vtesto
@@ -6,9 +6,38 @@
 # from time to time.
 #
 
+vg_version_warning() {
+  echo "This version of valgrind may not be compatible with later versions of Qt." 1>&2
+  echo "If you get \"unhandled instruction bytes: 0xF 0xC7\" warnings from" 1>&2
+  echo "valgrind your valgrind is too old." 1>&2
+  echo "valgrind 3.13.0 and later should not have this problem." 1>&2
+  echo "$(which valgrind) is $(valgrind --version)" 1>&2
+  echo "" 1>&2
+}
+
 QUIET="-q"
 BASEPATH=`dirname $0`
 
+# Older valgrind can choke with newer version of Qt.
+# valgrind 3.11.0 has this problem with Qt 5.12.1.
+# It is unknown if 3.12.0 has this problem with Qt 5.12.1.
+# valgrind 3.13.0 does not have this problem with Qt 5.12.1.
+# valgrind 3.11.0 is find with Qt 5.9.7.
+# vex amd64->IR: unhandled instruction bytes: 0xF 0xC7 0xF2 0xB9 0x1 0x0 0x0 0x0
+vgmajor=$(valgrind --version| cut -d- -f 2 | cut -d. -f 1)
+vgminor=$(valgrind --version| cut -d- -f 2 | cut -d. -f 2)
+if [ ${vgmajor} -lt 3 ]; then
+  vg_vesion_warning
+fi
+if [ ${vgmajor} -eq 3 ] ; then
+  if [ ${vgminor} -le 12 ]; then
+    vg_version_warning
+  fi
+fi
+
+# newer versons of Qt, e.g. 5.12.x, use a JIT compiler for QRegularExpression.
+# JITs use of self-modifying code can confuse valgrind.
+# We disable JIT with this environmental variable to keep valgrind happy.
 # https://doc.qt.io/qt-5/qregularexpression.html#debugging-code-that-uses-qregularexpression
 export QT_ENABLE_REGEXP_JIT=0
 


### PR DESCRIPTION
set an environmental variable when running valgrind to disable QRegularExpressions use of JIT which causes problems for valgrind.  The release build of Qt 5.12.1 uses JIT by default.  The debug build does not.

warn when running older version of valgrind that don't handle RDRAND instructions used by newer versions of Qt such as 5.12.1.

update the travis docker image with Qt 5.12.1.