### PR TITLE
fix stackfilter issues.

### DIFF
--- a/route.cc
+++ b/route.cc
@@ -521,8 +521,8 @@ RouteList::restore(RouteList* src)
 void RouteList::swap(RouteList& other)
 {
   const RouteList tmp_list = *this;
-  other = *this;
-  *this = tmp_list;
+  *this = other;
+  other = tmp_list;
 }
 
 void RouteList::sort(Compare cmp)

--- a/stackfilter.cc
+++ b/stackfilter.cc
@@ -166,6 +166,8 @@ void StackFilter::exit()
   }
   while (stack) {
     waypt_flush(&(stack->waypts));
+    stack->routes.flush();
+    stack->tracks.flush();
     tmp_elt = stack;
     stack = stack->next;
     delete tmp_elt;

--- a/testo.d/stackfilter.test
+++ b/testo.d/stackfilter.test
@@ -7,3 +7,7 @@
 
 gpsbabel -i geo -f ${REFERENCE}/../geocaching.loc -x stack,push,copy,nowarn -x stack,push,copy -x stack,push -x stack,pop,replace -x stack,pop,append -x stack,push,copy -x stack,pop,discard -x stack,swap,depth=1 -o arc -F ${TMPDIR}/stackfilt.txt
 
+gpsbabel -i geo -f ${REFERENCE}/../geocaching.loc -x transform,rte=wpt,del -x stack,push,copy,nowarn -x stack,push,copy -x stack,push -x stack,pop,replace -x stack,pop,append -x stack,push,copy -x stack,pop,discard -x stack,swap,depth=1 -o arc -F ${TMPDIR}/stackfilt.txt
+
+gpsbabel -i geo -f ${REFERENCE}/../geocaching.loc -x transform,trk=wpt,del -x stack,push,copy,nowarn -x stack,push,copy -x stack,push -x stack,pop,replace -x stack,pop,append -x stack,push,copy -x stack,pop,discard -x stack,swap,depth=1 -o arc -F ${TMPDIR}/stackfilt.txt
+


### PR DESCRIPTION
1. correct defect in the new RouteList::swap method.
2. correct an old bug in stackfilter that cleaned up
waypts on exit, but not routes or tracks.
3. enhance stackfilter test to test routes and tracks as well
as waypts.