### PR TITLE
use nullptr instead of empty functions

### DIFF
--- a/alan.cc
+++ b/alan.cc
@@ -933,11 +933,6 @@ static void alan_wr_deinit()
   fout = nullptr;
 }
 
-
-static void alan_exit()
-{
-}
-
 /**************************************************************************/
 
 ff_vecs_t alanwpr_vecs = {
@@ -953,7 +948,7 @@ ff_vecs_t alanwpr_vecs = {
   alan_wr_deinit,
   wpr_read,
   wpr_write,
-  alan_exit,
+  nullptr,
   &wpr_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
@@ -974,7 +969,7 @@ ff_vecs_t alantrl_vecs = {
   alan_wr_deinit,
   trl_read,
   trl_write,
-  alan_exit,
+  nullptr,
   &trl_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */

--- a/bcr.cc
+++ b/bcr.cc
@@ -323,16 +323,6 @@ bcr_wr_deinit()
   gbfclose(fout);
 }
 
-static void
-bcr_route_trailer(const route_head*)
-{
-}
-
-static void
-bcr_write_wpt(const Waypoint*)
-{
-}
-
 static void bcr_write_line(gbfile* fout, const QString& key, const int* index, const QString& value)
 {
   if (value.isEmpty()) {			/* this is mostly used in the world of windows */
@@ -473,7 +463,7 @@ bcr_data_write()
             target_rte_num, route_count());
   }
   curr_rte_num = 0;
-  route_disp_all(bcr_route_header, bcr_route_trailer, bcr_write_wpt);
+  route_disp_all(bcr_route_header, nullptr, nullptr);
 }
 
 ff_vecs_t bcr_vecs = {

--- a/dmtlog.cc
+++ b/dmtlog.cc
@@ -757,11 +757,6 @@ track_hdr_cb(const route_head* trk)
 }
 
 static void
-track_tlr_cb(const route_head*)
-{
-}
-
-static void
 track_wpt_cb(const Waypoint* wpt)
 {
   if (this_index != track_index) {
@@ -807,7 +802,7 @@ dmtlog_write()
 
   header_written = 0;
   this_index = 0;
-  track_disp_all(track_hdr_cb, track_tlr_cb, track_wpt_cb);
+  track_disp_all(track_hdr_cb, nullptr, track_wpt_cb);
   if (!header_written) {
     write_header(nullptr);
   }

--- a/garmin.cc
+++ b/garmin.cc
@@ -1111,11 +1111,6 @@ route_waypt_pr(const Waypoint* wpt)
 }
 
 static void
-route_noop(const route_head* )
-{
-}
-
-static void
 route_write()
 {
   int n = 2 * route_waypt_count(); /* Doubled for the islink crap. */
@@ -1127,7 +1122,7 @@ route_write()
     tx_routelist[i] = sane_GPS_Way_New();
   }
 
-  route_disp_all(route_hdr_pr, route_noop, route_waypt_pr);
+  route_disp_all(route_hdr_pr, nullptr, route_waypt_pr);
   GPS_Command_Send_Route(portname, tx_routelist, n);
 }
 
@@ -1171,7 +1166,7 @@ track_prepare()
     tx_tracklist[i] = GPS_Track_New();
   }
   my_track_count = 0;
-  track_disp_all(track_hdr_pr, route_noop, track_waypt_pr);
+  track_disp_all(track_hdr_pr, nullptr, track_waypt_pr);
 
   GPS_Prepare_Track_For_Device(&tx_tracklist, &n);
 

--- a/geo.cc
+++ b/geo.cc
@@ -152,7 +152,6 @@ geocache_container wpt_container(const QString& args)
 static void
 geo_rd_deinit()
 {
-
 }
 
 static void

--- a/gopal.cc
+++ b/gopal.cc
@@ -333,17 +333,6 @@ gopal_read()
 }
 
 static void
-gopal_route_hdr(const route_head*)
-{
-
-}
-
-static void
-gopal_route_tlr(const route_head*)
-{
-}
-
-static void
 gopal_write_waypt(const Waypoint* wpt)
 {
   char tbuffer[64];
@@ -386,12 +375,7 @@ gopal_wr_deinit()
 static void
 gopal_write()
 {
-  route_disp_all(gopal_route_hdr, gopal_route_tlr, gopal_write_waypt);
-}
-
-static void
-gopal_exit()		/* optional */
-{
+  route_disp_all(nullptr, nullptr, gopal_write_waypt);
 }
 
 /**************************************************************************/
@@ -412,7 +396,7 @@ ff_vecs_t gopal_vecs = {
   gopal_wr_deinit,
   gopal_read,
   gopal_write,
-  gopal_exit,
+  nullptr,
   &gopal_args,
   CET_CHARSET_ASCII, 0	/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */

--- a/hiketech.cc
+++ b/hiketech.cc
@@ -242,7 +242,6 @@ void	ht_trk_s(xg_string, const QXmlStreamAttributes*)
 static
 void	ht_trk_e(xg_string, const QXmlStreamAttributes*)
 {
-
 }
 
 static

--- a/ignrando.cc
+++ b/ignrando.cc
@@ -188,11 +188,6 @@ ignr_write_track_hdr(const route_head* track)
 }
 
 static void
-ignr_write_track_trl(const route_head*)
-{
-}
-
-static void
 ignr_write_waypt(const Waypoint* wpt)
 {
   if (track_num != track_index) {
@@ -239,7 +234,7 @@ ignr_write()
   gbfprintf(fout, "\t\t<HEURE>%s</HEURE>\n", buff);
 
   gbfprintf(fout, "\t</ENTETE>\n");
-  track_disp_all(ignr_write_track_hdr, ignr_write_track_trl, ignr_write_waypt);
+  track_disp_all(ignr_write_track_hdr, nullptr, ignr_write_waypt);
   gbfprintf(fout, "</RANDONNEE>\n");
 }
 

--- a/itracku.cc
+++ b/itracku.cc
@@ -654,11 +654,6 @@ itracku_write()
 }
 
 static void
-itracku_exit()		/* optional */
-{
-}
-
-static void
 itracku_rt_init(const QString& fname)
 {
   itracku_rd_ser_init(fname);
@@ -779,7 +774,7 @@ ff_vecs_t itracku_vecs = {
   nullptr,
   itracku_read,
   nullptr,
-  itracku_exit,
+  nullptr,
   &itracku_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */
@@ -800,7 +795,7 @@ ff_vecs_t itracku_fvecs = {
   itracku_wr_deinit,
   itracku_read,
   itracku_write,
-  itracku_exit,
+  nullptr,
   &itracku_args,
   CET_CHARSET_ASCII, 0, /* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */

--- a/magproto.cc
+++ b/magproto.cc
@@ -1401,11 +1401,6 @@ mag_waypt_pr(const Waypoint* waypointp)
 }
 
 static
-void mag_track_nop(const route_head*)
-{
-}
-
-static
 void mag_track_disp(const Waypoint* waypointp)
 {
   char obuf[200];
@@ -1456,7 +1451,7 @@ void mag_track_disp(const Waypoint* waypointp)
 static
 void mag_track_pr()
 {
-  track_disp_all(mag_track_nop, mag_track_nop, mag_track_disp);
+  track_disp_all(nullptr, nullptr, mag_track_disp);
 }
 
 /*
@@ -1531,15 +1526,10 @@ mag_route_trl(const route_head* rte)
 }
 
 static void
-mag_route_hdr(const route_head*)
-{
-}
-
-static void
 mag_route_pr()
 {
   route_out_count = 0;
-  route_disp_all(mag_route_hdr, mag_route_trl, mag_waypt_pr);
+  route_disp_all(nullptr, mag_route_trl, mag_waypt_pr);
 
 }
 

--- a/mapfactor.cc
+++ b/mapfactor.cc
@@ -93,7 +93,6 @@ mapfactor_read()
 static void
 mapfactor_rd_deinit()
 {
-
 }
 
 static void

--- a/mapsend.cc
+++ b/mapsend.cc
@@ -364,12 +364,6 @@ mapsend_route_hdr(const route_head* rte)
 }
 
 static void
-mapsend_noop(const route_head*)
-{
-  /* no-op */
-}
-
-static void
 mapsend_route_disp(const Waypoint* waypointp)
 {
   unsigned char c;
@@ -495,7 +489,7 @@ static void mapsend_track_disp(const Waypoint* wpt)
 static void
 mapsend_track_write()
 {
-  track_disp_all(mapsend_track_hdr, mapsend_noop, mapsend_track_disp);
+  track_disp_all(mapsend_track_hdr, nullptr, mapsend_track_disp);
 }
 
 static void
@@ -520,7 +514,7 @@ mapsend_wpt_write()
       gbfputint32(route_waypt_count(), mapsend_file_out);
 
       /* write points - all routes */
-      route_disp_all(mapsend_noop, mapsend_noop, mapsend_waypt_pr);
+      route_disp_all(nullptr, nullptr, mapsend_waypt_pr);
     }
 
     int n = route_count();
@@ -528,7 +522,7 @@ mapsend_wpt_write()
     gbfputint32(n, mapsend_file_out);
 
     if (n) {
-      route_disp_all(mapsend_route_hdr, mapsend_noop, mapsend_route_disp);
+      route_disp_all(mapsend_route_hdr, nullptr, mapsend_route_disp);
     }
   }
 }

--- a/mapsource.cc
+++ b/mapsource.cc
@@ -118,12 +118,6 @@ QVector<arglist_t> mps_args = {
 };
 
 static void
-mps_noop(const route_head*)
-{
-  /* no-op */
-}
-
-static void
 mps_wpt_q_init(QList<Waypoint *>* whichQueue)
 {
   whichQueue->clear();
@@ -1949,7 +1943,7 @@ mps_write()
        waypoints without consideration for uniqueness for "real" waypoints that haven't
        been output (phew!)
     */
-    route_disp_all(mps_noop, mps_noop, mps_route_wpt_w_unique_wrapper);
+    route_disp_all(nullptr, nullptr, mps_route_wpt_w_unique_wrapper);
 
     route_disp_all(mps_routehdr_w_wrapper, mps_routetrlr_w_wrapper, mps_routedatapoint_w_wrapper);
   }
@@ -2002,7 +1996,7 @@ mps_write()
         gbfread(&recType, 1, 1, mps_file_temp);
       }
     }
-    track_disp_all(mps_trackhdr_w_wrapper, mps_noop, mps_trackdatapoint_w_wrapper);
+    track_disp_all(mps_trackhdr_w_wrapper, nullptr, mps_trackdatapoint_w_wrapper);
   }
 
   if (mpsmergeout) {

--- a/nmn4.cc
+++ b/nmn4.cc
@@ -183,11 +183,6 @@ nmn4_route_hdr(const route_head*)
 }
 
 static void
-nmn4_route_tlr(const route_head*)
-{
-}
-
-static void
 nmn4_write_waypt(const Waypoint* wpt)
 {
   char city[128], street[128], zipc[32], number[32];
@@ -230,7 +225,7 @@ nmn4_write_data()
   }
 
   curr_rte_num = 0;
-  route_disp_all(nmn4_route_hdr, nmn4_route_tlr, nmn4_write_waypt);
+  route_disp_all(nmn4_route_hdr, nullptr, nmn4_write_waypt);
 }
 
 

--- a/pocketfms_bc.cc
+++ b/pocketfms_bc.cc
@@ -120,11 +120,6 @@ read_tracks()
 }
 
 static void
-route_head_noop(const route_head*)
-{
-}
-
-static void
 pocketfms_waypt_disp(const Waypoint* wpt)
 {
   breadcrumb bc;
@@ -169,7 +164,7 @@ data_read()
 static void
 data_write()
 {
-  track_disp_all(route_head_noop, route_head_noop, pocketfms_waypt_disp);
+  track_disp_all(nullptr, nullptr, pocketfms_waypt_disp);
 }
 
 ff_vecs_t pocketfms_bc_vecs = {

--- a/psitrex.cc
+++ b/psitrex.cc
@@ -732,12 +732,6 @@ psit_read()
 }
 
 static void
-psit_noop(const route_head*)
-{
-  /* no-op */
-}
-
-static void
 psit_write()
 {
   int short_length;
@@ -759,11 +753,11 @@ psit_write()
     waypt_disp_all(psit_waypoint_w_wrapper);
   }
   if (global_opts.objective == rtedata) {
-    route_disp_all(psit_routehdr_w_wrapper, psit_noop, psit_waypoint_w_wrapper);
+    route_disp_all(psit_routehdr_w_wrapper, nullptr, psit_waypoint_w_wrapper);
   }
   if (global_opts.objective == trkdata) {
     track_disp_all(psit_trackhdr_w_wrapper,
-                   psit_noop, psit_trackdatapoint_w_wrapper);
+                   nullptr, psit_trackdatapoint_w_wrapper);
   }
 
   mkshort_del_handle(&mkshort_handle);

--- a/sbn.cc
+++ b/sbn.cc
@@ -298,11 +298,6 @@ sbn_read()
   }
 }
 
-static void
-sbn_exit()
-{
-}
-
 /**********************************************************************/
 
 ff_vecs_t sbn_vecs = {
@@ -318,7 +313,7 @@ ff_vecs_t sbn_vecs = {
   nullptr,
   sbn_read,
   nullptr,
-  sbn_exit,
+  nullptr,
   &sbn_args,
   /* Characters are always encoded in ASCII. Even if the unit is set
    * to Chinese language, only ASCII characters can be entered. */

--- a/sbp.cc
+++ b/sbp.cc
@@ -108,11 +108,6 @@ sbp_read()
   }
 }
 
-static void
-sbp_exit()
-{
-}
-
 /**************************************************************************/
 
 ff_vecs_t sbp_vecs = {
@@ -128,7 +123,7 @@ ff_vecs_t sbp_vecs = {
   nullptr,
   sbp_read,
   nullptr,
-  sbp_exit,
+  nullptr,
   &sbp_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */

--- a/teletype.cc
+++ b/teletype.cc
@@ -88,11 +88,6 @@ teletype_read()
   }
 }
 
-static void
-teletype_exit()		/* optional */
-{
-}
-
 /**************************************************************************/
 
 // capabilities below means: we can only read and write waypoints
@@ -111,7 +106,7 @@ ff_vecs_t teletype_vecs = {
   nullptr,
   teletype_read,
   nullptr,
-  teletype_exit,
+  nullptr,
   &teletype_args,
   CET_CHARSET_ASCII, 0			/* ascii is the expected character set */
   /* not fixed, can be changed through command line parameter */

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -1756,13 +1756,6 @@ xcsv_waypt_pr(const Waypoint* wpt)
   waypt_out_count++;
 }
 
-static void
-xcsv_noop(const route_head* wp)
-{
-  (void)wp;
-  /* no-op */
-}
-
 // return |original| after performing token replacement.
 static QString
 xcsv_replace_tokens(const QString& original) {
@@ -1810,10 +1803,10 @@ xcsv_data_write()
     waypt_disp_all(xcsv_waypt_pr);
   }
   if ((xcsv_file.datatype == 0) || (xcsv_file.datatype == rtedata)) {
-    route_disp_all(xcsv_resetpathlen,xcsv_noop,xcsv_waypt_pr);
+    route_disp_all(xcsv_resetpathlen, nullptr, xcsv_waypt_pr);
   }
   if ((xcsv_file.datatype == 0) || (xcsv_file.datatype == trkdata)) {
-    track_disp_all(xcsv_resetpathlen,xcsv_noop,xcsv_waypt_pr);
+    track_disp_all(xcsv_resetpathlen, nullptr, xcsv_waypt_pr);
   }
 
   /* output epilogue lines, if any. */


### PR DESCRIPTION
for function pointers passed to route_disp_all, track_disp_all
and ff_vecs_t exit.