### PR TITLE
Remove unused minizip includes and targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1047,11 +1047,6 @@ yahoo.o: yahoo.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
 zlib/adler32.o: zlib/adler32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
   config.h
 zlib/compress.o: zlib/compress.c zlib/zlib.h zlib/zconf.h config.h
-zlib/contrib/minizip/ioapi.o: zlib/contrib/minizip/ioapi.c \
-  zlib/contrib/minizip/ioapi.h zlib/zlib.h zlib/zconf.h config.h
-zlib/contrib/minizip/zip.o: zlib/contrib/minizip/zip.c zlib/zlib.h \
-  zlib/zconf.h config.h zlib/contrib/minizip/zip.h \
-  zlib/contrib/minizip/ioapi.h zlib/contrib/minizip/crypt.h
 zlib/crc32.o: zlib/crc32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h config.h \
   zlib/crc32.h
 zlib/deflate.o: zlib/deflate.c zlib/deflate.h zlib/zutil.h zlib/zlib.h \

--- a/configure
+++ b/configure
@@ -6698,7 +6698,6 @@ done
 as_dir=jeeps; as_fn_mkdir_p
 as_dir=shapelib; as_fn_mkdir_p
 as_dir=src/core; as_fn_mkdir_p
-as_dir=zlib/contrib/minizip; as_fn_mkdir_p
 as_dir=testo.d; as_fn_mkdir_p
 
 ac_config_files="$ac_config_files Makefile gbversion.h gui/setup.iss xmldoc/makedoc tools/mkcapabilities win32/gpsbabel.rc"

--- a/configure.ac
+++ b/configure.ac
@@ -425,7 +425,6 @@ AC_SUBST(QT_LIBS)
 AS_MKDIR_P([jeeps])
 AS_MKDIR_P([shapelib])
 AS_MKDIR_P([src/core])
-AS_MKDIR_P([zlib/contrib/minizip])
 AS_MKDIR_P([testo.d])
 
 AC_CONFIG_FILES([Makefile gbversion.h gui/setup.iss xmldoc/makedoc tools/mkcapabilities win32/gpsbabel.rc])


### PR DESCRIPTION
HAVE_LIBMINIZIP was removed in:
ef579978 ("pull minizip from configure flow. (#339)", 2019-04-18)

---

Not sure if there is something else that should be changed to generate the Makefile.in changes, the section is headed "Machine generated from here down."

