### PR TITLE
Fix potential slicing with Filter class.

### DIFF
--- a/filter.h
+++ b/filter.h
@@ -35,12 +35,13 @@ public:
   // its base class type.
   // https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP52-CPP.+Do+not+delete+a+polymorphic+object+without+a+virtual+destructor
   virtual ~Filter() = default;
-  // And that requires us to explicitly default the move and copy operations.
+  // And that requires us to explicitly default or delete the move and copy operations.
+  // To prevent slicing we delete them.
   // https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all.
-  Filter(const Filter&) = default;
-  Filter& operator=(const Filter&) = default;
-  Filter(Filter&&) = default;
-  Filter& operator=(Filter&&) = default;
+  Filter(const Filter&) = delete;
+  Filter& operator=(const Filter&) = delete;
+  Filter(Filter&&) = delete;
+  Filter& operator=(Filter&&) = delete;
 
   virtual QVector<arglist_t>* get_args() = 0;
 


### PR DESCRIPTION
detected by clazy as:
warning: Polymorphic class Filter is copyable. Potential slicing. [-Wclazy-copyable-polymorphic]