### PR TITLE
Fix g++-8 warnings in jeeps.

### DIFF
--- a/jeeps/gpsread.cc
+++ b/jeeps/gpsread.cc
@@ -84,7 +84,7 @@ int32 GPS_Serial_Packet_Read(gpsdevh* fd, GPS_PPacket* packet)
   start = GPS_Time_Now();
   GPS_Diag("Rx Data:");
   while (GPS_Time_Now() < start + GPS_TIME_OUT) {
-    if (int32 n = GPS_Serial_Chars_Ready(fd)) {
+    if (GPS_Serial_Chars_Ready(fd)) {
       if (GPS_Serial_Read(fd, &u, 1) < 0) {
         perror("read");
         GPS_Error("GPS_Packet_Read: Read error");

--- a/jeeps/gpssend.cc
+++ b/jeeps/gpssend.cc
@@ -118,7 +118,7 @@ DiagS(void* buf, size_t sz)
 
 int32 GPS_Serial_Write_Packet(gpsdevh* fd, GPS_PPacket& packet)
 {
-  size_t ret;
+  int32 ret;
   const char* m1, *m2;
   GPS_Serial_OPacket ser_pkt;
   UC ser_pkt_data[MAX_GPS_PACKET_SIZE * sizeof(UC)];


### PR DESCRIPTION
Fix warnings:
jeeps/gpsread.cc:87:15: warning: unused variable ‘n’ [-Wunused-variable]
jeeps/gpssend.cc:137:71: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
jeeps/gpssend.cc:148:74: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
jeeps/gpssend.cc:167:70: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]

Note that test coverage of serial interface is minimal to non-existent, so manual review of this change is encouraged.
