### PR TITLE
Roll Qt to 5.12.3 and 5.9.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       compiler: gcc
       env:
         - BUILD_TYPE="local"
-        - QT_VERSION="5.9.7" # 5.12.1 vtesto stmsdf fails with valgrind 3.11.0 which is on xenial
+        - QT_VERSION="5.9.8" # 5.12.1 vtesto stmsdf fails with valgrind 3.11.0 which is on xenial
       addons:
         apt:
           packages:
@@ -51,14 +51,14 @@ matrix:
         timeout: 600
     - os: osx
       compiler: clang
-      env: QT_VERSION="5.9.7"
+      env: QT_VERSION="5.9.8"
       cache:
         directories:
           - $HOME/Cache
         timeout: 600
     - os: osx
       compiler: clang
-      env: QT_VERSION="5.12.2"
+      env: QT_VERSION="5.12.3"
       cache:
         directories:
           - $HOME/Cache
@@ -69,7 +69,7 @@ matrix:
       compiler: gcc
       env:
         - BUILD_TYPE="coverage"
-        - QT_VERSION="5.9.7"
+        - QT_VERSION="5.9.8"
       addons:
         apt:
           packages:
@@ -94,7 +94,7 @@ script:
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   # only deploy pushes to master or prs that target master.  the prs will go to transfr.sh, the pushes go to github.
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ] &&  [ "${QT_VERSION}" = "5.12.2" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash ./tools/uploadtool/upload.sh  gui/GPSBabel-*.dmg; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ] &&  [ "${QT_VERSION}" = "5.12.3" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash ./tools/uploadtool/upload.sh  gui/GPSBabel-*.dmg; fi
 
 branches:
   except:

--- a/tools/Dockerfile_qtio
+++ b/tools/Dockerfile_qtio
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # basic build and test tools
 COPY ./qtci/install-qt ./qtci/extract-qt-installer /app/
-RUN QT_CI_PACKAGES=qt.qt5.5122.gcc_64,qt.qt5.5122.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=/app:${PATH} ./install-qt 5.12.2 /opt
+RUN QT_CI_PACKAGES=qt.qt5.5123.gcc_64,qt.qt5.5123.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=/app:${PATH} ./install-qt 5.12.3 /opt
 
 FROM ubuntu:bionic
 LABEL maintainer="https://github.com/tsteven4"
@@ -83,8 +83,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 # Qt
-COPY --from=qt_install /opt/qt-5.12.2.env /opt/qtio.env
-COPY --from=qt_install /opt/Qt/5.12.2 /opt/Qt/5.12.2
+COPY --from=qt_install /opt/qt-5.12.3.env /opt/qtio.env
+COPY --from=qt_install /opt/Qt/5.12.3 /opt/Qt/5.12.3
 COPY --from=qt_install /opt/Qt/Licenses /opt/Qt/Licenses
 
 # pkgs needed to generate coverage report:


### PR DESCRIPTION
Merging this will result in CI using 5.12.3 for the macos build instead of 5.12.2.

In related news, appveyor may be about to upgrade their environment from 5.12.1 to 5.12.2, which will result in the windows build using 5.12.2.

These changes could result in a difference between the 1.6.0 beta and 1.6.0.