### PR TITLE
Standardize resource access

### DIFF
--- a/gui/advdlg.cc
+++ b/gui/advdlg.cc
@@ -40,8 +40,8 @@ AdvDlg::AdvDlg(QWidget* parent,
   ui_.previewGmap->setChecked(previewGmap);
   ui_.debugCombo->setCurrentIndex(debugLevel+1);
 #if defined (Q_OS_WIN)
-  ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":images/ok"));
-  ui_.buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":images/cancel"));
+  ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":/images/ok.png"));
+  ui_.buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":/images/cancel.png"));
 #endif // Q_OS_WIN
   connect(ui_.buttonBox, SIGNAL(accepted()), this, SLOT(acceptClicked()));
   connect(ui_.buttonBox, SIGNAL(rejected()), this, SLOT(rejectClicked()));

--- a/gui/filterdlg.cc
+++ b/gui/filterdlg.cc
@@ -60,8 +60,8 @@ FilterDialog::FilterDialog(QWidget* parent, AllFiltersData& fd): QDialog(parent)
   connect(ui_.resetButton, SIGNAL(clicked()), this, SLOT(resetX()));
 
 #if defined (Q_OS_WIN)
-  ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":images/ok"));
-  ui_.buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":images/cancel"));
+  ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":/images/ok.png"));
+  ui_.buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":/images/cancel.png"));
 #endif
 
   ui_.filterList->setCurrentRow(lastPage_);

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -199,8 +199,8 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 
 #if defined (Q_OS_WIN)
   // Windows users like the colored buttons.  They look out of place elsewhere.
-  ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":images/runit.png"));
-  ui_.buttonBox->button(QDialogButtonBox::Close)->setIcon(QIcon(":images/exit.png"));
+  ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":/images/runit.png"));
+  ui_.buttonBox->button(QDialogButtonBox::Close)->setIcon(QIcon(":/images/exit.png"));
 #endif
 
   ui_.inputOptionsText->setReadOnly(true);
@@ -212,10 +212,10 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
 #else
   setAcceptDrops(true);
 #endif
-  lights_[0] = QPixmap::fromImage(QImage(":images/00.png").scaledToHeight(20, Qt::SmoothTransformation));
-  lights_[1] = QPixmap::fromImage(QImage(":images/01.png").scaledToHeight(20, Qt::SmoothTransformation));
-  lights_[2] = QPixmap::fromImage(QImage(":images/10.png").scaledToHeight(20, Qt::SmoothTransformation));
-  lights_[3] = QPixmap::fromImage(QImage(":images/11.png").scaledToHeight(20, Qt::SmoothTransformation));
+  lights_[0] = QPixmap::fromImage(QImage(":/images/00.png").scaledToHeight(20, Qt::SmoothTransformation));
+  lights_[1] = QPixmap::fromImage(QImage(":/images/01.png").scaledToHeight(20, Qt::SmoothTransformation));
+  lights_[2] = QPixmap::fromImage(QImage(":/images/10.png").scaledToHeight(20, Qt::SmoothTransformation));
+  lights_[3] = QPixmap::fromImage(QImage(":/images/11.png").scaledToHeight(20, Qt::SmoothTransformation));
 
   ui_.outputWindow->setReadOnly(true);
 

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -123,7 +123,7 @@ OptionsDlg::OptionsDlg(QWidget* parent,  const QString& fmtName, QList<FormatOpt
       QLineEdit* lineEdit = new QLineEdit(this);
       QToolButton* button = new QToolButton(this);
       lineEdit->setText(getOptionValue(options_, k).toString());
-      button->setIcon(QIcon(inFile ? ":images/file.png" : ":images/save.png"));
+      button->setIcon(QIcon(inFile ? ":/images/file.png" : ":/images/save.png"));
       w = lineEdit;
       horizontalSpacer->changeSize(5, 20, QSizePolicy::Fixed, QSizePolicy::Minimum);
       horizontalLayout->addWidget(lineEdit);
@@ -209,8 +209,10 @@ OptionsDlg::OptionsDlg(QWidget* parent,  const QString& fmtName, QList<FormatOpt
   buttonBox_->setStandardButtons(QDialogButtonBox::Cancel|QDialogButtonBox::Ok);
   lay->addWidget(buttonBox_);
   verticalLayout->addLayout(lay);
-  buttonBox_->button(QDialogButtonBox::Ok)->setIcon(QIcon(":images/ok"));
-  buttonBox_->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":images/cancel"));
+#if defined (Q_OS_WIN)
+  buttonBox_->button(QDialogButtonBox::Ok)->setIcon(QIcon(":/images/ok.png"));
+  buttonBox_->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":/images/cancel.png"));
+#endif // Q_OS_WIN
 
   connect(buttonBox_, SIGNAL(accepted()), this, SLOT(acceptClicked()));
   connect(buttonBox_, SIGNAL(rejected()), this, SLOT(rejectClicked()));

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -123,7 +123,7 @@ OptionsDlg::OptionsDlg(QWidget* parent,  const QString& fmtName, QList<FormatOpt
       QLineEdit* lineEdit = new QLineEdit(this);
       QToolButton* button = new QToolButton(this);
       lineEdit->setText(getOptionValue(options_, k).toString());
-      button->setIcon(QIcon(inFile ? ":/images/file.png" : ":/images/save.png"));
+      button->setIcon(QIcon(inFile ? ":/images/open.png" : ":/images/save.png"));
       w = lineEdit;
       horizontalSpacer->changeSize(5, 20, QSizePolicy::Fixed, QSizePolicy::Minimum);
       horizontalLayout->addWidget(lineEdit);


### PR DESCRIPTION
avoid search paths (use :/) when looking for resources.
specify extensions when looking for resources.
use the ok/cancel icons only on windows in all cases instead of just some cases.

fix missing icon for file input in options dialog. This fixes #392.
