### PR TITLE
use QVectors for filter and format arguments.

### DIFF
--- a/alan.cc
+++ b/alan.cc
@@ -178,19 +178,17 @@ static gbfile* fin = nullptr, *fout = nullptr;
 static struct wprdata WPR;
 static struct trldata TRL;
 
-static arglist_t wpr_args[] = {
+static QVector<arglist_t> wpr_args = {
   /*
   {"os3", &osversion, "Operating system version 3",
           NULL, ARGTYPE_BOOL, ARGNOMINMAX },
   */
-  ARG_TERMINATOR
 };
-static arglist_t trl_args[] = {
+static QVector<arglist_t> trl_args = {
   /*
   {"os3", &osversion, "Operating system version 3",
           NULL, ARGTYPE_BOOL, ARGNOMINMAX },
   */
-  ARG_TERMINATOR
 };
 
 /**************************************************************************/
@@ -956,7 +954,7 @@ ff_vecs_t alanwpr_vecs = {
   wpr_read,
   wpr_write,
   alan_exit,
-  wpr_args,
+  &wpr_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   NULL_POS_OPS,
@@ -977,7 +975,7 @@ ff_vecs_t alantrl_vecs = {
   trl_read,
   trl_write,
   alan_exit,
-  trl_args,
+  &trl_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   NULL_POS_OPS,

--- a/an1.cc
+++ b/an1.cc
@@ -56,7 +56,7 @@ struct roadchange {
 static roadchange* roadchanges = nullptr;
 
 static
-arglist_t an1_args[] = {
+QVector<arglist_t> an1_args = {
   {
     "type", &output_type, "Type of .an1 file",
     "", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -94,7 +94,6 @@ arglist_t an1_args[] = {
     "radius", &opt_radius, "Radius for circles",
     nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 struct guid_t {
@@ -1213,7 +1212,7 @@ ff_vecs_t an1_vecs = {
   my_read,
   my_write,
   nullptr,
-  an1_args,
+  &an1_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/arcdist.h
+++ b/arcdist.h
@@ -30,9 +30,9 @@
 class ArcDistanceFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -54,7 +54,7 @@ private:
     Waypoint* arcpt1, * arcpt2;
   };
 
-  arglist_t args[8] = {
+  QVector<arglist_t> args = {
     {
       "file", &arcfileopt,  "File containing vertices of arc",
       nullptr, ARGTYPE_FILE, ARG_NOMINMAX, nullptr
@@ -83,7 +83,6 @@ private:
       "project", &projectopt, "Move waypoints to its projection on lines or vertices",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   void arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2);

--- a/bcr.cc
+++ b/bcr.cc
@@ -68,7 +68,7 @@ static char* radius_opt;
 static char* prefer_shortnames_opt;
 
 static
-arglist_t bcr_args[] = {
+QVector<arglist_t> bcr_args = {
   {
     "index", &rtenum_opt, "Index of route to write (if more than one in source)",
     nullptr, ARGTYPE_INT, "1", nullptr, nullptr
@@ -85,7 +85,6 @@ arglist_t bcr_args[] = {
     "prefer_shortnames", &prefer_shortnames_opt, "Use shortname instead of description",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 struct bcr_icon_mapping_t {
@@ -487,7 +486,7 @@ ff_vecs_t bcr_vecs = {
   bcr_data_read,
   bcr_data_write,
   nullptr,
-  bcr_args,
+  &bcr_args,
   CET_CHARSET_MS_ANSI, 0,	/* CET-REVIEW */
   NULL_POS_OPS,
   nullptr

--- a/bend.h
+++ b/bend.h
@@ -31,9 +31,9 @@
 class BendFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -48,7 +48,7 @@ private:
 
   RouteList* routes_orig = nullptr;
 
-  arglist_t args[3] = {
+  QVector<arglist_t> args = {
     {
       "distance", &distopt, "Distance to the bend in meters where the new points will be added",
       "25", ARGTYPE_FLOAT, ARG_NOMINMAX, nullptr
@@ -57,7 +57,6 @@ private:
       "minangle", &minangleopt, "Minimum bend angle in degrees", "5",
       ARGTYPE_FLOAT, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   Waypoint* create_wpt_dest(const Waypoint* wpt_orig, double lat_orig,

--- a/brauniger_iq.cc
+++ b/brauniger_iq.cc
@@ -263,8 +263,7 @@ static void data_read()
   }
 }
 
-static arglist_t brauniger_iq_args[] = {
-  ARG_TERMINATOR
+static QVector<arglist_t> brauniger_iq_args = {
 };
 
 ff_vecs_t brauniger_iq_vecs = {
@@ -277,7 +276,7 @@ ff_vecs_t brauniger_iq_vecs = {
   data_read,
   nullptr,
   nullptr,
-  brauniger_iq_args,
+  &brauniger_iq_args,
   CET_CHARSET_UTF8, 1		/* master process: don't convert anything | CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/bushnell.cc
+++ b/bushnell.cc
@@ -30,8 +30,7 @@ static QString ofname;
 static short_handle mkshort_handle = nullptr;
 
 static
-arglist_t bushnell_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> bushnell_args = {
 };
 
 // Apparently, the icons are undocumented, so we made up names,
@@ -260,7 +259,7 @@ ff_vecs_t bushnell_vecs = {
   bushnell_read,
   bushnell_write,
   nullptr,
-  bushnell_args,
+  &bushnell_args,
   CET_CHARSET_MS_ANSI, 0,  /* Not really sure... */
   NULL_POS_OPS,
   nullptr

--- a/bushnell_trl.cc
+++ b/bushnell_trl.cc
@@ -29,8 +29,7 @@ static int trkpt_count;
 static route_head* trk_head;
 
 static
-arglist_t bushnell_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> bushnell_args = {
 };
 
 static void
@@ -141,7 +140,7 @@ ff_vecs_t bushnell_trl_vecs = {
   bushnell_read,
   bushnell_write,
   nullptr,
-  bushnell_args,
+  &bushnell_args,
   CET_CHARSET_MS_ANSI, 0,  /* Not really sure... */
   NULL_POS_OPS,
   nullptr

--- a/compegps.cc
+++ b/compegps.cc
@@ -88,7 +88,7 @@ static char* option_radius;
 static char* option_snlen;
 
 static
-arglist_t compegps_args[] = {
+QVector<arglist_t> compegps_args = {
   {
     "deficon", &option_icon, "Default icon name",
     nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -105,7 +105,6 @@ arglist_t compegps_args[] = {
     "snlen", &option_snlen, "Length of generated shortnames (default 16)",
     "16", ARGTYPE_INT, "1", nullptr, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static
@@ -691,7 +690,7 @@ ff_vecs_t compegps_vecs = {
   compegps_data_read,
   compegps_data_write,
   nullptr,
-  compegps_args,
+  &compegps_args,
   CET_CHARSET_MS_ANSI, 1
   , NULL_POS_OPS,
   nullptr

--- a/cst.cc
+++ b/cst.cc
@@ -43,8 +43,7 @@ static route_head* temp_route;
 /* placeholders for options */
 
 static
-arglist_t cst_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> cst_args = {
 };
 
 /* helpers */
@@ -324,7 +323,7 @@ ff_vecs_t cst_vecs = {
   cst_data_read,
   nullptr,		/* cst_data_write, */
   nullptr,
-  cst_args,
+  &cst_args,
   CET_CHARSET_MS_ANSI, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/defs.h
+++ b/defs.h
@@ -984,14 +984,18 @@ void setshort_is_utf8(short_handle h, int is_utf8);
 #define ARGTYPE_FLAGMASK 0xfffff000U
 
 #define ARG_NOMINMAX nullptr, nullptr
-#define ARG_TERMINATOR {nullptr, nullptr, nullptr, nullptr, 0, ARG_NOMINMAX, nullptr}
 
 struct arglist_t {
   const char* argstring;
   char** argval;
   const char* helpstring;
   const char* defaultvalue;
-  const uint32_t argtype;
+#if !defined(_MSC_VER) || (_MSC_VER >= 1910) /* !MSVC or MSVC 2017 or newer */
+  const uint32_t argtype{ARGTYPE_UNKNOWN};
+#else
+  /* MSVC 2015 generates C2440, C2664 errors with the above. */
+  uint32_t argtype;
+#endif
   const char* minvalue;		/* minimum value for numeric options */
   const char* maxvalue;		/* maximum value for numeric options */
   char* argvalptr;	/* !!! internal helper. Not used in definitions !!! */
@@ -1049,7 +1053,7 @@ struct ff_vecs_t {
   ff_read read;
   ff_write write;
   ff_exit exit;
-  arglist_t* args;
+  QVector<arglist_t>* args;
   QString encode;
   int fixed_encode;
   position_ops_t position_ops;
@@ -1069,11 +1073,11 @@ void debug_print(int level, const char* fmt, ...) PRINTFLIKE(2,3);
 
 ff_vecs_t* find_vec(const QString&);
 void assign_option(const QString& vecname, arglist_t* arg, const char* val);
-void disp_vec_options(const QString& vecname, const arglist_t* args);
+void disp_vec_options(const QString& vecname, const QVector<arglist_t>* args);
 void disp_vecs();
 void disp_vec(const QString& vecname);
-void validate_options(const QStringList& options, const arglist_t* args, const QString& name);
-bool validate_args(const QString& name, const arglist_t* args);
+void validate_options(const QStringList& options, const QVector<arglist_t>* args, const QString& name);
+bool validate_args(const QString& name, const QVector<arglist_t>* args);
 bool validate_formats();
 void init_vecs();
 void exit_vecs();

--- a/destinator.cc
+++ b/destinator.cc
@@ -34,8 +34,7 @@
 #define DST_ITINERARY 	"City->Street"
 
 static
-arglist_t destinator_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> destinator_args = {
 };
 
 static gbfile* fin, *fout;
@@ -545,7 +544,7 @@ ff_vecs_t destinator_poi_vecs = {
   destinator_read_poi_wrapper,
   destinator_write_poi,
   nullptr,
-  destinator_args,
+  &destinator_args,
   CET_CHARSET_UTF8, 1			/* fixed */
   , NULL_POS_OPS,
   nullptr};
@@ -564,7 +563,7 @@ ff_vecs_t destinator_itn_vecs = {
   destinator_read_rte_wrapper,
   destinator_write_rte,
   nullptr,
-  destinator_args,
+  &destinator_args,
   CET_CHARSET_UTF8, 1			/* fixed */
   , NULL_POS_OPS,
   nullptr};
@@ -583,7 +582,7 @@ ff_vecs_t destinator_trl_vecs = {
   destinator_read_trk_wrapper,
   destinator_write_trk,
   nullptr,
-  destinator_args,
+  &destinator_args,
   CET_CHARSET_UTF8, 1			/* fixed */
   , NULL_POS_OPS,
   nullptr };

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -659,7 +659,7 @@ static char* erase;
 static char* erase_only;
 
 static
-arglist_t dg100_args[] = {
+QVector<arglist_t> dg100_args = {
   {
     "erase", &erase, "Erase device data after download",
     "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -668,7 +668,6 @@ arglist_t dg100_args[] = {
     "erase_only", &erase_only, "Only erase device data, do not download anything",
     "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 /*******************************************************************************
@@ -743,7 +742,7 @@ ff_vecs_t dg100_vecs = {
   dg100_read,
   nullptr,
   nullptr,
-  dg100_args,
+  &dg100_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,
@@ -764,7 +763,7 @@ ff_vecs_t dg200_vecs = {
   dg100_read,
   nullptr,
   nullptr,
-  dg100_args,
+  &dg100_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/discard.h
+++ b/discard.h
@@ -31,9 +31,9 @@
 class DiscardFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -64,7 +64,7 @@ private:
   gpsdata_type what;
   route_head* head;
 
-  arglist_t args[13] = {
+  QVector<arglist_t> args = {
     {
       "hdop", &hdopopt, "Suppress points with higher hdop",
       "-1.0", ARGTYPE_BEGIN_REQ | ARGTYPE_FLOAT, ARG_NOMINMAX, nullptr
@@ -117,7 +117,6 @@ private:
       "Suppress points where type matches given name", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   void fix_process_wpt(const Waypoint* wpt);

--- a/dmtlog.cc
+++ b/dmtlog.cc
@@ -60,12 +60,11 @@ static char* opt_index;
 static int track_index, this_index;
 
 static
-arglist_t dmtlog_args[] = {
+QVector<arglist_t> dmtlog_args = {
   {
     "index", &opt_index,
     "Index of track (if more than one in source)", "1", ARGTYPE_INT, "1", nullptr, nullptr
   },
-  ARG_TERMINATOR
 };
 
 
@@ -836,7 +835,7 @@ ff_vecs_t dmtlog_vecs = {
   dmtlog_read,
   dmtlog_write,
   nullptr,
-  dmtlog_args,
+  &dmtlog_args,
   CET_CHARSET_ASCII, 0
   , NULL_POS_OPS,
   nullptr

--- a/duplicate.h
+++ b/duplicate.h
@@ -30,9 +30,9 @@
 class DuplicateFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void process() override;
 
@@ -42,7 +42,7 @@ private:
   char* purge_duplicates = nullptr;
   char* correct_coords = nullptr;
 
-  arglist_t args[5] = {
+  QVector<arglist_t> args = {
     {
       "shortname", &snopt, "Suppress duplicate waypoints based on name",
       nullptr, ARGTYPE_BEGIN_REQ | ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -59,7 +59,6 @@ private:
       "correct", &correct_coords, "Use coords from duplicate points",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   struct btree_node {

--- a/easygps.cc
+++ b/easygps.cc
@@ -30,10 +30,9 @@ static short_handle mkshort_handle;
 #define MYNAME "EasyGPS"
 
 static
-arglist_t easygps_args[] = {
+QVector<arglist_t> easygps_args = {
   /*	{"deficon", &deficon, "Default icon name", "Waypoint",
     	ARGTYPE_STRING}, */
-  ARG_TERMINATOR
 };
 
 static void
@@ -217,7 +216,7 @@ ff_vecs_t easygps_vecs = {
   data_read,
   data_write,
   nullptr,
-  easygps_args,
+  &easygps_args,
   CET_CHARSET_ASCII, 0	/* CET REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/exif.cc
+++ b/exif.cc
@@ -197,12 +197,11 @@ static char* opt_filename, *opt_overwrite, *opt_frame, *opt_name;
 
 static uint8_t writer_gps_tag_version[4] = {2, 0, 0, 0};
 
-static arglist_t exif_args[] = {
+static QVector<arglist_t> exif_args = {
   { "filename", &opt_filename, "Set waypoint name to source filename", "Y", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
   { "frame", &opt_frame, "Time-frame (in seconds)", "10", ARGTYPE_INT, "0", nullptr, nullptr },
   { "name", &opt_name, "Locate waypoint for tagging by this name", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   { "overwrite", &opt_overwrite, "!OVERWRITE! the original file. Default=N", "N", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 // for debug only
@@ -1685,7 +1684,7 @@ ff_vecs_t exif_vecs = {
   exif_read,
   exif_write,
   nullptr,
-  exif_args,
+  &exif_args,
   CET_CHARSET_UTF8, 0,
   NULL_POS_OPS,
   nullptr

--- a/f90g_track.cc
+++ b/f90g_track.cc
@@ -42,8 +42,7 @@ static route_head* track = nullptr;
 
 
 static
-arglist_t f90g_track_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> f90g_track_args = {
 };
 
 /*******************************************************************************
@@ -151,7 +150,7 @@ ff_vecs_t f90g_track_vecs = {
   f90g_track_read,
   nullptr,
   nullptr,
-  f90g_track_args,
+  &f90g_track_args,
   CET_CHARSET_UTF8, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/filter.h
+++ b/filter.h
@@ -38,7 +38,7 @@ public:
   Filter(Filter&&) = default;
   Filter& operator=(Filter&&) = default;
 
-  virtual arglist_t* get_args() = 0;
+  virtual QVector<arglist_t>* get_args() = 0;
 
   virtual void init()
   {

--- a/filterdefs.h
+++ b/filterdefs.h
@@ -44,7 +44,7 @@ struct filter_vecs_t {
   filter_process f_process;
   filter_deinit f_deinit;
   filter_exit f_exit;
-  arglist_t* args;
+  QVector<arglist_t>* args;
 };
 
 Filter* find_filter_vec(const QString&);

--- a/format_skeleton.cc
+++ b/format_skeleton.cc
@@ -46,10 +46,9 @@
 // Values for ARGTYPE_xxx can be found in defs.h and are used to
 // select the type of option.
 static
-arglist_t format_skeleton_args[] = {
+QVector<arglist_t> format_skeleton_args = {
 // {"foo", &fooopt, "The text of the foo option in help",
 //   "default", ARGYTPE_STRING, ARG_NOMINMAX} ,
-  ARG_TERMINATOR
 };
 
 /*******************************************************************************
@@ -148,7 +147,7 @@ ff_vecs_t format_skeleton_vecs = {
   format_skeleton_read,
   format_skeleton_write,
   format_skeleton_exit,
-  format_skeleton_args,
+  &format_skeleton_args,
   CET_CHARSET_ASCII, 0,			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   NULL_POS_OPS, // Unless you do realtime positioning

--- a/g7towin.cc
+++ b/g7towin.cc
@@ -51,8 +51,7 @@ static int gardown;
 static int event_ct;
 
 static
-arglist_t g7towin_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> g7towin_args = {
 };
 
 #define WAYPT__OFS	0x00000
@@ -583,7 +582,7 @@ ff_vecs_t g7towin_vecs = {
   data_read,
   nullptr,
   nullptr,
-  g7towin_args,
+  &g7towin_args,
   CET_CHARSET_MS_ANSI, 0
   , NULL_POS_OPS,
   nullptr

--- a/garmin.cc
+++ b/garmin.cc
@@ -75,7 +75,7 @@ static ff_vecs_t* gpx_vec;
 static const char* valid_waypt_chars = MILITANT_VALID_WAYPT_CHARS " ";
 
 static
-arglist_t garmin_args[] = {
+QVector<arglist_t> garmin_args = {
   {
     "snlen", &snlen, "Length of generated shortnames", nullptr,
     ARGTYPE_INT, "1", nullptr, nullptr
@@ -113,7 +113,6 @@ arglist_t garmin_args[] = {
     "baud", &baudopt, "Speed in bits per second of serial port (baud=9600)",
     nullptr, ARGTYPE_INT, ARG_NOMINMAX, nullptr },
 
-  ARG_TERMINATOR
 };
 
 static const char* d103_symbol_from_icon_number(unsigned int n);
@@ -1252,7 +1251,7 @@ ff_vecs_t garmin_vecs = {
   data_read,
   data_write,
   nullptr,
-  garmin_args,
+  &garmin_args,
   CET_CHARSET_ASCII, 0,
   { pvt_init, pvt_read, rw_deinit, nullptr, nullptr, nullptr },
   nullptr

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -138,13 +138,12 @@ static bool write_header_msgs = false;
 
 
 static
-arglist_t fit_args[] = {
+QVector<arglist_t> fit_args = {
   {
     "allpoints", &opt_allpoints,
     "Read all points even if latitude or longitude is missing",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 const std::vector<std::pair<QString, int> > kCoursePointTypeMapping = {
@@ -1382,7 +1381,7 @@ ff_vecs_t format_fit_vecs = {
   fit_read,
   fit_write,
   nullptr,
-  fit_args,
+  &fit_args,
   CET_CHARSET_ASCII, 0		/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -88,7 +88,7 @@ static char* opt_writecodec;
 static double defspeed, defproximity;
 static int alerts;
 
-static arglist_t garmin_gpi_args[] = {
+static QVector<arglist_t> garmin_gpi_args = {
   {
     "alerts", &opt_alerts, "Enable alerts on speed or proximity distance",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -145,7 +145,6 @@ static arglist_t garmin_gpi_args[] = {
     "languagecode", &opt_lang, "language code to use for reading dual language files",
     nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 struct reader_data_t {
@@ -1636,7 +1635,7 @@ ff_vecs_t garmin_gpi_vecs = {
   garmin_gpi_read,
   garmin_gpi_write,
   nullptr,
-  garmin_gpi_args,
+  &garmin_gpi_args,
   CET_CHARSET_MS_ANSI, 0		/* WIN-CP1252 */
   , NULL_POS_OPS,
   nullptr

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -124,7 +124,7 @@ static char* opt_utc = nullptr;
 static char* opt_grid = nullptr;
 
 static
-arglist_t garmin_txt_args[] = {
+QVector<arglist_t> garmin_txt_args = {
   {"date",  &opt_date_format, "Read/Write date format (i.e. yyyy/mm/dd)", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
   {"datum", &opt_datum, 	    "GPS datum (def. WGS 84)", "WGS 84", ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
   {"dist",  &opt_dist,        "Distance unit [m=metric, s=statute]", "m", ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
@@ -133,7 +133,6 @@ arglist_t garmin_txt_args[] = {
   {"temp",  &opt_temp,        "Temperature unit [c=Celsius, f=Fahrenheit]", "c", ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
   {"time",  &opt_time_format, "Read/Write time format (i.e. HH:mm:ss xx)", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
   {"utc",   &opt_utc,         "Write timestamps with offset x to UTC time", nullptr, ARGTYPE_INT, "-23", "+23", nullptr},
-  ARG_TERMINATOR
 };
 
 struct info_t {
@@ -1395,7 +1394,7 @@ ff_vecs_t garmin_txt_vecs = {
   garmin_txt_read,
   garmin_txt_write,
   nullptr,
-  garmin_txt_args,
+  &garmin_txt_args,
   CET_CHARSET_MS_ANSI, 0
   , NULL_POS_OPS,
   nullptr

--- a/garmin_xt.cc
+++ b/garmin_xt.cc
@@ -56,12 +56,11 @@ static char*	opt_xt_ftype = nullptr;
 static char*	opt_trk_header = nullptr;
 
 static
-arglist_t format_garmin_xt_args[] = {
+QVector<arglist_t> format_garmin_xt_args = {
   {"ftype", &opt_xt_ftype, "Garmin Mobile XT ([ATRK]/STRK)", "ATRK", ARGTYPE_STRING | ARGTYPE_REQUIRED, ARG_NOMINMAX, nullptr},
   // TODO: SHIFT - can't test behaviour, do not have appropriate files
   //{"trk_header_opt", &opt_trk_header, "Track name processing option ([0]-nrm/1-ign/2-sht)", "0", ARGTYPE_INT, ARG_NOMINMAX},
   {"trk_header", &opt_trk_header, "Track name processing option ([0]-nrm/1-ign)", "0", ARGTYPE_INT, ARG_NOMINMAX, nullptr},
-  ARG_TERMINATOR
 };
 
 /*******************************************************************************
@@ -412,7 +411,7 @@ ff_vecs_t format_garmin_xt_vecs = {
   format_garmin_xt_read,
   nullptr,
   nullptr,
-  format_garmin_xt_args,
+  &format_garmin_xt_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/gdb.cc
+++ b/gdb.cc
@@ -1808,7 +1808,7 @@ write_data()
 #define GDB_OPT_BITCATEGORY	"bitscategory"
 #define GDB_OPT_ROADBOOK	"roadbook"
 
-static arglist_t gdb_args[] = {
+static QVector<arglist_t> gdb_args = {
   {
     GDB_OPT_CATEGORY, &gdb_opt_category,
     "Default category on output (1..16)",
@@ -1834,7 +1834,6 @@ static arglist_t gdb_args[] = {
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
 
-  ARG_TERMINATOR
 };
 
 ff_vecs_t gdb_vecs = {
@@ -1847,7 +1846,7 @@ ff_vecs_t gdb_vecs = {
   read_data,
   write_data,
   nullptr,
-  gdb_args,
+  &gdb_args,
   CET_CHARSET_MS_ANSI, 0	/* O.K.: changed to NON-FIXED */
   /* because of utf8 strings since GDB V3 */
   , NULL_POS_OPS,

--- a/geo.cc
+++ b/geo.cc
@@ -29,10 +29,9 @@ static QString ostring;
 static QXmlStreamWriter writer(&ostring);
 
 static
-arglist_t geo_args[] = {
+QVector<arglist_t> geo_args = {
   {"deficon", &deficon, "Default icon name", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   {"nuke_placer", &nuke_placer, "Omit Placer name", nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 #define MYNAME "geo"
@@ -266,7 +265,7 @@ ff_vecs_t geo_vecs = {
   geo_read,
   geo_write,
   nullptr,
-  geo_args,
+  &geo_args,
   CET_CHARSET_UTF8, 0,	/* CET-REVIEW */
   NULL_POS_OPS,
   nullptr

--- a/geojson.cc
+++ b/geojson.cc
@@ -47,10 +47,9 @@ static const QString DESCRIPTION = QStringLiteral("description");
 static const QString URL = QStringLiteral("url");
 static const QString URLNAME = QStringLiteral("urlname");
 
-static arglist_t geojson_args[] = {
+static QVector<arglist_t> geojson_args = {
   {"compact", &compact_opt, "Compact Output. Default is off.", 
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr } ,
-  ARG_TERMINATOR
 };
 
 static void
@@ -324,7 +323,7 @@ ff_vecs_t geojson_vecs = {
   geojson_read,
   geojson_write,
   nullptr,
-  geojson_args,
+  &geojson_args,
   CET_CHARSET_UTF8, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr  

--- a/ggv_log.cc
+++ b/ggv_log.cc
@@ -43,8 +43,7 @@ static gbfile* fin, *fout;
 static int ggv_log_ver;
 
 static
-arglist_t ggv_log_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> ggv_log_args = {
 };
 
 /*******************************************************************************
@@ -280,7 +279,7 @@ ff_vecs_t ggv_log_vecs = {
   ggv_log_read,
   ggv_log_write,
   nullptr,
-  ggv_log_args,
+  &ggv_log_args,
   CET_CHARSET_ASCII, 1
   , NULL_POS_OPS,
   nullptr

--- a/ggv_ovl.cc
+++ b/ggv_ovl.cc
@@ -35,8 +35,7 @@
 #define MYNAME "ggv_ovl"
 
 static
-arglist_t ggv_ovl_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> ggv_ovl_args = {
 };
 
 enum OVL_SYMBOL_TYP {
@@ -445,7 +444,7 @@ ff_vecs_t ggv_ovl_vecs = {
   ggv_ovl_read,
   ggv_ovl_write,
   nullptr,
-  ggv_ovl_args,
+  &ggv_ovl_args,
   CET_CHARSET_MS_ANSI, 0
   , NULL_POS_OPS,
   nullptr

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -56,12 +56,11 @@ static gbfile* dumpfile = nullptr;             // used for creating bin/RAW data
 static gbfile* in_file = nullptr;              // used for reading from bin/RAW datadump files, useful for testing
 
 static
-arglist_t globalsat_args[] = {
+QVector<arglist_t> globalsat_args = {
   {"showlist", &showlist, "list tracks", nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr},
   {"track", &track, "get track", "0", ARGTYPE_INT, ARG_NOMINMAX, nullptr},
   {"dump-file", &opt_dump_file, "Dump raw data to this file", nullptr, ARGTYPE_OUTFILE, ARG_NOMINMAX, nullptr},
   {"input-is-dump-file", &opt_input_dump_file, "Dump raw data to this file", nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr},
-  ARG_TERMINATOR
 };
 
 enum globalsat_commands_e {
@@ -823,7 +822,7 @@ ff_vecs_t globalsat_sport_vecs = {
   data_read,					// read
   nullptr,						// write
   nullptr,						// exit
-  globalsat_args,			// args
+  &globalsat_args,			// args
   CET_CHARSET_ASCII,	// encode
   0,									// fixed_encode
   NULL_POS_OPS,				// position_ops

--- a/glogbook.cc
+++ b/glogbook.cc
@@ -36,8 +36,7 @@ static route_head* trk_head;
 #define MYNAME "glogbook"
 
 static
-arglist_t glogbook_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> glogbook_args = {
 };
 
 /* Tracks */
@@ -187,7 +186,7 @@ ff_vecs_t glogbook_vecs = {
   glogbook_read,
   glogbook_write,
   nullptr,
-  glogbook_args,
+  &glogbook_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/gnav_trl.cc
+++ b/gnav_trl.cc
@@ -25,8 +25,7 @@
 #define MYNAME "gnav_trl"
 
 static
-arglist_t gnav_trl_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> gnav_trl_args = {
 };
 
 struct gnav_trl_t {
@@ -151,7 +150,7 @@ ff_vecs_t gnav_trl_vecs = {
   gnav_trl_read,
   gnav_trl_write,
   nullptr,
-  gnav_trl_args,
+  &gnav_trl_args,
   CET_CHARSET_UTF8, 1	/* CET - do nothing ! */
   , NULL_POS_OPS,
   nullptr

--- a/gopal.cc
+++ b/gopal.cc
@@ -73,12 +73,11 @@ static char* optclean= nullptr;
 static double minspeed,maxspeed;
 static struct tm opt_tm;	/* converted "date" parameter */
 static
-arglist_t gopal_args[] = {
+QVector<arglist_t> gopal_args = {
   {"date", &optdate, "Complete date-free tracks with given date (YYYYMMDD).", nullptr, ARGTYPE_INT, ARG_NOMINMAX, nullptr },
   {"maxspeed", &optmaxspeed, "The maximum speed (km/h) traveling from waypoint to waypoint.", "200", ARGTYPE_INT, "1", "1000", nullptr },
   {"minspeed", &optminspeed, "The minimum speed (km/h) traveling from waypoint to waypoint. Set >0 to remove duplicate waypoints", "0", ARGTYPE_INT, "0", "999", nullptr },
   {"clean", &optclean, "Cleanup common errors in trackdata", "1", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 #define CHECK_BOOL(a) if (a && (*a == '0')) a = NULL
@@ -414,7 +413,7 @@ ff_vecs_t gopal_vecs = {
   gopal_read,
   gopal_write,
   gopal_exit,
-  gopal_args,
+  &gopal_args,
   CET_CHARSET_ASCII, 0	/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/gpssim.cc
+++ b/gpssim.cc
@@ -36,7 +36,7 @@ static int trk_count;
 static int doing_tracks;
 
 static
-arglist_t gpssim_args[] = {
+QVector<arglist_t> gpssim_args = {
   {
     "wayptspd", &wayptspd, "Default speed for waypoints (knots/hr)",
     nullptr, ARGTYPE_FLOAT, ARG_NOMINMAX, nullptr
@@ -45,7 +45,6 @@ arglist_t gpssim_args[] = {
     "split", &splitfiles_opt, "Split input into separate files",
     "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 /*
@@ -198,7 +197,7 @@ ff_vecs_t gpssim_vecs = {
   nullptr,
   gpssim_write,
   nullptr,
-  gpssim_args,
+  &gpssim_args,
   CET_CHARSET_ASCII, 0
   , NULL_POS_OPS,
   nullptr

--- a/gpx.cc
+++ b/gpx.cc
@@ -2014,7 +2014,7 @@ gpx_exit()
 }
 
 static
-arglist_t gpx_args[] = {
+QVector<arglist_t> gpx_args = {
   {
     "snlen", &snlen, "Length of generated shortnames",
     "32", ARGTYPE_INT, "1", nullptr, nullptr
@@ -2052,7 +2052,6 @@ arglist_t gpx_args[] = {
     "Precision of elevations, number of decimals",
     "3", ARGTYPE_INT, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 ff_vecs_t gpx_vecs = {
@@ -2065,7 +2064,7 @@ ff_vecs_t gpx_vecs = {
   gpx_read,
   gpx_write,
   gpx_exit,
-  gpx_args,
+  &gpx_args,
   CET_CHARSET_UTF8, 0,	/* non-fixed to create non UTF-8 XML's for testing | CET-REVIEW */
   NULL_POS_OPS,
   nullptr,

--- a/gtm.cc
+++ b/gtm.cc
@@ -732,8 +732,7 @@ gtm_write()
 }
 
 static
-arglist_t gtm_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> gtm_args = {
 };
 
 ff_vecs_t gtm_vecs = {
@@ -746,7 +745,7 @@ ff_vecs_t gtm_vecs = {
   gtm_read,
   gtm_write,
   nullptr,
-  gtm_args,
+  &gtm_args,
   CET_CHARSET_ASCII, 0, /* CET-REVIEW */
   NULL_POS_OPS,
   nullptr

--- a/gtrnctr.cc
+++ b/gtrnctr.cc
@@ -55,7 +55,7 @@ static double gtc_end_long;
 static char* opt_sport, *opt_course;
 
 static
-arglist_t gtc_args[] = {
+QVector<arglist_t> gtc_args = {
   {
     "course", &opt_course, "Write course rather than history, default yes",
     "1", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -64,7 +64,6 @@ arglist_t gtc_args[] = {
     "sport", &opt_sport, "Sport: Biking (deflt), Running, MultiSport, Other",
     "Biking", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 /* Tracks */
@@ -646,7 +645,7 @@ ff_vecs_t gtc_vecs = {
   gtc_read,
   gtc_write,
   nullptr,
-  gtc_args,
+  &gtc_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/height.h
+++ b/height.h
@@ -32,9 +32,9 @@
 class HeightFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -44,7 +44,7 @@ private:
   char* wgs84tomslopt = nullptr;
   double addf;
 
-  arglist_t args[3] = {
+  QVector<arglist_t> args = {
     {
       "add", &addopt, "Adds a constant value to every altitude (meter, append \"f\" (x.xxf) for feet)",
       nullptr, ARGTYPE_BEGIN_REQ | ARGTYPE_FLOAT, ARG_NOMINMAX, nullptr
@@ -53,7 +53,6 @@ private:
       "wgs84tomsl", &wgs84tomslopt, "Converts WGS84 ellipsoidal height to orthometric height (MSL)",
       nullptr, ARGTYPE_END_REQ | ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   double bilinear(double x1, double y1, double x2, double y2, double x, double y, double z11, double z12, double z21, double z22);

--- a/hiketech.cc
+++ b/hiketech.cc
@@ -35,8 +35,7 @@ static route_head* trk_head;
 #define MYNAME "hiketech"
 
 static
-arglist_t hiketech_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> hiketech_args = {
 };
 
 /* Waypoints */
@@ -312,7 +311,7 @@ ff_vecs_t hiketech_vecs = {
   hiketech_read,
   hiketech_write,
   nullptr,
-  hiketech_args,
+  &hiketech_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/html.cc
+++ b/html.cc
@@ -38,7 +38,7 @@ static char* altunits = nullptr;
 #define MYNAME "HTML"
 
 static
-arglist_t html_args[] = {
+QVector<arglist_t> html_args = {
   {
     "stylesheet", &stylesheet,
     "Path to HTML style sheet", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -59,7 +59,6 @@ arglist_t html_args[] = {
     "altunits", &altunits,
     "Units for altitude (f)eet or (m)etres", "m", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 
@@ -290,7 +289,7 @@ ff_vecs_t html_vecs = {
   nullptr,
   data_write,
   nullptr,
-  html_args,
+  &html_args,
   CET_CHARSET_UTF8, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/humminbird.cc
+++ b/humminbird.cc
@@ -198,8 +198,7 @@ static int rte_num;
 static QMap<QString, Waypoint*> map;
 
 static
-arglist_t humminbird_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> humminbird_args = {
 };
 
 /* Takes a latitude in degrees,
@@ -951,7 +950,7 @@ ff_vecs_t humminbird_vecs = {
   humminbird_read,
   humminbird_write,
   nullptr, // humminbird_exit,
-  humminbird_args,
+  &humminbird_args,
   CET_CHARSET_ASCII, 1			/* ascii is the expected character set */
   /* currently fixed !!! */
   , NULL_POS_OPS,
@@ -976,7 +975,7 @@ ff_vecs_t humminbird_ht_vecs = {
   humminbird_read,
   humminbird_track_write,
   nullptr, // humminbird_exit,
-  humminbird_args,
+  &humminbird_args,
   CET_CHARSET_ASCII, 1			/* ascii is the expected character set */
   /* currently fixed !!! */
   , NULL_POS_OPS,

--- a/igc.cc
+++ b/igc.cc
@@ -938,13 +938,12 @@ static void data_write()
 }
 
 
-static arglist_t igc_args[] = {
+static QVector<arglist_t> igc_args = {
   {
     "timeadj", &timeadj,
     "(integer sec or 'auto') Barograph to GPS time diff",
     nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 ff_vecs_t igc_vecs = {
@@ -957,7 +956,7 @@ ff_vecs_t igc_vecs = {
   data_read,
   data_write,
   nullptr,
-  igc_args,
+  &igc_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/ignrando.cc
+++ b/ignrando.cc
@@ -38,9 +38,8 @@ static int xmlpoints;
 /* options */
 static char* index_opt = nullptr;
 
-static arglist_t ignr_args[] = {
+static QVector<arglist_t> ignr_args = {
   {"index", &index_opt, "Index of track to write (if more than one in source)", nullptr, ARGTYPE_INT, "1", nullptr , nullptr},
-  ARG_TERMINATOR
 };
 
 
@@ -254,7 +253,7 @@ ff_vecs_t ignr_vecs = {
   ignr_read,
   ignr_write,
   nullptr,
-  ignr_args,
+  &ignr_args,
   CET_CHARSET_MS_ANSI, 1
   , NULL_POS_OPS,
   nullptr

--- a/igo8.cc
+++ b/igo8.cc
@@ -108,11 +108,10 @@ static uint32_t point_count;
 static int in_point_count;
 
 // Exported options list
-static arglist_t igo8_options[] = {
+static QVector<arglist_t> igo8_options = {
   { "tracknum", &igo8_option_tracknum, "Track identification number", nullptr, ARGTYPE_INT, ARG_NOMINMAX, nullptr },
   { "title", &igo8_option_title, "Track title", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   { "description", &igo8_option_description, "Track description", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 // Sanity check
@@ -364,7 +363,7 @@ ff_vecs_t igo8_vecs = {
   igo8_read,
   igo8_write,
   nullptr,
-  igo8_options,
+  &igo8_options,
   CET_CHARSET_UTF8,
   1
   , NULL_POS_OPS,

--- a/ik3d.cc
+++ b/ik3d.cc
@@ -25,8 +25,7 @@
 #include "xmlgeneric.h"
 #include <QtCore/QXmlStreamAttributes>
 
-static arglist_t ikt_args[] = {
-  ARG_TERMINATOR
+static QVector<arglist_t> ikt_args = {
 };
 
 #define MYNAME "ikt"
@@ -157,7 +156,7 @@ ff_vecs_t ik3d_vecs = {
   ikt_read,
   nullptr,
   nullptr,
-  ikt_args,
+  &ikt_args,
   CET_CHARSET_UTF8, 1
   , NULL_POS_OPS,
   nullptr

--- a/interpolate.h
+++ b/interpolate.h
@@ -30,9 +30,9 @@
 class InterpolateFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -44,7 +44,7 @@ private:
   double dist = 0;
   char* opt_route = nullptr;
 
-  arglist_t args[4] = {
+  QVector<arglist_t> args = {
     {
       "time", &opt_interval, "Time interval in seconds", nullptr,
       ARGTYPE_BEGIN_EXCL | ARGTYPE_BEGIN_REQ | ARGTYPE_INT,
@@ -59,7 +59,6 @@ private:
       "route", &opt_route, "Interpolate routes instead", nullptr,
       ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
 };

--- a/itracku.cc
+++ b/itracku.cc
@@ -359,11 +359,10 @@ init_device()
 // Values for ARGTYPE_xxx can be found in defs.h and are used to
 // select the type of option.
 static
-arglist_t itracku_args[] = {
+QVector<arglist_t> itracku_args = {
   { "backup", &backup_file_name, "Appends the input to a backup file", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
   { "new", &only_new, "Only waypoints that are not the backup file", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
 //   "default", ARGYTPE_STRING, ARG_NOMINMAX} ,
-  ARG_TERMINATOR
 };
 
 /*******************************************************************************
@@ -781,7 +780,7 @@ ff_vecs_t itracku_vecs = {
   itracku_read,
   nullptr,
   itracku_exit,
-  itracku_args,
+  &itracku_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   { itracku_rt_init, itracku_rt_position, itracku_rt_deinit, nullptr, nullptr, nullptr },
@@ -802,7 +801,7 @@ ff_vecs_t itracku_fvecs = {
   itracku_read,
   itracku_write,
   itracku_exit,
-  itracku_args,
+  &itracku_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr },

--- a/jogmap.cc
+++ b/jogmap.cc
@@ -29,8 +29,7 @@
 
 static route_head* trk;
 
-static arglist_t jogmap_args[] = {
-  ARG_TERMINATOR
+static QVector<arglist_t> jogmap_args = {
 };
 
 #define MYNAME "xol"
@@ -107,7 +106,7 @@ ff_vecs_t jogmap_vecs = {
   jogmap_read,
   nullptr,
   nullptr,
-  jogmap_args,
+  &jogmap_args,
   CET_CHARSET_UTF8, 0
   , NULL_POS_OPS,
   nullptr

--- a/jtr.cc
+++ b/jtr.cc
@@ -30,8 +30,7 @@
 #define MYNAME "jtr"
 
 static
-arglist_t jtr_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> jtr_args = {
 };
 
 static gbfile* fin, *fout;
@@ -337,7 +336,7 @@ ff_vecs_t jtr_vecs = {
   jtr_read,
   jtr_write,
   nullptr,
-  jtr_args,
+  &jtr_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/kml.cc
+++ b/kml.cc
@@ -124,7 +124,7 @@ static const char kmt_power[] = "power";
 
 
 static
-arglist_t kml_args[] = {
+QVector<arglist_t> kml_args = {
   {"deficon", &opt_deficon, "Default icon name", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   {
     "lines", &opt_export_lines,
@@ -196,7 +196,6 @@ arglist_t kml_args[] = {
     "Precision of coordinates, number of decimals",
     DEFAULT_PRECISION, ARGTYPE_INT, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static
@@ -2224,7 +2223,7 @@ ff_vecs_t kml_vecs = {
   kml_read,
   kml_write,
   nullptr,
-  kml_args,
+  &kml_args,
   CET_CHARSET_UTF8, 1,	/* CET-REVIEW */
   { nullptr, nullptr, nullptr, kml_wr_position_init, kml_wr_position, kml_wr_position_deinit },
   nullptr

--- a/lmx.cc
+++ b/lmx.cc
@@ -43,13 +43,12 @@ static char* binary = nullptr;
 #define MYNAME "lmx"
 
 static
-arglist_t lmx_args[] = {
+QVector<arglist_t> lmx_args = {
   {
     "binary", &binary,
     "Compact binary representation",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 /*
@@ -411,7 +410,7 @@ ff_vecs_t lmx_vecs = {
   lmx_read,
   lmx_write,
   nullptr,
-  lmx_args,
+  &lmx_args,
   CET_CHARSET_UTF8, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -692,7 +692,7 @@ lowranceusr4_find_index_from_icon_desc_and_color_desc(const QString& icon, const
 // Combined arguments from previous lowranceusr and lowranceusr4 into single set.
 // Use output format specified to determine if args are ignored.
 static
-arglist_t lowranceusr_args[] = {
+QVector<arglist_t> lowranceusr_args = {
   {
     // Ignore Event Marker ICONs in input data
     "ignoreicons", &opt_ignoreicons, "(USR input) Ignore event marker icons on read",
@@ -732,7 +732,6 @@ arglist_t lowranceusr_args[] = {
     "", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
 
-  ARG_TERMINATOR
 };
 
 static void
@@ -2457,7 +2456,7 @@ ff_vecs_t lowranceusr_vecs = {
   data_read,
   data_write,
   nullptr,
-  lowranceusr_args,
+  &lowranceusr_args,
   CET_CHARSET_ASCII, 0   /* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/magproto.cc
+++ b/magproto.cc
@@ -684,7 +684,7 @@ static void termdeinit()
  *  Arg tables are doubled up so that -? can output appropriate help
  */
 static
-arglist_t mag_sargs[] = {
+QVector<arglist_t> mag_sargs = {
   {
     "deficon", &deficon, "Default icon name", nullptr, ARGTYPE_STRING,
     ARG_NOMINMAX, nullptr
@@ -705,11 +705,10 @@ arglist_t mag_sargs[] = {
     "nukewpt", &nukewpt, "Delete all waypoints", nullptr, ARGTYPE_BOOL,
     ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static
-arglist_t mag_fargs[] = {
+QVector<arglist_t> mag_fargs = {
   {
     "deficon", &deficon, "Default icon name", nullptr, ARGTYPE_STRING,
     ARG_NOMINMAX, nullptr
@@ -718,7 +717,6 @@ arglist_t mag_fargs[] = {
     "maxcmts", &cmts, "Max number of comments to write (maxcmts=200)",
     nullptr, ARGTYPE_INT, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 /*
@@ -1606,7 +1604,7 @@ ff_vecs_t mag_svecs = {
   mag_read,
   mag_write,
   nullptr,
-  mag_sargs,
+  &mag_sargs,
   CET_CHARSET_ASCII, 0,	/* CET-REVIEW */
   NULL_POS_OPS,
   nullptr,
@@ -1622,7 +1620,7 @@ ff_vecs_t mag_fvecs = {
   mag_read,
   mag_write,
   nullptr,
-  mag_fargs,
+  &mag_fargs,
   CET_CHARSET_ASCII, 0,	/* CET-REVIEW */
   NULL_POS_OPS,
   nullptr,
@@ -1641,7 +1639,7 @@ ff_vecs_t magX_fvecs = {
   mag_read,
   mag_write,
   nullptr,
-  mag_fargs,
+  &mag_fargs,
   CET_CHARSET_ASCII, 0,	/* CET-REVIEW */
   NULL_POS_OPS,
   nullptr,

--- a/mapasia.cc
+++ b/mapasia.cc
@@ -61,8 +61,7 @@ static const route_head* trk_tmp;
 static int course_tmp, speed_tmp;
 
 static
-arglist_t tr7_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> tr7_args = {
 };
 
 /*******************************************************************************
@@ -300,7 +299,7 @@ ff_vecs_t mapasia_tr7_vecs = {		/* we can read and write tracks */
   tr7_read,
   tr7_write,
   nullptr,
-  tr7_args,
+  &tr7_args,
   CET_CHARSET_UTF8, 1	/* FIXED - CET-REVIEW - */
   , NULL_POS_OPS,
   nullptr

--- a/mapbar_track.cc
+++ b/mapbar_track.cc
@@ -29,8 +29,7 @@
 static gbfile* fin;
 
 static
-arglist_t mapbar_track_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> mapbar_track_args = {
 };
 
 /*******************************************************************************
@@ -140,7 +139,7 @@ ff_vecs_t mapbar_track_vecs = {
   mapbar_track_read,
   nullptr,
   nullptr,
-  mapbar_track_args,
+  &mapbar_track_args,
   CET_CHARSET_UTF8, 0
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/mapfactor.cc
+++ b/mapfactor.cc
@@ -27,8 +27,7 @@ static gpsbabel::File* oqfile;
 static QXmlStreamWriter* writer;
 
 static
-arglist_t mapfactor_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> mapfactor_args = {
 };
 
 #define MYNAME "mapfactor"
@@ -156,7 +155,7 @@ ff_vecs_t mapfactor_vecs = {
   mapfactor_read,
   mapfactor_write,
   nullptr,
-  mapfactor_args,
+  &mapfactor_args,
   CET_CHARSET_UTF8, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/mapsend.cc
+++ b/mapsend.cc
@@ -52,13 +52,12 @@ static char* mapsend_opt_trkver = nullptr;
 #define MAPSEND_TRKVER_MAX 4
 
 static
-arglist_t mapsend_args[] = {
+QVector<arglist_t> mapsend_args = {
   {
     "trkver", &mapsend_opt_trkver,
     "MapSend version TRK file to generate (3,4)",
     "4", ARGTYPE_INT, "3", "4", nullptr
   },
-  ARG_TERMINATOR
 };
 
 static void
@@ -546,7 +545,7 @@ ff_vecs_t mapsend_vecs = {
   mapsend_read,
   mapsend_wpt_write,
   nullptr,
-  mapsend_args,
+  &mapsend_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/mapsource.cc
+++ b/mapsource.cc
@@ -87,7 +87,7 @@ static char* mpsusedepth = nullptr;
 static char* mpsuseprox = nullptr;
 
 static
-arglist_t mps_args[] = {
+QVector<arglist_t> mps_args = {
   {
     "snlen", &snlen, "Length of generated shortnames", "10", ARGTYPE_INT, "1",
     nullptr, nullptr
@@ -115,7 +115,6 @@ arglist_t mps_args[] = {
     "Use proximity values on output (default is ignore)",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static void
@@ -2048,7 +2047,7 @@ ff_vecs_t mps_vecs = {
   mps_read,
   mps_write,
   nullptr,
-  mps_args,
+  &mps_args,
   CET_CHARSET_MS_ANSI, 0,	/* CET-REVIEW */
   NULL_POS_OPS,
   nullptr,

--- a/mmo.cc
+++ b/mmo.cc
@@ -52,7 +52,7 @@
 static char* opt_locked, *opt_visible, *opt_version;
 
 static
-arglist_t mmo_args[] = {
+QVector<arglist_t> mmo_args = {
   {
     "locked", &opt_locked, "Write items 'locked' [default no]", "0",
     ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -65,7 +65,6 @@ arglist_t mmo_args[] = {
     "ver", &opt_version, "Write files with internal version [n]", nullptr,
     ARGTYPE_INT, "17", "18", nullptr
   },
-  ARG_TERMINATOR
 };
 
 struct mmo_data_t {
@@ -1467,7 +1466,7 @@ ff_vecs_t mmo_vecs = {
   mmo_read,
   mmo_write,
   nullptr,
-  mmo_args,
+  &mmo_args,
   CET_CHARSET_MS_ANSI, 0
   , NULL_POS_OPS,
   nullptr

--- a/mtk_locus.cc
+++ b/mtk_locus.cc
@@ -51,13 +51,12 @@ static char* opt_erase;
 static char* opt_status;
 static char* opt_enable;
 
-static arglist_t mtk_locus_args[] = {
+static QVector<arglist_t> mtk_locus_args = {
   {"baudrate", &opt_baudrate, "Speed in bits per second of serial port (autodetect=0)", "0", ARGTYPE_INT, ARG_NOMINMAX , nullptr},
   {"download", &opt_download, "Download logged fixes", "1", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
   {"erase", &opt_erase, "Erase device data after download", "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
   {"status", &opt_status, "Show device status", "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
   {"enable", &opt_enable, "Enable logging after download", "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 static void mtk_locus_rd_init(const QString& fname);
@@ -78,7 +77,7 @@ ff_vecs_t mtk_locus_vecs = {
   mtk_locus_read,
   nullptr,  // write
   nullptr, // exit
-  mtk_locus_args,
+  &mtk_locus_args,
   CET_CHARSET_ASCII, 0 /* ascii is the expected character set */
   , NULL_POS_OPS,
   nullptr

--- a/mtk_logger.cc
+++ b/mtk_logger.cc
@@ -263,7 +263,7 @@ static int mtk_parse_info(const unsigned char* data, int dataLen);
 
 // Arguments for log fetch 'mtk' command..
 
-static arglist_t mtk_sargs[] = {
+static QVector<arglist_t> mtk_sargs = {
   {
     "erase", &OPT_erase, "Erase device data after download",
     "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -284,7 +284,6 @@ static arglist_t mtk_sargs[] = {
     "block_size_kb", &OPT_block_size_kb, "Size of blocks in KB to request from device",
     "1", ARGTYPE_INT, "1", "64", nullptr
   },
-  ARG_TERMINATOR
 };
 
 static void dbg(int l, const char* msg, ...)
@@ -1675,7 +1674,7 @@ ff_vecs_t mtk_vecs = {
   mtk_read,
   nullptr,
   nullptr,
-  mtk_sargs,
+  &mtk_sargs,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,
@@ -1696,7 +1695,7 @@ ff_vecs_t mtk_m241_vecs = {
   mtk_read,
   nullptr,
   nullptr,
-  mtk_sargs,
+  &mtk_sargs,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,
@@ -1705,12 +1704,11 @@ ff_vecs_t mtk_m241_vecs = {
 
 /* used for mtk-bin */
 
-static arglist_t mtk_fargs[] = {
+static QVector<arglist_t> mtk_fargs = {
   {
     "csv",   &csv_file, "MTK compatible CSV output file",
     nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 ff_vecs_t mtk_fvecs = {
@@ -1723,7 +1721,7 @@ ff_vecs_t mtk_fvecs = {
   file_read,
   nullptr,
   nullptr,
-  mtk_fargs,
+  &mtk_fargs,
   CET_CHARSET_UTF8, 1         /* master process: don't convert anything | CET-REVIEW */
   , NULL_POS_OPS,
   nullptr
@@ -1739,7 +1737,7 @@ ff_vecs_t mtk_m241_fvecs = {
   file_read,
   nullptr,
   nullptr,
-  mtk_fargs,
+  &mtk_fargs,
   CET_CHARSET_UTF8, 1         /* master process: don't convert anything | CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/navicache.cc
+++ b/navicache.cc
@@ -25,12 +25,11 @@ static char* noretired = nullptr;
 static QString read_fname;
 
 static
-arglist_t nav_args[] = {
+QVector<arglist_t> nav_args = {
   {
     "noretired", &noretired, "Suppress retired geocaches",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 #define MYNAME "navicache"
@@ -214,7 +213,7 @@ ff_vecs_t navicache_vecs = {
   nav_read,
   nullptr,
   nullptr,
-  nav_args,
+  &nav_args,
   CET_CHARSET_UTF8, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/naviguide.cc
+++ b/naviguide.cc
@@ -92,7 +92,7 @@ static char temp_short_name[5];
 static void ng_read_file_header();
 
 static
-arglist_t ng_args[] = {
+QVector<arglist_t> ng_args = {
   {
     "output", &process, "'wp' - Create waypoint file , 'rte' - Create route file",
     "rte", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -102,7 +102,6 @@ arglist_t ng_args[] = {
     "n", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
 
-  ARG_TERMINATOR
 };
 
 /*===================Utilities ==========================================*/
@@ -417,7 +416,7 @@ ff_vecs_t ng_vecs = {
   data_read,
   data_write,
   nullptr,
-  ng_args,
+  &ng_args,
   CET_CHARSET_HEBREW, 0
   , NULL_POS_OPS,
   nullptr

--- a/navilink.cc
+++ b/navilink.cc
@@ -138,7 +138,7 @@ const char* const icon_table[] = {
 };
 
 static
-arglist_t navilink_args[] = {
+QVector<arglist_t> navilink_args = {
   {
     "nuketrk", &nuketrk, "Delete all track points", nullptr, ARGTYPE_BOOL,
     ARG_NOMINMAX, nullptr
@@ -163,7 +163,6 @@ arglist_t navilink_args[] = {
     "power_off", &poweroff, "Command unit to power itself down",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static void (*write_waypoint)(const Waypoint*) = nullptr;
@@ -1207,7 +1206,7 @@ ff_vecs_t navilink_vecs = {
   navilink_read,
   navilink_write,
   nullptr,
-  navilink_args,
+  &navilink_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/netstumbler.cc
+++ b/netstumbler.cc
@@ -48,7 +48,7 @@ static void	fix_netstumbler_dupes();
 #define MYNAME "NETSTUMBLER"
 
 static
-arglist_t netstumbler_args[] = {
+QVector<arglist_t> netstumbler_args = {
   {
     "nseicon", &nseicon, "Non-stealth encrypted icon name",
     "Red Square", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -69,7 +69,6 @@ arglist_t netstumbler_args[] = {
     "snmac", &snmac, "Shortname is MAC address", nullptr, ARGTYPE_BOOL,
     ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static void
@@ -343,7 +342,7 @@ ff_vecs_t netstumbler_vecs = {
   data_read,
   nullptr,
   nullptr,
-  netstumbler_args,
+  &netstumbler_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/nmea.cc
+++ b/nmea.cc
@@ -215,7 +215,7 @@ static int had_checksum;
 static Waypoint* nmea_rd_posn(posn_status*);
 static void nmea_rd_posn_init(const QString& fname);
 
-static arglist_t nmea_args[] = {
+static QVector<arglist_t> nmea_args = {
   {"snlen", &snlenopt, "Max length of waypoint name to write", "6", ARGTYPE_INT, "1", "64", nullptr },
   {"gprmc", &opt_gprmc, "Read/write GPRMC sentences", "1", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
   {"gpgga", &opt_gpgga, "Read/write GPGGA sentences", "1", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
@@ -231,7 +231,6 @@ static arglist_t nmea_args[] = {
   {"baud", &opt_baud, "Speed in bits per second of serial port (baud=4800)", nullptr, ARGTYPE_INT, ARG_NOMINMAX, nullptr },
   {"gisteq", &opt_gisteq, "Write tracks for Gisteq Phototracker", "0", ARGTYPE_BOOL, ARG_NOMINMAX , nullptr},
   {"ignore_fix", &opt_ignorefix, "Accept position fixes in gpgga marked invalid", "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr},
-  ARG_TERMINATOR
 };
 
 #define CHECK_BOOL(a) if (a && (*a == '0')) a = NULL
@@ -1419,7 +1418,7 @@ ff_vecs_t nmea_vecs = {
   nmea_read,
   nmea_write,
   nullptr,
-  nmea_args,
+  &nmea_args,
   CET_CHARSET_ASCII, 0, /* CET-REVIEW */
   {
     nmea_rd_posn_init, nmea_rd_posn, nmea_rd_deinit,

--- a/nmn4.cc
+++ b/nmn4.cc
@@ -42,9 +42,8 @@ static int curr_rte_num, target_rte_num;
 static char* index_opt;
 
 static
-arglist_t nmn4_args[] = {
+QVector<arglist_t> nmn4_args = {
   {"index", &index_opt, "Index of route to write (if more than one in source)", nullptr, ARGTYPE_INT, "1", nullptr , nullptr},
-  ARG_TERMINATOR
 };
 
 
@@ -285,7 +284,7 @@ ff_vecs_t nmn4_vecs = {
   nmn4_read,
   nmn4_write,
   nullptr,
-  nmn4_args,
+  &nmn4_args,
   CET_CHARSET_MS_ANSI, 1	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/nukedata.h
+++ b/nukedata.h
@@ -31,9 +31,9 @@
 class NukeDataFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void process() override;
 
@@ -42,7 +42,7 @@ private:
   char* nuketrks;
   char* nukertes;
 
-  arglist_t args[4] = {
+  QVector<arglist_t> args = {
     {
       "waypoints", &nukewpts, "Remove all waypoints from data stream",
       "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -55,7 +55,6 @@ private:
       "routes", &nukertes, "Remove all routes from data stream",
       "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
 };

--- a/osm.cc
+++ b/osm.cc
@@ -28,11 +28,10 @@
 
 static char* opt_tag, *opt_tagnd, *created_by;
 
-static arglist_t osm_args[] = {
+static QVector<arglist_t> osm_args = {
   { "tag", &opt_tag, 	"Write additional way tag key/value pairs", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
   { "tagnd", &opt_tagnd,	"Write additional node tag key/value pairs", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   { "created_by", &created_by, "Use this value as custom created_by value","GPSBabel", ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 #define MYNAME "osm"
@@ -978,7 +977,7 @@ ff_vecs_t osm_vecs = {
   osm_read,
   osm_write,
   osm_exit,
-  osm_args,
+  &osm_args,
   CET_CHARSET_UTF8, 0
   , NULL_POS_OPS,
   nullptr};

--- a/ozi.cc
+++ b/ozi.cc
@@ -99,7 +99,7 @@ static double prox_scale;
 static char* opt_codec;
 
 static
-arglist_t ozi_args[] = {
+QVector<arglist_t> ozi_args = {
   {
     "pack", &pack_opt, "Write all tracks into one file",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -144,7 +144,6 @@ arglist_t ozi_args[] = {
     "codec", &opt_codec, "codec to use for reading and writing strings (default windows-1252)",
     "windows-1252", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static gpsdata_type ozi_objective;
@@ -985,7 +984,7 @@ ff_vecs_t ozi_vecs = {
   data_read,
   data_write,
   nullptr,
-  ozi_args,
+  &ozi_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/pcx.cc
+++ b/pcx.cc
@@ -43,12 +43,12 @@ static int lon_col;
 
 #define MYNAME "PCX"
 
-static arglist_t pcx_args[] = {{"deficon", &deficon, "Default icon name",
+static QVector<arglist_t> pcx_args = {{"deficon", &deficon, "Default icon name",
                                 "Waypoint", ARGTYPE_STRING, ARG_NOMINMAX, nullptr},
                                {"cartoexploreur", &cartoexploreur,
                                 "Write tracks compatible with Carto Exploreur",
                                 nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr},
-                               ARG_TERMINATOR};
+                               };
 
 static void rd_init(const QString& fname) {
   file_in = gbfopen(fname, "rb", MYNAME);
@@ -403,7 +403,7 @@ static void data_write() {
 
 ff_vecs_t pcx_vecs = {
     ff_type_file,      FF_CAP_RW_ALL, rd_init,    wr_init, rd_deinit,
-    wr_deinit,         data_read,     data_write, nullptr,    pcx_args,
+    wr_deinit,         data_read,     data_write, nullptr,    &pcx_args,
     CET_CHARSET_ASCII, 1 /* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/polygon.h
+++ b/polygon.h
@@ -30,9 +30,9 @@
 class PolygonFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void process() override;
 
@@ -45,7 +45,7 @@ private:
     unsigned short override;
   };
 
-  arglist_t args[3] = {
+  QVector<arglist_t> args = {
     {
       "file", &polyfileopt,  "File containing vertices of polygon",
       nullptr, ARGTYPE_FILE | ARGTYPE_REQUIRED, ARG_NOMINMAX, nullptr
@@ -54,7 +54,6 @@ private:
       "exclude", &exclopt, "Exclude points inside the polygon",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   void polytest(double lat1, double lon1,

--- a/position.h
+++ b/position.h
@@ -30,9 +30,9 @@
 class PositionFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -47,7 +47,7 @@ private:
   char* purge_duplicates = nullptr;
   bool check_time;
 
-  arglist_t args[4] = {
+  QVector<arglist_t> args = {
     {
       "distance", &distopt, "Maximum positional distance",
       nullptr, ARGTYPE_FLOAT | ARGTYPE_REQUIRED, ARG_NOMINMAX, nullptr
@@ -61,7 +61,6 @@ private:
       "time", &timeopt, "Maximum time in seconds between two points",
       nullptr, ARGTYPE_FLOAT | ARGTYPE_REQUIRED, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   class WptRecord

--- a/psitrex.cc
+++ b/psitrex.cc
@@ -65,10 +65,9 @@ static char psit_current_token[256];
 static char* snlen;
 
 static
-arglist_t psit_args[] = {
+QVector<arglist_t> psit_args = {
   /*	{"snlen", &snlen, "Length of generated shortnames",
    	NULL, ARGTYPE_INT, "1", NULL }, */
-  ARG_TERMINATOR
 };
 
 /* Taken from PsiTrex 1.13 */
@@ -781,7 +780,7 @@ ff_vecs_t psit_vecs = {
   psit_read,
   psit_write,
   nullptr,
-  psit_args,
+  &psit_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/radius.h
+++ b/radius.h
@@ -30,9 +30,9 @@
 class RadiusFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -55,7 +55,7 @@ private:
     double distance;
   };
 
-  arglist_t args[8] = {
+  QVector<arglist_t> args = {
     {
       "lat", &latopt,       "Latitude for center point (D.DDDDD)",
       nullptr, ARGTYPE_FLOAT | ARGTYPE_REQUIRED, ARG_NOMINMAX, nullptr
@@ -84,7 +84,6 @@ private:
       "asroute", &routename,"Put resulting waypoints in route of this name",
       nullptr, ARGTYPE_STRING, nullptr, nullptr, nullptr
     },
-    ARG_TERMINATOR
   };
 
   double gc_distance(double lat1, double lon1, double lat2, double lon2);

--- a/random.cc
+++ b/random.cc
@@ -32,7 +32,7 @@
 
 static char* opt_points, *opt_seed, *opt_nodelay;
 
-static arglist_t random_args[] = {
+static QVector<arglist_t> random_args = {
   {
     "points", &opt_points, "Generate # points", nullptr,
     ARGTYPE_INT, "1", nullptr, nullptr
@@ -45,7 +45,6 @@ static arglist_t random_args[] = {
     "nodelay", &opt_nodelay, "Output realtime points without delay", nullptr,
     ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 //  this generator is invariant across platforms.
@@ -348,7 +347,7 @@ ff_vecs_t random_vecs = {
   random_read,
   nullptr,	/* write */
   nullptr,	/* exit */
-  random_args,
+  &random_args,
   CET_CHARSET_ASCII, 1,			/* fixed */
   {
   random_rd_posn_init, random_rd_posn, random_rd_posn_deinit,

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -65,9 +65,8 @@ static char* opt_location;
 #define MYNAME "raymarine"
 
 static
-arglist_t raymarine_args[] = {
+QVector<arglist_t> raymarine_args = {
   { "location", &opt_location, "Default location", "My Waypoints", ARGTYPE_STRING, ARG_NOMINMAX , nullptr},
-  ARG_TERMINATOR
 };
 
 /* from csv_util.c: convert excel time (days since 1900) to time_t and back again */
@@ -508,7 +507,7 @@ ff_vecs_t raymarine_vecs = {
   raymarine_read,
   raymarine_write,
   nullptr,
-  raymarine_args,
+  &raymarine_args,
   CET_CHARSET_ASCII, 0	/* should we force this to 1 ? */
   , NULL_POS_OPS,
   nullptr

--- a/reverse_route.h
+++ b/reverse_route.h
@@ -26,17 +26,16 @@
 class ReverseRouteFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
 
 private:
   int prev_new_trkseg;
-  arglist_t args[1] = {
-    ARG_TERMINATOR
+  QVector<arglist_t> args = {
   };
 
   void reverse_route_wpt(const Waypoint* waypointp);

--- a/saroute.cc
+++ b/saroute.cc
@@ -36,7 +36,7 @@ static char* timesynth = nullptr;
 static int control = 0;
 
 static
-arglist_t saroute_args[] = {
+QVector<arglist_t> saroute_args = {
   {
     "turns_important", &turns_important,
     "Keep turns if simplify filter is used",
@@ -58,7 +58,6 @@ arglist_t saroute_args[] = {
     "times", &timesynth, "Synthesize track times",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 #define ReadShort(f) gbfgetint16(f)
@@ -457,7 +456,7 @@ ff_vecs_t saroute_vecs = {
   my_read,
   nullptr,
   nullptr,
-  saroute_args,
+  &saroute_args,
   CET_CHARSET_UTF8, 1	/* do nothing | CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/sbn.cc
+++ b/sbn.cc
@@ -27,8 +27,7 @@
 static gbfile* file_handle = nullptr;
 
 static
-arglist_t sbn_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> sbn_args = {
 };
 
 
@@ -320,7 +319,7 @@ ff_vecs_t sbn_vecs = {
   sbn_read,
   nullptr,
   sbn_exit,
-  sbn_args,
+  &sbn_args,
   /* Characters are always encoded in ASCII. Even if the unit is set
    * to Chinese language, only ASCII characters can be entered. */
   CET_CHARSET_ASCII, 0

--- a/sbp.cc
+++ b/sbp.cc
@@ -28,8 +28,7 @@
 static gbfile* file_handle = nullptr;
 
 static
-arglist_t sbp_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> sbp_args = {
 };
 
 /*******************************************************************************
@@ -130,7 +129,7 @@ ff_vecs_t sbp_vecs = {
   sbp_read,
   nullptr,
   sbp_exit,
-  sbp_args,
+  &sbp_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/shape.cc
+++ b/shape.cc
@@ -47,7 +47,7 @@ static char* opt_name = nullptr;
 static char* opt_url = nullptr;
 
 static
-arglist_t shp_args[] = {
+QVector<arglist_t> shp_args = {
   {
     "name", &opt_name, "Source for name field in .dbf",
     nullptr, ARGTYPE_STRING, "0", nullptr, nullptr
@@ -56,7 +56,6 @@ arglist_t shp_args[] = {
     "url", &opt_url, "Source for URL field in .dbf",
     nullptr, ARGTYPE_STRING, "0", nullptr, nullptr
   },
-  ARG_TERMINATOR
 };
 
 
@@ -536,7 +535,7 @@ ff_vecs_t shape_vecs = {
   my_read,
   my_write,
   nullptr,
-  shp_args,
+  &shp_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/skyforce.cc
+++ b/skyforce.cc
@@ -31,8 +31,7 @@
 
 
 static
-arglist_t skyforce_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> skyforce_args = {
 };
 
 static gbfile* fin, *fout;
@@ -378,7 +377,7 @@ ff_vecs_t skyforce_vecs = {
   skyforce_read,
   skyforce_write,
   nullptr,
-  skyforce_args,
+  &skyforce_args,
   CET_CHARSET_ASCII, 1
   , NULL_POS_OPS,
   nullptr

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -73,7 +73,7 @@ static char* opt_gps_utc_offset = nullptr;
 static char* opt_gps_week_rollover = nullptr;
 
 static
-arglist_t skytraq_args[] = {
+QVector<arglist_t> skytraq_args = {
   {
     "erase", &opt_erase, "Erase device data after download",
     "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -122,11 +122,10 @@ arglist_t skytraq_args[] = {
     "gps-week-rollover", &opt_gps_week_rollover, "GPS week rollover period we're in (-1: best guess)",
     "-1", ARGTYPE_INT, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR,
 };
 
 static
-arglist_t skytraq_fargs[] = {
+QVector<arglist_t> skytraq_fargs = {
   {
     "first-sector", &opt_first_sector, "First sector to be read from the file",
     "0", ARGTYPE_INT, "0", "65535", nullptr
@@ -143,7 +142,6 @@ arglist_t skytraq_fargs[] = {
     "gps-week-rollover", &opt_gps_week_rollover, "GPS week rollover period we're in (-1: best guess)",
     "-1", ARGTYPE_INT, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static void
@@ -1437,7 +1435,7 @@ ff_vecs_t skytraq_vecs = {
   skytraq_read,
   nullptr,
   nullptr,
-  skytraq_args,
+  &skytraq_args,
   CET_CHARSET_UTF8, 1         /* master process: don't convert anything */
  , NULL_POS_OPS,
  nullptr
@@ -1457,7 +1455,7 @@ ff_vecs_t skytraq_fvecs = {
   file_read,
   nullptr,
   nullptr,
-  skytraq_fargs,
+  &skytraq_fargs,
   CET_CHARSET_UTF8, 1         /* master process: don't convert anything */
  , NULL_POS_OPS,
  nullptr
@@ -1477,7 +1475,7 @@ static char* opt_set_poi_car = nullptr;	/* set if a "poi" option was used */
 static char* opt_set_poi_boat = nullptr;	/* set if a "poi" option was used */
 static char* opt_set_poi_heart = nullptr;	/* set if a "poi" option was used */
 static char* opt_set_poi_bar = nullptr;	/* set if a "poi" option was used */
-static arglist_t miniHomer_args[] = {
+static QVector<arglist_t> miniHomer_args = {
   { "baud",         &opt_dlbaud,        "Baud rate used for download", "115200", ARGTYPE_INT, "0", "115200", nullptr },
   { "dump-file",    &opt_dump_file,     "Dump raw data to this file", nullptr, ARGTYPE_OUTFILE, ARG_NOMINMAX, nullptr },
   { "erase",        &opt_erase,         "Erase device data after download", "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
@@ -1499,7 +1497,6 @@ static arglist_t miniHomer_args[] = {
     "gps-week-rollover", &opt_gps_week_rollover, "GPS week rollover period we're in (-1: best guess)",
     "-1", ARGTYPE_INT, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 /*
  * Names of the POIs on miniHomer
@@ -1690,7 +1687,7 @@ ff_vecs_t miniHomer_vecs = {
   miniHomer_read,
   nullptr,
   nullptr,
-  miniHomer_args,
+  &miniHomer_args,
   CET_CHARSET_UTF8, 1,         /* master process: don't convert anything */
   NULL_POS_OPS,
   nullptr

--- a/smplrout.h
+++ b/smplrout.h
@@ -67,9 +67,9 @@
 class SimplifyRouteFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -87,7 +87,7 @@ private:
   char* relopt;
   void (*waypt_del_fnp)(route_head* rte, Waypoint* wpt);
 
-  arglist_t args[6] = {
+  QVector<arglist_t> args = {
     {
       "count", &countopt,  "Maximum number of points in route",
       nullptr, ARGTYPE_INT | ARGTYPE_BEGIN_REQ | ARGTYPE_BEGIN_EXCL, "1", nullptr, nullptr
@@ -108,7 +108,6 @@ private:
       "relative", &relopt, "Use relative error", nullptr,
       ARGTYPE_BOOL | ARGTYPE_END_EXCL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   struct xte_intermed;

--- a/sort.h
+++ b/sort.h
@@ -30,9 +30,9 @@
 class SortFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -62,7 +62,7 @@ private:
   char* opt_sm_rtenum, *opt_sm_rtename, *opt_sm_rtedesc;
   char* opt_sm_trknum, *opt_sm_trkname, *opt_sm_trkdesc;
 
-  arglist_t args[11] = {
+  QVector<arglist_t> args = {
     {
       "description", &opt_sm_description, "Sort waypoints by description",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -103,7 +103,6 @@ private:
       "trknum", &opt_sm_trknum, "Sort tracks by number",
       nullptr, ARGTYPE_BEGIN_EXCL | ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   static bool sort_comp_wpt_by_description(const Waypoint* a, const Waypoint* b);

--- a/stackfilter.h
+++ b/stackfilter.h
@@ -30,9 +30,9 @@
 class StackFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -52,7 +52,7 @@ private:
   int  warnings_enabled = 1;
   int  swapdepth = 0;
 
-  arglist_t args[10] = {
+  QVector<arglist_t> args = {
     {
       "push", &opt_push, "Push waypoint list onto stack", nullptr,
       ARGTYPE_BEGIN_EXCL | ARGTYPE_BEGIN_REQ | ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -89,7 +89,6 @@ private:
       "nowarn", &nowarn, "Suppress cleanup warning", nullptr,
       ARGTYPE_BOOL | ARGTYPE_HIDDEN, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   struct stack_elt

--- a/stmsdf.cc
+++ b/stmsdf.cc
@@ -106,12 +106,11 @@ static char* opt_route_index;
 static int opt_route_index_value;
 
 static
-arglist_t stmsdf_args[] = {
+QVector<arglist_t> stmsdf_args = {
   {
     "index", &opt_route_index,
     "Index of route (if more than one in source)", "1", ARGTYPE_INT, "1", nullptr, nullptr
   },
-  ARG_TERMINATOR
 };
 
 
@@ -820,7 +819,7 @@ ff_vecs_t stmsdf_vecs = {
   data_read,
   data_write,
   nullptr,
-  stmsdf_args,
+  &stmsdf_args,
   CET_CHARSET_MS_ANSI, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/stmwpp.cc
+++ b/stmwpp.cc
@@ -50,12 +50,11 @@ static int what;
 static char* index_opt = nullptr;
 
 static
-arglist_t stmwpp_args[] = {
+QVector<arglist_t> stmwpp_args = {
   {
     "index", &index_opt, "Index of route/track to write (if more than one in source)",
     nullptr, ARGTYPE_INT, "1", nullptr, nullptr
   },
-  ARG_TERMINATOR
 };
 
 
@@ -328,7 +327,7 @@ ff_vecs_t stmwpp_vecs = {
   stmwpp_data_read,
   stmwpp_data_write,
   nullptr,
-  stmwpp_args,
+  &stmwpp_args,
   CET_CHARSET_MS_ANSI, 0
   , NULL_POS_OPS,
   nullptr

--- a/subrip.cc
+++ b/subrip.cc
@@ -260,13 +260,12 @@ subrip_write()
 
 /* arguments: definitions of format-specific arguments */
 
-static arglist_t subrip_args[] = {
+static QVector<arglist_t> subrip_args = {
   // FIXME: document that gps_date and gps_time must be specified together or they will both be ignored and the timestamp of the first trackpoint will be used.
   {"video_time", &opt_videotime, "Video position for which exact GPS time is known (hhmmss, default is 0:00:00)", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   {"gps_time", &opt_gpstime, "GPS time at position video_time (hhmmss, default is first timestamp of track)", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   {"gps_date", &opt_gpsdate, "GPS date at position video_time (hhmmss, default is first timestamp of track)", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
   {"format", &opt_format, "Format for subtitles", "%s km/h %e m\\n%t %l", ARGTYPE_STRING, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 /* manifest: capabilities of this module, pointers to exported functions and others */
@@ -281,7 +280,7 @@ ff_vecs_t subrip_vecs = {
   nullptr,
   subrip_write,
   nullptr,
-  subrip_args,
+  &subrip_args,
   CET_CHARSET_ASCII, 0
   , NULL_POS_OPS,
   nullptr

--- a/swapdata.h
+++ b/swapdata.h
@@ -23,6 +23,7 @@
 #ifndef SWAPDATA_H_INCLUDED_
 #define SWAPDATA_H_INCLUDED_
 
+#include "defs.h"    // for arglist_t, Waypoint
 #include "filter.h"  // for Filter
 
 #if FILTERS_ENABLED

--- a/swapdata.h
+++ b/swapdata.h
@@ -23,7 +23,6 @@
 #ifndef SWAPDATA_H_INCLUDED_
 #define SWAPDATA_H_INCLUDED_
 
-#include "defs.h"    // for Waypoint (ptr only), arglist_t, ARG_TERMINATOR
 #include "filter.h"  // for Filter
 
 #if FILTERS_ENABLED
@@ -31,15 +30,14 @@
 class SwapDataFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void process() override;
 
 private:
-  arglist_t args[1] = {
-    ARG_TERMINATOR
+  QVector<arglist_t> args = {
   };
 
   void swapdata_cb(const Waypoint* ref);

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -36,12 +36,11 @@ static route_head* route = nullptr;
 
 static char* routevia = nullptr;
 
-static arglist_t tef_xml_args[] = {
+static QVector<arglist_t> tef_xml_args = {
   {
     "routevia", &routevia, "Include only via stations in route",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 #define MYNAME "TourExchangeFormat"
@@ -328,7 +327,7 @@ ff_vecs_t tef_xml_vecs = {
   tef_xml_read,
   nullptr,
   nullptr,
-  tef_xml_args,
+  &tef_xml_args,
   CET_CHARSET_UTF8, 1
   , NULL_POS_OPS,
   nullptr

--- a/teletype.cc
+++ b/teletype.cc
@@ -26,8 +26,7 @@
 
 
 static
-arglist_t teletype_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> teletype_args = {
 };
 
 /*******************************************************************************
@@ -113,7 +112,7 @@ ff_vecs_t teletype_vecs = {
   teletype_read,
   nullptr,
   teletype_exit,
-  teletype_args,
+  &teletype_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/text.cc
+++ b/text.cc
@@ -41,7 +41,7 @@ static QString output_name;
 #define MYNAME "TEXT"
 
 static
-arglist_t text_args[] = {
+QVector<arglist_t> text_args = {
   {
     "nosep", &suppresssep,
     "Suppress separator lines between waypoints",
@@ -68,7 +68,6 @@ arglist_t text_args[] = {
     "Write each waypoint in a separate file", nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
 
-  ARG_TERMINATOR
 };
 
 
@@ -272,7 +271,7 @@ ff_vecs_t text_vecs = {
   nullptr,
   data_write,
   nullptr,
-  text_args,
+  &text_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/tiger.cc
+++ b/tiger.cc
@@ -63,7 +63,7 @@ static char* clickmap = NULL;
 
 
 static
-arglist_t tiger_args[] = {
+QVector<arglist_t> tiger_args = {
   {
     "nolabels", &nolabels, "Suppress labels on generated pins",
     nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -121,7 +121,6 @@ arglist_t tiger_args[] = {
     NULL, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
 #endif
-  ARG_TERMINATOR
 };
 
 
@@ -323,7 +322,7 @@ ff_vecs_t tiger_vecs = {
   data_read,
   data_write,
   nullptr,
-  tiger_args,
+  &tiger_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/tomtom.cc
+++ b/tomtom.cc
@@ -54,8 +54,7 @@ static gbfile* file_in;
 static gbfile* file_out;
 
 static
-arglist_t tomtom_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> tomtom_args = {
 };
 
 static void
@@ -473,7 +472,7 @@ ff_vecs_t tomtom_vecs = {
   data_read,
   data_write,
   nullptr,
-  tomtom_args,
+  &tomtom_args,
   CET_CHARSET_MS_ANSI, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/tpg.cc
+++ b/tpg.cc
@@ -39,9 +39,8 @@ static int tpg_datum_idx;
 static unsigned int waypt_out_count;
 
 static
-arglist_t tpg_args[] = {
+QVector<arglist_t> tpg_args = {
   {"datum", &tpg_datum_opt, "Datum (default=NAD27)", "N. America 1927 mean", ARGTYPE_STRING, ARG_NOMINMAX , nullptr},
-  ARG_TERMINATOR
 };
 
 static int
@@ -315,7 +314,7 @@ ff_vecs_t tpg_vecs = {
   tpg_read,
   tpg_write,
   nullptr,
-  tpg_args,
+  &tpg_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr};

--- a/tpo.cc
+++ b/tpo.cc
@@ -98,12 +98,11 @@ static char* output_state = nullptr;
 
 #ifdef ENABLE_TPO_WRITE
 static
-arglist_t tpo2_args[] = {
+QVector<arglist_t> tpo2_args = {
 	{ "dumpheader", &dumpheader, "Display the file header bytes",
 		"0", ARGTYPE_BOOL, ARG_NOMINMAX} ,
 	{ "state", &output_state, "State map format to write, default=CA",
 	  "CA", ARGTYPE_STRING, ARG_NOMINMAX} ,
-	ARG_TERMINATOR
 };
 #else
 //
@@ -114,14 +113,12 @@ arglist_t tpo2_args[] = {
 // above.
 //
 static
-arglist_t tpo2_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> tpo2_args = {
 };
 #endif
 
 static
-arglist_t tpo3_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> tpo3_args = {
 };
 
 
@@ -1834,7 +1831,7 @@ ff_vecs_t tpo2_vecs = {
   nullptr,
 #endif
   nullptr,
-  tpo2_args,
+  &tpo2_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr
@@ -1851,7 +1848,7 @@ ff_vecs_t tpo3_vecs = {
   tpo_read,
   nullptr,
   nullptr,
-  tpo3_args,
+  &tpo3_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -65,13 +65,11 @@
 int TrackFilter::trackfilter_opt_count()
 {
   int res = 0;
-  arglist_t* a = args;
 
-  while (a->argstring) {
-    if (*a->argval != nullptr) {
+  for (const auto& arg : qAsConst(args)) {
+    if (*arg.argval != nullptr) {
       res++;
     }
-    a++;
   }
   return res;
 }

--- a/trackfilter.h
+++ b/trackfilter.h
@@ -53,9 +53,9 @@
 class TrackFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void init() override;
   void process() override;
@@ -82,7 +82,7 @@ private:
   char* opt_minpoints = nullptr;
   int minimum_points{0};
 
-  arglist_t args[19] = {
+  QVector<arglist_t> args = {
     {
       TRACKFILTER_MOVE_OPTION, &opt_move,
       "Correct trackpoint timestamps by a delta", nullptr, ARGTYPE_STRING,
@@ -169,7 +169,6 @@ private:
       "Discard tracks with fewer than these points",
       nullptr, ARGTYPE_INT, "0", "50", nullptr
     },
-    ARG_TERMINATOR
   };
 
   QList<route_head*> track_list;

--- a/transform.h
+++ b/transform.h
@@ -32,9 +32,9 @@
 class TransformFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void process() override;
 
@@ -50,7 +50,7 @@ private:
 
   const QString RPT = "RPT";
 
-  arglist_t args[7] = {
+  QVector<arglist_t> args = {
     {
       "wpt", &opt_waypts, "Transform track(s) or route(s) into waypoint(s) [R/T]", nullptr,
       ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -75,7 +75,6 @@ private:
       "del", &opt_delete, "Delete source data after transformation", "N",
       ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   void transform_waypoints();

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -285,7 +285,7 @@ static int unicsv_waypt_ct;
 static char unicsv_detect;
 static int llprec;
 
-static arglist_t unicsv_args[] = {
+static QVector<arglist_t> unicsv_args = {
   {
     "datum", &opt_datum, "GPS datum (def. WGS 84)",
     "WGS 84", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -318,7 +318,6 @@ static arglist_t unicsv_args[] = {
     "codec", &opt_codec, "codec to use for reading and writing strings (default UTF-8)",
     "UTF-8", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 
@@ -2102,7 +2101,7 @@ ff_vecs_t unicsv_vecs = {
   unicsv_rd,
   unicsv_wr,
   nullptr,
-  unicsv_args,
+  &unicsv_args,
   CET_CHARSET_UTF8, 0
   , NULL_POS_OPS,
   nullptr

--- a/validate.h
+++ b/validate.h
@@ -31,9 +31,9 @@
 class ValidateFilter:public Filter
 {
 public:
-  arglist_t* get_args() override
+  QVector<arglist_t>* get_args() override
   {
-    return args;
+    return &args;
   }
   void process() override;
 
@@ -46,7 +46,7 @@ private:
   unsigned int head_ct;
   unsigned int segment_ct_start;
   const char* segment_type;
-  arglist_t args[3] = {
+  QVector<arglist_t> args = {
     {
       "checkempty", &opt_checkempty, "Check for empty input",
       "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
@@ -55,7 +55,6 @@ private:
       "debug", &opt_debug, "Output debug messages instead of possibly issuing a fatal error",
       "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
-    ARG_TERMINATOR
   };
 
   void validate_head(const route_head*);

--- a/vcf.cc
+++ b/vcf.cc
@@ -32,12 +32,11 @@ static char* vcf_encrypt = nullptr;
 #define MYNAME "VCF"
 
 static
-arglist_t vcf_args[] = {
+QVector<arglist_t> vcf_args = {
   {
     "encrypt", &vcf_encrypt,
     "Encrypt hints using ROT13", nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static void
@@ -142,7 +141,7 @@ ff_vecs_t vcf_vecs = {
   nullptr,
   data_write,
   nullptr,
-  vcf_args,
+  &vcf_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/vidaone.cc
+++ b/vidaone.cc
@@ -43,13 +43,12 @@ static char* vidaone_opt_ver;
 static int vidaone_ver;
 
 static
-arglist_t vidaone_args[] = {
+QVector<arglist_t> vidaone_args = {
   {
     VIDAONE_VER, &vidaone_opt_ver,
     "Version of VidaOne file to read or write (1 or 2)",
     "1", ARGTYPE_INT, "1", "2", nullptr
   },
-  ARG_TERMINATOR
 };
 
 static gbfile* fin, *fout;
@@ -146,7 +145,7 @@ ff_vecs_t vidaone_vecs = {
   vidaone_read,
   vidaone_write,
   nullptr,
-  vidaone_args,
+  &vidaone_args,
   CET_CHARSET_UTF8, 1
   , NULL_POS_OPS,
   nullptr

--- a/vpl.cc
+++ b/vpl.cc
@@ -114,8 +114,7 @@ C - Checksum
 static void vpl_parse_75_sentence(const char*);
 
 static
-arglist_t vpl_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> vpl_args = {
 };
 
 static gbfile* vpl_file_in;
@@ -222,7 +221,7 @@ ff_vecs_t vpl_vecs = {
   vpl_read,
   nullptr,
   nullptr,
-  vpl_args,
+  &vpl_args,
   CET_CHARSET_ASCII, /* ascii is the expected character set */
   1	               /* fixed, can't be changed through command line parameter */
   , NULL_POS_OPS,

--- a/wbt-200.cc
+++ b/wbt-200.cc
@@ -1054,12 +1054,11 @@ static void data_read()
 
 /* wbt */
 
-static arglist_t wbt_sargs[] = {
+static QVector<arglist_t> wbt_sargs = {
   {
     "erase", &erase, "Erase device data after download",
     "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 ff_vecs_t wbt_svecs = {
@@ -1072,7 +1071,7 @@ ff_vecs_t wbt_svecs = {
   data_read,
   nullptr,
   nullptr,
-  wbt_sargs,
+  &wbt_sargs,
   CET_CHARSET_UTF8, 1         /* master process: don't convert anything | CET-REVIEW */
   , NULL_POS_OPS,
   nullptr
@@ -1080,8 +1079,7 @@ ff_vecs_t wbt_svecs = {
 
 /* used for wbt-bin /and/ wbt-tk1 */
 
-static arglist_t wbt_fargs[] = {
-  ARG_TERMINATOR
+static QVector<arglist_t> wbt_fargs = {
 };
 
 ff_vecs_t wbt_fvecs = {
@@ -1094,7 +1092,7 @@ ff_vecs_t wbt_fvecs = {
   file_read,
   nullptr,
   nullptr,
-  wbt_fargs,
+  &wbt_fargs,
   CET_CHARSET_UTF8, 1         /* master process: don't convert anything | CET-REVIEW */
   , NULL_POS_OPS,
   nullptr

--- a/wfff_xml.cc
+++ b/wfff_xml.cc
@@ -30,7 +30,7 @@ static char* 	ahoicon =nullptr;
 static char* 	snmac	=nullptr;
 
 static
-arglist_t wfff_xml_args[] = {
+QVector<arglist_t> wfff_xml_args = {
   {
     "aicicon", &aicicon, "Infrastructure closed icon name",
     "Red Square", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
@@ -48,7 +48,6 @@ arglist_t wfff_xml_args[] = {
     "Green Diamond", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
   {"snmac", &snmac, "Shortname is MAC address", nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr },
-  ARG_TERMINATOR
 };
 
 #define xfreez(p) { if (p) xfree(p); p=0; }
@@ -234,7 +233,7 @@ ff_vecs_t wfff_xml_vecs = {
   wfff_xml_read,
   nullptr,
   nullptr,
-  wfff_xml_args,
+  &wfff_xml_args,
   CET_CHARSET_UTF8, 0,
   NULL_POS_OPS,
   nullptr

--- a/wintec_tes.cc
+++ b/wintec_tes.cc
@@ -93,8 +93,7 @@ wintec_tes_read()
 }
 
 static
-arglist_t wintec_tes_args[] = {
-  ARG_TERMINATOR
+QVector<arglist_t> wintec_tes_args = {
 };
 
 ff_vecs_t wintec_tes_vecs = {
@@ -111,7 +110,7 @@ ff_vecs_t wintec_tes_vecs = {
   wintec_tes_read,
   nullptr,
   nullptr,
-  wintec_tes_args,
+  &wintec_tes_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
   , NULL_POS_OPS,

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -213,7 +213,7 @@ static char* opt_datum;
 static const char* intstylebuf = nullptr;
 
 static
-arglist_t xcsv_args[] = {
+QVector<arglist_t> xcsv_args = {
   {
     "style", &styleopt, "Full path to XCSV style file", nullptr,
     ARGTYPE_FILE | ARGTYPE_REQUIRED, ARG_NOMINMAX, nullptr
@@ -247,7 +247,6 @@ arglist_t xcsv_args[] = {
     "datum", &opt_datum, "GPS datum (def. WGS 84)",
     "WGS 84", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 /* something to map config file constants to chars */
@@ -2234,7 +2233,7 @@ ff_vecs_t xcsv_vecs = {
   xcsv_data_read,
   xcsv_data_write,
   nullptr,
-  xcsv_args,
+  &xcsv_args,
   CET_CHARSET_ASCII, 0,	/* CET-REVIEW */
   { nullptr, nullptr, nullptr, xcsv_wr_position_init, xcsv_wr_position, xcsv_wr_position_deinit },
   nullptr

--- a/xol.cc
+++ b/xol.cc
@@ -38,7 +38,7 @@ static short_handle short_h;
 static gpsbabel::File* oqfile;
 static gpsbabel::XmlStreamWriter* writer;
 
-static arglist_t xol_args[] = {ARG_TERMINATOR};
+static QVector<arglist_t> xol_args = {};
 
 #define MYNAME "xol"
 
@@ -306,7 +306,7 @@ ff_vecs_t xol_vecs = {ff_type_file,
                       xol_read,
                       xol_write,
                       nullptr,
-                      xol_args,
+                      &xol_args,
                       CET_CHARSET_UTF8,
                       0  , NULL_POS_OPS,
   nullptr

--- a/yahoo.cc
+++ b/yahoo.cc
@@ -29,13 +29,12 @@ static char* as;
 #define MYNAME "yahoo"
 
 static
-arglist_t yahoo_args[] = {
+QVector<arglist_t> yahoo_args = {
   {
     "addrsep", &as,
     "String to separate concatenated address fields (default=\", \")",
     ", ", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
-  ARG_TERMINATOR
 };
 
 static xg_callback	wpt_s, wpt_lat, wpt_lon, wpt_e;
@@ -111,7 +110,7 @@ ff_vecs_t yahoo_vecs = {
   yahoo_read,
   nullptr,
   nullptr,
-  yahoo_args,
+  &yahoo_args,
   CET_CHARSET_ASCII, 0	/* CET-REVIEW */
   , NULL_POS_OPS,
   nullptr


### PR DESCRIPTION
This includes a work around MSVC 2015 errors C2440, C2664.  See
the conditional code in defs.h and the comments in vecs.cc regarding default constructability of arglist_t.

Also see assertions and comments in vecs.cc regarding detection of COW issues.  I haven't experienced any issues.  The worst issue I have created by intentionally introducing a copy is a memory leak.  To do this I had find_vec operate on a copy of the args QVector.  Then we never clean up the memory allocated by assign_option because we lose track of argvalptr.