### PR TITLE
Cleanups: make a gbfreadbuf, move units from defs and into dedicated file, reduce xstrdup,xmalloc use, reduce CString/QString roundtrips, more.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ set(HEADERS
   session.h
   shapelib/shapefil.h
   strptime.h
+  units.h
   xcsv.h
   xmlgeneric.h
   zlib/crc32.h

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -137,6 +137,7 @@ HEADERS =  \
 	session.h \
 	shapelib/shapefil.h \
 	strptime.h \
+	units.h \
 	xcsv.h \
 	xmlgeneric.h \
 	zlib/crc32.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -778,7 +778,7 @@ jtr.o: jtr.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
 kml.o: kml.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
   gbfile.h session.h src/core/datetime.h src/core/optional.h grtcirc.h \
   src/core/file.h src/core/xmlstreamwriter.h src/core/xmltag.h \
-  xmlgeneric.h
+  units.h xmlgeneric.h
 lmx.o: lmx.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
   gbfile.h session.h src/core/datetime.h src/core/optional.h \
   xmlgeneric.h
@@ -980,7 +980,7 @@ unicsv.o: unicsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h \
   src/core/logging.h src/core/textstream.h src/core/file.h
 units.o: units.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
-  inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+  inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h units.h
 util.o: util.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
   gbfile.h session.h src/core/datetime.h src/core/optional.h \
   src/core/xmltag.h

--- a/alan.cc
+++ b/alan.cc
@@ -617,7 +617,7 @@ static void trl_read()
       WP->longitude =  pt2deg(trklog->pt[j].x);
       WP->altitude  =  hgt2m(trklog->sh[j].height);
       if (trklog->sh[j].speed >= 0)
-        WAYPT_SET(WP, speed, sp2mps(trklog->sh[j].speed))
+        WAYPT_SET(WP, speed, sp2mps(trklog->sh[j].speed));
         else {			/* bad speed < 0 - set to 0.0 */
           WAYPT_UNSET(WP, speed);
         }

--- a/arcdist.cc
+++ b/arcdist.cc
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib> // strtod
+#include <src/core/logging.h>
 
 #if FILTERS_ENABLED
 #define MYNAME "Arc filter"
@@ -60,6 +61,13 @@ void ArcDistanceFilter::arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2)
           prjlon = arcpt2->longitude;
           frac = 1.0;
         } else {
+          if (waypointp == nullptr) {
+            Fatal() << "Internal error. Attempt to project through a waypoint that doesn't exist";
+          }
+          if (arcpt1 == nullptr) {
+            Fatal() << "Internal error: Attempt to project waypoint without predecessor";
+          }
+
           dist = linedistprj(arcpt1->latitude,
                              arcpt1->longitude,
                              arcpt2->latitude,

--- a/cet_util.cc
+++ b/cet_util.cc
@@ -83,7 +83,7 @@ static signed int
 cet_cs_alias_qsort_cb(const void* a, const void* b)
 {
   const auto* va = (const cet_cs_alias_t*) a;
-  const cet_cs_alias_t* vb = (const cet_cs_alias_t*) b;
+  const auto* vb = (const cet_cs_alias_t*) b;
   return case_ignore_strcmp(va->name, vb->name);
 }
 

--- a/cet_util.cc
+++ b/cet_util.cc
@@ -82,7 +82,7 @@ cet_str_any_to_any(const char* src, const cet_cs_vec_t* src_vec, const cet_cs_ve
 static signed int
 cet_cs_alias_qsort_cb(const void* a, const void* b)
 {
-  const cet_cs_alias_t* va = (const cet_cs_alias_t*) a;
+  const auto* va = (const cet_cs_alias_t*) a;
   const cet_cs_alias_t* vb = (const cet_cs_alias_t*) b;
   return case_ignore_strcmp(va->name, vb->name);
 }
@@ -219,7 +219,7 @@ cet_find_cs_by_name(const QString& name)
 
   while (i <= j) {
     int a = (i + j) >> 1;
-    cet_cs_alias_t* n = &cet_cs_alias[a];
+    auto n = &cet_cs_alias[a];
     int x = case_ignore_strcmp(name, n->name);
     if (x == 0) {
       return n->vec;
@@ -376,7 +376,7 @@ cet_convert_string(const QString& str)
 static void
 cet_convert_waypt(const Waypoint* wpt)
 {
-  Waypoint* w = const_cast<Waypoint*>(wpt);
+  auto* w = const_cast<Waypoint*>(wpt);
 
   if ((cet_output == 0) && (w->wpt_flags.cet_converted != 0)) {
     return;
@@ -398,7 +398,7 @@ cet_convert_waypt(const Waypoint* wpt)
 static void
 cet_convert_route_hdr(const route_head* route)
 {
-  route_head* rte = const_cast<route_head*>(route);
+  auto* rte = const_cast<route_head*>(route);
 
   if ((cet_output == 0) && (rte->cet_converted != 0)) {
     return;

--- a/defs.h
+++ b/defs.h
@@ -453,7 +453,7 @@ struct bounds {
   double min_alt;	/* -unknown_alt => invalid */
 };
 
-#define WAYPT_SET(wpt,member,val) { (wpt)->member = (val); wpt->wpt_flags.member = 1; }
+#define WAYPT_SET(wpt,member,val) do { (wpt)->member = (val); wpt->wpt_flags.member = 1; } while (0)
 #define WAYPT_GET(wpt,member,def) ((wpt->wpt_flags.member) ? (wpt->member) : (def))
 #define WAYPT_UNSET(wpt,member) wpt->wpt_flags.member = 0
 #define WAYPT_HAS(wpt,member) (wpt->wpt_flags.member)

--- a/defs.h
+++ b/defs.h
@@ -91,7 +91,7 @@
 #define SECONDS_PER_DAY (24L*60*60)
 
 /* meters/second to kilometers/hour */
-#define MPS_TO_KPH(a) ((double)(a)*SECONDS_PER_HOUR/1000)
+#define MPS_TO_KPH(a) ((a)*SECONDS_PER_HOUR/1000.0)
 
 /* meters/second to miles/hour */
 #define MPS_TO_MPH(a) (METERS_TO_MILES(a) * SECONDS_PER_HOUR)
@@ -100,7 +100,7 @@
 #define MPS_TO_KNOTS(a) (MPS_TO_KPH((a)/1.852))
 
 /* kilometers/hour to meters/second */
-#define KPH_TO_MPS(a) ((double)(a)*1000/SECONDS_PER_HOUR)
+#define KPH_TO_MPS(a) ((a)*1000.0/SECONDS_PER_HOUR)
 
 /* miles/hour to meters/second */
 #define MPH_TO_MPS(a) (MILES_TO_METERS(a) / SECONDS_PER_HOUR)

--- a/defs.h
+++ b/defs.h
@@ -66,47 +66,39 @@
 #  define M_PI 3.14159265358979323846
 #endif
 
-#ifndef FALSE
-#  define FALSE false
-#endif
+constexpr double FEET_TO_METERS(double feetsies) { return (feetsies) * 0.3048; };
+constexpr double METERS_TO_FEET(double meetsies) { return (meetsies) * 3.2808399; };
 
-#ifndef TRUE
-#  define TRUE true
-#endif
+constexpr double NMILES_TO_METERS(double a) { return a * 1852.0;};	/* nautical miles */
+constexpr double METERS_TO_NMILES(double a) { return a / 1852.0;};
 
-#define FEET_TO_METERS(feetsies) ((feetsies) * 0.3048)
-#define METERS_TO_FEET(meetsies) ((meetsies) * 3.2808399)
+constexpr double MILES_TO_METERS(double a) { return (a) * 1609.344;};
+constexpr double METERS_TO_MILES(double a) { return (a) / 1609.344;};
+constexpr double FATHOMS_TO_METERS(double a) { return (a) * 1.8288;};
 
-#define NMILES_TO_METERS(a) ((a) * 1852.0)	/* nautical miles */
-#define METERS_TO_NMILES(a) ((a) / 1852.0)
+constexpr double CELSIUS_TO_FAHRENHEIT(double a) { return (((a) * 1.8) + 32);};
+constexpr double FAHRENHEIT_TO_CELSIUS(double a) { return (((a) - 32) / 1.8);};
 
-#define MILES_TO_METERS(a) ((a) * 1609.344)
-#define METERS_TO_MILES(a) ((a) / 1609.344)
-#define FATHOMS_TO_METERS(a) ((a) * 1.8288)
-
-#define CELSIUS_TO_FAHRENHEIT(a) (((a) * 1.8) + 32)
-#define FAHRENHEIT_TO_CELSIUS(a) (((a) - 32) / 1.8)
-
-#define SECONDS_PER_HOUR (60L*60)
-#define SECONDS_PER_DAY (24L*60*60)
+constexpr double SECONDS_PER_HOUR = 60L * 60;
+constexpr double SECONDS_PER_DAY = 24L * 60 * 60;
 
 /* meters/second to kilometers/hour */
-#define MPS_TO_KPH(a) ((a)*SECONDS_PER_HOUR/1000.0)
+constexpr double MPS_TO_KPH(double a) { return (a)*SECONDS_PER_HOUR/1000.0;};
 
 /* meters/second to miles/hour */
-#define MPS_TO_MPH(a) (METERS_TO_MILES(a) * SECONDS_PER_HOUR)
+constexpr double MPS_TO_MPH(double a) { return METERS_TO_MILES(a) * SECONDS_PER_HOUR;};
 
 /* meters/second to knots */
-#define MPS_TO_KNOTS(a) (MPS_TO_KPH((a)/1.852))
+constexpr double MPS_TO_KNOTS(double a) { return MPS_TO_KPH((a)/1.852);};
 
 /* kilometers/hour to meters/second */
-#define KPH_TO_MPS(a) ((a)*1000.0/SECONDS_PER_HOUR)
+constexpr double KPH_TO_MPS(double a) { return a * 1000.0/SECONDS_PER_HOUR;};
 
 /* miles/hour to meters/second */
 #define MPH_TO_MPS(a) (MILES_TO_METERS(a) / SECONDS_PER_HOUR)
 
 /* knots to meters/second */
-#define KNOTS_TO_MPS(a) (KPH_TO_MPS((a)*1.852))
+constexpr double KNOTS_TO_MPS(double a)  {return KPH_TO_MPS(a) * 1.852; };
 
 #define MILLI_TO_MICRO(t) ((t) * 1000)  /* Milliseconds to Microseconds */
 #define MICRO_TO_MILLI(t) ((t) / 1000)  /* Microseconds to Milliseconds*/

--- a/defs.h
+++ b/defs.h
@@ -1253,22 +1253,6 @@ int parse_speed(const QString& str, double* val, double scale, const char* modul
 unsigned long get_crc32(const void* data, int datalen);
 
 /*
- *  From units.c
- */
-enum fmt_units {
-  units_unknown = 0,
-  units_statute = 1,
-  units_metric = 2,
-  units_nautical =3,
-  units_aviation =4
-};
-
-int    fmt_setunits(fmt_units);
-double fmt_distance(double, const char** tag);
-double fmt_altitude(double, const char** tag);
-double fmt_speed(double, const char** tag);
-
-/*
  * From nmea.c
  */
 int nmea_cksum(const char* buf);

--- a/energympro.cc
+++ b/energympro.cc
@@ -22,7 +22,6 @@
 
 #include "defs.h"
 #include <QtCore/QDebug>
-#include <climits>
 
 #define MYNAME "energympro"
 
@@ -126,11 +125,11 @@ struct tw_lap {
 static void
 read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime)
 {
-  tw_point point;
+  tw_point point{};
   gbfread(&point,sizeof(tw_point),1,file_in);
   if (global_opts.debug_level > 1) {
-    printf("Point: lat:%8d long:%8d alt:%8d ",point.Latitude,point.Longitude,point.Altitude);
-    printf("speed:%6d dist:%5d time:%5d Status:%1d", point.Speed,point.IntervalDist,point.lntervalTime,point.Status);
+    printf("Point: lat:%8u long:%8u alt:%8d ",point.Latitude,point.Longitude,point.Altitude);
+    printf("speed:%6u dist:%5u time:%5d Status:%1u", point.Speed,point.IntervalDist,point.lntervalTime,point.Status);
     printf("HR:(%3d,%1d)", point.HR_Heartrate,point.HR_Status);
     printf("Speed:(%8d,%1d)", point.Speed_Speed,point.Speed_Status);
     printf("Cad:(%3d,%1d)", point.Cadence_Cadence, point.Cadence_Status);
@@ -151,7 +150,7 @@ read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime)
   qint64 mSecsSinceEpoc = gpsbabeltime.toMSecsSinceEpoch();
   gpsbabeltime.setMSecsSinceEpoch(mSecsSinceEpoc-mSecsSinceEpoc%1000);
 
-  Waypoint* waypt = new Waypoint;
+  auto waypt = new Waypoint;
   waypt->latitude = (point.Latitude / 1000000.0);
   waypt->longitude = (point.Longitude / 1000000.0);
   waypt->altitude = point.Altitude;
@@ -182,7 +181,7 @@ read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime)
 static void
 read_lap()
 {
-  tw_lap lap;
+  tw_lap lap{};
   gbfread(&lap,sizeof(tw_lap),1,file_in);
   if (global_opts.debug_level > 1) {
     printf("LAP: splitTime:%6ds TotalTime:%6ds LapNumber:%5d ",lap.splitTime/10,lap.TotalTime/10,lap.Number);
@@ -234,20 +233,20 @@ track_read()
 
   gbfseek(file_in, 0L, SEEK_END);
   gbfseek(file_in, -(int32_t)(sizeof(tw_workout)), SEEK_CUR);
-  tw_workout workout;
+  tw_workout workout{};
   workout.dateStart.Year = gbfgetc(file_in);
   workout.dateStart.Month = gbfgetc(file_in);
   workout.dateStart.Day = gbfgetc(file_in);
   workout.timeStart.Hour = gbfgetc(file_in);
   workout.timeStart.Minute = gbfgetc(file_in);
   workout.timeStart.Second = gbfgetc(file_in);
-  workout.TotalRecPt = gbfgetint16(file_in);
-  workout.TotalTime = gbfgetint32(file_in);
-  workout.TotalDist = gbfgetint32(file_in);
-  workout.LapNumber = gbfgetint16(file_in);
-  workout.Calory = gbfgetint16(file_in);
-  workout.MaxSpeed = gbfgetint32(file_in);
-  workout.AvgSpeed = gbfgetint32(file_in);
+  workout.TotalRecPt = gbfgetuint16(file_in);
+  workout.TotalTime = gbfgetuint32(file_in);
+  workout.TotalDist = gbfgetuint32(file_in);
+  workout.LapNumber = gbfgetuint16(file_in);
+  workout.Calory = gbfgetuint16(file_in);
+  workout.MaxSpeed = gbfgetuint32(file_in);
+  workout.AvgSpeed = gbfgetuint32(file_in);
   workout.MaxHeart = gbfgetc(file_in);
   workout.AvgHeart = gbfgetc(file_in);
 

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -692,8 +692,8 @@ gbfread(void* buf, const gbsize_t size, const gbsize_t members, gbfile* file)
   }
   return file->fileread(buf, size, members, file);
 }
-
 // This probably makes an unnecessary alloc/copy, but keeps the above (kinda
+
 // goofy) calling signature.
 gbsize_t
 gbfread(QString& buf, const gbsize_t size, 
@@ -704,6 +704,18 @@ gbfread(QString& buf, const gbsize_t size,
   gbsize_t retval = gbfread(tmp.data(), size, members, file);
   buf = QString(tmp);
   return retval;
+}
+
+QByteArray gbfreadbuf(gbsize_t size, gbfile* file) {
+  QByteArray tmp;
+  tmp.resize(size);
+  gbsize_t nbytes = gbfread(tmp.data(), 1, size, file);
+
+  if (nbytes != size) {
+    Fatal() << file->module << "Attempted to read " << size <<
+    "bytes, but only " << nbytes << "were available.";
+  }
+  return tmp;
 }
 
 /*

--- a/gbfile.h
+++ b/gbfile.h
@@ -93,6 +93,8 @@ void gbfclose(gbfile* file);
 
 gbsize_t gbfread(void* buf, gbsize_t size, gbsize_t members, gbfile* file);
 gbsize_t gbfread(QString& buf, gbsize_t size, gbsize_t members, gbfile* file);
+// Convenience wrapper for above, but ignoring the possibility of endian swapping.
+QByteArray gbfreadbuf(gbsize_t size, gbfile* file);
 int gbfgetc(gbfile* file);
 QString gbfgets(char* buf, int len, gbfile* file);
 

--- a/gbser_win.cc
+++ b/gbser_win.cc
@@ -242,19 +242,19 @@ int gbser_set_port(void* handle, unsigned speed, unsigned bits, unsigned parity,
   GetCommState(h->comport, &tio);
 
   tio.BaudRate            = mkspeed(speed);
-  tio.fBinary             = TRUE;
-  tio.fParity             = TRUE;
-  tio.fOutxCtsFlow        = FALSE;
-  tio.fOutxDsrFlow        = FALSE;
+  tio.fBinary             = true;
+  tio.fParity             = true;
+  tio.fOutxCtsFlow        = false;
+  tio.fOutxDsrFlow        = false;
   tio.fDtrControl         = DTR_CONTROL_ENABLE;
-  tio.fDsrSensitivity     = FALSE;
-  tio.fTXContinueOnXoff   = TRUE;
-  tio.fOutX               = FALSE;
-  tio.fInX                = FALSE;
-  tio.fErrorChar          = FALSE;
-  tio.fNull               = FALSE;
+  tio.fDsrSensitivity     = false;
+  tio.fTXContinueOnXoff   = true;
+  tio.fOutX               = false;
+  tio.fInX                = false;
+  tio.fErrorChar          = false;
+  tio.fNull               = false;
   tio.fRtsControl         = RTS_CONTROL_ENABLE;
-  tio.fAbortOnError       = FALSE;
+  tio.fAbortOnError       = false;
   tio.ByteSize            = bits;
   tio.Parity              = parity == 0 ? NOPARITY :
                             (parity == 1 ? ODDPARITY : EVENPARITY);

--- a/gpx.cc
+++ b/gpx.cc
@@ -557,7 +557,7 @@ start_something_else(const QString& el, const QXmlStreamAttributes& attr)
     return;
   }
 
-  xml_tag* new_tag = new xml_tag;
+  auto* new_tag = new xml_tag;
   new_tag->tagname = el;
 
   int attr_count = attr.size();
@@ -593,7 +593,7 @@ start_something_else(const QString& el, const QXmlStreamAttributes& attr)
       new_tag->parent = cur_tag;
     }
   } else {
-    fs_xml* fs_gpx = (fs_xml*)fs_chain_find(*fs_ptr, FS_GPX);
+    auto* fs_gpx = (fs_xml*)fs_chain_find(*fs_ptr, FS_GPX);
 
     if (fs_gpx && fs_gpx->tag) {
       cur_tag = fs_gpx->tag;
@@ -624,7 +624,7 @@ static void
 tag_log_wpt(const QXmlStreamAttributes& attr)
 {
   /* create a new waypoint */
-  Waypoint* lwp_tmp = new Waypoint;
+  auto* lwp_tmp = new Waypoint;
 
   /* extract the lat/lon attributes */
   if (attr.hasAttribute("lat")) {
@@ -903,7 +903,6 @@ xml_parse_time(const QString& dateTimeString)
 static void
 gpx_end(const QString&)
 {
-  float x;
   int passthrough;
   static QDateTime gc_log_date;
 
@@ -976,8 +975,7 @@ gpx_end(const QString&)
     wpt_tmp->AllocGCData()->type = gs_mktype(cdatastr);
     break;
   case tt_cache_difficulty:
-    x = cdatastr.toDouble();
-    wpt_tmp->AllocGCData()->diff = x * 10;
+    wpt_tmp->AllocGCData()->diff = cdatastr.toFloat() * 10;
     break;
   case tt_cache_hint:
     wpt_tmp->AllocGCData()->hint = cdatastr;
@@ -995,8 +993,7 @@ gpx_end(const QString&)
   }
   break;
   case tt_cache_terrain:
-    x = cdatastr.toDouble();
-    wpt_tmp->AllocGCData()->terr = x * 10;
+    wpt_tmp->AllocGCData()->terr = cdatastr.toFloat() * 10;
     break;
   case tt_cache_placer:
     wpt_tmp->AllocGCData()->placer = cdatastr;
@@ -1177,7 +1174,7 @@ gpx_end(const QString&)
     wpt_tmp->SetCreationTime(xml_parse_time(cdatastr));
     break;
   case tt_wpttype_geoidheight:
-    WAYPT_SET(wpt_tmp, geoidheight, cdatastr.toDouble());
+    WAYPT_SET(wpt_tmp, geoidheight, cdatastr.toDouble())
     break;
   case tt_wpttype_cmt:
     wpt_tmp->description = cdatastr;
@@ -1186,16 +1183,16 @@ gpx_end(const QString&)
     wpt_tmp->notes = cdatastr;
     break;
   case tt_wpttype_pdop:
-    wpt_tmp->pdop = cdatastr.toDouble();
+    wpt_tmp->pdop = cdatastr.toFloat();
     break;
   case tt_wpttype_hdop:
-    wpt_tmp->hdop = cdatastr.toDouble();
+    wpt_tmp->hdop = cdatastr.toFloat();
     break;
   case tt_wpttype_vdop:
-    wpt_tmp->vdop = cdatastr.toDouble();
+    wpt_tmp->vdop = cdatastr.toFloat();
     break;
   case tt_wpttype_sat:
-    wpt_tmp->sat = cdatastr.toDouble();
+    wpt_tmp->sat = cdatastr.toInt();
     break;
   case tt_wpttype_fix:
     if (cdatastr == QLatin1String("none")) {
@@ -1780,8 +1777,8 @@ gpx_waypt_pr(const Waypoint* waypointp)
   gpx_write_common_acc(waypointp);
 
   if (!(opt_humminbirdext || opt_garminext)) {
-    fs_xml* fs_gpx = (fs_xml*)fs_chain_find(waypointp->fs, FS_GPX);
-    garmin_fs_t* gmsd = GMSD_FIND(waypointp); /* gARmIN sPECIAL dATA */
+    auto* fs_gpx = (fs_xml*)fs_chain_find(waypointp->fs, FS_GPX);
+    auto* gmsd = GMSD_FIND(waypointp); /* gARmIN sPECIAL dATA */
     if (fs_gpx) {
       if (! gmsd) {
         fprint_xml_chain(fs_gpx->tag, waypointp);
@@ -1813,7 +1810,7 @@ gpx_track_hdr(const route_head* rte)
 
   if (gpx_wversion_num > 10) {
     if (!(opt_humminbirdext || opt_garminext)) {
-      fs_xml* fs_gpx = (fs_xml*)fs_chain_find(rte->fs, FS_GPX);
+      auto* fs_gpx = (fs_xml*)fs_chain_find(rte->fs, FS_GPX);
       if (fs_gpx) {
         fprint_xml_chain(fs_gpx->tag, nullptr);
       }
@@ -1860,7 +1857,7 @@ gpx_track_disp(const Waypoint* waypointp)
   gpx_write_common_acc(waypointp);
 
   if (!(opt_humminbirdext || opt_garminext)) {
-    fs_xml* fs_gpx = (fs_xml*)fs_chain_find(waypointp->fs, FS_GPX);
+    auto* fs_gpx = (fs_xml*)fs_chain_find(waypointp->fs, FS_GPX);
     if (fs_gpx) {
       fprint_xml_chain(fs_gpx->tag, waypointp);
     }
@@ -1902,7 +1899,7 @@ gpx_route_hdr(const route_head* rte)
 
   if (gpx_wversion_num > 10) {
     if (!(opt_humminbirdext || opt_garminext)) {
-      fs_xml* fs_gpx = (fs_xml*)fs_chain_find(rte->fs, FS_GPX);
+      auto* fs_gpx = (fs_xml*)fs_chain_find(rte->fs, FS_GPX);
       if (fs_gpx) {
         fprint_xml_chain(fs_gpx->tag, nullptr);
       }
@@ -1939,7 +1936,7 @@ gpx_route_disp(const Waypoint* waypointp)
   gpx_write_common_acc(waypointp);
 
   if (!(opt_humminbirdext || opt_garminext)) {
-    fs_xml* fs_gpx = (fs_xml*)fs_chain_find(waypointp->fs, FS_GPX);
+    auto* fs_gpx = (fs_xml*)fs_chain_find(waypointp->fs, FS_GPX);
     if (fs_gpx) {
       fprint_xml_chain(fs_gpx->tag, waypointp);
     }

--- a/gpx.cc
+++ b/gpx.cc
@@ -1042,7 +1042,7 @@ gpx_end(const QString&)
    */
   case tt_humminbird_wpt_depth:
   case tt_humminbird_trk_trkseg_trkpt_depth:
-    WAYPT_SET(wpt_tmp, depth, cdatastr.toDouble() / 100.0)
+    WAYPT_SET(wpt_tmp, depth, cdatastr.toDouble() / 100.0);
     break;
   /*
    * Route-specific tags.
@@ -1174,7 +1174,7 @@ gpx_end(const QString&)
     wpt_tmp->SetCreationTime(xml_parse_time(cdatastr));
     break;
   case tt_wpttype_geoidheight:
-    WAYPT_SET(wpt_tmp, geoidheight, cdatastr.toDouble())
+    WAYPT_SET(wpt_tmp, geoidheight, cdatastr.toDouble());
     break;
   case tt_wpttype_cmt:
     wpt_tmp->description = cdatastr;

--- a/jeeps/gpscom.cc
+++ b/jeeps/gpscom.cc
@@ -1255,7 +1255,9 @@ int32 GPS_Command_Send_Track_As_Course(const char* port, GPS_PTrack* trk, int32 
         trk_idx = strtoul(ctk[j]->trk_ident, nullptr, 0);
         continue;
       }
-
+      if (wpt[i] == nullptr || ctk[j] == nullptr) {
+        fatal("Internal error in GPS_Command_Send_Track_As_Course");
+      }
       dist = gcgeodist(wpt[i]->lat, wpt[i]->lon, ctk[j]->lat, ctk[j]->lon);
       if (dist < min_dist) {
         min_dist = dist;
@@ -1264,6 +1266,9 @@ int32 GPS_Command_Send_Track_As_Course(const char* port, GPS_PTrack* trk, int32 
       }
     }
 
+    if (wpt[i] == nullptr) {
+      fatal("Internal error in GPS_Command_Send_Track_As_Course: no wpt");
+    }
     cpt[i+n_cpt] = GPS_Course_Point_New();
     strncpy(cpt[i+n_cpt]->name, wpt[i]->cmnt,
             sizeof(cpt[i+n_cpt]->name) - 1);

--- a/kml.cc
+++ b/kml.cc
@@ -417,11 +417,13 @@ void trk_coord(xg_string args, const QXmlStreamAttributes*)
     QStringList coords = vec.split(',');
     auto csize = coords.size();
     auto trkpt = new Waypoint;
-    if (csize >= 2) {
+
+    if (csize == 3) {
+      trkpt->altitude = coords[2].toDouble();
+    }
+    if (csize == 2 || csize == 3) {
       trkpt->latitude = coords[1].toDouble();
       trkpt->longitude = coords[0].toDouble();
-    } else if (csize >= 3) {
-      trkpt->altitude = coords[2].toDouble();
     } else {
       Warning() << MYNAME << ": malformed coordinates " << vec;
     }

--- a/kml.cc
+++ b/kml.cc
@@ -53,6 +53,7 @@
 #include "src/core/xmlstreamwriter.h"   // for XmlStreamWriter
 #include "src/core/xmltag.h"            // for xml_findfirst, xml_tag, fs_xml, xml_attribute, xml_findnext
 #include "xmlgeneric.h"                 // for cb_cdata, cb_end, cb_start, xg_callback, xg_string, xg_cb_type, xml_deinit, xml_ignore_tags, xml_init, xml_read, xg_tag_mapping
+#include "units.h"
 
 // options
 static char* opt_deficon = nullptr;

--- a/kml.cc
+++ b/kml.cc
@@ -413,9 +413,9 @@ void trk_coord(xg_string args, const QXmlStreamAttributes*)
   }
   track_add_head(trk_head);
 
-  auto vecs = args.simplified().split(' ');
+  const auto vecs = args.simplified().split(' ');
   for(const auto& vec : vecs) {
-    QStringList coords = vec.split(',');
+    const QStringList coords = vec.split(',');
     auto csize = coords.size();
     auto trkpt = new Waypoint;
 

--- a/kml.cc
+++ b/kml.cc
@@ -49,10 +49,10 @@
 #include "src/core/datetime.h"          // for DateTime
 #include "src/core/file.h"              // for File
 #include "src/core/optional.h"          // for optional
+#include <src/core/logging.h>           // for Warning
 #include "src/core/xmlstreamwriter.h"   // for XmlStreamWriter
 #include "src/core/xmltag.h"            // for xml_findfirst, xml_tag, fs_xml, xml_attribute, xml_findnext
 #include "xmlgeneric.h"                 // for cb_cdata, cb_end, cb_start, xg_callback, xg_string, xg_cb_type, xml_deinit, xml_ignore_tags, xml_init, xml_read, xg_tag_mapping
-
 
 // options
 static char* opt_deficon = nullptr;
@@ -107,8 +107,8 @@ enum kml_point_type {
 
 static int realtime_positioning;
 static bounds kml_bounds;
-static gpsbabel::DateTime kml_time_min;
 static gpsbabel::DateTime kml_time_max;
+static gpsbabel::DateTime kml_time_min;
 
 #define DEFAULT_PRECISION "6"
 
@@ -208,7 +208,7 @@ struct {
   { 0,  ICON_BASE "youarehere-0.png" }, // Green
 };
 
-#define ICON_NOSAT ICON_BASE "youarehere-warning.png";
+#define ICON_NOSAT ICON_BASE "youarehere-warning.png"
 #define ICON_WPT "https://maps.google.com/mapfiles/kml/pal4/icon61.png"
 #define ICON_TRK ICON_BASE "track-directional/track-none.png"
 #define ICON_RTE ICON_BASE "track-directional/track-none.png"
@@ -406,34 +406,26 @@ void wpt_icon(xg_string args, const QXmlStreamAttributes*)
 
 void trk_coord(xg_string args, const QXmlStreamAttributes*)
 {
-  int consumed = 0;
-  double lat, lon, alt;
-  Waypoint* trkpt;
-  int n = 0;
-
   route_head* trk_head = route_head_alloc();
-
-  QString iargs = args;
   if (wpt_tmp && !wpt_tmp->shortname.isEmpty()) {
     trk_head->rte_name  = wpt_tmp->shortname;
   }
   track_add_head(trk_head);
-  while ((n = sscanf(CSTRc(iargs), "%lf,%lf,%lf%n", &lon, &lat, &alt, &consumed)) > 0) {
-    trkpt = new Waypoint;
-    trkpt->latitude = lat;
-    trkpt->longitude = lon;
 
-    // Line malformed or two-arg format without alt .  Rescan.
-    if (2 == n) {
-      sscanf(CSTRc(iargs), "%lf,%lf%n", &lon, &lat, &consumed);
+  auto vecs = args.simplified().split(' ');
+  for(const auto& vec : vecs) {
+    QStringList coords = vec.split(',');
+    auto csize = coords.size();
+    auto trkpt = new Waypoint;
+    if (csize >= 2) {
+      trkpt->latitude = coords[1].toDouble();
+      trkpt->longitude = coords[0].toDouble();
+    } else if (csize >= 3) {
+      trkpt->altitude = coords[2].toDouble();
+    } else {
+      Warning() << MYNAME << ": malformed coordinates " << vec;
     }
-
-    if (3 == n) {
-      trkpt->altitude = alt;
-    }
-
     track_add_wpt(trk_head, trkpt);
-    iargs = iargs.mid(consumed);
   }
 
   /* The track coordinates do not have a time associated with them. This is specified by using:
@@ -451,8 +443,8 @@ void trk_coord(xg_string args, const QXmlStreamAttributes*)
     if (trk_head->rte_waypt_ct > 0) {
       qint64 timespan_ms = wpt_timespan_begin.msecsTo(wpt_timespan_end);
       qint64 ms_per_waypoint = timespan_ms / trk_head->rte_waypt_ct;
-      foreach (Waypoint* trkpt, trk_head->waypoint_list) {
-        trkpt->SetCreationTime(wpt_timespan_begin);
+      foreach (Waypoint* trackpoint, trk_head->waypoint_list) {
+        trackpoint->SetCreationTime(wpt_timespan_begin);
         wpt_timespan_begin = wpt_timespan_begin.addMSecs(ms_per_waypoint);
       }
     }
@@ -1927,7 +1919,9 @@ static void kml_write_AbstractView()
       // the network position.  So we shove the end of the timespan out to
       // ensure the right edge of that time slider includes us.
       //
-      gpsbabel::DateTime time_max = realtime_positioning ? kml_time_max.addSecs(600) : kml_time_max;
+      gpsbabel::DateTime time_max;
+      time_max = realtime_positioning ? kml_time_max.addSecs(600)
+                                      : kml_time_max;
       writer->writeTextElement(QStringLiteral("end"), time_max.toPrettyString());
     }
     writer->writeEndElement(); // Close gx:TimeSpan tag

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -101,6 +101,7 @@
 #include <QtCore/QTime>          // for QTime
 #include <QtCore/Qt>             // for CaseInsensitive, UTC
 #include <QtCore/QtGlobal>       // for qPrintable, uint, foreach
+#include <src/core/logging.h>
 
 #include "defs.h"
 #include "gbfile.h"              // for gbfgetint32, gbfputint32, gbfputint16, gbfgetc, gbfgetint16, gbfputc, gbfwrite, gbfeof, gbfgetflt, gbfclose, gbfgetdbl, gbfputdbl, gbfile, gbfputflt, gbfread, gbfseek, gbfopen_le
@@ -1129,6 +1130,8 @@ lowranceusr_parse_waypts()
     case 6:
       lowranceusr4_parse_waypt(wpt_tmp);
       break;
+      default:
+        Warning() << MYNAME << ": Unknown internal version " << reading_version;
     }
     waypt_add(wpt_tmp);
   }

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -1749,7 +1749,7 @@ lowranceusr_waypt_disp(const Waypoint* wpt)
     /* Lowrance needs it as seconds since Jan 1, 2000 */
     Time -= base_time_secs;
     if (global_opts.debug_level >= 2) {
-      printf("creation_time %d, '%s'", (int)Time, qPrintable(wpt->GetCreationTime().toString("yyyy-MM-dd hh:mm:ss")));
+      printf("creation_time %d, '%s'", Time, qPrintable(wpt->GetCreationTime().toString("yyyy-MM-dd hh:mm:ss")));
     }
   } else {
     /* If false, make sure it is an unknown time value */
@@ -2005,31 +2005,26 @@ lowranceusr_trail_hdr(const route_head* trk)
 static void
 lowranceusr_route_hdr(const route_head* rte)
 {
-  char* name, tmp_name[20];
-  char route_reversed=0;
+  QString name;
 
   /* route name */
   //TODO: This whole function needs to be replaced...
   if (!rte->rte_name.isEmpty()) {
-    name = xstrdup(rte->rte_name);
+    name = rte->rte_name;
   } else if (!rte->rte_desc.isEmpty()) {
-    name = xstrdup(rte->rte_desc);
+    name = rte->rte_desc;
   } else {
-    tmp_name[0]='\0';
-    snprintf(tmp_name, sizeof(tmp_name), "Babel R%d", ++lowrance_route_count);
-    name = xstrdup(tmp_name);
+    name = QString().sprintf("Babel R%d", ++lowrance_route_count);
   }
-  int text_len = strlen(name);
-  if (text_len > MAXUSRSTRINGSIZE) {
-    text_len = MAXUSRSTRINGSIZE;
-  }
+  int text_len = std::min(name.size(), MAXUSRSTRINGSIZE);
+  name.truncate(text_len);
   gbfputint32(text_len, file_out);
-  gbfwrite(name, 1, text_len, file_out);
-  xfree(name);
+  gbfputs(name, file_out);
 
   /* num legs */
   short num_legs = (short) rte->rte_waypt_ct;
   gbfputint16(num_legs, file_out);
+  char route_reversed=0;
   gbfwrite(&route_reversed, 1, 1, file_out);
 
   if (global_opts.debug_level >= 1)
@@ -2129,29 +2124,24 @@ lowranceusr_trail_disp(const Waypoint* wpt)
 static void
 lowranceusr_merge_trail_hdr(const route_head* trk)
 {
-  char* name, tmp_name[20];
-
+  QString name;
   if (++trail_count == 1) {
     if (!trk->rte_name.isEmpty()) {
-      name = xstrdup(trk->rte_name);
+      name = trk->rte_name;
     } else if (!trk->rte_desc.isEmpty()) {
-      name = xstrdup(trk->rte_desc);
+      name = trk->rte_desc;
     } else {
-      tmp_name[0]='\0';
-      snprintf(tmp_name, sizeof(tmp_name), "Babel %d", trail_count);
-      name = xstrdup(tmp_name);
+      name = QString().sprintf("Babel %d", trail_count);
     }
-    int text_len = strlen(name);
-    if (text_len > MAXUSRSTRINGSIZE) {
-      text_len = MAXUSRSTRINGSIZE;
-    }
+
+    int text_len = std::min(MAXUSRSTRINGSIZE, name.size());
+    name.truncate(text_len);
     gbfputint32(text_len, file_out);
+    gbfputs(name, file_out);
 
     if (global_opts.debug_level >= 1) {
-      printf(MYNAME " trail_hdr: trail name = %s\n", name);
+      printf(MYNAME " trail_hdr: trail name = %s\n", CSTR(name));
     }
-
-    gbfwrite(name, 1, text_len, file_out);
   }
 
   trail_point_count += (short) trk->rte_waypt_ct;

--- a/msvc/GPSBabel.vcxproj
+++ b/msvc/GPSBabel.vcxproj
@@ -412,6 +412,7 @@
     <ClInclude Include="swapdata.h" />
     <ClInclude Include="trackfilter.h" />
     <ClInclude Include="transform.h" />
+    <ClInclude Include="units.h" />
     <ClInclude Include="zlib\trees.h" />
     <ClInclude Include="src\core\usasciicodec.h" />
     <ClInclude Include="validate.h" />

--- a/msvc/GPSBabel.vcxproj.filters
+++ b/msvc/GPSBabel.vcxproj.filters
@@ -848,6 +848,9 @@
     <ClInclude Include="src\core\usasciicodec.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="units.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="validate.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/nmea.cc
+++ b/nmea.cc
@@ -774,7 +774,7 @@ gpvtg_parse(char* ibuf)
   if (curr_waypt) {
     WAYPT_SET(curr_waypt, course, course);
     if (speed_k > 0) {
-      WAYPT_SET(curr_waypt, speed, KPH_TO_MPS(speed_k))
+      WAYPT_SET(curr_waypt, speed, KPH_TO_MPS(speed_k));
     } else {
       WAYPT_SET(curr_waypt, speed, KNOTS_TO_MPS(speed_n));
     }

--- a/nmea.cc
+++ b/nmea.cc
@@ -233,7 +233,7 @@ static QVector<arglist_t> nmea_args = {
   {"ignore_fix", &opt_ignorefix, "Accept position fixes in gpgga marked invalid", "0", ARGTYPE_BOOL, ARG_NOMINMAX, nullptr},
 };
 
-#define CHECK_BOOL(a) if (a && (*a == '0')) a = NULL
+#define CHECK_BOOL(a) if ((a) && (*(a) == '0')) (a) = NULL
 
 /*
  * Slightly different than the Magellan checksum fn.
@@ -354,7 +354,7 @@ nmea_wr_init(const QString& portname)
   CHECK_BOOL(opt_gpgsa);
   CHECK_BOOL(opt_gisteq);
 
-  append_output = atoi(opt_append);
+  append_output = strtod(opt_append, nullptr);
 
   file_out = gbfopen(portname, append_output ? "a+" : "w+", MYNAME);
 
@@ -533,18 +533,20 @@ gpgga_parse(char* ibuf)
   waypt->hdop = hdop;
 
   switch (fix) {
-  case 0:
-    waypt->fix = fix_none;
-    break;
-  case 1:
-    waypt->fix  = (nsats>3)?(fix_3d):(fix_2d);
-    break;
-  case 2:
-    waypt->fix = fix_dgps;
-    break;
-  case 3:
-    waypt->fix = fix_pps;
-    break;
+    case 0:
+      waypt->fix = fix_none;
+      break;
+    case 1:
+      waypt->fix = (nsats > 3) ? (fix_3d) : (fix_2d);
+      break;
+    case 2:
+      waypt->fix = fix_dgps;
+      break;
+    case 3:
+      waypt->fix = fix_pps;
+      break;
+    default:
+      Warning() << MYNAME << ": unknown vix value" << fix;
   }
 
   nmea_release_wpt(curr_waypt);
@@ -730,12 +732,12 @@ gpgsa_parse(char* ibuf)
   }
 
   float pdop = 0, hdop = 0, vdop = 0;
-  if (nfields > 14) pdop = fields[15].toDouble();
-  if (nfields > 15) hdop = fields[16].toDouble();
+  if (nfields > 14) pdop = fields[15].toFloat();
+  if (nfields > 15) hdop = fields[16].toFloat();
   if (nfields > 16) {
      // Last one is special. The checksum isn't split out above.
     fields[17].chop(3);
-    vdop = fields[17].toDouble();
+    vdop = fields[17].toFloat();
   }
 
   if (curr_waypt) {
@@ -1369,9 +1371,9 @@ nmea_trackpt_pr(const Waypoint* wpt)
     }
     snprintf(obuf,sizeof(obuf),"GPGSA,A,%c,,,,,,,,,,,,,%.1f,%.1f,%.1f",
              fix,
-             (wpt->pdop>0)?(wpt->pdop):(0),
-             (wpt->hdop>0)?(wpt->hdop):(0),
-             (wpt->vdop>0)?(wpt->vdop):(0));
+             (wpt->pdop > 0) ? (wpt->pdop) : (0),
+             (wpt->hdop > 0) ? (wpt->hdop) : (0),
+             (wpt->vdop > 0) ? (wpt->vdop) : (0));
     cksum = nmea_cksum(obuf);
     gbfprintf(file_out, "$%s*%02X\n", obuf, cksum);
   }

--- a/teletype.cc
+++ b/teletype.cc
@@ -70,19 +70,11 @@ teletype_read()
 
     if (true) {  // need bit value of NEWFORMAT
       int len = gbfgetuint16(fin);
-      // probably could treat as a pascal string
-      char* junk = (char*) xmalloc(len);
-      gbfread(junk, len, 1, fin);
-      xfree(junk);
+      gbfseek(fin, len, SEEK_CUR);
     }
     wpt->latitude = gbfgetint32(fin) / 1000000.0 ;
     wpt->longitude = gbfgetint32(fin) / 1000000.0 ;
-
-    {
-      char jibberish[21];
-      gbfread(jibberish, sizeof(jibberish), 1, fin);
-    }
-
+    gbfseek(fin, 21, SEEK_CUR);
 
     waypt_add(wpt);
   }

--- a/units.cc
+++ b/units.cc
@@ -20,6 +20,7 @@
  */
 
 #include "defs.h"
+#include "units.h"
 
 static int units = units_statute;
 

--- a/units.h
+++ b/units.h
@@ -1,0 +1,47 @@
+/*
+    Display scaled distances in 'local' units.
+
+    Copyright (C) 2006 Robert Lipe, robertlipe+source@gpsbabel.org
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ */
+
+
+#ifndef GPSBABEL_UNITS_H
+#define GPSBABEL_UNITS_H
+
+/*
+ *  From units.c
+ */
+enum fmt_units {
+  units_unknown = 0,
+  units_statute = 1,
+  units_metric = 2,
+  units_nautical =3,
+  units_aviation =4
+};
+
+int    fmt_setunits(fmt_units);
+
+double fmt_distance(double, const char** tag);
+
+double fmt_altitude(double, const char** tag);
+
+double fmt_speed(double, const char** tag);
+
+#include "defs.h"
+
+#endif //GPSBABEL_UNITS_H


### PR DESCRIPTION
I'd meant to have this in multiple submits, but here we are. Most of this is fairly mechanical. The KML change is worth a callout.

Our KML coordinate reader has been around the block. At various times,
it's been SAX, DOM, raw expat, expat front-ended for sane buffer management,
and is now a weird combination of C-level scanf and QString. I would have
guessed it to be faster than making two additional copies, the second of
which is parsed again after the first parse knocks down whitespace to make
the second level easy to parse for commas.

I'd have been very wrong.




With the existing code, parsing an arbitrary file of about 38,000
points takes about 9.8 seconds as measured by
$ time ./gpsbabel -t -i kml -f test.kml

With the new code, it's about .45 seconds.

It still passes validation. A 21x speedup that's also way simpler to read
isn't bad.