### PR TITLE
[WIP] Support make install for GUI on Linux systems

### DIFF
--- a/gui/app.pro
+++ b/gui/app.pro
@@ -33,58 +33,6 @@ unix {
         DEFINES += HAVE_UDEV
         PKGCONFIG += libudev
     }
-
-    # Setting PKGDATADIR will:
-    # 1. Look for gmapbase.html in PKGDATADIR instead
-    # of in QApplication::applicationDirPath().
-    # E.g. qmake PKGDATADIR=/usr/share/gpsbabel
-    # will use /usr/share/gpsbabel/gmapbase.html instead of
-    # QApplication::applicationDirPath() + "/gmapbase.html".
-    # 2. Substitude PKGDATADIR/translations in the search path for
-    # translation files instead of
-    # QApplication::applicationDirPath() + "/translations".
-    # E.g. qmake PKGDATADIR=/usr/share/gpsbabel
-    # will look in /usr/share/gpsbabel/translations instead of
-    # QApplication::applicationDirPath() + "/translations".
-
-    # We search for translation files (*.qm) in this order:
-    # 1a. Relative to the executable, specifically at
-    # QApplication::applicationDirPath() + "/translations".
-    # This works when we package the app on windows and macos.
-    # It also works we create a bundled app on linux,
-    # for example with the package target.  However, linux packagers typically
-    # install the translation files in another location.
-    #  OR
-    # 1b. In PKGDATADIR/translations.  This works for linux packages that
-    # place the translations in PKGDATADIR/translations, e.g.
-    # qmake PKGDATADIR=/usr/share/gpsbabel with the translations in
-    # /usr/share/gpsbabel/translations.
-    # 2. In the Qt TranslationsPath.  If this is not overridden in qt.conf it
-    # will point to the hard-coded paths that are compiled into the Qt library.
-    # This hard-coded path can be found with "qmake -query QT_INSTALL_TRANSLATIONS".
-    # This works for linux packages that have some or all translation files
-    # installed in the original location they used when compiling Qt.
-
-    # There are three sets of translation files that should be available
-    # when running gpsbabelfe:
-    # 1. gpsbabelfe_*.qm
-    # 2. gpsbabel_*.qm
-    # 3a. The Qt supplied meta catalogs (qt_*.qm) and the module files they
-    #     refer to (qt*_*.qm).
-    #     Note if you are counting on finding the Qt supplied translations,
-    #     then the package that provides the Qt translations
-    #     needs to be a prerequisite to the gpsbabel gui package.
-    #  OR
-    # 3b. The concatentated translation files for the modules that gpsbabelfe
-    #     uses.  These files are created by building the package target.
-    #     These are named identically to the Qt translation meta catalogs, i.e.
-    #     qt_*.qm, but contain the necessary translation data for the modules
-    #     gpsbabelfe uses.
-    # A description of the meta catalogs and concatentation process is
-    # available at
-    # https://doc.qt.io/qt-5/linguist-programmers.html#deploying-translations
-
-    !isEmpty(PKGDATADIR):DEFINES += PKGDATADIR=\\\"$$PKGDATADIR\\\"
 }
 
 UI_DIR = tmp
@@ -189,3 +137,79 @@ macx|linux{
   QMAKE_DISTCLEAN += compile_commands.json
 }
 
+linux:!isEmpty(PREFIX) {
+  DATADIR = $$PREFIX/share
+  ICONSDIR = $$DATADIR/pixmaps
+  PKGDATADIR = $$DATADIR/gpsbabel
+
+  target.path = $$PREFIX/bin
+
+  desktop.path = $$DATADIR/applications
+  desktop.files = gpsbabel.desktop
+
+  icon.path = $$ICONSDIR
+  icon.extra = $(INSTALL_FILE) images/appicon.png $(INSTALL_ROOT)$$ICONSDIR/gpsbabel.png
+
+  gmapbase.files = gmapbase.html
+  gmapbase.path = $$PKGDATADIR
+
+  translations.files = gpsbabelfe_*.qm
+  translations.files += coretool/gpsbabel_*.qm
+  translations.path = $$PKGDATADIR/translations
+
+  INSTALLS += target desktop icon gmapbase translations
+}
+
+unix {
+    # Setting PKGDATADIR will:
+    # 1. Look for gmapbase.html in PKGDATADIR instead
+    # of in QApplication::applicationDirPath().
+    # E.g. qmake PKGDATADIR=/usr/share/gpsbabel
+    # will use /usr/share/gpsbabel/gmapbase.html instead of
+    # QApplication::applicationDirPath() + "/gmapbase.html".
+    # 2. Substitude PKGDATADIR/translations in the search path for
+    # translation files instead of
+    # QApplication::applicationDirPath() + "/translations".
+    # E.g. qmake PKGDATADIR=/usr/share/gpsbabel
+    # will look in /usr/share/gpsbabel/translations instead of
+    # QApplication::applicationDirPath() + "/translations".
+
+    # We search for translation files (*.qm) in this order:
+    # 1a. Relative to the executable, specifically at
+    # QApplication::applicationDirPath() + "/translations".
+    # This works when we package the app on windows and macos.
+    # It also works we create a bundled app on linux,
+    # for example with the package target.  However, linux packagers typically
+    # install the translation files in another location.
+    #  OR
+    # 1b. In PKGDATADIR/translations.  This works for linux packages that
+    # place the translations in PKGDATADIR/translations, e.g.
+    # qmake PKGDATADIR=/usr/share/gpsbabel with the translations in
+    # /usr/share/gpsbabel/translations.
+    # 2. In the Qt TranslationsPath.  If this is not overridden in qt.conf it
+    # will point to the hard-coded paths that are compiled into the Qt library.
+    # This hard-coded path can be found with "qmake -query QT_INSTALL_TRANSLATIONS".
+    # This works for linux packages that have some or all translation files
+    # installed in the original location they used when compiling Qt.
+
+    # There are three sets of translation files that should be available
+    # when running gpsbabelfe:
+    # 1. gpsbabelfe_*.qm
+    # 2. gpsbabel_*.qm
+    # 3a. The Qt supplied meta catalogs (qt_*.qm) and the module files they
+    #     refer to (qt*_*.qm).
+    #     Note if you are counting on finding the Qt supplied translations,
+    #     then the package that provides the Qt translations
+    #     needs to be a prerequisite to the gpsbabel gui package.
+    #  OR
+    # 3b. The concatentated translation files for the modules that gpsbabelfe
+    #     uses.  These files are created by building the package target.
+    #     These are named identically to the Qt translation meta catalogs, i.e.
+    #     qt_*.qm, but contain the necessary translation data for the modules
+    #     gpsbabelfe uses.
+    # A description of the meta catalogs and concatentation process is
+    # available at
+    # https://doc.qt.io/qt-5/linguist-programmers.html#deploying-translations
+
+    !isEmpty(PKGDATADIR):DEFINES += PKGDATADIR=\\\"$$PKGDATADIR\\\"
+}

--- a/gui/app.pro
+++ b/gui/app.pro
@@ -33,6 +33,30 @@ unix {
         DEFINES += HAVE_UDEV
         PKGCONFIG += libudev
     }
+
+    # To override the installed location of gmapbase.html set PKGDATADIR.
+    # e.g. qmake PKGDATADIR=/usr/share/gpsbabel
+    !isEmpty(PKGDATADIR):DEFINES += PKGDATADIR=\\\"$$PKGDATADIR\\\"
+
+    # To override the installed location of the translation files (*.qm)
+    # set QTTRANSLATIONDIR.
+    # Common use case 1:
+    # If the translations are installed local to the package then 
+    # gpsbabel_*.qm, gpsbabelfe_*.qm and the concatenated qt_*.qm must all
+    # be in QTTRANSLATIONDIR.
+    # .e.g. qmake QTTRANSLATIONDIR=/usr/share/gpsbabel/translations
+    # Note that the package_app target will create the concatenated qt_*.qm files.
+    # The concatenated qt_*.qm files are DIFFERENT from the
+    # the Qt provided meta catalog file of the same name, the concatenated
+    # qt_*.qm files include all the necessary Qt provided module qm files.
+    # Common use case 2:
+    # If the translations are installed in the directory that contains all the
+    # original Qt provided translations, then only gpsbabel_*.qm and
+    # gpsbabelfe_*.qm need be installed alongside the original Qt provided
+    # translations (which include the meta catalogs as well as the module
+    # qm files.)
+    # .e.g. qmake QTTRANSLATIONDIR=/usr/share/qt5/translations
+    !isEmpty(QTTRANSLATIONDIR):DEFINES += QTTRANSLATIONDIR=\\\"$$QTTRANSLATIONDIR\\\"
 }
 
 UI_DIR = tmp

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -219,8 +219,11 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 
   ui_.outputWindow->setReadOnly(true);
 
-  langPath_ = QApplication::applicationDirPath();
-  langPath_.append("/translations/");
+#ifdef QTTRANSLATIONDIR
+  langPath_ = QTTRANSLATIONDIR;
+#else
+  langPath_ = QApplication::applicationDirPath() + "/translations";
+#endif
 
   // Start up in the current system language.
   loadLanguage(QLocale::system().name());

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -70,7 +70,6 @@ private:
   QTranslator     translatorCore_; // translation for the core application.
   QTranslator     translatorQt_;   // translations for Qt.
   QString         currLang_;       // currently loaded language.
-  QString         langPath_;       // Absolute path of language files.
 
 private:
   void loadFormats();

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -90,13 +90,16 @@ Map::Map(QWidget* parent,
   connect(mclicker, SIGNAL(logTime(QString)), this, SLOT(logTime(QString)));
 #endif
 
+#ifdef PKGDATADIR
+  QString baseFile =  PKGDATADIR + "/gmapbase.html";
+#else
   QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
+#endif
   if (!QFile(baseFile).exists()) {
     QMessageBox::critical(nullptr, appName,
                           tr("Missing \"gmapbase.html\" file.  Check installation"));
   } else {
-    QString urlStr = "file:///" + baseFile;
-    this->load(QUrl(urlStr));
+    this->load(QUrl::fromLocalFile(baseFile));
   }
 
 #ifdef DEBUG_JS_GENERATION

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -91,7 +91,7 @@ Map::Map(QWidget* parent,
 #endif
 
 #ifdef PKGDATADIR
-  QString baseFile =  PKGDATADIR + "/gmapbase.html";
+  QString baseFile =  PKGDATADIR  "/gmapbase.html";
 #else
   QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
 #endif


### PR DESCRIPTION
Worth some review but this is my ideal, requiring:
```
qmake PREFIX=/usr
make
make install
```
and you have a working GUI with translations, while hopefully not changing anything for package_app (untested).

I can get make to run lrelease by adding `CONFIG += lrelease` but can't see how to get the qm files created in .qm subdirectory installed.
https://bugreports.qt.io/browse/QTBUG-77398
