### PR TITLE
update language processing for macos.

### DIFF
--- a/tools/convert_qt_translations
+++ b/tools/convert_qt_translations
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+# It is recommended to combine Qts .qm files, this script does that for
+# linux and macos, windeployqt does this for windows.
+# https://doc.qt.io/qt-5/linguist-programmers.html#deploying-translations
+#
+# This script is created from the log of the windows build from windeployqt
+# with Qt 5.12.1.
+# From the log you can see which translation files are used which depends on
+# which Qt modules we use.
+# In our case these are qtbase_*.qm, qtdeclarative_*qm and qtserialport_*.qm.
+#
+# Note with Qt5 the Qt distributed qt_xx.qm files are metacatalogs, and just
+# copying or converting them won't copy the dependencies.
+
+QT_INSTALL_TRANSLATIONS="$(qmake -query QT_INSTALL_TRANSLATIONS)"
+LCONVERT="$(qmake -query QT_INSTALL_BINS)/lconvert"
+OUTDIR="$(pwd)"
+
+cd "${QT_INSTALL_TRANSLATIONS}"
+languages=($(echo qtbase_??.qm | sed 's/qtbase_\(..\).qm/\1/g'))
+for language in "${languages[@]}"
+do
+  inputs=()
+  inputs+=("qtbase_${language}.qm")
+  if [ -e "qtdeclarative_${language}.qm" ]; then inputs+=("qtdeclarative_${language}.qm"); fi
+  if [ -e "qtserialport_${language}.qm" ]; then inputs+=("qtserialport_${language}.qm"); fi
+  "${LCONVERT}" -o "${OUTDIR}/qt_${language}.qm" "${inputs[@]}"
+done

--- a/tools/mac-localize
+++ b/tools/mac-localize
@@ -1,29 +1,35 @@
-# Create locversion.plist in the bundle to trigger translations for 
+#!/bin/bash -e
+# Create locversion.plist in the bundle to trigger translations for
 # the application menu and system buttons.  See description at
-# http://doc.qt.nokia.com/4.6/mac-differences.html#translating-the-application-menu-and-native-dialogs
+# https://doc.qt.io/qt-5/macos-issues.html#translating-the-application-menu-and-native-dialogs
 
-QTDIR=`qmake -query QT_INSTALL_TRANSLATIONS`
-
-LANGDIR=objects/GPSBabelFE.app/Contents/MacOS/translations
+LANGDIR="objects/GPSBabelFE.app/Contents/MacOS/translations"
 
 
 mkplist() {
-  D=objects/GPSBabelFE.app/Contents/Resources/$1.lproj 
-  [ ! -d $D ] && mkdir $D
-  sed "s/LANGUAGE/$1/" ../tools/skeleton-locversion-plist > $D/locversion.plist
-  # optional as en, it, and hu aren't translated in Qt yet.
-  [ ! -f "$QTDIR/qt_$1.qm" ]  && echo "Bad QTDIR for $1"
-  [  -f "$QTDIR/qt_$1.qm" ] && cp "$QTDIR/qt_$1.qm" $LANGDIR
-  [ -f gpsbabelfe_${1}.qm ] && cp gpsbabelfe_${1}.qm  $LANGDIR
+  D="objects/GPSBabelFE.app/Contents/Resources/$1.lproj"
+  if [ ! -d "$D" ]; then mkdir -p "$D"; fi
+  sed "s/LANGUAGE/$1/" ../tools/skeleton-locversion-plist > "$D/locversion.plist"
+  if [ -f "objects/qt_${1}.qm" ]; then cp "objects/qt_${1}.qm" "$LANGDIR"; fi
+  if [ -f "gpsbabelfe_${1}.qm" ]; then cp "gpsbabelfe_${1}.qm" "$LANGDIR"; fi
 }
 
-cd gui 
-[ ! -d $LANGDIR ] && mkdir $LANGDIR
-for i in $(echo  gpsbabelfe_??.ts | sed 's/gpsbabelfe_\(..\).ts/\1/g')
-do
-	mkplist $i
-done
+cd gui
+if [ ! -d "$LANGDIR" ]; then mkdir -p "$LANGDIR"; fi
 
-mkplist en
+# combine the Qt translation files we use into local qt_??.qm files.
+cd objects
+../../tools/convert_qt_translations
+languages=($(echo qt_??.qm | sed 's/qt_\(..\).qm/\1/g'))
+cd ..
+
+# We assume all the languages corresponding to gpsbabelfe_??.qm
+# are also translated by Qt, so they are in $languages.
+# Note there are langauages Qt has translations for that we don't.
+# Note Qt has *_en.qm files, so en is in $languages.
+for language in "${languages[@]}"
+do
+	mkplist "$language"
+done
 
 exit 0

--- a/tools/skeleton-locversion-plist
+++ b/tools/skeleton-locversion-plist
@@ -1,15 +1,15 @@
- <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
- "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
-     <key>LprojCompatibleVersion</key>
-     <string>123</string>
-     <key>LprojLocale</key>
-     <string>LANGUAGE</string>
-     <key>LprojRevisionLevel</key>
-     <string>1</string>
-     <key>LprojVersion</key>
-     <string>123</string>
- </dict>
- </plist>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LprojCompatibleVersion</key>
+    <string>123</string>
+    <key>LprojLocale</key>
+    <string>LANGUAGE</string>
+    <key>LprojRevisionLevel</key>
+    <string>1</string>
+    <key>LprojVersion</key>
+    <string>123</string>
+</dict>
+</plist>

--- a/tools/travis_script_osx
+++ b/tools/travis_script_osx
@@ -25,10 +25,10 @@ popd
 
 # package the app
 mkdir -p gui/objects/GPSBabelFE.app/Contents/MacOS/translations
-cp gui/*.qm  gui/objects/gpsbabelFE.app/Contents/MacOS/translations
 cp GPSBabel gui/objects/GPSBabelFE.app/Contents/MacOS/gpsbabel
 cp gui/gmapbase.html gui/objects/GPSBabelFE.app/Contents/MacOS
 cp gui/COPYING.txt gui/objects/GPSBabelFE.app/Contents/MacOS
+# bundle Qt qm files, deploy them with our .qm files, make & deploy locversion.plist files.
 tools/mac-localize
 
 rm -f gui/objects/GPSBabelFE.dmg


### PR DESCRIPTION
merge relevant Qt .qm files into one qt_xx.qm file as
recommended by Qt.

deploy these meged .qm files with macos builds.
Since Qt5 we only deployed the meta catalog, but not it's
dependencies.  This should have led to the dependencies not
being available without Qt being installed.

whitespace corrections to locversion.plist skeleton.

eliminate double copying of our .qm files for mac. 

gpsbabel.qm and gpsbabelfe.qm are no longer included in the dmg, as it should be.