### PR TITLE
clang-tidy modernize-use-using

### DIFF
--- a/an1.cc
+++ b/an1.cc
@@ -48,10 +48,10 @@ static double radius = 0.0;
 static long serial=10000;
 static long rtserial=1;
 
-typedef struct roadchange {
+struct roadchange {
   long type;
   char* name;
-} roadchange;
+};
 
 static roadchange* roadchanges = nullptr;
 
@@ -97,11 +97,11 @@ arglist_t an1_args[] = {
   ARG_TERMINATOR
 };
 
-typedef struct guid {
+struct guid_t {
   unsigned long l;
   unsigned short s[3];
   unsigned char c[6];
-} GUID;
+};
 
 #include "an1sym.h"
 
@@ -127,7 +127,7 @@ ReadString(gbfile* f, short len)
 #define WriteString(f,s) gbfputs((s),f)
 
 static void
-ReadGuid(gbfile* f, GUID* guid)
+ReadGuid(gbfile* f, guid_t* guid)
 {
   guid->l = ReadLong(f);
   for (unsigned short &i : guid->s) {
@@ -139,7 +139,7 @@ ReadGuid(gbfile* f, GUID* guid)
 }
 
 static void
-WriteGuid(gbfile* f, GUID* guid)
+WriteGuid(gbfile* f, guid_t* guid)
 {
   WriteLong(f, guid->l);
   for (int i = 0; i < 3; i++) {
@@ -169,15 +169,15 @@ EncodeOrd(double ord)
   return (int32_t)(0x80000000 - (int32_t)(ord * 0x800000));
 }
 
-typedef struct {
+struct an1_symbol_record {
   short hotspotxhi;
   long hotspoty;
   long unk1;
-  GUID guid;
+  guid_t guid;
   char* name;
-} an1_symbol_record;
+};
 
-typedef struct {
+struct an1_waypoint_record {
   format_specific_data fs;
   short magic;
   long unk1;
@@ -196,7 +196,7 @@ typedef struct {
   double radius; /* in km */
   char* name;
   char* fontname;
-  GUID guid;
+  guid_t guid;
   long fontcolor;
   long fontstyle;
   long fontsize;
@@ -214,18 +214,18 @@ typedef struct {
   long creation_time;
   long modification_time;
   char* image_name;
-} an1_waypoint_record;
+};
 
-typedef struct {
+struct an1_vertex_record {
   format_specific_data fs;
   short magic;
   long unk0;
   long lon;
   long lat;
   short unk1;
-} an1_vertex_record;
+};
 
-typedef struct {
+struct an1_line_record {
   format_specific_data fs;
   long roadtype;
   short serial;
@@ -243,7 +243,7 @@ typedef struct {
   long unk7;
   short unk8;
   long pointcount;
-} an1_line_record;
+};
 
 static an1_waypoint_record* Alloc_AN1_Waypoint();
 

--- a/an1sym.h
+++ b/an1sym.h
@@ -61,7 +61,7 @@
  */
 
 static struct defguid {
-  GUID guid;
+  guid_t guid;
   const char* name;
 } default_guids[] = {
   { {0xb610bc70,{0x377e, 0x11d6, 0xaeb3}, {0x00, 0x01, 0x02, 0x31, 0x5f, 0xfd}},
@@ -708,21 +708,21 @@ static struct defguid {
   },
 };
 
-static int FindIconByName(const char* name, GUID* guid)
+static int FindIconByName(const char* name, guid_t* guid)
 {
   for (unsigned int i = 0; i < (sizeof(default_guids)/sizeof(struct defguid)); i++) {
     if (!case_ignore_strcmp(name, default_guids[i].name)) {
-      memcpy(guid, &(default_guids[i].guid), sizeof(GUID));
+      memcpy(guid, &(default_guids[i].guid), sizeof(guid_t));
       return 1;
     }
   }
   return 0;
 }
 
-static int FindIconByGuid(GUID* guid, char** name)
+static int FindIconByGuid(guid_t* guid, char** name)
 {
   for (unsigned int i = 0; i < (sizeof(default_guids)/sizeof(struct defguid)); i++) {
-    if (!memcmp(guid, &default_guids[i].guid, sizeof(GUID))) {
+    if (!memcmp(guid, &default_guids[i].guid, sizeof(guid_t))) {
       *name = const_cast<char*>(default_guids[i].name);
       return 1;
     }

--- a/arcdist.h
+++ b/arcdist.h
@@ -47,12 +47,12 @@ private:
   char* ptsopt = nullptr;
   char* projectopt = nullptr;
 
-  typedef struct {
+  struct extra_data {
     double distance;
     double prjlatitude, prjlongitude;
     double frac;
     Waypoint* arcpt1, * arcpt2;
-  } extra_data;
+  };
 
   arglist_t args[8] = {
     {

--- a/bcr.cc
+++ b/bcr.cc
@@ -88,12 +88,12 @@ arglist_t bcr_args[] = {
   ARG_TERMINATOR
 };
 
-typedef struct {
+struct bcr_icon_mapping_t {
   const char* bcr_name;
   const char* mps_name;
   const char* symbol_DE;
   bool  warned;
-} bcr_icon_mapping_t;
+};
 
 static
 bcr_icon_mapping_t bcr_icon_mapping[] = {

--- a/brauniger_iq.cc
+++ b/brauniger_iq.cc
@@ -27,7 +27,7 @@ static void* serial_handle;
 #define MYNAME "BRAUNIGER-IQ"
 #define PRESTRKNAME "PRESALTTRK"
 
-typedef enum {
+enum state_t {
   st_sync,
   st_fl_num,
   st_data_len,
@@ -45,7 +45,7 @@ typedef enum {
   st_sample_alt,
   st_sample_spd,
   num_states
-} state_t;
+};
 static state_t state;
 inline state_t& operator++(state_t& s) // prefix
 {

--- a/bushnell.cc
+++ b/bushnell.cc
@@ -37,12 +37,12 @@ arglist_t bushnell_args[] = {
 // Apparently, the icons are undocumented, so we made up names,
 // preferring them to be consistent with other brands where possible.
 
-typedef struct  {
-  const signed int symbol;
+struct bushnell_icon_mapping_t {
+  signed int symbol;
   const char* icon;
-} icon_mapping_t;
+};
 
-static icon_mapping_t bushnell_icons[] = {
+static const bushnell_icon_mapping_t bushnell_icons[] = {
   { 0x00, "Yellow Square"},
   { 0x01, "Blue Grey Circle" },
   { 0x02, "Yellow Diamond" },
@@ -134,7 +134,7 @@ bushnell_get_icon_from_name(QString name)
     name = "Waypoint";
   }
 
-  for (icon_mapping_t* t = bushnell_icons; t->icon != nullptr; t++) {
+  for (const bushnell_icon_mapping_t* t = bushnell_icons; t->icon != nullptr; t++) {
     if (0 == name.compare(t->icon, Qt::CaseInsensitive)) {
       return t->symbol;
     }
@@ -145,7 +145,7 @@ bushnell_get_icon_from_name(QString name)
 static const char*
 bushnell_get_name_from_symbol(signed int s)
 {
-  for (icon_mapping_t* t = bushnell_icons; t->icon != nullptr; t++) {
+  for (const bushnell_icon_mapping_t* t = bushnell_icons; t->icon != nullptr; t++) {
     if (s == t->symbol) {
       return t->icon;
     }

--- a/cet.h
+++ b/cet.h
@@ -27,15 +27,15 @@
 #define CET_ERROR	1
 #define CET_SUCCESS	0
 
-typedef struct cet_ucs4_link_s {
+struct cet_ucs4_link_t {
   int value;			/* UCS-4 value 			*/
   short origin;			/* associated character 	*/
-} cet_ucs4_link_t;
+};
 
-typedef struct cet_cs_vec_s {
+struct cet_cs_vec_t {
   const char* name;			/* name of character set 	*/
   const char** alias;			/* alias table  		*/
-  struct cet_cs_vec_s* fallback;		/* fallback character set       */
+  cet_cs_vec_t* fallback;		/* fallback character set       */
   void* unused;
   const int* ucs4_map;			/* char to UCS-4 value table 	*/
   const int ucs4_offset;			/* first non standard character */
@@ -44,8 +44,8 @@ typedef struct cet_cs_vec_s {
   const int ucs4_links;			/* number of links 		*/
   const cet_ucs4_link_t* ucs4_extra;	/* Non standard UCS-4 to ...    */
   const int ucs4_extras;			/* number of extra links 	*/
-  struct cet_cs_vec_s* next;
-} cet_cs_vec_t;
+  cet_cs_vec_t* next;
+};
 
 /* single char/value transmission */
 

--- a/cet_util.cc
+++ b/cet_util.cc
@@ -31,10 +31,10 @@
 
 static cet_cs_vec_t* cet_cs_vec_root = nullptr;
 
-typedef struct cet_cs_alias_s {
+struct cet_cs_alias_t {
   char* name;
   cet_cs_vec_t* vec;
-} cet_cs_alias_t;
+};
 
 static cet_cs_alias_t* cet_cs_alias;
 static int cet_cs_alias_ct = 0;

--- a/defs.h
+++ b/defs.h
@@ -165,13 +165,13 @@
  * Important for "file types" that are essentially a communication
  * protocol for a receiver, like the Magellan serial data.
  */
-typedef enum {
+enum gpsdata_type {
   unknown_gpsdata = 0,
   trkdata = 1,
   wptdata,
   rtedata,
   posndata
-} gpsdata_type;
+};
 
 #define NOTHINGMASK		0U
 #define WPTDATAMASK		1U
@@ -186,7 +186,7 @@ typedef enum {
 #define	doing_rtes ((global_opts.masked_objective & RTEDATAMASK) == RTEDATAMASK)
 #define	doing_posn ((global_opts.masked_objective & POSNDATAMASK) == POSNDATAMASK)
 
-typedef struct {
+struct global_options {
   int synthesize_shortnames;
   int debug_level;
   gpsdata_type objective;
@@ -198,34 +198,34 @@ typedef struct {
   QString charset_name;
   inifile_t* inifile;
   QTextCodec* codec;
-} global_options;
+};
 
 extern global_options global_opts;
 extern const char gpsbabel_version[];
 extern time_t gpsbabel_now;	/* gpsbabel startup-time; initialized in main.c with time() */
 extern time_t gpsbabel_time;	/* gpsbabel startup-time; initialized in main.c with current_time(), ! ZERO within testo ! */
 
-typedef enum {
+enum fix_type {
   fix_unknown=-1,
   fix_none=0,
   fix_2d=1,
   fix_3d,
   fix_dgps,
   fix_pps
-} fix_type;
+};
 
-typedef enum {
+enum status_type {
   status_unknown=0,
   status_true,
   status_false
-} status_type;
+};
 
 /*
  * Extended data if waypoint happens to represent a geocache.  This is
  * totally voluntary data...
  */
 
-typedef enum {
+enum geocache_type {
   gt_unknown = 0,
   gt_traditional,
   gt_multi,
@@ -241,9 +241,9 @@ typedef enum {
   gt_ape,
   gt_mega,
   gt_wherigo
-} geocache_type;
+};
 
-typedef enum {
+enum geocache_container {
   gc_unknown = 0,
   gc_micro,
   gc_other,
@@ -251,7 +251,7 @@ typedef enum {
   gc_large,
   gc_virtual,
   gc_small
-} geocache_container;
+};
 
 class utf_string
 {
@@ -301,18 +301,18 @@ public:
   QString personal_note;
 };
 
-typedef void (*fs_destroy)(void*);
-typedef void (*fs_copy)(void**, void*);
-typedef void (*fs_convert)(void*);
+using fs_destroy = void (*)(void*);
+using fs_copy = void (*)(void**, void*);
+using fs_convert = void (*)(void*);
 
-typedef struct format_specific_data {
+struct format_specific_data {
   long type;
   struct format_specific_data* next;
 
   fs_destroy destroy;
   fs_copy copy;
   fs_convert convert;
-} format_specific_data;
+};
 
 class gb_color
 {
@@ -444,14 +444,14 @@ public:
 /*
  *  Bounding box information.
  */
-typedef struct {
+struct bounds {
   double max_lat;
   double max_lon;
   double max_alt;	/*  unknown_alt => invalid */
   double min_lat;
   double min_lon;
   double min_alt;	/* -unknown_alt => invalid */
-} bounds;
+};
 
 #define WAYPT_SET(wpt,member,val) { (wpt)->member = (val); wpt->wpt_flags.member = 1; }
 #define WAYPT_GET(wpt,member,def) ((wpt->wpt_flags.member) ? (wpt->member) : (def))
@@ -570,13 +570,13 @@ public:
   int EmptyGCData() const;
 };
 
-typedef void (*waypt_cb)(const Waypoint*);
+using waypt_cb = void (*)(const Waypoint*);
 
 // TODO: Consider using composition instead of private inheritance.
 class WaypointList : private QList<Waypoint*>
 {
 public:
-  typedef bool (*Compare)(const Waypoint* a, const Waypoint* b);
+  using Compare = bool (*)(const Waypoint*, const Waypoint*);
 
   void waypt_add(Waypoint* wpt); // a.k.a. append(), push_back()
   void add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, const QString& namepart, int number_digits);
@@ -733,14 +733,14 @@ public:
   ~route_head();
 };
 
-typedef void (*route_hdr)(const route_head*);
-typedef void (*route_trl)(const route_head*);
+using route_hdr = void (*)(const route_head*);
+using route_trl = void (*)(const route_head*);
 
 // TODO: Consider using composition instead of private inheritance.
 class RouteList : private QList<route_head*>
 {
 public:
-  typedef bool (*Compare)(const route_head* a, const route_head* b);
+  using Compare = bool (*)(const route_head*, const route_head*);
 
   int waypt_count() const;
   void add_head(route_head* rte); // a.k.a. append(), push_back()
@@ -906,19 +906,19 @@ track_disp_all(T1 rh, T2 rt, T3 wc)
   global_track_list->disp_all(rh, rt, wc);
 }
 
-typedef struct {
+struct posn_status {
   volatile int request_terminate;
-} posn_status;
+};
 
 extern posn_status tracking_status;
 
-typedef void (*ff_init)(const QString&);
-typedef void (*ff_deinit)();
-typedef void (*ff_read)();
-typedef void (*ff_write)();
-typedef void (*ff_exit)();
-typedef void (*ff_writeposn)(Waypoint*);
-typedef Waypoint* (*ff_readposn)(posn_status*);
+using ff_init = void (*)(const QString&);
+using ff_deinit = void (*)();
+using ff_read = void (*)();
+using ff_write = void (*)();
+using ff_exit = void (*)();
+using ff_writeposn = void (*)(Waypoint*);
+using ff_readposn = Waypoint* (*)(posn_status*);
 
 char* get_option(const char* iarglist, const char* argname);
 
@@ -932,7 +932,7 @@ geocache_container gs_mkcont(const QString& t);
 // This is a crutch until the new C++ shorthandle goes in.
 
 struct mkshort_handle_imp; // forward declare, definition in mkshort.cc
-typedef mkshort_handle_imp* short_handle;
+using short_handle = mkshort_handle_imp*;
 
 char* mkshort(short_handle,  const char*);
 QString mkshort(short_handle,  const QString&);
@@ -997,23 +997,23 @@ struct arglist_t {
   char* argvalptr;	/* !!! internal helper. Not used in definitions !!! */
 };
 
-typedef enum {
+enum ff_type {
   ff_type_file = 1,	/* normal format: useful to a GUI. */
   ff_type_internal,	/* fmt not useful with default options */
   ff_type_serial		/* format describes a serial protocol (GUI can display port names) */
-} ff_type;
+};
 
-typedef enum {
+enum ff_cap_array {
   ff_cap_rw_wpt,
   ff_cap_rw_trk,
   ff_cap_rw_rte
-} ff_cap_array;
+};
 
-typedef enum {
+enum ff_cap {
   ff_cap_none,
   ff_cap_read = 1,
   ff_cap_write = 2
-} ff_cap;
+};
 
 #define FF_CAP_RW_ALL \
 	{ (ff_cap) (ff_cap_read | ff_cap_write), (ff_cap) (ff_cap_read | ff_cap_write), (ff_cap) (ff_cap_read | ff_cap_write) }
@@ -1024,7 +1024,7 @@ typedef enum {
 /*
  * Format capabilities for realtime positioning.
  */
-typedef struct position_ops {
+struct position_ops_t {
   ff_init rd_init;
   ff_readposn rd_position;
   ff_deinit rd_deinit;
@@ -1032,14 +1032,14 @@ typedef struct position_ops {
   ff_init wr_init;
   ff_writeposn wr_position;
   ff_deinit wr_deinit;
-} position_ops_t;
+};
 
-#define NULL_POS_OPS { 0, 0, 0, 0, 0, 0, }
+#define NULL_POS_OPS { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, }
 
 /*
  *  Describe the file format to the caller.
  */
-typedef struct ff_vecs {
+struct ff_vecs_t {
   ff_type type;
   ff_cap cap[3];
   ff_init rd_init;
@@ -1054,7 +1054,7 @@ typedef struct ff_vecs {
   int fixed_encode;
   position_ops_t position_ops;
   const char* name;		/* dyn. initialized by find_vec */
-} ff_vecs_t;
+};
 
 struct style_vecs_t {
   const char* name;
@@ -1203,7 +1203,7 @@ void   le_write_double(void* ptr, double value);
 double ddmm2degrees(double pcx_val);
 double degrees2ddmm(double deg_val);
 
-typedef enum {
+enum grid_type {
   grid_unknown = -1,
   grid_lat_lon_ddd = 0,
   grid_lat_lon_dmm = 1,
@@ -1211,7 +1211,7 @@ typedef enum {
   grid_bng = 3,
   grid_utm = 4,
   grid_swiss = 5
-} grid_type;
+};
 
 #define GRID_INDEX_MIN	grid_lat_lon_ddd
 #define GRID_INDEX_MAX	grid_swiss
@@ -1249,13 +1249,13 @@ unsigned long get_crc32(const void* data, int datalen);
 /*
  *  From units.c
  */
-typedef enum {
+enum fmt_units {
   units_unknown = 0,
   units_statute = 1,
   units_metric = 2,
   units_nautical =3,
   units_aviation =4
-} fmt_units;
+};
 
 int    fmt_setunits(fmt_units);
 double fmt_distance(double, const char** tag);

--- a/defs.h
+++ b/defs.h
@@ -307,7 +307,7 @@ using fs_convert = void (*)(void*);
 
 struct format_specific_data {
   long type;
-  struct format_specific_data* next;
+  format_specific_data* next;
 
   fs_destroy destroy;
   fs_copy copy;

--- a/delgpl.cc
+++ b/delgpl.cc
@@ -23,7 +23,7 @@
 
 #define MYNAME "GPL"
 
-typedef struct gpl_point {
+struct gpl_point_t {
   unsigned int status;
   unsigned int dummy1;
   double lat;
@@ -33,7 +33,7 @@ typedef struct gpl_point {
   double speed; /* mph */
   unsigned int tm;
   unsigned int dummy3;
-} gpl_point_t;
+};
 
 static gbfile* gplfile_in;
 static gbfile* gplfile_out;
@@ -42,9 +42,9 @@ static void
 gpl_rd_init(const QString& fname)
 {
   gplfile_in = gbfopen_le(fname, "rb", MYNAME);
-  if (sizeof(struct gpl_point) != 56) {
+  if (sizeof(gpl_point_t) != 56) {
     fatal(MYNAME ": gpl_point is %lu instead of 56.\n",
-          (unsigned long) sizeof(struct gpl_point));
+          (unsigned long) sizeof(gpl_point_t));
   }
 }
 

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -38,14 +38,14 @@
 
 #define MYNAME "DG-100"
 
-typedef struct {
+struct model_t {
   const char *name;
   unsigned speed;
   int has_trailing_bytes;
   int has_payload_end_seq;
   struct dg100_command *commands;
   unsigned int numcommands;
-} model_t;
+};
 
 static const model_t* model;
 

--- a/duplicate.h
+++ b/duplicate.h
@@ -62,19 +62,20 @@ private:
     ARG_TERMINATOR
   };
 
-  typedef struct btree_node {
-    struct btree_node* left, *right;
+  struct btree_node {
+    btree_node* left;
+    btree_node* right;
     unsigned long data;
     Waypoint* wpt;
-  } btree_node;
+  };
 
   btree_node* addnode(btree_node* tree, btree_node* newnode, btree_node** oldnode);
   void free_tree(btree_node* tree);
 
-  typedef struct {
+  struct wpt_ptr {
     Waypoint* wpt;
     int index;
-  } wpt_ptr;
+  };
 
   static int compare(const void* a, const void* b);
 

--- a/energympro.cc
+++ b/energympro.cc
@@ -3,7 +3,7 @@
 
     Copyright (c) 2014 Zingo Andersen zingo@vectrace.com
     Copyright (C) 2014 Robert Lipe, robertlipe+source@gpsbabel.org
- 
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -28,118 +28,113 @@
 
 static gbfile* file_in;
 
-typedef struct tagDATE
-{
+struct tw_date {
   uint8_t Year;
   uint8_t Month;
   uint8_t Day;
-} tw_date;
+};
 
-typedef struct tagTIME
-{
+struct tw_time {
   uint8_t Hour;
   uint8_t Minute;
   uint8_t Second;
-} tw_time;
+};
 
-typedef struct Workout
-    {
-    tw_date       dateStart;            // start date
-    tw_time       timeStart;            // start time
-    uint16_t      TotalRecPt;           // Total record Point
-    uint32_t      TotalTime;            // Total Time
-    uint32_t      TotalDist;            // Total Distance
-    uint16_t      LapNumber;            // Lap Number
-    uint16_t      Calory;               // Calory  
-    uint32_t      MaxSpeed;             // Max Speed   
-    uint32_t      AvgSpeed;             // average Speed   
-    uint8_t       MaxHeart;             // Max Heartrate  
-    uint8_t       AvgHeart;             // average Heart   
-    uint16_t      Ascent;               // Ascent   
-    uint16_t      Descent;              // Descent   
-    int16_t       MinAlti;              // Min Altitude
-    int16_t       MaxAlti;              // Max Altitude
-    uint8_t       AvgCad;               // average Cadence
-    uint8_t       MaxCad;               // Best Cadence
-    uint16_t      AvgPower;             // average Power 
-    uint16_t      MaxPower;             // Max Power 
-    char          VersionProduct[15];
-    uint8_t       reserved1;
-    uint8_t       VersionVerNum;   
-    uint8_t       reserved2[17];
-    } tw_workout;
+struct tw_workout {
+  tw_date       dateStart;            // start date
+  tw_time       timeStart;            // start time
+  uint16_t      TotalRecPt;           // Total record Point
+  uint32_t      TotalTime;            // Total Time
+  uint32_t      TotalDist;            // Total Distance
+  uint16_t      LapNumber;            // Lap Number
+  uint16_t      Calory;               // Calory
+  uint32_t      MaxSpeed;             // Max Speed
+  uint32_t      AvgSpeed;             // average Speed
+  uint8_t       MaxHeart;             // Max Heartrate
+  uint8_t       AvgHeart;             // average Heart
+  uint16_t      Ascent;               // Ascent
+  uint16_t      Descent;              // Descent
+  int16_t       MinAlti;              // Min Altitude
+  int16_t       MaxAlti;              // Max Altitude
+  uint8_t       AvgCad;               // average Cadence
+  uint8_t       MaxCad;               // Best Cadence
+  uint16_t      AvgPower;             // average Power
+  uint16_t      MaxPower;             // Max Power
+  char          VersionProduct[15];
+  uint8_t       reserved1;
+  uint8_t       VersionVerNum;
+  uint8_t       reserved2[17];
+};
 
 
-typedef struct Point
-    {
-    uint32_t  Latitude;
-    uint32_t  Longitude;
-    int16_t   Altitude;
-    uint16_t  reserved1;
-    uint32_t  Speed;
-    uint16_t  IntervalDist;          // Interval Distance
-    uint16_t  reserved2;
-    uint32_t  lntervalTime;          // Interval time
-    uint8_t   Status;                //Status (0 = ok, 1 = miss, 2 = no good, 3 = bad)
-    uint8_t   HR_Heartrate;
-    uint8_t   HR_Status;
-    uint8_t   reserved3;
-    uint32_t  Speed_Speed; 
-    uint8_t   Speed_Status;
-    uint8_t   reserved4;
-    uint8_t   reserved5;
-    uint8_t   reserved6;
-    uint8_t   Cadence_Cadence; 
-    uint8_t   Cadence_Status; 
-    uint16_t  Power_Cadence;
-    uint16_t  Power_Power;
-    uint8_t   Power_Status;
-    uint8_t   reserved7;
-    uint8_t   Temp;  
-    uint8_t   reserved8;
-    uint8_t   reserved9;
-    uint8_t   reserved10;
-    } tw_point;
+struct tw_point {
+  uint32_t  Latitude;
+  uint32_t  Longitude;
+  int16_t   Altitude;
+  uint16_t  reserved1;
+  uint32_t  Speed;
+  uint16_t  IntervalDist;          // Interval Distance
+  uint16_t  reserved2;
+  uint32_t  lntervalTime;          // Interval time
+  uint8_t   Status;                //Status (0 = ok, 1 = miss, 2 = no good, 3 = bad)
+  uint8_t   HR_Heartrate;
+  uint8_t   HR_Status;
+  uint8_t   reserved3;
+  uint32_t  Speed_Speed;
+  uint8_t   Speed_Status;
+  uint8_t   reserved4;
+  uint8_t   reserved5;
+  uint8_t   reserved6;
+  uint8_t   Cadence_Cadence;
+  uint8_t   Cadence_Status;
+  uint16_t  Power_Cadence;
+  uint16_t  Power_Power;
+  uint8_t   Power_Status;
+  uint8_t   reserved7;
+  uint8_t   Temp;
+  uint8_t   reserved8;
+  uint8_t   reserved9;
+  uint8_t   reserved10;
+};
 
-typedef struct Lap
-    {
-    uint32_t       splitTime;        // split time
-    uint32_t       TotalTime;        // Total Time
-    uint16_t       Number;           // Number
-    uint16_t       reserved1;
-    uint32_t       lDistance;        // Distance
-    uint16_t       Calorie;          // Calorie   
-    uint16_t       reserved2;
-    uint32_t       MaxSpeed;         // Max Speed   
-    uint32_t       AvgSpeed;         // average Speed  
-    uint8_t        MaxHeartrate;     // Max Heartrate   
-    uint8_t        AvgHeartrate;     // average Heartrate   
-    int16_t        MinAlti;          // Min Altitude
-    int16_t        MaxAlti;          // Max Altitude
-    uint8_t        AvgCad;           // average Cadence
-    uint8_t        MaxCad;           // Max Cadence
-    uint16_t       AvgPower;         // average Power 
-    uint16_t       MaxPower;         // Max Power    
-    uint16_t       StartRecPt;       // start record point
-    uint16_t       FinishRecPt;      // Finish record point
-    } tw_lap;
+struct tw_lap {
+  uint32_t       splitTime;        // split time
+  uint32_t       TotalTime;        // Total Time
+  uint16_t       Number;           // Number
+  uint16_t       reserved1;
+  uint32_t       lDistance;        // Distance
+  uint16_t       Calorie;          // Calorie
+  uint16_t       reserved2;
+  uint32_t       MaxSpeed;         // Max Speed
+  uint32_t       AvgSpeed;         // average Speed
+  uint8_t        MaxHeartrate;     // Max Heartrate
+  uint8_t        AvgHeartrate;     // average Heartrate
+  int16_t        MinAlti;          // Min Altitude
+  int16_t        MaxAlti;          // Max Altitude
+  uint8_t        AvgCad;           // average Cadence
+  uint8_t        MaxCad;           // Max Cadence
+  uint16_t       AvgPower;         // average Power
+  uint16_t       MaxPower;         // Max Power
+  uint16_t       StartRecPt;       // start record point
+  uint16_t       FinishRecPt;      // Finish record point
+};
 
 
 //*******************************************************************************
 //           local helper functions
 //*******************************************************************************
-static void 
+static void
 read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime)
 {
   tw_point point;
   gbfread(&point,sizeof(tw_point),1,file_in);
   if (global_opts.debug_level > 1) {
-    printf ("Point: lat:%8d long:%8d alt:%8d ",point.Latitude,point.Longitude,point.Altitude);
-    printf ("speed:%6d dist:%5d time:%5d Status:%1d", point.Speed,point.IntervalDist,point.lntervalTime,point.Status); 
-    printf ("HR:(%3d,%1d)" , point.HR_Heartrate,point.HR_Status);
-    printf ("Speed:(%8d,%1d)" , point.Speed_Speed,point.Speed_Status);
-    printf ("Cad:(%3d,%1d)" , point.Cadence_Cadence, point.Cadence_Status);
-    printf ("Power (Cad:%6d Pow:%6d,%2d)Temp:%3d\n" , point.Power_Cadence, point.Power_Power, point.Power_Status, point.Temp);
+    printf("Point: lat:%8d long:%8d alt:%8d ",point.Latitude,point.Longitude,point.Altitude);
+    printf("speed:%6d dist:%5d time:%5d Status:%1d", point.Speed,point.IntervalDist,point.lntervalTime,point.Status);
+    printf("HR:(%3d,%1d)", point.HR_Heartrate,point.HR_Status);
+    printf("Speed:(%8d,%1d)", point.Speed_Speed,point.Speed_Status);
+    printf("Cad:(%3d,%1d)", point.Cadence_Cadence, point.Cadence_Status);
+    printf("Power (Cad:%6d Pow:%6d,%2d)Temp:%3d\n", point.Power_Cadence, point.Power_Power, point.Power_Status, point.Temp);
 
     qDebug() << "DateTime1:" << gpsDateTime.toString();
     qDebug() << "point.lntervalTime:" << point.lntervalTime;
@@ -151,7 +146,7 @@ read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime)
   gpsDateTime.setDate(gpsbabeltime.date());
   gpsDateTime.setTime(gpsbabeltime.time());
 
-  //remove parts of sec (on purpose) on reported time, we keep track of parts of sec in 
+  //remove parts of sec (on purpose) on reported time, we keep track of parts of sec in
   // global structure so we don't drift
   qint64 mSecsSinceEpoc = gpsbabeltime.toMSecsSinceEpoch();
   gpsbabeltime.setMSecsSinceEpoch(mSecsSinceEpoc-mSecsSinceEpoc%1000);
@@ -184,19 +179,19 @@ read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime)
 }
 
 
-static void 
+static void
 read_lap()
 {
   tw_lap lap;
   gbfread(&lap,sizeof(tw_lap),1,file_in);
   if (global_opts.debug_level > 1) {
-    printf ("LAP: splitTime:%6ds TotalTime:%6ds LapNumber:%5d ",lap.splitTime/10,lap.TotalTime/10,lap.Number);
-    printf ("dist:%08dm Cal:%5d Speed:(%6d,%6d) ", lap.lDistance,lap.Calorie,lap.MaxSpeed,lap.AvgSpeed);
-    printf ("HR:(%3d,%3d)" , lap.MaxHeartrate,lap.AvgHeartrate);
-    printf ("Alt:(%6d,%6d) ", lap.MinAlti,lap.MaxAlti);
-    printf ("Cad:(%3d,%3d) ", lap.AvgCad,lap.MaxCad);
-    printf ("Power:(%3d,%3d)w ", lap.AvgPower,lap.MaxPower);
-    printf ("Pt:(%6d,%6d)\n", lap.StartRecPt,lap.FinishRecPt);
+    printf("LAP: splitTime:%6ds TotalTime:%6ds LapNumber:%5d ",lap.splitTime/10,lap.TotalTime/10,lap.Number);
+    printf("dist:%08dm Cal:%5d Speed:(%6d,%6d) ", lap.lDistance,lap.Calorie,lap.MaxSpeed,lap.AvgSpeed);
+    printf("HR:(%3d,%3d)", lap.MaxHeartrate,lap.AvgHeartrate);
+    printf("Alt:(%6d,%6d) ", lap.MinAlti,lap.MaxAlti);
+    printf("Cad:(%3d,%3d) ", lap.AvgCad,lap.MaxCad);
+    printf("Power:(%3d,%3d)w ", lap.AvgPower,lap.MaxPower);
+    printf("Pt:(%6d,%6d)\n", lap.StartRecPt,lap.FinishRecPt);
   }
 }
 
@@ -208,15 +203,15 @@ static void
 rd_init(const QString& fname)
 {
   if (global_opts.debug_level > 1) {
-    printf (MYNAME " rd_deinit()\n");
+    printf(MYNAME " rd_deinit()\n");
   }
   gbfile* fileorg_in = gbfopen(fname, "rb", MYNAME);
 
   /* copy file to memory stream (needed for seek-ops and piped commands) */
   file_in = gbfopen(nullptr, "wb", MYNAME);
   gbsize_t size = gbfcopyfrom(file_in, fileorg_in, 0x7FFFFFFF);
-  if(global_opts.debug_level > 1) {
-    printf (MYNAME "  filesize=%d\n",size);
+  if (global_opts.debug_level > 1) {
+    printf(MYNAME "  filesize=%d\n",size);
   }
   gbfclose(fileorg_in);
 }
@@ -225,16 +220,16 @@ static void
 rd_deinit()
 {
   if (global_opts.debug_level > 1) {
-    printf (MYNAME " rd_deinit()\n");
+    printf(MYNAME " rd_deinit()\n");
   }
   gbfclose(file_in);
 }
 
-static void 
+static void
 track_read()
 {
-  if(global_opts.debug_level > 1) {
-    printf (MYNAME "  waypoint_read()\n");
+  if (global_opts.debug_level > 1) {
+    printf(MYNAME "  waypoint_read()\n");
   }
 
   gbfseek(file_in, 0L, SEEK_END);
@@ -246,7 +241,7 @@ track_read()
   workout.timeStart.Hour = gbfgetc(file_in);
   workout.timeStart.Minute = gbfgetc(file_in);
   workout.timeStart.Second = gbfgetc(file_in);
-  workout.TotalRecPt = gbfgetint16(file_in); 
+  workout.TotalRecPt = gbfgetint16(file_in);
   workout.TotalTime = gbfgetint32(file_in);
   workout.TotalDist = gbfgetint32(file_in);
   workout.LapNumber = gbfgetint16(file_in);
@@ -257,9 +252,9 @@ track_read()
   workout.AvgHeart = gbfgetc(file_in);
 
   if (global_opts.debug_level > 1) {
-    printf ("%04d-%02d-%02d ", workout.dateStart.Year+2000,workout.dateStart.Month, workout.dateStart.Day);
-    printf ("%02d:%02d:%02d ", workout.timeStart.Hour,workout.timeStart.Minute, workout.timeStart.Second);
-    printf ("Total(RecPt:%6d Time:%6ds Dist:%9dm) LapNumber:%5d \n",workout.TotalRecPt,workout.TotalTime/10, workout.TotalDist, workout.LapNumber);
+    printf("%04d-%02d-%02d ", workout.dateStart.Year+2000,workout.dateStart.Month, workout.dateStart.Day);
+    printf("%02d:%02d:%02d ", workout.timeStart.Hour,workout.timeStart.Minute, workout.timeStart.Second);
+    printf("Total(RecPt:%6d Time:%6ds Dist:%9dm) LapNumber:%5d \n",workout.TotalRecPt,workout.TotalTime/10, workout.TotalDist, workout.LapNumber);
   }
 
   /*
@@ -270,16 +265,16 @@ track_read()
   gpsbabel::DateTime gpsDateTime = gpsbabel::DateTime(gpsDate,gpsTime);
   gpsDateTime.setTimeSpec(Qt::UTC);
   route_head* gpsbabel_route = route_head_alloc();
-  
+
   track_add_head(gpsbabel_route);
   gbfseek(file_in, 0L, SEEK_SET);
 
-  for(int point=0;point<workout.TotalRecPt;point++) {
+  for (int point=0; point<workout.TotalRecPt; point++) {
     read_point(gpsbabel_route,gpsDateTime);
   }
 
   gbfseek(file_in, sizeof(tw_point)*(workout.TotalRecPt), SEEK_SET);
-  for(int lap=0;lap<workout.LapNumber;lap++) {
+  for (int lap=0; lap<workout.LapNumber; lap++) {
     read_lap();
   }
 }
@@ -288,7 +283,7 @@ static void
 data_read()
 {
   if (global_opts.debug_level > 1) {
-    printf (MYNAME " data_read()\n");
+    printf(MYNAME " data_read()\n");
   }
 
   track_read();

--- a/enigma.cc
+++ b/enigma.cc
@@ -62,7 +62,7 @@ union wpt_data {
   int32_t     dummy;        // waypoint type 7, unused
 };
 
-typedef struct enigma_wpt {
+struct enigma_wpt {
   int32_t			latitude;
   int32_t			longitude;
   union wpt_data  data;
@@ -71,7 +71,7 @@ typedef struct enigma_wpt {
   char            shortname[6];
   uint8_t         longname_len;
   char            longname[27];
-} ENIGMA_WPT;
+};
 
 static gbfile* file_in, *file_out;
 
@@ -103,7 +103,7 @@ static float enigmaPositionToDec(int32_t val)
 static void
 data_read()
 {
-  struct enigma_wpt ewpt;
+  enigma_wpt ewpt;
   route_head* route = route_head_alloc();
   route_add_head(route);
 
@@ -169,7 +169,7 @@ wr_init(const QString& fname)
 static void
 enigma_waypt_disp(const Waypoint* wpt)
 {
-  struct enigma_wpt ewpt;
+  enigma_wpt ewpt;
 
   memset(&ewpt, 0, sizeof(ewpt));
 

--- a/explorist_ini.h
+++ b/explorist_ini.h
@@ -2,11 +2,11 @@
 /*
  * Interesting traits of the device from the *.ini files.
  */
-typedef struct {
+struct mag_info {
   char* geo_path;
   char* track_path;
   char* waypoint_path;
-} mag_info;
+};
 
 mag_info* explorist_ini_get(const char** directory_list);
 void explorist_ini_done(mag_info* info);

--- a/filter.h
+++ b/filter.h
@@ -87,7 +87,7 @@ protected:
   class RteHdFunctor
   {
   public:
-    typedef void (MyFilter::*RteHdCb)(const route_head*);
+    using RteHdCb = void (MyFilter::*)(const route_head*);
     RteHdFunctor(MyFilter* obj, RteHdCb cb) : that(obj), _cb(cb) {}
     void operator()(const route_head* rh)
     {
@@ -103,7 +103,7 @@ protected:
   class WayptFunctor
   {
   public:
-    typedef void (MyFilter::*WayptCb)(const Waypoint*);
+    using WayptCb = void (MyFilter::*)(const Waypoint*);
     WayptFunctor(MyFilter* obj, WayptCb cb) : that(obj), _cb(cb) {}
     void operator()(const Waypoint* wpt)
     {

--- a/filterdefs.h
+++ b/filterdefs.h
@@ -34,18 +34,18 @@
 
 extern WaypointList* global_waypoint_list;
 
-typedef void (*filter_init)();
-typedef void (*filter_process)();
-typedef void (*filter_deinit)();
-typedef void (*filter_exit)();
+using filter_init = void (*)();
+using filter_process = void (*)();
+using filter_deinit = void (*)();
+using filter_exit = void (*)();
 
-typedef struct filter_vecs {
+struct filter_vecs_t {
   filter_init f_init;
   filter_process f_process;
   filter_deinit f_deinit;
   filter_exit f_exit;
   arglist_t* args;
-} filter_vecs_t;
+};
 
 Filter* find_filter_vec(const char* const, const char**);
 void free_filter_vec(Filter*);

--- a/garmin_device_xml.h
+++ b/garmin_device_xml.h
@@ -23,24 +23,24 @@
 /*
  * Describes a file on the unit.
  */
-typedef struct {
+struct gdx_file {
   char* path;
   char* basename;
   char* extension;
   char* canon;	// full name, when applicable.
-} gdx_file;
+};
 
 /*
  * The interesting traits of this device.
  */
-typedef struct {
+struct gdx_info {
   const char* device_desc;
   const char* device_id;
   const char* device_mounted_path; // Not from the file; about the file.
   gdx_file from_device;
   gdx_file to_device;
 //	gdx_file geocache_logs;
-} gdx_info;
+};
 
 const gdx_info* gdx_read(const char* fname);
 const gdx_info* gdx_get_info();

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -162,18 +162,18 @@ const std::vector<std::pair<QString, int> > kCoursePointTypeMapping = {
 };
 
 
-typedef struct {
+struct fit_field_t {
   int id;
   int size;
   int type;
-} fit_field_t;
+};
 
-typedef struct {
+struct fit_message_def {
   int endian;
   int global_id;
   int num_fields;
   fit_field_t* fields;
-} fit_message_def;
+};
 
 static struct {
   int len;

--- a/garmin_fs.h
+++ b/garmin_fs.h
@@ -28,11 +28,11 @@
 #include "jeeps/gps.h"
 
 /* this order is used by most devices */
-/* typedef enum {
+/* enum garmin_display_t {
 	garmin_display_symbol_and_name = 0,
 	garmin_display_symbol_only = 1,
 	garmin_display_symbol_and_description = 2
-} garmin_display_t;
+};
 */
 
 /* macros */
@@ -60,13 +60,13 @@
 /* GMSD_GETNSTR(a,b,c): a = gmsd field, b = target, c = sizeof(target) */
 #define GMSD_GETNSTR(a,b,c) if (gmsd && gmsd->flags.a) strncpy((b),gmsd->a,(c))
 
-typedef struct garmin_ilink_s {
+struct garmin_ilink_t {
   int ref_count;
   double lat, lon, alt;
-  struct garmin_ilink_s* next;
-} garmin_ilink_t;
+  garmin_ilink_t* next;
+};
 
-typedef struct {
+struct garmin_fs_flags_t {
   unsigned int icon:1;
   unsigned int wpt_class:1;
   unsigned int display:1;
@@ -86,9 +86,9 @@ typedef struct {
 #ifdef GMSD_EXPERIMENTAL
   unsigned int subclass:1;
 #endif
-} garmin_fs_flags_t;
+};
 
-typedef struct garmin_fs_s {
+struct garmin_fs_t {
   format_specific_data fs;
   garmin_fs_flags_t flags;
 
@@ -114,7 +114,8 @@ typedef struct garmin_fs_s {
 #ifdef GMSD_EXPERIMENTAL
   char subclass[22];
 #endif
-} garmin_fs_t, *garmin_fs_p;
+};
+using garmin_fs_p = garmin_fs_t*;
 
 garmin_fs_t* garmin_fs_alloc(int protocol);
 void garmin_fs_destroy(void* fs);

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -148,7 +148,7 @@ static arglist_t garmin_gpi_args[] = {
   ARG_TERMINATOR
 };
 
-typedef struct {
+struct reader_data_t {
 public:
   int D2;
   char S3[9];		/* "GRMRECnn" */
@@ -157,7 +157,7 @@ public:
   char S8[3];
   QString group;
   QString category;
-} reader_data_t;
+};
 
 struct writer_data_t {
   QList<Waypoint*> waypt_list;
@@ -170,13 +170,13 @@ struct writer_data_t {
   writer_data_t* bottom_right{nullptr};
 };
 
-typedef struct gpi_waypt_data_s {
+struct gpi_waypt_data_t {
   int sz;
   char* addr;
   char* postal_code;
-} gpi_waypt_data_t;
+};
 
-typedef struct {
+struct bmp_header_t {
   int32_t size;
   int16_t res1;
   int16_t res2;
@@ -192,9 +192,9 @@ typedef struct {
   int32_t resolution_v;
   int32_t used_colors;
   int32_t important_colors;
-} bmp_header_t;
+};
 
-typedef struct {
+struct gpi_bitmap_header_t {
   int16_t index;
   int16_t height;
   int16_t width;
@@ -207,9 +207,9 @@ typedef struct {
   int32_t tr_color;
   int32_t flag2;
   int32_t size_2c;
-} gpi_bitmap_header_t;
+};
 
-typedef struct {
+struct gpi_waypt_t {
   int sz;
   int alerts;
   short mask;
@@ -220,7 +220,7 @@ typedef struct {
   char* phone_nr;
   char* postal_code;
   char* state;
-} gpi_waypt_t;
+};
 
 static gbfile* fin, *fout;
 static uint16_t codepage;	/* code-page, e.g. 1252, 65001 */

--- a/garmin_tables.cc
+++ b/garmin_tables.cc
@@ -28,7 +28,7 @@
 #define MYNAME "garmin_tables"
 
 /* MapSource 4.13 */
-icon_mapping_t garmin_icon_table[] = {
+const icon_mapping_t garmin_icon_table[] = {
   /*	  mps    pcx    desc */
   {   107, 16384, "Airport" },
   {    73,  8204, "Amusement Park" },
@@ -340,7 +340,7 @@ icon_mapping_t garmin_icon_table[] = {
   {    -1,    -1, nullptr },
 };
 
-icon_mapping_t garmin_smart_icon_table[] = {
+const icon_mapping_t garmin_smart_icon_table[] = {
   /* Additional (optional, activated with -Si) icons */
   {    92,  8227, "Micro-Cache" },   	/* icon for "Toll Booth" */
   {    48,   161, "Virtual cache" }, 	/* icon for "Scenic Area" */
@@ -609,11 +609,11 @@ const char* gt_display_mode_names[] = {
   "Symbol & Description"
 };
 
-typedef struct {
+struct grid_mapping_t {
   const char* shortname;
   const char* longname;
   grid_type grid;
-} grid_mapping_t;
+};
 
 /* gt_mps_grid_names: !!! degree sign substituted with '*' !!! */
 
@@ -629,10 +629,10 @@ grid_mapping_t gt_mps_grid_names[] = {
 
 /* gt_mps_datum_names: */
 
-typedef struct {
+struct datum_mapping_t {
   const char* jeeps_name;
   const char* mps_name;
-} datum_mapping_t;
+};
 
 /* will be continued (when requested) */
 static datum_mapping_t gt_mps_datum_names[] = {
@@ -651,10 +651,10 @@ static datum_mapping_t gt_mps_datum_names[] = {
   { nullptr,	nullptr }
 };
 
-typedef struct garmin_color_s {
+struct garmin_color_t {
   const char* name;
   int32_t rgb;
-} garmin_color_t;
+};
 
 static garmin_color_t gt_colors[] = {
   { "Unknown",		unknown_color },
@@ -749,7 +749,7 @@ gt_find_desc_from_icon_number(const int icon, garmin_formats_e garmin_format)
     return QString("Custom %1").arg(icon - 7680);
   }
 
-  for (icon_mapping_t* i = garmin_icon_table; i->icon; i++) {
+  for (const icon_mapping_t* i = garmin_icon_table; i->icon; i++) {
     switch (garmin_format) {
     case MAPSOURCE:
     case GDB:
@@ -773,7 +773,7 @@ gt_find_desc_from_icon_number(const int icon, garmin_formats_e garmin_format)
 int gt_find_icon_number_from_desc(const QString& desc, garmin_formats_e garmin_format)
 {
   static int find_flag = 0;
-  icon_mapping_t* i;
+  const icon_mapping_t* i;
   int def_icon = DEFAULT_ICON_VALUE;
 
   if (desc.isNull()) {

--- a/garmin_tables.h
+++ b/garmin_tables.h
@@ -28,20 +28,20 @@
 #define DEFAULT_ICON_DESCR "Waypoint"
 #define DEFAULT_ICON_VALUE 18
 
-typedef const struct icon_mapping {
-  const int mpssymnum;
-  const int pcxsymnum;
+struct icon_mapping_t {
+  int mpssymnum;
+  int pcxsymnum;
   const char* icon;
-} icon_mapping_t;
+};
 
-typedef enum {MAPSOURCE, PCX, GARMIN_SERIAL, GDB} garmin_formats_e;
+enum garmin_formats_e {MAPSOURCE, PCX, GARMIN_SERIAL, GDB};
 
 const QString gt_find_desc_from_icon_number(int icon, garmin_formats_e garmin_format);
 int gt_find_icon_number_from_desc(const QString& desc, garmin_formats_e garmin_format);
 
-extern icon_mapping_t garmin_icon_table[];
+extern const icon_mapping_t garmin_icon_table[];
 
-typedef enum {
+enum gt_waypt_classes_e {
   gt_waypt_class_user_waypoint = 0,
   gt_waypt_class_airport,
   gt_waypt_class_intersection,
@@ -55,14 +55,14 @@ typedef enum {
   gt_waypt_class_map_intersection,
   gt_waypt_class_map_address,
   gt_waypt_class_map_line
-} gt_waypt_classes_e;
+};
 
 extern const char* gt_waypt_class_names[];
 
-typedef struct gt_country_code_s {
+struct gt_country_code_t {
   const char* cc;
   const char* country;
-} gt_country_code_t;
+};
 
 extern gt_country_code_t gt_country_codes[];
 
@@ -70,22 +70,22 @@ const char* gt_get_icao_country(const QString& cc);
 const char* gt_get_icao_cc(const QString& country, const QString& shortname);
 
 /* this order is used by most devices */
-typedef enum {
+enum gt_display_modes_e {
   gt_display_mode_symbol_and_name = 0,
   gt_display_mode_symbol,
   gt_display_mode_symbol_and_comment
-} gt_display_modes_e;
+};
 
 extern const char* gt_display_mode_names[];
 
 #define GT_DISPLAY_MODE_MIN gt_display_mode_symbol_and_name
 #define GT_DISPLAY_MODE_MAX gt_display_mode_symbol_and_comment
 
-typedef enum {
+enum gt_gdb_display_modes_e {
   gt_gdb_display_mode_symbol = 0,
   gt_gdb_display_mode_symbol_and_name,
   gt_gdb_display_mode_symbol_and_comment
-} gt_gdb_display_modes_e;
+};
 
 unsigned char gt_convert_category(const char* name, int* category);
 

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -38,14 +38,14 @@
 
 #define MYNAME "garmin_txt"
 
-typedef struct gtxt_flags_s {
+struct gtxt_flags_t {
   unsigned int metric:1;
   unsigned int celsius:1;
   unsigned int utc:1;
   unsigned int enum_waypoints:1;
   unsigned int route_header_written:1;
   unsigned int track_header_written:1;
-} gtxt_flags_t;
+};
 
 static gbfile* fin, *fout;
 static route_head* current_trk, *current_rte;
@@ -67,14 +67,14 @@ static const unsigned char kDegreeSymbol = 0xB0;
 
 static gtxt_flags_t gtxt_flags;
 
-typedef enum {
+enum header_type {
   waypt_header = 0,
   rtept_header,
   trkpt_header,
   route_header,
   track_header,
   unknown_header
-} header_type;
+};
 
 inline header_type& operator++(header_type& s) // prefix
 {
@@ -136,7 +136,7 @@ arglist_t garmin_txt_args[] = {
   ARG_TERMINATOR
 };
 
-typedef struct info_s {
+struct info_t {
   double length;
   time_t start;
   time_t time;
@@ -146,7 +146,7 @@ typedef struct info_s {
   const Waypoint* prev_wpt;
   const Waypoint* first_wpt;
   const Waypoint* last_wpt;
-} info_t;
+};
 
 static info_t* route_info;
 static int route_idx;
@@ -840,7 +840,7 @@ garmin_txt_write()
     xfree(wpt_a);
 
     route_idx = 0;
-    route_info = (info_t*) xcalloc(route_count(), sizeof(struct info_s));
+    route_info = (info_t*) xcalloc(route_count(), sizeof(info_t));
     routepoints = 0;
     route_disp_all(prework_hdr_cb, prework_tlr_cb, prework_wpt_cb);
     if (routepoints > 0) {
@@ -851,7 +851,7 @@ garmin_txt_write()
   }
 
   route_idx = 0;
-  route_info = (info_t*) xcalloc(track_count(), sizeof(struct info_s));
+  route_info = (info_t*) xcalloc(track_count(), sizeof(info_t));
   routepoints = 0;
   track_disp_all(prework_hdr_cb, prework_tlr_cb, prework_wpt_cb);
 

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -25,11 +25,11 @@
 #include <QtCore/QtGlobal>     // for qPrintable
 
 #include <cassert>             // for assert
+#include <cctype>              // for tolower
+#include <cerrno>              // for errno
 #include <cstdarg>             // for va_list, va_end, va_copy, va_start
 #include <cstdio>              // for EOF, ferror, ftell, SEEK_SET, SEEK_CUR, SEEK_END, clearerr, fclose, feof, fflush, fileno, fread, fseek, fwrite, ungetc, vsnprintf, FILE, stdin, stdout
 #include <cstring>             // for memcpy, strlen, strchr, strcpy, strncat
-#include <ctype.h>             // for tolower
-#include <errno.h>             // for errno
 
 #include "defs.h"
 #include "gbfile.h"

--- a/gbfile.h
+++ b/gbfile.h
@@ -27,29 +27,28 @@
 #include <QtCore/QString>       // for QString
 
 #include <cstdarg>             // for va_list
-#include <cstdio>              // for FILE
 #include <cstdint>             // for int32_t, int16_t, uint32_t
+#include <cstdio>              // for FILE
 
 #include "defs.h"
 
 
-struct gbfile_s;
-typedef struct gbfile_s gbfile;
-typedef uint32_t gbsize_t;
+struct gbfile;
+using gbsize_t = uint32_t;
 
-typedef void (*gbfclearerr_cb)(gbfile* self);
-typedef int (*gbfclose_cb)(gbfile* self);
-typedef int (*gbfeof_cb)(gbfile* self);
-typedef int (*gbferror_cb)(gbfile* self);
-typedef int (*gbfflush_cb)(gbfile* self);
-typedef gbfile* (*gbfopen_cb)(gbfile* self, const char* mode);
-typedef gbsize_t (*gbfread_cb)(void* buf, const gbsize_t size, const gbsize_t members, gbfile* self);
-typedef int (*gbfseek_cb)(gbfile* self, int32_t offset, int whence);
-typedef gbsize_t (*gbftell_cb)(gbfile* self);
-typedef gbsize_t (*gbfwrite_cb)(const void* buf, const gbsize_t size, const gbsize_t members, gbfile* self);
-typedef int (*gbfungetc_cb)(const int c, gbfile* self);
+using gbfclearerr_cb = void (*)(gbfile* self);
+using gbfclose_cb = int (*)(gbfile* self);
+using gbfeof_cb = int (*)(gbfile* self);
+using gbferror_cb = int (*)(gbfile* self);
+using gbfflush_cb = int (*)(gbfile* self);
+using gbfopen_cb = gbfile* (*)(gbfile* self, const char* mode);
+using gbfread_cb = gbsize_t (*)(void* buf, const gbsize_t size, const gbsize_t members, gbfile* self);
+using gbfseek_cb = int (*)(gbfile* self, int32_t offset, int whence);
+using gbftell_cb = gbsize_t (*)(gbfile* self);
+using gbfwrite_cb = gbsize_t (*)(const void* buf, const gbsize_t size, const gbsize_t members, gbfile* self);
+using gbfungetc_cb = int (*)(const int c, gbfile* self);
 
-typedef struct gbfile_s {
+struct gbfile {
   union {
     FILE* std;
     unsigned char* mem;
@@ -84,7 +83,7 @@ typedef struct gbfile_s {
   gbftell_cb filetell;
   gbfungetc_cb fileungetc;
   gbfwrite_cb filewrite;
-} gbfile_t;
+};
 
 
 gbfile* gbfopen(const QString& filename, const char* mode, const char* module);

--- a/gbser_posix.cc
+++ b/gbser_posix.cc
@@ -32,7 +32,7 @@
 #include <termios.h>
 #include <unistd.h>
 
-typedef struct {
+struct gbser_handle {
   struct termios  old_tio;
   struct termios  new_tio;
   int             fd;
@@ -41,7 +41,7 @@ typedef struct {
 
   unsigned char   inbuf[BUFSIZE];
   unsigned        inbuf_used;
-} gbser_handle;
+};
 
 /* Wrapper to safely cast a void * into a gbser_handle */
 static gbser_handle* gbser__get_handle(void* p)
@@ -84,7 +84,7 @@ speed_t mkspeed(unsigned br)
   }
 }
 
-typedef struct timeval hp_time;
+using hp_time = struct timeval;
 
 static void get_time(hp_time* tv)
 {

--- a/gbser_win.cc
+++ b/gbser_win.cc
@@ -30,14 +30,14 @@
 #include <cstdarg>
 #include <cstdio>
 
-typedef struct {
+struct gbser_handle {
   HANDLE          comport;
   DWORD           timeout;
   unsigned long   magic;
 
   unsigned char   inbuf[BUFSIZE];
   unsigned        inbuf_used;
-} gbser_handle;
+};
 
 #define DEV_PREFIX "\\\\.\\\\"
 
@@ -86,7 +86,7 @@ DWORD mkspeed(unsigned br)
   }
 }
 
-typedef LARGE_INTEGER hp_time;
+using hp_time = LARGE_INTEGER;
 
 static void get_time(hp_time* tv)
 {

--- a/ggv_ovl.cc
+++ b/ggv_ovl.cc
@@ -39,7 +39,7 @@ arglist_t ggv_ovl_args[] = {
   ARG_TERMINATOR
 };
 
-typedef enum {
+enum OVL_SYMBOL_TYP {
   OVL_SYMBOL_BITMAP = 1,
   OVL_SYMBOL_TEXT,
   OVL_SYMBOL_LINE,
@@ -47,9 +47,9 @@ typedef enum {
   OVL_SYMBOL_RECTANGLE,
   OVL_SYMBOL_CIRCLE,
   OVL_SYMBOL_TRIANGLE
-} OVL_SYMBOL_TYP;
+};
 
-typedef enum {
+enum OVL_COLOR_TYP {
   OVL_COLOR_RED = 1,	/* = 1 */
   OVL_COLOR_LIME,		/* = 2 */
   OVL_COLOR_BLUE,		/* = 3 */
@@ -59,7 +59,7 @@ typedef enum {
   OVL_COLOR_7,		/* = 7 (draws only a simple line) */
   OVL_COLOR_FUCHSIA,	/* = 8 */
   OVL_COLOR_AQUA,		/* = 9 */
-} OVL_COLOR_TYP;
+};
 
 /* some hints:
 		# "col":   color

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -64,7 +64,7 @@ arglist_t globalsat_args[] = {
   ARG_TERMINATOR
 };
 
-typedef enum {
+enum globalsat_commands_e {
   CommandWhoAmI = 0xBF,
   CommandGetSystemInformation = 0x85,
   CommandGetSystemConfiguration = 0x86,
@@ -94,21 +94,21 @@ typedef enum {
   ResponseInsufficientMemory = 0x95,
   ResponseResendTrackSection = 0x92,
   ResponseSendTrackFinish = 0x9A
-} globalsat_commands_e;
+};
 
-typedef struct tagDATE {
+struct gh_date {
   uint8_t Year;
   uint8_t Month;
   uint8_t Day;
-} gh_date;
+};
 
-typedef struct tagTIME {
+struct gh_time {
   uint8_t Hour;
   uint8_t Minute;
   uint8_t Second;
-} gh_time;
+};
 
-typedef struct tagTRAINHEADER {
+struct gh_trainheader {
   gh_date dateStart;
   gh_time timeStart;
   uint32_t TotalPoint;		//6-9
@@ -124,9 +124,9 @@ typedef struct tagTRAINHEADER {
     uint32_t EndPt;
   } gh_laprec;			//24-27
   uint8_t DataType;		//28
-} gh_trainheader;
+};
 
-typedef struct tagDB_TRAIN {
+struct gh_db_train {
   gh_date dateStart;
   gh_time timeStart;
   uint32_t TotalPoint;		//6-9
@@ -161,9 +161,9 @@ typedef struct tagDB_TRAIN {
   uint8_t Sport3;
   uint8_t Sport4;
   uint8_t Sport5;
-} gh_db_train;
+};
 
-typedef struct tagDB_LAP {
+struct gh_db_lap {
   uint32_t AccruedTime;
   uint32_t TotalTime;
   uint32_t TotalDistance;
@@ -180,9 +180,9 @@ typedef struct tagDB_LAP {
   uint8_t MultiSportIndex;
   uint32_t StartPt;
   uint32_t EndPt;
-} gh_db_lap;
+};
 
-typedef struct tagRECPOINT {
+struct gh_recpoint {
   uint32_t Latitude;
   uint32_t Longitude;
   int16_t Altitude;
@@ -192,7 +192,7 @@ typedef struct tagRECPOINT {
   uint16_t Cadence;
   uint16_t PwrCadence;
   uint16_t Power;
-} gh_recpoint;
+};
 
 static void
 serial_init(const char* fname)

--- a/gnav_trl.cc
+++ b/gnav_trl.cc
@@ -29,12 +29,12 @@ arglist_t gnav_trl_args[] = {
   ARG_TERMINATOR
 };
 
-typedef struct gnav_trl_s {
+struct gnav_trl_t {
   uint32_t time;
   float lat;
   float lon;
   uint32_t alt;
-} gnav_trl_t;
+};
 
 static gbfile* fin, *fout;
 

--- a/gpx.cc
+++ b/gpx.cc
@@ -103,13 +103,13 @@ static void gpx_write_bounds();
 #  define CREATOR_NAME_URL "GPSBabel - http://www.gpsbabel.org"
 #endif
 
-typedef enum  {
+enum gpx_point_type {
   gpxpt_waypoint,
   gpxpt_track,
   gpxpt_route
-} gpx_point_type;
+};
 
-typedef enum  {
+enum tag_type {
   tt_unknown = 0,
   tt_gpx,
 
@@ -207,7 +207,7 @@ typedef enum  {
   tt_humminbird_wpt_depth,
   tt_humminbird_wpt_status,
   tt_humminbird_trk_trkseg_trkpt_depth,
-} tag_type;
+};
 
 /*
  * The file-level information.
@@ -298,11 +298,11 @@ gpx_write_gdata(const QStringList& ge, const QString& tag)
 }
 
 
-typedef struct tag_mapping {
+struct tag_mapping {
   tag_type tag_type_;		/* enum from above for this tag */
   int tag_passthrough;		/* true if we don't generate this */
   const char* tag_name;		/* xpath-ish tag name */
-} tag_mapping;
+};
 
 /*
  * xpath(ish) mappings between full tag paths and internal identifiers.

--- a/holux.h
+++ b/holux.h
@@ -49,33 +49,33 @@
 #define OFFS_WPT        0x05E4          /* offet for waypoint table */
 
 
-typedef  struct tagWPTHDR {
+struct WPTHDR {
   DWORD	    id;			            /* WPT_HDR_ID */
   short		num;			        /* Current wpt number */
   short		next;			        /* next wpt number */
   short		idx[MAXWPT];	        /* saving wpt index here for each wpt, default was -1*/
   BYTE		used[MAXWPT];	        /* Have the match wpt been used (0xFF), Default was 0 */
-} WPTHDR;
+};
 
 
 
 
-typedef  struct tagPOINT {
+struct POINT {
   signed int  iLongitude;
   signed int  iLatitude;
-} POINT;
+};
 
 
 
 
-typedef  struct tagDATE {
+struct HX_DATE {
   BYTE    day;
   BYTE    month;
   short   year;
-} HX_DATE;
+};
 
 
-typedef struct tagWPT {
+struct WPT {
   char name[8];				        /* wpt name  */
   char comment[12];			        /* comment string */
   POINT	 pt;				        /* waypoint location  */
@@ -85,21 +85,21 @@ typedef struct tagWPT {
   unsigned time;			            /* time	 */
   char     checked;				    /* Active or not */
   BYTE     dummy[3];                  /* fill bytes */
-} WPT;
+};
 
 
 
-typedef  struct tagRTEHDR {
+struct RTEHDR {
   DWORD	        id;			             /* RTE_HDR_ID */
   short		    num;			         /* Current route number */
   short		    next;			         /* next route number */
   signed short	idx[MAXRTE];	         /* saving route index here for each route, default was -1  */
   BYTE		    used[MAXRTE];	         /* Have the wpt been used (0xFF), Default was 0 */
   signed short    rteno;			         /* Saving navigationroute number here */
-} RTEHDR;
+};
 
 
-typedef  struct tagRTE {
+struct RTE {
   char name[8];				         /* route name */
   char comment[12];			         /* comment string */
   short wptnum;				         /* the total waypoint number */
@@ -107,5 +107,5 @@ typedef  struct tagRTE {
   short reserved;
   int date;				             /* date */
   int time;				             /* time	 */
-} RTE;
+};
 

--- a/humminbird.cc
+++ b/humminbird.cc
@@ -59,7 +59,7 @@ Still, they're useful in the code as a plain signature.
 
 /* The hwr data format is records-based, and the records are 36 bytes long. */
 
-typedef struct humminbird_waypt_s {
+struct humminbird_waypt_t {
   /* O.K.: the file can also contain routes with a different magic. */
   /* uint32_t signature; */   /* Just for error checking(?) */
   uint16_t num;          /* Always ascending in the file. */
@@ -72,9 +72,9 @@ typedef struct humminbird_waypt_s {
   int32_t  east;
   int32_t  north;
   char     name[WPT_NAME_LEN];
-} humminbird_waypt_t;
+};
 
-typedef struct humminbird_rte_s {
+struct humminbird_rte_t {
   /* O.K.: the file can contain also routes with a different magic. */
   /* uint32_t signature; */   /* Just for error checking(?) */
   uint16_t num;
@@ -86,9 +86,9 @@ typedef struct humminbird_rte_s {
   uint32_t time;
   char     name[RTE_NAME_LEN];
   uint16_t points[MAX_RTE_POINTS];
-} humminbird_rte_t;
+};
 
-typedef struct humminbird_trk_header_s {      /* 68 bytes, incl signature */
+struct humminbird_trk_header_t {      /* 68 bytes, incl signature */
   /* uint32_t signature; */
   uint16_t trk_num;
   uint16_t zero;
@@ -107,16 +107,16 @@ typedef struct humminbird_trk_header_s {      /* 68 bytes, incl signature */
   int32_t ne_north;
 
   char     name[20];
-} humminbird_trk_header_t;
+};
 
 
-typedef struct humminbird_trk_point_s {
+struct humminbird_trk_point_t {
   int16_t  deltaeast;
   int16_t  deltanorth;
   uint16_t depth;		/* in centimeters */
-} humminbird_trk_point_t;
+};
 
-typedef struct humminbird_trk_header_old_s {      /* 16 bytes, incl signature */
+struct humminbird_trk_header_old_t {      /* 16 bytes, incl signature */
   /* uint32_t signature; */
   uint16_t trk_num;
   uint16_t zero;
@@ -129,14 +129,14 @@ typedef struct humminbird_trk_header_old_s {      /* 16 bytes, incl signature */
   int32_t end_east;	/* end of track */
   int32_t end_north;
 
-} humminbird_trk_header_old_t;
+};
 
-typedef struct humminbird_trk_point_old_s {
+struct humminbird_trk_point_old_t {
   int16_t  deltaeast;
   int16_t  deltanorth;
-} humminbird_trk_point_old_t;
+};
 
-typedef struct group_header {
+struct group_header_t {
   uint8_t status;
   uint8_t icon;
   uint16_t depth;
@@ -146,14 +146,14 @@ typedef struct group_header {
   uint16_t first_body_index;
   uint16_t reserved2;
   char name[WPT_NAME_LEN];
-} group_header_t;
+};
 
-typedef struct group_body {
+struct group_body_t {
   uint8_t status;
   uint8_t icon;
   uint16_t next_idx;
   uint16_t item[MAX_ITEMS_PER_GROUP];
-} group_body_t;
+};
 
 
 static const char* humminbird_icons[] = {

--- a/igc.cc
+++ b/igc.cc
@@ -62,7 +62,7 @@ static int lineno;
  * IGC record types.
  * These appear as the first char in each record.
  */
-typedef enum {
+enum igc_rec_type_t {
   rec_manuf_id = 'A',		// FR manufacturer and identification
   rec_fix = 'B',		// Fix
   rec_task = 'C',		// Task/declaration
@@ -80,7 +80,7 @@ typedef enum {
 
   rec_none = 0,		// No record
   rec_bad = 1,		// Bad record
-} igc_rec_type_t;
+};
 
 /*
  * See if two lat/lon pairs are approximately equal.
@@ -148,7 +148,7 @@ static void rd_deinit()
   gbfclose(file_in);
 }
 
-typedef enum { id, takeoff, start, turnpoint, finish, landing } state_t;
+enum state_t { id, takeoff, start, turnpoint, finish, landing };
 inline state_t& operator++(state_t& s) // prefix
 {
   return s = static_cast<state_t>(s + 1);

--- a/igo8.cc
+++ b/igo8.cc
@@ -70,25 +70,28 @@
 #define IGO8_HEADER_SIZE (sizeof(igo8_id_block) + 256)
 #define MYNAME "IGO8"
 
-typedef struct _igo8_id_block {
+struct igo8_id_block {
   uint32_t unknown_1;
   uint32_t unknown_2;
   uint32_t unknown_3;
   uint32_t track_number;
   uint32_t unknown_4;
-} igo8_id_block, *p_igo8_id_block;
+};
+using p_igo8_id_block = igo8_id_block*;
 
-typedef struct _igo8_information_block {
+struct igo8_information_block {
   uint32_t start_time;       // In Unix time
   uint32_t zero;             // Doesn't appear to serve a purpose
   uint32_t total_file_size;  // In bytes
-} igo8_information_block, *p_igo8_information_block;
+};
+using p_igo8_information_block = igo8_information_block*;
 
-typedef struct _igo8_point {
+struct igo8_point {
   uint32_t unix_time;
   uint32_t lon;
   uint32_t lat;
-} igo8_point, *p_igo8_point;
+};
+using p_igo8_point = igo8_point*;
 
 // Files
 static gbfile* igo8_file_in;

--- a/itracku.cc
+++ b/itracku.cc
@@ -53,14 +53,14 @@
 #define MYNAME "itracku"
 
 /* memory layout of the iTrackU data record */
-typedef struct {
+struct itracku_data_record {
   uint8_t longitude[4];
   uint8_t latitude[4];
   uint8_t creation_time[4];
   uint8_t altitude[2];
   uint8_t speed;
   uint8_t flag;
-} itracku_data_record;
+};
 
 static int itracku_is_valid_data_record(itracku_data_record* d);
 static void to_itracku_data_record(const Waypoint* wp, itracku_data_record* d);

--- a/kml.cc
+++ b/kml.cc
@@ -96,14 +96,14 @@ static QList<std::tuple<int, double, double, double>>* gx_trk_coords;
 static gpsbabel::File* oqfile;
 static gpsbabel::XmlStreamWriter* writer;
 
-typedef enum  {
+enum kml_point_type {
   kmlpt_unknown,
   kmlpt_waypoint,
   kmlpt_track,
   kmlpt_route,
   kmlpt_multitrack,
   kmlpt_other
-} kml_point_type;
+};
 
 static int realtime_positioning;
 static bounds kml_bounds;
@@ -1708,13 +1708,13 @@ static void kml_track_tlr(const route_head* header)
 
 // Helper to write gx:SimpleList, iterating over a route queue and writing out.
 
-typedef enum {
+enum wp_field {
   fld_cadence,
   fld_depth,
   fld_heartrate,
   fld_temperature,
   fld_power
-} wp_field;
+};
 
 static void kml_mt_simple_array(const route_head* header,
                                 const char* name,

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -107,10 +107,10 @@
 #include "src/core/datetime.h"   // for DateTime
 
 
-typedef struct lowranceusr_icon_mapping {
-  const int    value;
+struct lowranceusr_icon_mapping_t {
+  int    value;
   const char*  icon;
-} lowranceusr_icon_mapping_t;
+};
 
 #define DEF_ICON            10001
 #define X_1_ICON            10003
@@ -279,11 +279,11 @@ const lowranceusr_icon_mapping_t lowranceusr_icon_value_table[] = {
 #define DEF_USR4_ICON  2
 #define DEF_USR4_COLOR 0
 
-typedef struct lowranceusr4_icon_mapping {
-  const int      value;
+struct lowranceusr4_icon_mapping_t {
+  int      value;
   const char*    icon;
   const char*    color[7];
-} lowranceusr4_icon_mapping_t;
+};
 
 const lowranceusr4_icon_mapping_t lowranceusr4_icon_value_table[] = {
 
@@ -366,7 +366,7 @@ static QTextCodec*    utf16le_codec{nullptr};
 /* Jan 1, 2000 00:00:00 */
 const time_t base_time_secs = 946706400;
 
-typedef struct {
+struct lowranceusr4_fsdata {
   format_specific_data fs;
   uint uid_unit;
   uint uid_unit2;
@@ -381,7 +381,7 @@ typedef struct {
   const char *color_desc;
   int  icon_num;
   float depth;
-} lowranceusr4_fsdata;
+};
 
 class Lowranceusr4Timestamp {
   public:

--- a/magellan.h
+++ b/magellan.h
@@ -29,7 +29,7 @@
  * This doesn't mean I actually have TRIED all models listed below.
  * (Donations welcome. :-)
  */
-typedef enum {
+enum meridian_model {
   mm_unknown = 0 ,
   mm_gps315320,
   mm_map410,
@@ -37,18 +37,18 @@ typedef enum {
   mm_gps310,
   mm_meridian,
   mm_sportrak
-} meridian_model;
+};
 
-typedef struct pid_to_model {
+struct pid_to_model_t {
   meridian_model model;
   int pid;
   const char* model_n;
-} pid_to_model_t;
+};
 
-typedef struct icon_mapping {
+struct magellan_icon_mapping_t {
   const char* token;
   const char* icon;
-} icon_mapping_t;
+};
 
 QString mag_find_descr_from_token(const char* token);
 QString mag_find_token_from_descr(const QString& icon);

--- a/magproto.cc
+++ b/magproto.cc
@@ -44,7 +44,7 @@
 #include "explorist_ini.h"         // for explorist_ini_done, explorist_ini_get, mag_info
 #include "gbfile.h"                // for gbfclose, gbfeof, gbfgets, gbfopen, gbfwrite, gbfile
 #include "gbser.h"                 // for gbser_deinit, gbser_init, gbser_is_serial, gbser_read_line, gbser_set_port, gbser_write, gbser_OK
-#include "magellan.h"              // for mm_meridian, mm_sportrak, icon_mapping_t, mm_gps315320, mm_unknown, mm_map330, mm_map410, pid_to_model_t, mm_gps310, m330_cleanse, mag_checksum, mag_find_descr_from_token, mag_find_token_from_descr, mag_rteparse, mag_trkparse
+#include "magellan.h"              // for mm_meridian, mm_sportrak, magellan_icon_mapping_t, mm_gps315320, mm_unknown, mm_map330, mm_map410, pid_to_model_t, mm_gps310, m330_cleanse, mag_checksum, mag_find_descr_from_token, mag_find_token_from_descr, mag_rteparse, mag_trkparse
 #include "src/core/datetime.h"     // for DateTime
 
 
@@ -90,11 +90,11 @@ static QStringList os_gpx_files(const char* dirname);
  */
 static int suppress_ack;
 
-typedef enum {
+enum mag_rxstate {
   mrs_handoff = 0,
   mrs_handon,
   mrs_awaiting_ack
-} mag_rxstate;
+};
 
 /*
  *   An individual element of a route.
@@ -126,11 +126,11 @@ static route_head* trk_head;
 static int ignore_unable;
 
 static Waypoint* mag_wptparse(char*);
-typedef QString (cleanse_fn)(const char*);
+using cleanse_fn = QString (const char*);
 static cleanse_fn* mag_cleanse;
 static const char** os_get_magellan_mountpoints();
 
-static icon_mapping_t gps315_icon_table[] = {
+static const magellan_icon_mapping_t gps315_icon_table[] = {
   { "a", "filled circle" },
   { "b", "box" },
   { "c", "red buoy" },
@@ -154,7 +154,7 @@ static icon_mapping_t gps315_icon_table[] = {
   { nullptr, nullptr }
 };
 
-static icon_mapping_t map330_icon_table[] = {
+static const magellan_icon_mapping_t map330_icon_table[] = {
   { "a", "crossed square" },
   { "b", "box" },
   { "c", "house" },
@@ -230,7 +230,7 @@ pid_to_model_t pid_to_model[] = {
   { mm_unknown, 0, nullptr }
 };
 
-static icon_mapping_t* icon_mapping = map330_icon_table;
+static const magellan_icon_mapping_t* icon_mapping = map330_icon_table;
 
 /*
  *   For each receiver type, return a "cleansed" version of the string
@@ -1160,7 +1160,7 @@ mag_find_descr_from_token(const char* token)
     return "unknown";
   }
 
-  for (icon_mapping_t* i = icon_mapping; i->token; i++) {
+  for (const magellan_icon_mapping_t* i = icon_mapping; i->token; i++) {
     if (token[0] == 0) {
       break;
     }
@@ -1174,7 +1174,7 @@ mag_find_descr_from_token(const char* token)
 QString
 mag_find_token_from_descr(const QString& icon)
 {
-  icon_mapping_t* i = icon_mapping;
+  const magellan_icon_mapping_t* i = icon_mapping;
 
   if (i == nullptr || icon == nullptr) {
     return "a";

--- a/make-an1sym.pl
+++ b/make-an1sym.pl
@@ -277,7 +277,7 @@ print <<'END';
  */
 
 static struct defguid {
-	GUID guid;
+	guid_t guid;
 	const char *name;
 } default_guids[] = {
 END
@@ -287,23 +287,23 @@ sub print_footer {
 print <<'END';
 };
 
-static int FindIconByName( const char *name, GUID *guid ) {
+static int FindIconByName( const char *name, guid_t *guid ) {
 	unsigned int i = 0; 
 	for ( i = 0; i < (sizeof(default_guids)/sizeof(struct defguid)); i++ )
 	{
 		if ( !case_ignore_strcmp(name, default_guids[i].name)) {
-			memcpy( guid, &(default_guids[i].guid), sizeof(GUID));
+			memcpy( guid, &(default_guids[i].guid), sizeof(guid_t));
 			return 1;
 		}
 	}
 	return 0;
 }
 
-static int FindIconByGuid( GUID *guid, char **name ) {
+static int FindIconByGuid( guid_t *guid, char **name ) {
 	unsigned int i = 0; 
 	for ( i = 0; i < (sizeof(default_guids)/sizeof(struct defguid)); i++ )
 	{
-		if ( !memcmp(guid, &default_guids[i].guid, sizeof(GUID))) {
+		if ( !memcmp(guid, &default_guids[i].guid, sizeof(guid_t))) {
 			*name = default_guids[i].name;
 			return 1;
 		}

--- a/mapsend.h
+++ b/mapsend.h
@@ -28,17 +28,17 @@
  *
  */
 
-typedef struct {
+struct mapsend_hdr {
   char ms_length;
   char ms_signature[11];
   char ms_version[2];
   char ms_type;
   char _ms_type[3];
-} mapsend_hdr;
+};
 
-typedef enum {
+enum ms_type {
   ms_type_rgn = 0,
   ms_type_wpt = 1,
   ms_type_track = 2,
   ms_type_log = 3
-} ms_type;
+};

--- a/mmo.cc
+++ b/mmo.cc
@@ -68,7 +68,7 @@ arglist_t mmo_args[] = {
   ARG_TERMINATOR
 };
 
-typedef struct mmo_data_s {
+struct mmo_data_t {
   int objid;		/* internal object id */
   char* name;
   const char* category;	/* currently not handled */
@@ -78,11 +78,11 @@ typedef struct mmo_data_s {
   int left;		/* number of unread route points */
   void* data;		/* can be a waypoint, a route or a track */
   int refct;
-  struct mmo_data_s** members;
+  mmo_data_t** members;
   unsigned char visible:1;
   unsigned char locked:1;
   unsigned char loaded:1;
-} mmo_data_t;
+};
 
 static gbfile* fin, *fout;
 static int mmo_version;
@@ -104,10 +104,10 @@ static QHash<int, QString> icons;
 static QHash<int, mmo_data_t*> objects;
 static QHash<QString, unsigned> mmobjects;
 
-typedef struct mmo_icon_mapping_s {
-  const int	value;
+struct mmo_icon_mapping_t {
+  int	value;
   const char*	icon;
-} mmo_icon_mapping_t;
+};
 
 /* standard icons; no bitmaps in file */
 

--- a/mynav.cc
+++ b/mynav.cc
@@ -26,7 +26,7 @@
 
 #define MYNAME "mynav"
 
-typedef enum {
+enum field_e {
   fld_type = 0,
   fld_lon,
   fld_lat,
@@ -43,7 +43,7 @@ typedef enum {
   fld_id,
   fld_total_duration,
   fld_terminator
-} field_e;
+};
 
 static route_head* mynav_track;
 static gbfile* fin;

--- a/naviguide.cc
+++ b/naviguide.cc
@@ -33,15 +33,15 @@
 /************* Specific Naviguide data formats ****************/
 
 /* Naviguide file header */
-typedef struct {
+struct ng_file_header_t {
   uint16_t nof_wp;    /* Little endean format */
   unsigned char pad1[6];      /* 0xff, 0xff, 0x01, 0x00, 0x06, 0x00 */
   char signature[9]; /* cWaypoint */
   unsigned char pad2[4];      /* 0x01, 0x00, 0x00, 0x00 */
-} ng_file_header_t;
+};
 
 /* Naviguide waypoint/rout data  */
-typedef struct {
+struct ng_wp_data_t {
   unsigned char pad1[8];   /*  0xfe, 0xff, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00 */
   /* coordination are in old israeli grid */
   int32_t East;
@@ -49,19 +49,19 @@ typedef struct {
   unsigned char pad2[2];  /* 0x01, 0x01 */
   uint32_t Alt;
   char CommentLength;
-} ng_wp_data_t;
+};
 
-typedef struct {
+struct ng_next_wp_t {
   unsigned char pad1[2]; /* 0x01, 0x80 */
   uint16_t next_wp;
   unsigned char pad2[2]; /* 0x00, 0x00 */
-} ng_next_wp_t;
+};
 
-typedef struct {
+struct ng_wp_no_comment_t {
   unsigned char chHeaderLen;
   char strName[255];
   ng_wp_data_t wp_data;
-} ng_wp_no_comment_t;
+};
 
 
 /* Global variables */

--- a/netstumbler.cc
+++ b/netstumbler.cc
@@ -257,10 +257,10 @@ data_read()
   fix_netstumbler_dupes();
 }
 
-typedef struct {
+struct htable_t {
   unsigned long crc;
   Waypoint* wpt;
-} htable_t;
+};
 
 static
 int

--- a/nmea.cc
+++ b/nmea.cc
@@ -160,12 +160,12 @@ struct NmeaWaypoint : Waypoint
   bool added{false};
 };
 
-typedef enum {
+enum preferred_posn_type {
   gp_unknown = 0,
   gpgga,
   gplgll,
   gprmc
-} preferred_posn_type;
+};
 
 static enum {
   rm_unknown = 0,

--- a/osm.cc
+++ b/osm.cc
@@ -40,8 +40,9 @@ static arglist_t osm_args[] = {
 static QHash<QString, const Waypoint*> waypoints;
 
 static QHash<QString, int> keys;
-static QHash<QString, const struct osm_icon_mapping_s*> values;
-static QHash<QString, const struct osm_icon_mapping_s*> icons;
+struct osm_icon_mapping_t;
+static QHash<QString, const osm_icon_mapping_t*> values;
+static QHash<QString, const osm_icon_mapping_t*> icons;
 
 static gbfile* fout;
 static int node_id;
@@ -90,16 +91,16 @@ static const char* osm_features[] = {
   nullptr
 };
 
-typedef struct osm_icon_mapping_s {
-  const int key;
+struct osm_icon_mapping_t {
+  int key;
   const char* value;
   const char* icon;
-} osm_icon_mapping_t;
+};
 
 
 /* based on <http://wiki.openstreetmap.org/index.php/Map_Features> */
 
-static osm_icon_mapping_t osm_icon_mappings[] = {
+static const osm_icon_mapping_t osm_icon_mappings[] = {
 
   /* cycleway ...*/
 

--- a/pocketfms_bc.cc
+++ b/pocketfms_bc.cc
@@ -25,7 +25,7 @@
 
 static char header_id[] = "BRC";
 
-typedef struct breadcrumb {
+struct breadcrumb {
   // header
   char		id[4];		  // 0x42 0x52 0x43 0x00 <=> "BRC"
   uint16_t	version;	// 0x0100
@@ -49,7 +49,7 @@ typedef struct breadcrumb {
   uint16_t	minute;		// 0..59
   uint16_t	second;		// 0..59
   uint16_t	reserve2;	// 0x0000
-} BREADCRUMB;
+};
 
 static gbfile* file_in, *file_out;
 
@@ -80,7 +80,7 @@ wr_deinit()
 static void
 read_tracks()
 {
-  struct breadcrumb bc;
+  breadcrumb bc;
   route_head* trk_head = route_head_alloc();
   trk_head->rte_num = 1;
   trk_head->rte_name = "PocketFMS";
@@ -127,7 +127,7 @@ route_head_noop(const route_head*)
 static void
 pocketfms_waypt_disp(const Waypoint* wpt)
 {
-  struct breadcrumb bc;
+  breadcrumb bc;
 
   memset(&bc, 0, sizeof(bc));
   const time_t tt = wpt->GetCreationTime().toTime_t();

--- a/polygon.h
+++ b/polygon.h
@@ -40,10 +40,10 @@ private:
   char* polyfileopt = nullptr;
   char* exclopt = nullptr;
 
-  typedef struct {
+  struct extra_data {
     unsigned short state;
     unsigned short override;
-  } extra_data;
+  };
 
   arglist_t args[3] = {
     {

--- a/psitrex.cc
+++ b/psitrex.cc
@@ -38,18 +38,18 @@
 
 #define MYNAME "PSITREX"
 
-typedef enum {
+enum psit_tokenSep_type {
   ltrimEOL = 1 ,		/* skip spaces & tabs to start; ends on EOL */
   EOL,				/* don't skip spaces and tabs to start; end on EOL */
   comma,				/* skip spaces & tabs to start; ends on comma or EOL */
   whitespace,			/* skip spaces & tabs to start; ends on white space or EOL */
   wscomma				/* skip spaces & tabs to start; ends on white space, comma or EOL */
-} psit_tokenSep_type;
+};
 
-typedef struct psit_icon_mapping {
-  const int	value;
+struct psit_icon_mapping_t {
+  int	value;
   const char*	icon;
-} psit_icon_mapping_t;
+};
 
 static gbfile* psit_file_in;
 static gbfile* psit_file_out;

--- a/radius.h
+++ b/radius.h
@@ -51,9 +51,9 @@ private:
 
   Waypoint* home_pos;
 
-  typedef struct {
+  struct extra_data {
     double distance;
-  } extra_data;
+  };
 
   arglist_t args[8] = {
     {

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -52,7 +52,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-typedef unsigned long long guid_t;
+using guid_t = unsigned long long;
 
 static inifile_t* fin;
 static gbfile* fout;
@@ -79,12 +79,12 @@ arglist_t raymarine_args[] = {
 
 /* Bitmaps */
 
-typedef struct {
+struct raymarine_symbol_mapping_t {
   const char* name;
   const char* mps_name;
-} raymarine_symbol_mapping_t;
+};
 
-static raymarine_symbol_mapping_t raymarine_symbols[] = {
+static const raymarine_symbol_mapping_t raymarine_symbols[] = {
   { /* 0 */  "Unknown Symbol 0", nullptr },
   { /* 1 */  "Unknown Symbol 1", nullptr },
   { /* 2 */  "Unknown Symbol 2", nullptr },
@@ -144,7 +144,7 @@ static int
 find_symbol_num(const QString& descr)
 {
   if (!descr.isNull()) {
-    raymarine_symbol_mapping_t* a = &raymarine_symbols[0];
+    const raymarine_symbol_mapping_t* a = &raymarine_symbols[0];
 
     for (unsigned int i = 0; i < RAYMARINE_SYMBOL_CT; i++, a++) {
       if (descr.compare(a->name, Qt::CaseInsensitive) == 0) {

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -708,28 +708,28 @@ make_trackpoint(struct read_state* st, double lat, double lon, double alt)
   return wpt;
 }
 
-typedef struct {
+struct full_item {
   uint32_t gps_week;
   uint32_t gps_sec;
   int32_t  x;
   int32_t  y;
   int32_t  z;
-} full_item;
+};
 
-typedef struct {
+struct compact_item {
   uint16_t dt;
   int16_t dx;
   int16_t dy;
   int16_t dz;
-} compact_item;
+};
 
-typedef struct {
+struct multi_hz_item {
   uint32_t gps_week;
   uint32_t gps_sec;
   int32_t  lat;
   int32_t  lon;
   int32_t  alt;
-} multi_hz_item;
+};
 
 
 struct full_item_frame {
@@ -752,14 +752,14 @@ struct multi_hz_item_frame {
   unsigned char alt[4];
 };
 
-typedef struct {
+struct item_frame {
   unsigned char type_and_speed[2];
   union {
-    struct multi_hz_item_frame multi_hz;
-    struct full_item_frame full;
-    struct compact_item_frame comp;
+    multi_hz_item_frame multi_hz;
+    full_item_frame full;
+    compact_item_frame comp;
   };
-} item_frame;
+};
 #define ITEM_WEEK_NUMBER(item) (item->type_and_speed[1] | ((item->type_and_speed[0] & 0x03) << 8))
 
 #define POW_2_M20 0.000000953674316

--- a/src/core/xmltag.h
+++ b/src/core/xmltag.h
@@ -38,9 +38,9 @@ xml_tag* xml_findnext(xml_tag* root, xml_tag* cur, const char* tagname);
 char* xml_attribute(xml_tag* tag, const char* attrname);
 void free_gpx_extras(xml_tag* tag);
 
-typedef struct fs_xml {
+struct fs_xml {
   format_specific_data fs;
   xml_tag* tag;
-} fs_xml;
+};
 
 fs_xml* fs_xml_alloc(long type);

--- a/stmsdf.cc
+++ b/stmsdf.cc
@@ -58,12 +58,12 @@
 
 #define ALT(a) (a->altitude != unknown_alt) ? a->altitude : 0
 
-typedef enum {
+enum sdf_section_e {
   sdf_unknown,
   sdf_header,
   sdf_points,
   sdf_custom
-} sdf_section_e;
+};
 
 static gbfile* fin, *fout;
 

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -62,7 +62,7 @@
 
 /* GPSBabel internal and calculated fields */
 
-typedef enum {
+enum field_e {
   fld_shortname = 0,
   fld_latitude,
   fld_longitude,
@@ -135,7 +135,7 @@ typedef enum {
   fld_gc_placer_id,
   fld_gc_hint,
   fld_terminator
-} field_e;
+};
 
 #define STR_LEFT	1
 #define STR_RIGHT	2
@@ -145,11 +145,11 @@ typedef enum {
 
 #define unicsv_unknown	1e25
 
-typedef struct {
+struct field_t {
   const char* name;
   field_e type;
   uint32_t options;
-} field_t;
+};
 
 /*
  * ! Please use always underscores in field names !

--- a/util.cc
+++ b/util.cc
@@ -1465,11 +1465,11 @@ strip_html(const utf_string* in)
 #endif
 }
 
-typedef struct {
+struct entity_types {
   const char* text;
   const char* entity;
   int  not_html;
-} entity_types;
+};
 
 static
 entity_types stdentities[] =  {

--- a/waypt.cc
+++ b/waypt.cc
@@ -34,7 +34,7 @@
 #include <QtCore/QtGlobal>      // for qPrintable
 
 #include "defs.h"
-#include "garmin_fs.h"          // for garmin_ilink_t, garmin_fs_s, GMSD_FIND, garmin_fs_p
+#include "garmin_fs.h"          // for garmin_ilink_t, garmin_fs_t, GMSD_FIND, garmin_fs_p
 #include "grtcirc.h"            // for RAD, gcdist, heading_true_degrees, radtometers
 #include "session.h"            // for curr_session, session_t
 #include "src/core/datetime.h"  // for DateTime

--- a/wbt-200.cc
+++ b/wbt-200.cc
@@ -93,9 +93,9 @@ static FILE* fl;
 static char* port;
 static char* erase;
 
-typedef enum {
+enum wintec_gps_types {
   UNKNOWN, WBT200, WBT201, WSG1000
-} wintec_gps_types;
+};
 
 static wintec_gps_types dev_type = UNKNOWN;
 

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -83,7 +83,7 @@
  * statements below, add it to xcsv_tokens.in, and rebuild on a system
  * that has GNU gperf on it.
  */
-typedef enum {
+enum xcsv_token {
   XT_unused = 0,
   XT_ALT_FEET,
   XT_ALT_METERS,
@@ -171,7 +171,7 @@ typedef enum {
   XT_UTM_NORTHING,
   XT_URL_LINK_TEXT,
   XT_YYYYMMDD_TIME
-} xcsv_token;
+};
 
 #include "xcsv_tokens.gperf"       // for Perfect_Hash, xt_mapping
 
@@ -251,10 +251,10 @@ arglist_t xcsv_args[] = {
 };
 
 /* something to map config file constants to chars */
-typedef struct char_map {
+struct char_map_t {
   const QString key;
   const QString chars;
-} char_map_t;
+};
 
 /* a table of config file constants mapped to chars */
 static

--- a/xmlgeneric.h
+++ b/xmlgeneric.h
@@ -28,23 +28,23 @@
 // of its own; this was a crutch during the move from char* to QString.
 // It's "just" a search and replace to make it go away, but it might
 // be convenient to overload some day.
-typedef const QString& xg_string;
+using xg_string = const QString&;
 
 
-typedef enum {
+enum xg_cb_type {
   cb_start = 1,
   cb_cdata,
   cb_end,
-} xg_cb_type;
+};
 
 class QXmlStreamAttributes;
-typedef void (xg_callback)(xg_string, const QXmlStreamAttributes*);
+using xg_callback = void (xg_string, const QXmlStreamAttributes*);
 
-typedef struct xg_tag_mapping {
+struct xg_tag_mapping {
   xg_callback* tag_cb;
   xg_cb_type cb_type;
   const char* tag_name;
-} xg_tag_mapping;
+};
 
 extern const char* xhtml_entities;
 void xml_ignore_tags(const char** taglist);


### PR DESCRIPTION
replace typedef syntax.
this was done by hand.

there is also some cleanup of icon mapping tables wrt const.