### PR TITLE
clang-tidy fixes for the gui

### DIFF
--- a/gui/filterdata.cc
+++ b/gui/filterdata.cc
@@ -35,7 +35,7 @@ QStringList WayPtsFilterData::makeOptionString()
     args << QString("radius,distance=%1%2,lat=%3,lon=%4")
          .arg(radiusVal).arg("MK"[radiusUnit]).arg(latVal, 0, 'f', 8).arg(longVal, 0, 'f', 8);
   }
-  if (duplicates && (shortNames ^ locations)) {
+  if (duplicates && ((shortNames ^ locations) != 0)) {
     args << QString("-x");
     QString s = "duplicate";
     if (shortNames) {
@@ -142,7 +142,7 @@ QStringList TrackFilterData::makeOptionString()
     s += QString(",title=%1").arg(titleString);
   }
 
-  if (s.length()) {
+  if (s.length() != 0) {
     args << "-x" << "track" + s;
   }
 

--- a/gui/filterdlg.cc
+++ b/gui/filterdlg.cc
@@ -125,7 +125,7 @@ void FilterDialog::helpX()
 //------------------------------------------------------------------------
 void FilterDialog::runDialog()
 {
-  if (exec()) {
+  if (exec() != 0) {
     for (int i=0; i<pages_.size(); i++) {
       pages_[i]->getWidgetValues();
       *(usePages_[i]) = ui_.filterList->item(i)->checkState() == Qt::Checked;

--- a/gui/format.cc
+++ b/gui/format.cc
@@ -70,7 +70,7 @@ void Format::restoreSettings(QSettings& settings)
 void Format::setToDefault()
 {
   for (int i=0; i<inputOptions_.size(); i++) {
-    if (inputOptions_[i].getType() == FormatOption::OPTbool && inputOptions_[i].getDefaultValue().toBool() == true) {
+    if (inputOptions_[i].getType() == FormatOption::OPTbool && inputOptions_[i].getDefaultValue().toBool()) {
       inputOptions_[i].setSelected(true);
     } else {
       inputOptions_[i].setSelected(false);
@@ -78,7 +78,7 @@ void Format::setToDefault()
     inputOptions_[i].setValue(QVariant());
   }
   for (int i=0; i<outputOptions_.size(); i++) {
-    if (outputOptions_[i].getType() == FormatOption::OPTbool && outputOptions_[i].getDefaultValue().toBool() == true) {
+    if (outputOptions_[i].getType() == FormatOption::OPTbool && outputOptions_[i].getDefaultValue().toBool()) {
       outputOptions_[i].setSelected(true);
     } else {
       outputOptions_[i].setSelected(false);

--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -156,7 +156,7 @@ bool FormatLoad::getFormats(QList<Format>& formatList)
     Format format;
     if (!processFormat(format)) {
       QMessageBox::information
-      (0, appName,
+      (nullptr, appName,
        QObject::tr("Error processing formats from running process \"gpsbabel -^3\" at line %1").arg(lineList[currentLine_]));
     } else {
       formatList << format;

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -250,7 +250,7 @@ void GMapDialog::itemChangedX(QStandardItem* it)
   else {
     // Individual items, find the right one.
     GpxItem* git = static_cast<GpxItem*>(it->data().value<void*>());
-    if (git != 0) {
+    if (git != nullptr) {
       git->setVisible(show);
       for (int i=0; i<gpx_.getWaypoints().size(); i++) {
         if (&gpx_.getWaypoints()[i] == git) {

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -498,7 +498,7 @@ void GMapDialog::showOnlyThisWaypoint()
 {
   QList <GpxWaypoint>& tlist = gpx_.getWaypoints();
   for (int i=0; i<tlist.size(); i++) {
-    tlist[i].setVisible(i == menuIndex_? true: false);
+    tlist[i].setVisible(i == menuIndex_);
     trkList_[i]->setCheckState(i==menuIndex_? Qt::Checked: Qt::Unchecked);
   }
   wptItem_->setCheckState(Qt::Checked);
@@ -509,7 +509,7 @@ void GMapDialog::showOnlyThisTrack()
 {
   QList <GpxTrack>& tlist = gpx_.getTracks();
   for (int i=0; i<tlist.size(); i++) {
-    tlist[i].setVisible(i == menuIndex_? true: false);
+    tlist[i].setVisible(i == menuIndex_);
     trkList_[i]->setCheckState(i==menuIndex_? Qt::Checked: Qt::Unchecked);
   }
   trkItem_->setCheckState(Qt::Checked);
@@ -521,7 +521,7 @@ void GMapDialog::showOnlyThisRoute()
 {
   QList <GpxRoute>& rlist = gpx_.getRoutes();
   for (int i=0; i<rlist.size(); i++) {
-    rlist[i].setVisible(i == menuIndex_? true: false);
+    rlist[i].setVisible(i == menuIndex_);
     rteList_[i]->setCheckState(i==menuIndex_? Qt::Checked: Qt::Unchecked);
   }
   rteItem_->setCheckState(Qt::Checked);

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -49,7 +49,7 @@ static bool trackIsEmpty(const GpxTrack& trk)
 class GpxHandler: public QXmlDefaultHandler
 {
 public:
-  GpxHandler(): QXmlDefaultHandler()
+  GpxHandler()
 
   {
     state = e_noop;

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -74,9 +74,9 @@ public:
   elementState state;
   QList <elementState> stateStack;
 
-  virtual bool startElement(const QString&,
+  bool startElement(const QString&,
                             const QString& localName, const QString&,
-                            const QXmlAttributes& atts)
+                            const QXmlAttributes& atts) override
   {
     if (localName == "wpt") {
       currentWpt = GpxWaypoint();
@@ -134,9 +134,9 @@ public:
     return true;
   };
 
-  virtual bool endElement(const QString&,
+  bool endElement(const QString&,
                           const QString& localName,
-                          const QString&)
+                          const QString&) override
   {
     if (localName == "wpt") {
       state = stateStack.takeLast();
@@ -207,7 +207,7 @@ public:
     return true;
   };
 
-  virtual bool characters(const QString& x)
+  bool characters(const QString& x) override
   {
     textChars = x;
     return true;

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -29,7 +29,7 @@
 #include "gpx.h"
 
 
-static QDateTime decodeDateTime(const QString s)
+static QDateTime decodeDateTime(const QString& s)
 {
   QDateTime utc = QDateTime::fromString(s, "yyyy-MM-dd'T'HH:mm:ss'Z'");
   return utc;

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -55,9 +55,9 @@ public:
     state = e_noop;
   }
 
-  typedef enum {e_noop, e_wpt, e_trk,
-                e_trkpt, e_trkseg, e_rte, e_rtept
-               } elementState;
+  enum elementState {e_noop, e_wpt, e_trk,
+                     e_trkpt, e_trkseg, e_rte, e_rtept
+                    };
   QString textChars;
   GpxWaypoint currentWpt;
   QList <GpxWaypoint> wptList;
@@ -75,8 +75,8 @@ public:
   QList <elementState> stateStack;
 
   bool startElement(const QString& /*namespaceURI*/,
-                            const QString& localName, const QString& /*qName*/,
-                            const QXmlAttributes& atts) override
+                    const QString& localName, const QString& /*qName*/,
+                    const QXmlAttributes& atts) override
   {
     if (localName == "wpt") {
       currentWpt = GpxWaypoint();
@@ -135,8 +135,8 @@ public:
   };
 
   bool endElement(const QString& /*namespaceURI*/,
-                          const QString& localName,
-                          const QString& /*qName*/) override
+                  const QString& localName,
+                  const QString& /*qName*/) override
   {
     if (localName == "wpt") {
       state = stateStack.takeLast();

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -235,7 +235,7 @@ bool Gpx::read(const QString& fileName)
     tracks = gpxHandler.trkList;
     routes = gpxHandler.rteList;
     return true;
-  } else {
-    return false;
   }
+  return false;
+
 }

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -74,8 +74,8 @@ public:
   elementState state;
   QList <elementState> stateStack;
 
-  bool startElement(const QString&,
-                            const QString& localName, const QString&,
+  bool startElement(const QString& /*namespaceURI*/,
+                            const QString& localName, const QString& /*qName*/,
                             const QXmlAttributes& atts) override
   {
     if (localName == "wpt") {
@@ -134,9 +134,9 @@ public:
     return true;
   };
 
-  bool endElement(const QString&,
+  bool endElement(const QString& /*namespaceURI*/,
                           const QString& localName,
-                          const QString&) override
+                          const QString& /*qName*/) override
   {
     if (localName == "wpt") {
       state = stateStack.takeLast();

--- a/gui/main.cc
+++ b/gui/main.cc
@@ -63,7 +63,7 @@ int main(int argc, char** argv)
   QCoreApplication::setOrganizationDomain("gpsbabel.org");
   QCoreApplication::setApplicationName("GPSBabel");
 
-  MainWindow mainWindow(0);
+  MainWindow mainWindow(nullptr);
   mainWindow.show();
   app->exec();
 

--- a/gui/main.cc
+++ b/gui/main.cc
@@ -49,9 +49,8 @@ int main(int argc, char** argv)
 #error this version of Qt is not supported.
 #endif
 
-  QApplication* app;
-  app = new QApplication(argc, argv);
-  app->setWindowIcon(QIcon(":/images/appicon.png"));
+  QApplication app(argc, argv);
+  QApplication::setWindowIcon(QIcon(":/images/appicon.png"));
 
   QString newPath = "PATH=" + QApplication::applicationDirPath() +
                     QString(pathSeparator) + getenv("PATH");
@@ -65,7 +64,7 @@ int main(int argc, char** argv)
 
   MainWindow mainWindow(nullptr);
   mainWindow.show();
-  app->exec();
+  QApplication::exec();
 
   return 0;
 }

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -1068,7 +1068,7 @@ void MainWindow::closeActionX()
 }
 
 //------------------------------------------------------------------------
-void MainWindow::closeEvent(QCloseEvent*)
+void MainWindow::closeEvent(QCloseEvent* /*event*/)
 {
   closeActionX();
 }

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -226,9 +226,9 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 //------------------------------------------------------------------------
 MainWindow::~MainWindow()
 {
-  if (upgrade) {
+  
     delete upgrade;
-  }
+  
 }
 //------------------------------------------------------------------------
 // Dynamic language switching courtesy of

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -226,9 +226,9 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 //------------------------------------------------------------------------
 MainWindow::~MainWindow()
 {
-  
-    delete upgrade;
-  
+
+  delete upgrade;
+
 }
 //------------------------------------------------------------------------
 // Dynamic language switching courtesy of
@@ -854,8 +854,9 @@ bool MainWindow::isOkToGo()
   if (babelData_.outputType_ == BabelData::noType_ && !babelData_.previewGmap_) {
     QMessageBox::information(nullptr, QString(appName), tr("No valid output specified"));
     return false;
-  } else if (babelData_.outputType_ == BabelData::fileType_ &&
-             babelData_.outputFileName_.length() == 0) {
+  }
+  if (babelData_.outputType_ == BabelData::fileType_ &&
+      babelData_.outputFileName_.length() == 0) {
     QMessageBox::information(nullptr, QString(appName), tr("No output file specified"));
     return false;
   }

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -120,7 +120,7 @@ static QString MakeOptions(const QList<FormatOption>& options)
 static QString MakeOptionsNoLeadingComma(const QList<FormatOption>& options)
 {
   QString str = MakeOptions(options);
-  return (str.length()) ? str.mid(1) : str;
+  return (str.length()) != 0 ? str.mid(1) : str;
 
 }
 

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -849,9 +849,9 @@ bool MainWindow::isOkToGo()
     return false;
   }
 
-  if (babelData_.outputType_ == BabelData::noType_ && babelData_.previewGmap_ == true) {
+  if (babelData_.outputType_ == BabelData::noType_ && babelData_.previewGmap_) {
   }
-  if (babelData_.outputType_ == BabelData::noType_ && babelData_.previewGmap_ == false) {
+  if (babelData_.outputType_ == BabelData::noType_ && !babelData_.previewGmap_) {
     QMessageBox::information(nullptr, QString(appName), tr("No valid output specified"));
     return false;
   } else if (babelData_.outputType_ == BabelData::fileType_ &&

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -216,7 +216,7 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
   }
 
   if (!babelData_.ignoreVersionMismatch_ && babelVersion_ != VERSION) {
-    VersionMismatch vm(0, babelVersion_, QString(VERSION));
+    VersionMismatch vm(nullptr, babelVersion_, QString(VERSION));
 
     vm.exec();
     babelData_.ignoreVersionMismatch_ = vm.neverAgain();
@@ -277,7 +277,7 @@ void MainWindow::createLanguageMenu(void)
 // Called every time, when a menu entry of the language menu is called
 void MainWindow::slotLanguageChanged(QAction* action)
 {
-  if (0 != action) {
+  if (nullptr != action) {
     // load the language dependant on the action content.
     loadLanguage(action->data().toString());
   }
@@ -311,7 +311,7 @@ void MainWindow::loadLanguage(const QString& rLanguage)
 
 void MainWindow::changeEvent(QEvent* event)
 {
-  if (0 != event) {
+  if (nullptr != event) {
     switch (event->type()) {
     // This event is sent if a translator is loaded.
     case QEvent::LanguageChange:
@@ -536,7 +536,7 @@ void MainWindow::browseInputFile()
   }
 
   QStringList userList =
-    QFileDialog::getOpenFileNames(0, tr("Select one or more input files"),
+    QFileDialog::getOpenFileNames(nullptr, tr("Select one or more input files"),
                                   startFile,
                                   filterForFormat(idx));
   if (!userList.empty()) {
@@ -564,7 +564,7 @@ void MainWindow::browseOutputFile()
   }
 
   QString str =
-    QFileDialog::getSaveFileName(0, tr("Output File Name"),
+    QFileDialog::getSaveFileName(nullptr, tr("Output File Name"),
                                  startFile,
                                  filterForFormat(idx));
   if (str.length() != 0) {
@@ -627,7 +627,7 @@ QList<int> MainWindow::outputDeviceFormatIndices()
 void MainWindow::loadFormats()
 {
   if (!FormatLoad().getFormats(formatList_)) {
-    QMessageBox::information(0, QString(appName),
+    QMessageBox::information(nullptr, QString(appName),
                              tr("Error reading format configuration.  "
                                 "Check that the backend program \"gpsbabel\" is properly installed "
                                 "and is in the current PATH\n\n"
@@ -638,7 +638,7 @@ void MainWindow::loadFormats()
       inputDeviceFormatIndices().empty() ||
       outputFileFormatIndices().empty() ||
       outputDeviceFormatIndices().empty()) {
-    QMessageBox::information(0, QString(appName),
+    QMessageBox::information(nullptr, QString(appName),
                              tr("Some file/device formats were not found during initialization.  "
                                 "Check that the backend program \"gpsbabel\" is properly installed "
                                 "and is in the current PATH\n\n"
@@ -786,10 +786,10 @@ void MainWindow::inputOptionButtonClicked()
   int fidx = currentComboFormatIndex(ui_.inputFormatCombo);
   if (formatList_[fidx].getInputOptionsRef()->empty()) {
     QMessageBox::information
-    (0, appName,
+    (nullptr, appName,
      tr("There are no input options for format \"%1\"").arg(formatList_[fidx].getDescription()));
   } else {
-    OptionsDlg optionDlg(0,
+    OptionsDlg optionDlg(nullptr,
                          formatList_[fidx].getName(),
                          formatList_[fidx].getInputOptionsRef(),
                          formatList_[fidx].getHtml());
@@ -805,10 +805,10 @@ void MainWindow::outputOptionButtonClicked()
   int fidx = currentComboFormatIndex(ui_.outputFormatCombo);
   if (formatList_[fidx].getOutputOptionsRef()->empty()) {
     QMessageBox::information
-    (0, appName,
+    (nullptr, appName,
      tr("There are no output options for format \"%1\"").arg(formatList_[fidx].getDescription()));
   } else {
-    OptionsDlg optionDlg(0,
+    OptionsDlg optionDlg(nullptr,
                          formatList_[fidx].getName(),
                          formatList_[fidx].getOutputOptionsRef(),
                          formatList_[fidx].getHtml());
@@ -826,7 +826,7 @@ bool MainWindow::isOkToGo()
   if (!((ui_.xlateWayPtsCk->isChecked() && ui_.xlateWayPtsCk->isEnabled()) ||
         (ui_.xlateRoutesCk->isChecked() && ui_.xlateRoutesCk->isEnabled()) ||
         (ui_.xlateTracksCk->isChecked() && ui_.xlateTracksCk->isEnabled()))) {
-    QMessageBox::information(0, QString(appName), tr("No valid waypoints/routes/tracks translation specified"));
+    QMessageBox::information(nullptr, QString(appName), tr("No valid waypoints/routes/tracks translation specified"));
     return false;
   }
 
@@ -845,18 +845,18 @@ bool MainWindow::isOkToGo()
 
   if ((babelData_.inputType_ == BabelData::fileType_) &&
       (babelData_.inputFileNames_.empty())) {
-    QMessageBox::information(0, QString(appName), tr("No input file specified"));
+    QMessageBox::information(nullptr, QString(appName), tr("No input file specified"));
     return false;
   }
 
   if (babelData_.outputType_ == BabelData::noType_ && babelData_.previewGmap_ == true) {
   }
   if (babelData_.outputType_ == BabelData::noType_ && babelData_.previewGmap_ == false) {
-    QMessageBox::information(0, QString(appName), tr("No valid output specified"));
+    QMessageBox::information(nullptr, QString(appName), tr("No valid output specified"));
     return false;
   } else if (babelData_.outputType_ == BabelData::fileType_ &&
              babelData_.outputFileName_.length() == 0) {
-    QMessageBox::information(0, QString(appName), tr("No output file specified"));
+    QMessageBox::information(nullptr, QString(appName), tr("No output file specified"));
     return false;
   }
   return true;
@@ -866,10 +866,10 @@ bool MainWindow::isOkToGo()
 bool MainWindow::runGpsbabel(const QStringList& args, QString& errorString,
                              QString& outputString)
 {
-  QProcess* proc = new QProcess(0);
+  QProcess* proc = new QProcess(nullptr);
   QString name = "gpsbabel";
   proc->start(name, args);
-  ProcessWaitDialog* waitDlg = new ProcessWaitDialog(0, proc);
+  ProcessWaitDialog* waitDlg = new ProcessWaitDialog(nullptr, proc);
 
   if (proc->state() == QProcess::NotRunning) {
     errorString = QString(tr("Process \"%1\" did not start")).arg(name);
@@ -1031,7 +1031,7 @@ void MainWindow::applyActionX()
     ui_.outputWindow->appendPlainText(tr("Translation successful"));
     if (babelData_.previewGmap_) {
       this->hide();
-      GMapDialog dlg(0, tempName, babelData_.debugLevel_ >=1 ? ui_.outputWindow : 0);
+      GMapDialog dlg(nullptr, tempName, babelData_.debugLevel_ >=1 ? ui_.outputWindow : nullptr);
       dlg.show();
       dlg.exec();
       QFile(tempName).remove();
@@ -1054,7 +1054,7 @@ void MainWindow::closeActionX()
   QDateTime now = QDateTime::currentDateTime();
   if ((babelData_.runCount_ == 1) ||
       ((babelData_.runCount_ > 5) && (babelData_.donateSplashed_.daysTo(now) > 30))) {
-    Donate donate(0);
+    Donate donate(nullptr);
     if (babelData_.donateSplashed_.date() == QDate(2010,1,1)) {
       donate.showNever(false);
     }
@@ -1063,7 +1063,7 @@ void MainWindow::closeActionX()
   }
   saveSettings();
   delete upgrade;
-  upgrade = 0;
+  upgrade = nullptr;
   qApp->exit(0);
 }
 
@@ -1172,7 +1172,7 @@ void MainWindow::resetFormatDefaults()
 //------------------------------------------------------------------------
 void MainWindow::moreOptionButtonClicked()
 {
-  AdvDlg advDlg(0, babelData_.synthShortNames_,
+  AdvDlg advDlg(nullptr, babelData_.synthShortNames_,
                 babelData_.previewGmap_, babelData_.debugLevel_);
   connect(advDlg.formatButton(), SIGNAL(clicked()),
           this, SLOT(resetFormatDefaults()));
@@ -1181,7 +1181,7 @@ void MainWindow::moreOptionButtonClicked()
 //------------------------------------------------------------------------
 void MainWindow::aboutActionX()
 {
-  AboutDlg aboutDlg(0, babelVersion_, QString(appName) + QString(" " VERSION), babelData_.installationUuid_);
+  AboutDlg aboutDlg(nullptr, babelVersion_, QString(appName) + QString(" " VERSION), babelData_.installationUuid_);
   aboutDlg.setWindowTitle(tr("About %1").arg(appName));
   aboutDlg.exec();
 }
@@ -1197,7 +1197,7 @@ void MainWindow::upgradeCheckActionX()
 //------------------------------------------------------------------------
 void MainWindow::preferencesActionX()
 {
-  Preferences preferences(0, formatList_, babelData_);
+  Preferences preferences(nullptr, formatList_, babelData_);
   preferences.exec();
 
   // We may have changed the list of displayed formats.  Resynchronize.
@@ -1213,7 +1213,7 @@ void MainWindow::helpActionX()
 //------------------------------------------------------------------------
 void MainWindow::filtersClicked()
 {
-  FilterDialog dlg(0, filterData_);
+  FilterDialog dlg(nullptr, filterData_);
   dlg.runDialog();
   updateFilterStatus();
 }
@@ -1326,5 +1326,5 @@ QString MainWindow::getFormatNameForExtension(const QString& ext)
       }
     }
   }
-  return 0;
+  return nullptr;
 }

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -477,7 +477,7 @@ QString MainWindow::filterForFormat(int idx)
 
   // If we don't have any meaningful extensions available for this format,
   // don't be clever here; just fall through to "All files" case.
-  if (extensions.size() > 0 && !extensions[0].isEmpty()) {
+  if (!extensions.empty() && !extensions[0].isEmpty()) {
     str += " (";
     for (int i=0; i<extensions.size(); i++) {
       if (i!= 0) {
@@ -496,7 +496,7 @@ QString MainWindow::ensureExtensionPresent(const QString& name, int idx)
   QString outname = name;
   if (QFileInfo(name).suffix().length() == 0) {
     QStringList extensions = formatList_[idx].getExtensions();
-    if (extensions.size() > 0 && !extensions[0].isEmpty()) {
+    if (!extensions.empty() && !extensions[0].isEmpty()) {
       outname += "." + extensions[0];
     }
   }
@@ -528,7 +528,7 @@ int MainWindow::currentComboFormatIndex(QComboBox* comboBox)
 //------------------------------------------------------------------------
 void MainWindow::browseInputFile()
 {
-  QString startFile = babelData_.inputFileNames_.size() ? babelData_.inputFileNames_[0] : babelData_.inputBrowse_;
+  QString startFile = !babelData_.inputFileNames_.empty() ? babelData_.inputFileNames_[0] : babelData_.inputBrowse_;
   int idx = currentComboFormatIndex(ui_.inputFormatCombo);
   QFileInfo finfo(startFile);
   if (!finfo.isDir() && (!filterForFormatIncludes(idx, finfo.suffix()))) {
@@ -539,7 +539,7 @@ void MainWindow::browseInputFile()
     QFileDialog::getOpenFileNames(0, tr("Select one or more input files"),
                                   startFile,
                                   filterForFormat(idx));
-  if (userList.size()) {
+  if (!userList.empty()) {
     babelData_.inputBrowse_ = userList[0];
     babelData_.inputFileNames_ = userList;
     QString str;
@@ -634,10 +634,10 @@ void MainWindow::loadFormats()
                                 "This program cannot continue."));
     exit(1);
   }
-  if (inputFileFormatIndices().size() == 0 ||
-      inputDeviceFormatIndices().size() == 0 ||
-      outputFileFormatIndices().size() == 0 ||
-      outputDeviceFormatIndices().size() == 0) {
+  if (inputFileFormatIndices().empty() ||
+      inputDeviceFormatIndices().empty() ||
+      outputFileFormatIndices().empty() ||
+      outputDeviceFormatIndices().empty()) {
     QMessageBox::information(0, QString(appName),
                              tr("Some file/device formats were not found during initialization.  "
                                 "Check that the backend program \"gpsbabel\" is properly installed "
@@ -747,7 +747,7 @@ void MainWindow::inputFormatChanged(int comboIdx)
     return;
   }
   int fidx = ui_.inputFormatCombo->itemData(comboIdx).toInt();
-  ui_.inputOptionsBtn->setEnabled(formatList_[fidx].getInputOptions().size()>0);
+  ui_.inputOptionsBtn->setEnabled(!formatList_[fidx].getInputOptions().empty());
   displayOptionsText(ui_.inputOptionsText,  ui_.inputFormatCombo, true);
   crossCheckInOutFormats();
 
@@ -767,7 +767,7 @@ void MainWindow::outputFormatChanged(int comboIdx)
     return;
   }
   int fidx = ui_.outputFormatCombo->itemData(comboIdx).toInt();
-  ui_.outputOptionsBtn->setEnabled(formatList_[fidx].getOutputOptions().size()>0);
+  ui_.outputOptionsBtn->setEnabled(!formatList_[fidx].getOutputOptions().empty());
   displayOptionsText(ui_.outputOptionsText,  ui_.outputFormatCombo, false);
   crossCheckInOutFormats();
 
@@ -784,7 +784,7 @@ void MainWindow::outputFormatChanged(int comboIdx)
 void MainWindow::inputOptionButtonClicked()
 {
   int fidx = currentComboFormatIndex(ui_.inputFormatCombo);
-  if (formatList_[fidx].getInputOptionsRef()->size() == 0) {
+  if (formatList_[fidx].getInputOptionsRef()->empty()) {
     QMessageBox::information
     (0, appName,
      tr("There are no input options for format \"%1\"").arg(formatList_[fidx].getDescription()));
@@ -803,7 +803,7 @@ void MainWindow::inputOptionButtonClicked()
 void MainWindow::outputOptionButtonClicked()
 {
   int fidx = currentComboFormatIndex(ui_.outputFormatCombo);
-  if (formatList_[fidx].getOutputOptionsRef()->size() == 0) {
+  if (formatList_[fidx].getOutputOptionsRef()->empty()) {
     QMessageBox::information
     (0, appName,
      tr("There are no output options for format \"%1\"").arg(formatList_[fidx].getDescription()));
@@ -833,7 +833,7 @@ bool MainWindow::isOkToGo()
   // Paper over what didn't happen in inputBrowse() if the user edited
   // the filename fields directly.
   if ((babelData_.inputType_ == BabelData::fileType_) &&
-      (babelData_.inputFileNames_.size() == 0) &&
+      (babelData_.inputFileNames_.empty()) &&
       (!ui_.inputFileNameText->text().isEmpty())) {
     babelData_.inputFileNames_ << ui_.inputFileNameText->text();
   }
@@ -844,7 +844,7 @@ bool MainWindow::isOkToGo()
   }
 
   if ((babelData_.inputType_ == BabelData::fileType_) &&
-      (babelData_.inputFileNames_.size() == 0)) {
+      (babelData_.inputFileNames_.empty())) {
     QMessageBox::information(0, QString(appName), tr("No input file specified"));
     return false;
   }
@@ -1222,7 +1222,7 @@ void MainWindow::filtersClicked()
 //------------------------------------------------------------------------
 void MainWindow::updateFilterStatus()
 {
-  bool filterActive = filterData_.getAllFilterStrings().size();
+  bool filterActive = !filterData_.getAllFilterStrings().empty();
   ui_.filterStatus->setEnabled(filterActive);
   if (filterActive) {
     ui_.filterStatus->setToolTip(tr("One or more data filters are active"));

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -1316,7 +1316,7 @@ void MainWindow::getWidgetValues()
 // It's also kind of dumb to return the name which SetCombo then looks up,
 // but there's not a 1:1 correlation between offsets in the combo box and
 // in the list of formats.
-QString MainWindow::getFormatNameForExtension(QString ext)
+QString MainWindow::getFormatNameForExtension(const QString& ext)
 {
   for (int i = 0; i < formatList_.size(); i++) {
     QStringList extensions = formatList_[i].getExtensions();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -97,7 +97,7 @@ private:
   UpgradeCheck* upgrade;
   bool allowBetaUpgrades();
   void osLoadDeviceNameCombos(QComboBox*);
-  QString getFormatNameForExtension(QString ext);
+  QString getFormatNameForExtension(const QString& ext);
 
 protected:
   void closeEvent(QCloseEvent*);

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -48,7 +48,7 @@ using std::string;
 using std::vector;
 
 //------------------------------------------------------------------------
-static QString stripDoubleQuotes(const QString s)
+static QString stripDoubleQuotes(const QString& s)
 {
   QString out;
   foreach (QChar c, s) {

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -129,10 +129,10 @@ Map::~Map()
 void Map::loadFinishedX(bool f)
 {
   this->logTime("Done initial page load");
-  if (!f)
+  if (!f) {
     QMessageBox::critical(nullptr, appName,
                           tr("Failed to load Google maps base page"));
-  else {
+  } else {
     QApplication::processEvents();
     showGpxData();
   }

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -92,7 +92,7 @@ Map::Map(QWidget* parent,
 
   QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
   if (!QFile(baseFile).exists()) {
-    QMessageBox::critical(0, appName,
+    QMessageBox::critical(nullptr, appName,
                           tr("Missing \"gmapbase.html\" file.  Check installation"));
   } else {
     QString urlStr = "file:///" + baseFile;
@@ -130,7 +130,7 @@ void Map::loadFinishedX(bool f)
 {
   this->logTime("Done initial page load");
   if (!f)
-    QMessageBox::critical(0, appName,
+    QMessageBox::critical(nullptr, appName,
                           tr("Failed to load Google maps base page"));
   else {
     QApplication::processEvents();

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -301,7 +301,7 @@ void Map::markerClicked(int t, int i)
 void Map::logTime(const QString& s)
 {
   //  fprintf(stderr, "Log: %s:  %d ms\n", s.toStdString().c_str(), stopWatch.elapsed());
-  if (textEdit_) {
+  if (textEdit_ != nullptr) {
     textEdit_->appendPlainText(QString("%1: %2 ms").arg(s).arg(stopWatch_.elapsed()));
   }
   stopWatch_.start();

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -222,7 +222,7 @@ void OptionsDlg::acceptClicked()
 {
   for (int k=0; k<options_.size(); k++) {
     options_[k].setSelected(checkBoxes_[k]->isChecked());
-    if (fields_[k]) {
+    if (fields_[k] != nullptr) {
       if (options_[k].getType() == FormatOption::OPTboundedInt) {
         int value = static_cast<QSpinBox*>(fields_[k])->value();
         value = qMax(qMin(value, options_[k].getMaxValue().toInt()),options_[k].getMinValue().toInt());

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -62,8 +62,7 @@ QVariant getOptionValue(QList<FormatOption> opts, int k)
 
 //------------------------------------------------------------------------
 FileDlgManager::~FileDlgManager()
-{
-}
+= default;
 
 //------------------------------------------------------------------------
 void FileDlgManager::buttonClicked()

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -55,14 +55,14 @@ QVariant getOptionValue(QList<FormatOption> opts, int k)
 {
   if (opts[k].getValue().toString() != "") {
     return opts[k].getValue();
-  } else {
-    return opts[k].getDefaultValue();
   }
+  return opts[k].getDefaultValue();
+
 }
 
 //------------------------------------------------------------------------
 FileDlgManager::~FileDlgManager()
-= default;
+  = default;
 
 //------------------------------------------------------------------------
 void FileDlgManager::buttonClicked()

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -69,11 +69,11 @@ void FileDlgManager::buttonClicked()
 {
   QString str;
   if (isInFile) {
-    str = QFileDialog::getOpenFileName(0, tr("Select input file"),
+    str = QFileDialog::getOpenFileName(nullptr, tr("Select input file"),
                                        le->text(),
                                        "All Files (*.*)");
   } else {
-    str = QFileDialog::getSaveFileName(0, tr("Select output file"),
+    str = QFileDialog::getSaveFileName(nullptr, tr("Select output file"),
                                        le->text(),
                                        "All Files (*.*)");
   }
@@ -106,7 +106,7 @@ OptionsDlg::OptionsDlg(QWidget* parent,  const QString& fmtName, QList<FormatOpt
     QSpacerItem* horizontalSpacer = new QSpacerItem(0, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
     horizontalLayout->addItem(horizontalSpacer);
 
-    QWidget* w = 0;
+    QWidget* w = nullptr;
     switch (options_[k].getType()) {
     case FormatOption::OPTstring: {
       QLineEdit* lineEdit = new QLineEdit(this);
@@ -135,7 +135,7 @@ OptionsDlg::OptionsDlg(QWidget* parent,  const QString& fmtName, QList<FormatOpt
     case FormatOption::OPTbool:
       // If it was selected before, select it again.
       checkBox->setChecked(options_[k].getSelected());
-      w = 0;
+      w = nullptr;
       break;
 
     case FormatOption::OPTfloat: {

--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -186,7 +186,7 @@ void ProcessWaitDialog::finishedX(int exitCode, QProcess::ExitStatus es)
 void ProcessWaitDialog::appendToText(const char* ptr)
 {
   outputString_ += QString(ptr);
-  for (const char* cptr = ptr; *cptr; cptr++) {
+  for (const char* cptr = ptr; *cptr != 0; cptr++) {
     if (*cptr == '\r') {
       continue;
     }

--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -118,8 +118,7 @@ ProcessWaitDialog::ProcessWaitDialog(QWidget* parent, QProcess* process):
 
 //------------------------------------------------------------------------
 ProcessWaitDialog::~ProcessWaitDialog()
-{
-};
+= default;
 //------------------------------------------------------------------------
 bool ProcessWaitDialog::getExitedNormally()
 {

--- a/gui/serial_unix.cc
+++ b/gui/serial_unix.cc
@@ -98,7 +98,7 @@ void MainWindow::osLoadDeviceNameCombos(QComboBox* box)
   const QStringList devices = dynamicDevices();
   box->addItems(devices);
 
-  for (int i=0; deviceNames[i]; i++) {
+  for (int i=0; deviceNames[i] != nullptr; i++) {
     if (!devices.contains(deviceNames[i])) {
       box->addItem(deviceNames[i]);
     }

--- a/gui/serial_unix.cc
+++ b/gui/serial_unix.cc
@@ -90,7 +90,7 @@ static const char* deviceNames[] = {
   "/dev/ttyS3",
   "/dev/ttyUSB0",
   "/dev/rfcomm0",
-  0
+  nullptr
 };
 
 void MainWindow::osLoadDeviceNameCombos(QComboBox* box)

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -60,11 +60,11 @@ UpgradeCheck::UpgradeCheck(QWidget* parent, QList<Format>& formatList,
 
 UpgradeCheck::~UpgradeCheck()
 {
-  if (replyId_) {
+  if (replyId_ != nullptr) {
     replyId_->abort();
     replyId_ = nullptr;
   }
-  if (manager_) {
+  if (manager_ != nullptr) {
     delete manager_;
     manager_ = nullptr;
   }
@@ -123,7 +123,7 @@ UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
   args += "&os=" + getOsName();
   args += "&cpu=" + getCpuArchitecture();
   args += "&os_ver=" + getOsVersion();
-  args += QString("&beta_ok=%1").arg(allowBeta);
+  args += QString("&beta_ok=%1").arg(static_cast<int>(allowBeta));
   args += "&lang=" + QLocale::languageToString(locale.language());
   args += "&last_checkin=" + lastCheckTime.toString(Qt::ISODate);
   args += QString("&ugcb=%1").arg(babelData_.upgradeCallbacks_);
@@ -139,14 +139,14 @@ UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
     int rc = formatList_[i].getReadUseCount();
     int wc = formatList_[i].getWriteUseCount();
     QString formatName = formatList_[i].getName();
-    if (rc) {
+    if (rc != 0) {
       args += QString("&uc%1=rd/%2/%3").arg(j++).arg(formatName).arg(rc);
     }
-    if (wc) {
+    if (wc != 0) {
       args += QString("&uc%1=wr/%2/%3").arg(j++).arg(formatName).arg(wc);
     }
   }
-  if (j && babelData_.reportStatistics_) {
+  if ((j != 0) && babelData_.reportStatistics_) {
     args += QString("&uc=%1").arg(j);
   }
 
@@ -282,7 +282,7 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
     }
   }
 
-  if (response.length()) {
+  if (response.length() != 0) {
     QMessageBox information;
     information.setWindowTitle(tr("Upgrade"));
 

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -175,7 +175,8 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
   if (reply == nullptr) {
     babelData_.upgradeErrors_++;
     return;
-  } else if (reply != replyId_) {
+  }
+  if (reply != replyId_) {
     QMessageBox::information(nullptr, tr("HTTP"),
                              tr("Unexpected reply."));
   } else if (reply->error() != QNetworkReply::NoError) {

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -49,8 +49,8 @@ static const bool testing = false;
 UpgradeCheck::UpgradeCheck(QWidget* parent, QList<Format>& formatList,
                            BabelData& bd) :
   QObject(parent),
-  manager_(0),
-  replyId_(0),
+  manager_(nullptr),
+  replyId_(nullptr),
   upgradeUrl_(QUrl("http://www.gpsbabel.org/upgrade_check.html")),
   formatList_(formatList),
   updateStatus_(updateUnknown),
@@ -62,11 +62,11 @@ UpgradeCheck::~UpgradeCheck()
 {
   if (replyId_) {
     replyId_->abort();
-    replyId_ = 0;
+    replyId_ = nullptr;
   }
   if (manager_) {
     delete manager_;
-    manager_ = 0;
+    manager_ = nullptr;
   }
 }
 
@@ -172,18 +172,18 @@ UpgradeCheck::updateStatus UpgradeCheck::getStatus()
 void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
 {
 
-  if (reply == 0) {
+  if (reply == nullptr) {
     babelData_.upgradeErrors_++;
     return;
   } else if (reply != replyId_) {
-    QMessageBox::information(0, tr("HTTP"),
+    QMessageBox::information(nullptr, tr("HTTP"),
                              tr("Unexpected reply."));
   } else if (reply->error() != QNetworkReply::NoError) {
     babelData_.upgradeErrors_++;
-    QMessageBox::information(0, tr("HTTP"),
+    QMessageBox::information(nullptr, tr("HTTP"),
                              tr("Download failed: %1.")
                              .arg(reply->errorString()));
-    replyId_ = 0;
+    replyId_ = nullptr;
     reply->deleteLater();
     return;
   }
@@ -202,7 +202,7 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
       // Change the url for the next update check.
       // TOODO: kick off another update check.
       upgradeUrl_ = redirectUrl;
-      replyId_ = 0;
+      replyId_ = nullptr;
       reply->deleteLater();
       return;
     }
@@ -214,11 +214,11 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
   }
   if (statusCode != 200) {
     QVariant reason = reply->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
-    QMessageBox::information(0, tr("HTTP"),
+    QMessageBox::information(nullptr, tr("HTTP"),
                              tr("Download failed: %1: %2.")
                              .arg(statusCode.toInt())
                              .arg(reason.toString()));
-    replyId_ = 0;
+    replyId_ = nullptr;
     reply->deleteLater();
     return;
   }
@@ -231,12 +231,12 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
   QString error_text;
   // This shouldn't ever be seen by a user.
   if (!document.setContent(oresponse, &error_text, &line)) {
-    QMessageBox::critical(0, tr("Error"),
+    QMessageBox::critical(nullptr, tr("Error"),
                           tr("Invalid return data at line %1: %2.")
                           .arg(line)
                           .arg(error_text));
     babelData_.upgradeErrors_++;
-    replyId_ = 0;
+    replyId_ = nullptr;
     reply->deleteLater();
     return;
   }
@@ -312,6 +312,6 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
   for (int i = 0; i < formatList_.size(); i++) {
     formatList_[i].zeroUseCounts();
   }
-  replyId_ = 0;
+  replyId_ = nullptr;
   reply->deleteLater();
 }


### PR DESCRIPTION
hicpp-use-equals-default
performance-unnecessary-value-param
readability-redundant-member-init
readability-container-size-empty
readability-delete-null-pointer
modernize-use-nullptr
readability-implicit-bool-conversion.
readability-static-accessed-through-instance
readability-braces-around-statements
readability-simplify-boolean-expr
hicpp-use-override
readability-named-parameter
manual fix suggested by clang-tidy modernize-use-using.
readability-else-after-return 