### PR TITLE
hook GUI up to sort filter.

### DIFF
--- a/gui/filterdata.cc
+++ b/gui/filterdata.cc
@@ -210,5 +210,24 @@ QStringList MiscFltFilterData::makeOptionString()
     }
     args << s;
   }
+
+  if (sortWpt_ || sortRte_ || sortTrk_) {
+    args << "-x";
+    QString s = "sort";
+    if (sortWpt_) {
+      const QStringList wptopts= {"description", "gcid", "shortname", "time"};
+      s += QString(",%1").arg(wptopts.at(sortWptBy_));
+    }
+    if (sortRte_) {
+      const QStringList rteopts= {"rtedesc", "rtename", "rtenum"};
+      s += QString(",%1").arg(rteopts.at(sortRteBy_));
+    }
+    if (sortTrk_) {
+      const QStringList trkopts= {"trkdesc", "trkname", "trknum"};
+      s += QString(",%1").arg(trkopts.at(sortTrkBy_));
+    }
+    args << s;
+    
+  }
   return args;
 }

--- a/gui/filterdata.h
+++ b/gui/filterdata.h
@@ -137,7 +137,7 @@ class WayPtsFilterData: public FilterData
 public:
   WayPtsFilterData(): FilterData(),
     duplicates(false), shortNames(true), locations(false),
-    position(false), radius(false), sort(false),
+    position(false), radius(false),
     positionVal(0.0), radiusVal(0.0),
     longVal(0.0), latVal(0.0),
     positionUnit(0), radiusUnit(0)
@@ -159,12 +159,11 @@ public:
     sg.addVarSetting(new BoolSetting("wpts.position", position));
     sg.addVarSetting(new DoubleSetting("wpts.positionVal", positionVal));
     sg.addVarSetting(new IntSetting("wpts.positionUnit", positionUnit));
-    sg.addVarSetting(new BoolSetting("wpts.sort", sort));
   }
 
 
 public:
-  bool duplicates, shortNames, locations, position, radius, sort;
+  bool duplicates, shortNames, locations, position, radius;
   double positionVal;
   double radiusVal;
   double longVal, latVal;
@@ -207,7 +206,13 @@ public:
     transform_(false),
     del_(false),
     swap_(false),
-    transformVal_(0)
+    sortWpt_(false),
+    sortRte_(false),
+    sortTrk_(false),
+    transformVal_(0),
+    sortWptBy_(0),
+    sortRteBy_(0),
+    sortTrkBy_(0)
   {
   }
 
@@ -222,12 +227,20 @@ public:
     sg.addVarSetting(new IntSetting("mscflt.transformVal", transformVal_));
     sg.addVarSetting(new BoolSetting("mscflt.delete", del_));
     sg.addVarSetting(new BoolSetting("mscflt.swap", swap_));
+    sg.addVarSetting(new BoolSetting("mscflt.sortWpt", sortWpt_));
+    sg.addVarSetting(new IntSetting("mscflt.sortWptBy", sortWptBy_));
+    sg.addVarSetting(new BoolSetting("mscflt.sortRte", sortRte_));
+    sg.addVarSetting(new IntSetting("mscflt.sortRteBy", sortRteBy_));
+    sg.addVarSetting(new BoolSetting("mscflt.sortTrk", sortTrk_));
+    sg.addVarSetting(new IntSetting("mscflt.sortTrkBy", sortTrkBy_));
   }
 
 public:
   bool nukeRoutes_, nukeTracks_, nukeWaypoints_;
   bool transform_, del_, swap_;
+  bool sortWpt_, sortRte_, sortTrk_;
   int transformVal_;
+  int sortWptBy_, sortRteBy_, sortTrkBy_;
 };
 
 

--- a/gui/filterwidgets.cc
+++ b/gui/filterwidgets.cc
@@ -174,7 +174,6 @@ WayPtsWidget::WayPtsWidget(QWidget* parent, WayPtsFilterData& wfd): FilterWidget
   fopts << new BoolFilterOption(wfd.locations, ui.locationsCheck);
   fopts << new BoolFilterOption(wfd.position, ui.positionCheck);
   fopts << new BoolFilterOption(wfd.radius, ui.radiusCheck);
-  fopts << new BoolFilterOption(wfd.sort, ui.sortCheck);
   fopts << new DoubleFilterOption(wfd.positionVal, ui.positionText, 0.0, 1.0E308);
   fopts << new DoubleFilterOption(wfd.radiusVal, ui.radiusText, 0.0, 1.0E308);
   fopts << new DoubleFilterOption(wfd.longVal, ui.longText, -180, 180, 7, 'f');
@@ -230,6 +229,9 @@ MiscFltWidget::MiscFltWidget(QWidget* parent, MiscFltFilterData& mfd): FilterWid
   ui.transformCombo->addItem(QString("%1 %2 %3").arg(tr("Waypoints")).arg(QChar(8594)).arg(tr("Tracks")));
   addCheckEnabler(ui.transformCheck,
                   QList<QWidget*>() << ui.transformCombo << ui.deleteCheck);
+  addCheckEnabler(ui.sortWptCheck, ui.sortWptBy);
+  addCheckEnabler(ui.sortRteCheck, ui.sortRteBy);
+  addCheckEnabler(ui.sortTrkCheck, ui.sortTrkBy);
 
   fopts << new BoolFilterOption(mfd.transform_, ui.transformCheck);
   fopts << new BoolFilterOption(mfd.swap_, ui.swapCheck);
@@ -237,7 +239,13 @@ MiscFltWidget::MiscFltWidget(QWidget* parent, MiscFltFilterData& mfd): FilterWid
   fopts << new BoolFilterOption(mfd.nukeTracks_, ui.nukeTracks);
   fopts << new BoolFilterOption(mfd.nukeRoutes_, ui.nukeRoutes);
   fopts << new BoolFilterOption(mfd.nukeWaypoints_, ui.nukeWaypoints);
+  fopts << new BoolFilterOption(mfd.sortWpt_, ui.sortWptCheck);
+  fopts << new BoolFilterOption(mfd.sortRte_, ui.sortRteCheck);
+  fopts << new BoolFilterOption(mfd.sortTrk_, ui.sortTrkCheck);
   fopts << new ComboFilterOption(mfd.transformVal_,  ui.transformCombo);
+  fopts << new ComboFilterOption(mfd.sortWptBy_, ui.sortWptBy);
+  fopts << new ComboFilterOption(mfd.sortRteBy_, ui.sortRteBy);
+  fopts << new ComboFilterOption(mfd.sortTrkBy_, ui.sortTrkBy);
 
   setWidgetValues();
   checkChecks();

--- a/gui/miscfltui.ui
+++ b/gui/miscfltui.ui
@@ -6,138 +6,284 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>303</width>
-    <height>175</height>
+    <width>310</width>
+    <height>250</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <pointsize>11</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Misc. Filters</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Nuke (Remove) Data Types</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="nukeRoutes">
-        <property name="text">
-         <string>Routes</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="nukeTracks">
-        <property name="text">
-         <string>Tracks</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="nukeWaypoints">
-        <property name="text">
-         <string>Waypoints</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="transformCheck">
-       <property name="toolTip">
-        <string>Convert routes, waypoints and tracks to different types.</string>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="5" column="0">
+      <widget class="QCheckBox" name="sortRteCheck">
+       <property name="text">
+        <string>Sort Routes</string>
        </property>
-       <property name="whatsThis">
-        <string>This filter can be used to convert GPS data between different data types.
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="2">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QCheckBox" name="transformCheck">
+         <property name="toolTip">
+          <string>Convert routes, waypoints and tracks to different types.</string>
+         </property>
+         <property name="whatsThis">
+          <string>This filter can be used to convert GPS data between different data types.
 
 Some GPS data formats support only some subset of waypoints, tracks, and routes. The transform filter allows you to convert between these types. For example, it can be used to convert a pile of waypoints (such as those from a CSV file) into a track or vice versa. </string>
+         </property>
+         <property name="text">
+          <string>Transform</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="transformCombo">
+         <property name="toolTip">
+          <string>Type of transformation. </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="deleteCheck">
+         <property name="toolTip">
+          <string>Delete original data after transform to prevent duplicated data. </string>
+         </property>
+         <property name="text">
+          <string>Delete</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Nuke (Remove) Data Types</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="nukeRoutes">
+          <property name="text">
+           <string>Routes</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="nukeTracks">
+          <property name="text">
+           <string>Tracks</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="nukeWaypoints">
+          <property name="text">
+           <string>Waypoints</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>By</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="sortWptBy">
+         <item>
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>GCID</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Time</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="sortWptCheck">
+       <property name="text">
+        <string>Sort Waypoints</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>By</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="sortRteBy">
+         <item>
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Number</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QCheckBox" name="swapCheck">
+       <property name="toolTip">
+        <string>Swap Longitude and Latitudes for badly formatted data formats.</string>
+       </property>
+       <property name="whatsThis">
+        <string>Simple filter to swap the coordinate values (latitude and longitude) of all points. This can be helpful for wrong defined/coded data. Or if you think, you can use one of our xcsv formats, but latitude and longitude are in opposite order. </string>
        </property>
        <property name="text">
-        <string>Transform</string>
+        <string>Swap Coordinates</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QComboBox" name="transformCombo">
-       <property name="toolTip">
-        <string>Type of transformation. </string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="deleteCheck">
-       <property name="toolTip">
-        <string>Delete original data after transform to prevent duplicated data. </string>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
        </property>
        <property name="text">
-        <string>Delete</string>
+        <string>Misc. Filters</string>
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="sortTrkCheck">
+       <property name="text">
+        <string>Sort Tracks</string>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>By</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="sortTrkBy">
+         <item>
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Number</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="swapCheck">
-     <property name="toolTip">
-      <string>Swap Longitude and Latitudes for badly formatted data formats.</string>
-     </property>
-     <property name="whatsThis">
-      <string>Simple filter to swap the coordinate values (latitude and longitude) of all points. This can be helpful for wrong defined/coded data. Or if you think, you can use one of our xcsv formats, but latitude and longitude are in opposite order. </string>
-     </property>
-     <property name="text">
-      <string>Swap Coordinates</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>1</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/gui/wayptsui.ui
+++ b/gui/wayptsui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>523</width>
-    <height>195</height>
+    <width>466</width>
+    <height>173</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,70 @@
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="radiusCheck">
+       <property name="toolTip">
+        <string>Include points only within radius</string>
+       </property>
+       <property name="whatsThis">
+        <string>This filter includes or excludes waypoints based on their proximity to a central point. All waypoints more than the specified distance from the specified point will be removed from the dataset.
+
+By default, all remaining points are sorted so that points closer to the center appear earlier in the output file. </string>
+       </property>
+       <property name="text">
+        <string>Radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="positionCheck">
+       <property name="toolTip">
+        <string>Remove points based on proximity</string>
+       </property>
+       <property name="whatsThis">
+        <string>Maximum positional distance.
+
+This option specifies the minimum allowable distance between two points. If two points are closer than this distance, only one of them is kept. </string>
+       </property>
+       <property name="text">
+        <string>Position</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QLabel" name="latLabel">
+       <property name="text">
+        <string>Lat.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="QLineEdit" name="latText">
+       <property name="minimumSize">
+        <size>
+         <width>110</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Latitude of the central point in decimal degrees.  South latitudes should be expressed as a negative number.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QComboBox" name="radiusUnitCombo">
+       <item>
+        <property name="text">
+         <string>Miles</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>km</string>
+        </property>
+       </item>
+      </widget>
+     </item>
      <item row="0" column="0" colspan="5">
       <widget class="QLabel" name="label">
        <property name="font">
@@ -28,6 +92,71 @@
        <property name="text">
         <string>Waypoints Filters</string>
        </property>
+      </widget>
+     </item>
+     <item row="4" column="4">
+      <widget class="QLineEdit" name="longText">
+       <property name="minimumSize">
+        <size>
+         <width>110</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Longitude of the central point in decimal degrees. West longitudes should be expressed as a negative number.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="positionText">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Maximum positional distance.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="3">
+      <widget class="QLabel" name="longLabel">
+       <property name="text">
+        <string>Long.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QCheckBox" name="locationsCheck">
+       <property name="toolTip">
+        <string>Suppress duplicate waypoint based on coords. </string>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Suppress duplicate waypoint based on coords. &lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This option causes the duplicate filter to remove any additional waypoint that has the same coordinates (to six decimal degrees) as a waypoint that came before. This option may be used to remove duplicate waypoints if the names are not expected to be the same. It also might be used along with the &lt;span style=&quot; font-family:'Courier New,courier';&quot;&gt;shortname&lt;/span&gt; option to remove duplicate waypoints if the names of several unrelated groups of waypoints might be the same. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Locations</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QComboBox" name="positionUnitCombo">
+       <item>
+        <property name="text">
+         <string>Feet</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Meters</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="1" column="0">
@@ -67,81 +196,6 @@ p, li { white-space: pre-wrap; }
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QCheckBox" name="locationsCheck">
-       <property name="toolTip">
-        <string>Suppress duplicate waypoint based on coords. </string>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Suppress duplicate waypoint based on coords. &lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This option causes the duplicate filter to remove any additional waypoint that has the same coordinates (to six decimal degrees) as a waypoint that came before. This option may be used to remove duplicate waypoints if the names are not expected to be the same. It also might be used along with the &lt;span style=&quot; font-family:'Courier New,courier';&quot;&gt;shortname&lt;/span&gt; option to remove duplicate waypoints if the names of several unrelated groups of waypoints might be the same. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Locations</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="positionCheck">
-       <property name="toolTip">
-        <string>Remove points based on proximity</string>
-       </property>
-       <property name="whatsThis">
-        <string>Maximum positional distance.
-
-This option specifies the minimum allowable distance between two points. If two points are closer than this distance, only one of them is kept. </string>
-       </property>
-       <property name="text">
-        <string>Position</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="positionText">
-       <property name="maximumSize">
-        <size>
-         <width>80</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Maximum positional distance.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QComboBox" name="positionUnitCombo">
-       <item>
-        <property name="text">
-         <string>Feet</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Meters</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="radiusCheck">
-       <property name="toolTip">
-        <string>Include points only within radius</string>
-       </property>
-       <property name="whatsThis">
-        <string>This filter includes or excludes waypoints based on their proximity to a central point. All waypoints more than the specified distance from the specified point will be removed from the dataset.
-
-By default, all remaining points are sorted so that points closer to the center appear earlier in the output file. </string>
-       </property>
-       <property name="text">
-        <string>Radius</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1">
       <widget class="QLineEdit" name="radiusText">
        <property name="maximumSize">
@@ -152,73 +206,6 @@ By default, all remaining points are sorted so that points closer to the center 
        </property>
        <property name="toolTip">
         <string>Maximum distance from center. </string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QComboBox" name="radiusUnitCombo">
-       <item>
-        <property name="text">
-         <string>Miles</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>km</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="3">
-      <widget class="QLabel" name="latLabel">
-       <property name="text">
-        <string>Lat.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="4">
-      <widget class="QLineEdit" name="latText">
-       <property name="minimumSize">
-        <size>
-         <width>110</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Latitude of the central point in decimal degrees.  South latitudes should be expressed as a negative number.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="3">
-      <widget class="QLabel" name="longLabel">
-       <property name="text">
-        <string>Long.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="4">
-      <widget class="QLineEdit" name="longText">
-       <property name="minimumSize">
-        <size>
-         <width>110</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Longitude of the central point in decimal degrees. West longitudes should be expressed as a negative number.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QCheckBox" name="sortCheck">
-       <property name="toolTip">
-        <string>This filter sorts waypoints into alphabetical order</string>
-       </property>
-       <property name="whatsThis">
-        <string>This filter sorts waypoints into alphabetical order</string>
-       </property>
-       <property name="text">
-        <string>Sort</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This resolved an issue pointed out on Gpsbabel-misc by Tim Zenner.  Part of the issue was a bug in previous releases, and part was new in the 1.6.0 beta.

The Data Filters Waypoints widget offered to sort the waypoints, however if this checkbox was selected nothing happened.  The widget also did not ask how the waypoints should be sorted.  This is an old bug.  This option was removed.
![Annotation 2019-04-21 060018](https://user-images.githubusercontent.com/13596209/56469775-4067db00-63fb-11e9-9c8c-0054a276c1c5.png)

New to 1.6.0 is the ability of the sort filter to sort routes and tracks as well as waypoints.  These options can now be controlled on the Data Filters Miscellaneous widget.  Furthermore they actually cause the sort filter to be invoked.
![Annotation 2019-04-21 045827](https://user-images.githubusercontent.com/13596209/56469795-9177cf00-63fb-11e9-891b-39c1cadce1db.png)
