### PR TITLE
Gdb string read

### DIFF
--- a/gbfile.cc
+++ b/gbfile.cc
@@ -20,13 +20,22 @@
 
  */
 
+#include <QtCore/QByteArray>   // for QByteArray
+#include <QtCore/QString>      // for QString
+#include <QtCore/QtGlobal>     // for qPrintable
+
+#include <cassert>             // for assert
+#include <cstdarg>             // for va_list, va_end, va_copy, va_start
+#include <cstdio>              // for EOF, ferror, ftell, SEEK_SET, SEEK_CUR, SEEK_END, clearerr, fclose, feof, fflush, fileno, fread, fseek, fwrite, ungetc, vsnprintf, FILE, stdin, stdout
+#include <cstring>             // for memcpy, strlen, strchr, strcpy, strncat
+#include <ctype.h>             // for tolower
+#include <errno.h>             // for errno
+
 #include "defs.h"
 #include "gbfile.h"
 #include "src/core/logging.h"
 
-#include <cassert>
-#include <cstdarg> // for va_copy
-#include <cstdio>
+#include "cet.h"               // for cet_ucs4_to_utf8
 
 #if __WIN32__
 /* taken from minigzip.c (part of the zlib project) */
@@ -997,6 +1006,15 @@ gbfgetcstr(gbfile* file)
 {
   char* result = gbfgetcstr_old(file);
   QString rv(result);
+  xfree(result);
+  return rv; 
+}
+
+QByteArray
+gbfgetnativecstr(gbfile* file)
+{
+  char* result = gbfgetcstr_old(file);
+  QByteArray rv(result);
   xfree(result);
   return rv; 
 }

--- a/gbfile.h
+++ b/gbfile.h
@@ -23,11 +23,15 @@
 #ifndef GBFILE_H
 #define GBFILE_H
 
+#include <QtCore/QByteArray>    // for QByteArray
+#include <QtCore/QString>       // for QString
+
+#include <cstdarg>             // for va_list
+#include <cstdio>              // for FILE
+#include <cstdint>             // for int32_t, int16_t, uint32_t
 
 #include "defs.h"
-#include "cet.h"
 
-#include <QtCore/QString>
 
 struct gbfile_s;
 typedef struct gbfile_s gbfile;
@@ -117,6 +121,7 @@ float gbfgetflt(gbfile* file);			// read a float value
 char* gbfgetstr(gbfile* file);			// read until any type of line-breaks or EOF
 QString gbfgetpstr(gbfile* file);		// read a pascal string
 QString gbfgetcstr(gbfile* file);		// read a null terminated string
+QByteArray gbfgetnativecstr(gbfile* file);  // read a null terminated string
 char* gbfgetcstr_old(gbfile* file);		// read a null terminated string
 
 int gbfputint16(int16_t i, gbfile* file);

--- a/gdb.cc
+++ b/gdb.cc
@@ -449,7 +449,7 @@ read_file_header()
   }
 
   QByteArray applicationField = FREAD_STR();
-  is_fatal(!((applicationField == "MapSource") || (applicationField ==  "BaseCamp")), MYNAME ": Not a recognized signature in header");
+  is_fatal(!((applicationField == "MapSource") || (applicationField == "BaseCamp")), MYNAME ": Not a recognized signature in header");
 }
 
 /*-----------------------------------------------------------------------------*/


### PR DESCRIPTION
harden gdb reader to long string input.

fix bug in the gdb reader that resulted in file position being lost
if a string was truncated when reading due to the finite buffer size.

fix bug in the gdb reader that could result in data being written outside
the provided buffer.

enhance gdb readers to remove length limit on reading strings.