### PR TITLE
provide method to override file locations.

### DIFF
--- a/gui/app.pro
+++ b/gui/app.pro
@@ -33,6 +33,30 @@ unix {
         DEFINES += HAVE_UDEV
         PKGCONFIG += libudev
     }
+
+    # To override the installed location of gmapbase.html set PKGDATADIR.
+    # e.g. qmake PKGDATADIR=/usr/share/gpsbabel
+    !isEmpty(PKGDATADIR):DEFINES += PKGDATADIR=\\\"$$PKGDATADIR\\\"
+
+    # To override the installed location of the translation files (*.qm)
+    # set QTTRANSLATIONDIR.
+    # Common use case 1:
+    # If the translations are installed local to the package then 
+    # gpsbabel_*.qm, gpsbabelfe_*.qm and the concatenated qt_*.qm must all
+    # be in QTTRANSLATIONDIR.
+    # .e.g. qmake QTTRANSLATIONDIR=/usr/share/gpsbabel/translations
+    # Note that the package_app target will create the concatenated qt_*.qm files.
+    # The concatenated qt_*.qm files are DIFFERENT from the
+    # the Qt provided meta catalog file of the same name, the concatenated
+    # qt_*.qm files include all the necessary Qt provided module qm files.
+    # Common use case 2:
+    # If the translations are installed in the directory that contains all the
+    # original Qt provided translations, then only gpsbabel_*.qm and
+    # gpsbabelfe_*.qm need be installed alongside the original Qt provided
+    # translations (which include the meta catalogs as well as the module
+    # qm files.)
+    # .e.g. qmake QTTRANSLATIONDIR=/usr/share/qt5/translations
+    !isEmpty(QTTRANSLATIONDIR):DEFINES += QTTRANSLATIONDIR=\\\"$$QTTRANSLATIONDIR\\\"
 }
 
 UI_DIR = tmp

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -222,8 +222,11 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 
   ui_.outputWindow->setReadOnly(true);
 
-  langPath_ = QApplication::applicationDirPath();
-  langPath_.append("/translations/");
+#ifdef QTTRANSLATIONDIR
+  langPath_ = QTTRANSLATIONDIR;
+#else
+  langPath_ = QApplication::applicationDirPath() + "/translations";
+#endif
 
   // Start up in the current system language.
   loadLanguage(QLocale::system().name());

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -26,11 +26,14 @@
 #include <QtCore/QEvent>               // for QEvent (& QEvent::LanguageChange, QEvent::LocaleChange)
 #include <QtCore/QFile>                // for QFile
 #include <QtCore/QFileInfo>            // for QFileInfo
+#include <QtCore/QLibraryInfo>         // for QLibraryInfo, QLibraryInfo::TranslationsPath
 #include <QtCore/QLocale>              // for QLocale
 #include <QtCore/QMimeData>            // for QMimeData
 #include <QtCore/QProcess>             // for QProcess, QProcess::NotRunning
 #include <QtCore/QRegExp>              // for QRegExp
 #include <QtCore/QSettings>            // for QSettings
+#include <QtCore/QString>              // for QString
+#include <QtCore/QStringList>          // for QStringList
 #include <QtCore/QTemporaryFile>       // for QTemporaryFile
 #include <QtCore/QTime>                // for QTime
 #include <QtCore/QUrl>                 // for QUrl
@@ -39,7 +42,6 @@
 #include <QtCore/QtGlobal>             // for foreach
 #include <QtGui/QCursor>               // for QCursor
 #include <QtGui/QDesktopServices>      // for QDesktopServices
-#include <QtGui/QIcon>                 // for QIcon
 #include <QtGui/QImage>                // for QImage
 #include <QtWidgets/QApplication>      // for QApplication, qApp
 #include <QtWidgets/QCheckBox>         // for QCheckBox
@@ -222,12 +224,6 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 
   ui_.outputWindow->setReadOnly(true);
 
-#ifdef QTTRANSLATIONDIR
-  langPath_ = QTTRANSLATIONDIR;
-#else
-  langPath_ = QApplication::applicationDirPath() + "/translations";
-#endif
-
   // Start up in the current system language.
   loadLanguage(QLocale::system().name());
   loadFormats();
@@ -317,9 +313,22 @@ void MainWindow::switchTranslator(QTranslator& translator, const QString& filena
   // remove the old translator
   qApp->removeTranslator(&translator);
 
-  // load the new translator
-  if (translator.load(filename, langPath_)) {
-    qApp->installTranslator(&translator);
+  // Set a list of directories to search for the translation file.
+  const QStringList directories = {
+#ifdef PKGDATADIR
+    PKGDATADIR "/translations",
+#else
+    QApplication::applicationDirPath() + "/translations",
+#endif
+    QLibraryInfo::location(QLibraryInfo::TranslationsPath)
+  };
+
+  // Load the new translator.
+  for (const auto& directory : directories) {
+    if (translator.load(filename, directory)) {
+      qApp->installTranslator(&translator);
+      break;
+    }
   }
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -70,7 +70,6 @@ private:
   QTranslator     translatorCore_; // translation for the core application.
   QTranslator     translatorQt_;   // translations for Qt.
   QString         currLang_;       // currently loaded language.
-  QString         langPath_;       // Absolute path of language files.
 
 private:
   void loadFormats();

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -90,13 +90,16 @@ Map::Map(QWidget* parent,
   connect(mclicker, SIGNAL(logTime(QString)), this, SLOT(logTime(QString)));
 #endif
 
+#ifdef PKGDATADIR
+  QString baseFile =  PKGDATADIR + "/gmapbase.html";
+#else
   QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
+#endif
   if (!QFile(baseFile).exists()) {
     QMessageBox::critical(nullptr, appName,
                           tr("Missing \"gmapbase.html\" file.  Check installation"));
   } else {
-    QString urlStr = "file:///" + baseFile;
-    this->load(QUrl(urlStr));
+    this->load(QUrl::fromLocalFile(baseFile));
   }
 
 #ifdef DEBUG_JS_GENERATION

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -91,7 +91,7 @@ Map::Map(QWidget* parent,
 #endif
 
 #ifdef PKGDATADIR
-  QString baseFile =  PKGDATADIR + "/gmapbase.html";
+  QString baseFile =  PKGDATADIR  "/gmapbase.html";
 #else
   QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
 #endif


### PR DESCRIPTION
linux installs typically install the translation files
and gmapbase.html out of the tree.  These operations are now
supported, see. gui/app.pro and look for PKGDATADIR, QTTRANSLATIONDIR.