### PR TITLE
enable gui to load Qt provided translation meta catalogs.

### DIFF
--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -314,10 +314,8 @@ void MainWindow::switchTranslator(QTranslator& translator, const QString& filena
   // remove the old translator
   qApp->removeTranslator(&translator);
 
-  QString full_filename(langPath_ + "/" + filename);
-
   // load the new translator
-  if (translator.load(full_filename)) {
+  if (translator.load(filename, langPath_)) {
     qApp->installTranslator(&translator);
   }
 }


### PR DESCRIPTION
QTranslate::load fails to load a meta catalog if
the absolute file name is given as the filename parameter, and
the directory parameter is omitted.
It succeeds if the file name is provided as the filename parameter
and the directory is provided as the diretory parameter.

This should resolve #359.