### PR TITLE
Allow gpsbabelfe to be run from a Linux directory structure

### DIFF
--- a/gui/app.pro
+++ b/gui/app.pro
@@ -33,6 +33,10 @@ unix {
         DEFINES += HAVE_UDEV
         PKGCONFIG += libudev
     }
+    !isEmpty(PREFIX) {
+        PKGDATADIR = $$PREFIX/share/gpsbabel
+        DEFINES += PKGDATADIR=\\\"$$PKGDATADIR\\\"
+    }
 }
 
 UI_DIR = tmp

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -222,7 +222,11 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 
   ui_.outputWindow->setReadOnly(true);
 
+#ifdef PKGDATADIR
+  langPath_ = QLatin1String(PKGDATADIR);
+#else
   langPath_ = QApplication::applicationDirPath();
+#endif
   langPath_.append("/translations/");
 
   // Start up in the current system language.

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -227,7 +227,7 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 #else
   langPath_ = QApplication::applicationDirPath();
 #endif
-  langPath_.append("/translations/");
+  langPath_.append(QLatin1String("/translations"));
 
   // Start up in the current system language.
   loadLanguage(QLocale::system().name());

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -100,8 +100,7 @@ Map::Map(QWidget* parent,
     QMessageBox::critical(nullptr, appName,
                           tr("Missing \"gmapbase.html\" file.  Check installation"));
   } else {
-    QString urlStr = "file:///" + baseFile;
-    this->load(QUrl(urlStr));
+    this->load(QUrl::fromLocalFile(baseFile));
   }
 
 #ifdef DEBUG_JS_GENERATION

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -90,7 +90,12 @@ Map::Map(QWidget* parent,
   connect(mclicker, SIGNAL(logTime(QString)), this, SLOT(logTime(QString)));
 #endif
 
-  QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
+#ifdef PKGDATADIR
+  QString baseFile = QLatin1String(PKGDATADIR);
+#else
+  QString baseFile = QApplication::applicationDirPath();
+#endif
+  baseFile.append(QLatin1String("/gmapbase.html"));
   if (!QFile(baseFile).exists()) {
     QMessageBox::critical(nullptr, appName,
                           tr("Missing \"gmapbase.html\" file.  Check installation"));


### PR DESCRIPTION
Enable data files to be stored separately from the executable.
Create a qmake variable PREFIX which if set is used to construct a
directory path PREFIX/share/gpsbabel that the translations subdirectory
and gmapbase.html are expected to be found in.

---

Would typically install the executable as `/usr/bin/gpsbabelfe` but with the data files in `/usr/share/gpsbabel/`.

A couple of additional tidy ups, not required for this but in the same area of code. Kept separate for clarity but happy to squash in if preferred.
