### PR TITLE
store gmapbase.html as an internal resource.

### DIFF
--- a/gui/app.qrc
+++ b/gui/app.qrc
@@ -15,6 +15,7 @@
      <file>images/cancel.png</file>
      <file>images/reload.png</file>
      <file>images/appicon.png</file>
+     <file>gmapbase.html</file>
  </qresource>
  </RCC>
 

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -90,14 +90,9 @@ Map::Map(QWidget* parent,
   connect(mclicker, SIGNAL(logTime(QString)), this, SLOT(logTime(QString)));
 #endif
 
-  QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
-  if (!QFile(baseFile).exists()) {
-    QMessageBox::critical(nullptr, appName,
-                          tr("Missing \"gmapbase.html\" file.  Check installation"));
-  } else {
-    QString urlStr = "file:///" + baseFile;
-    this->load(QUrl(urlStr));
-  }
+  // gmapbase.html is stored as an internal resource.
+  // gmapbase.html does NOT need to be distributed with gpsbabel.
+  this->load(QUrl("qrc:///gmapbase.html"));
 
 #ifdef DEBUG_JS_GENERATION
   dbgdata_ = new QFile("mapdebug.js");

--- a/gui/package_app
+++ b/gui/package_app
@@ -109,11 +109,9 @@ cp coretool/gpsbabel_??.qm "${LANGDIR}"
 if [ "${machine}" = "Linux" ]; then
   cp objects/gpsbabelfe "${APPDIR}"
   cp ../gpsbabel "${APPDIR}"
-  cp gmapbase.html "${APPDIR}"
   cp COPYING.txt "${APPDIR}"
 else # Mac
   cp ../GPSBabel "${APPDIR}/Contents/MacOS/gpsbabel"
-  cp gmapbase.html "${APPDIR}/Contents/MacOS"
   cp COPYING.txt "${APPDIR}/Contents/MacOS"
   rm -f GPSBabelFE.dmg
   # macdeploytqt likes relative paths or else the dmg mount points get funky.

--- a/gui/setup.iss
+++ b/gui/setup.iss
@@ -42,7 +42,6 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: gmapbase.html; 			DestDir: "{app}"; Flags: ignoreversion
 Source: qt.conf;       			DestDir: "{app}"; Flags: ignoreversion
 
 Source: "..\{#gui_build_dir_name}\release\*"; Excludes: "app.res,vcredist_*.exe,*.cpp,*.h,*.o,*.obj"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/gui/setup.iss.in
+++ b/gui/setup.iss.in
@@ -42,7 +42,6 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: gmapbase.html; 			DestDir: "{app}"; Flags: ignoreversion
 Source: qt.conf;       			DestDir: "{app}"; Flags: ignoreversion
 
 Source: "..\{#gui_build_dir_name}\release\*"; Excludes: "app.res,vcredist_*.exe,*.cpp,*.h,*.o,*.obj"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
This removes all requirements about gmapbase.html from
any packaging efforts, it is no longer necessary to include it
in the package on all systems including Windows, Macos, and Linux.