### PR TITLE
tweaks for format vectors.

### DIFF
--- a/hiketech.cc
+++ b/hiketech.cc
@@ -302,7 +302,7 @@ void	ht_trk_alt(xg_string args, const QXmlStreamAttributes*)
 
 ff_vecs_t hiketech_vecs = {
   ff_type_file,
-  { (ff_cap)(ff_cap_read | ff_cap_write), (ff_cap)(ff_cap_read | ff_cap_write) },
+  { (ff_cap)(ff_cap_read | ff_cap_write), (ff_cap)(ff_cap_read | ff_cap_write), ff_cap_none },
   hiketech_rd_init,
   hiketech_wr_init,
   hiketech_rd_deinit,

--- a/vecs.cc
+++ b/vecs.cc
@@ -1454,9 +1454,8 @@ sort_and_unify_vecs()
     xcsv_read_internal_style(svec.style_buf);
     vecs_t uvec;
     uvec.name = svec.name;
-    uvec.vec = new ff_vecs_t; /* LEAK */
     uvec.extensions = xcsv_file.extension;
-    *uvec.vec = *vec_list.at(0).vec; /* Inherits xcsv opts */
+    uvec.vec = new ff_vecs_t(*vec_list.at(0).vec); /* Inherits xcsv opts */ /* LEAK */
     /* Reset file type to inherit ff_type from xcsv. */
     uvec.vec->type = xcsv_file.type;
     /* Skip over the first help entry for all but the


### PR DESCRIPTION
flush out hiketech capability array.

use copy constructor of ff_vecs_t when creating unified vector list.