### PR TITLE
use QDebug in logging.

### DIFF
--- a/nmea.cc
+++ b/nmea.cc
@@ -547,7 +547,7 @@ gpgga_parse(char* ibuf)
       waypt->fix = fix_pps;
       break;
     default:
-      Warning() << MYNAME << ": unknown vix value" << fix;
+      Warning() << MYNAME ": unknown fix value" << fix;
   }
 
   nmea_release_wpt(curr_waypt);
@@ -963,7 +963,7 @@ nmea_parse_one_line(char* ibuf)
     int ckcmp;
     sscanf(ck, "%2X", &ckcmp);
     if (ckval != ckcmp) {
-      Warning() << "Invalid NMEA checksum. Computed " << ckval << " but found " << ckcmp << ". Ignoring sentence";
+      Warning().nospace() <<  hex << "Invalid NMEA checksum.  Computed 0x" << ckval << " but found 0x" << ckcmp << ".  Ignoring sentence.";
       return;
     }
 

--- a/nmea.cc
+++ b/nmea.cc
@@ -547,7 +547,7 @@ gpgga_parse(char* ibuf)
       waypt->fix = fix_pps;
       break;
     default:
-      Warning() << MYNAME ": unknown fix value" << fix;
+      break;
   }
 
   nmea_release_wpt(curr_waypt);


### PR DESCRIPTION
This gives us full access to all the methods, stream operators and
manipulators that QDebug has access to.  There is a demonstration using nospace() and hex in nmea.cc.

It seems like we should be able to do this more directly with one of the other QDebug constructors, but I haven't found a way to flush when using those constructors.  Without the flush we lose output directed to Fatal().

I don't really like invoking exit in the destructor, but we don't want to throw an exception from a destructor.

