### PR TITLE
Support storing GUI translations in a subdirectory or system location

### DIFF
--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -26,6 +26,7 @@
 #include <QtCore/QEvent>               // for QEvent (& QEvent::LanguageChange, QEvent::LocaleChange)
 #include <QtCore/QFile>                // for QFile
 #include <QtCore/QFileInfo>            // for QFileInfo
+#include <QtCore/QLibraryInfo>         // for QLibraryInfo
 #include <QtCore/QLocale>              // for QLocale
 #include <QtCore/QMimeData>            // for QMimeData
 #include <QtCore/QProcess>             // for QProcess, QProcess::NotRunning
@@ -222,9 +223,6 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 
   ui_.outputWindow->setReadOnly(true);
 
-  langPath_ = QApplication::applicationDirPath();
-  langPath_.append("/translations/");
-
   // Start up in the current system language.
   loadLanguage(QLocale::system().name());
   loadFormats();
@@ -315,7 +313,8 @@ void MainWindow::switchTranslator(QTranslator& translator, const QString& filena
   qApp->removeTranslator(&translator);
 
   // load the new translator
-  if (translator.load(filename, langPath_)) {
+  if (translator.load(filename,
+                      QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
     qApp->installTranslator(&translator);
   }
 }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -70,7 +70,6 @@ private:
   QTranslator     translatorCore_; // translation for the core application.
   QTranslator     translatorQt_;   // translations for Qt.
   QString         currLang_;       // currently loaded language.
-  QString         langPath_;       // Absolute path of language files.
 
 private:
   void loadFormats();

--- a/gui/package_app
+++ b/gui/package_app
@@ -106,15 +106,22 @@ cp coretool/gpsbabel_??.qm "${LANGDIR}"
 # and, for macos, make & deploy locversion.plist files.
 (convert_qt_translations)
 
+cat > qt.conf <<-EOT
+[PATH]
+Translations=${LANGDIR}
+EOT
+
 if [ "${machine}" = "Linux" ]; then
   cp objects/gpsbabelfe "${APPDIR}"
   cp ../gpsbabel "${APPDIR}"
   cp gmapbase.html "${APPDIR}"
   cp COPYING.txt "${APPDIR}"
+  cp qt.conf "${APPDIR}"
 else # Mac
   cp ../GPSBabel "${APPDIR}/Contents/MacOS/gpsbabel"
   cp gmapbase.html "${APPDIR}/Contents/MacOS"
   cp COPYING.txt "${APPDIR}/Contents/MacOS"
+  cp qt.conf "${APPDIR}/Contents/Resources"
   rm -f GPSBabelFE.dmg
   # macdeploytqt likes relative paths or else the dmg mount points get funky.
   "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -dmg -verbose=2


### PR DESCRIPTION
Find the translations using QLibraryInfo::TranslationsPath which will
point to the system location unless overriden by qt.conf.

The system location can be found using:
qmake -query QT_INSTALL_TRANSLATIONS

---

I've only tested the system location, not package_app.
