### PR TITLE
Don't lie to mkshort about utf8.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -918,7 +918,7 @@ geocache_container gs_mkcont(const QString& t);
 struct mkshort_handle_imp; // forward declare, definition in mkshort.cc
 using short_handle = mkshort_handle_imp*;
 
-char* mkshort(short_handle,  const char*);
+char* mkshort(short_handle,  const char*, bool);
 QString mkshort(short_handle,  const QString&);
 short_handle mkshort_new_handle();
 QString mkshort_from_wpt(short_handle h, const Waypoint* wpt);
@@ -931,7 +931,6 @@ void setshort_mustuniq(short_handle,  int n);
 void setshort_whitespace_ok(short_handle,  int n);
 void setshort_repeating_whitespace_ok(short_handle,  int n);
 void setshort_defname(short_handle, const char* s);
-void setshort_is_utf8(short_handle h, int is_utf8);
 
 #define ARGTYPE_UNKNOWN    0x00000000
 #define ARGTYPE_INT        0x00000001

--- a/garmin.cc
+++ b/garmin.cc
@@ -952,7 +952,7 @@ waypoint_prepare()
      */
     char* ident = mkshort(mkshort_handle,
                            global_opts.synthesize_shortnames ? CSTRc(src) :
-                             CSTRc(wpt->shortname));
+                             CSTRc(wpt->shortname), false);
     /* Should not be a strcpy as 'ident' isn't really a C string,
      * but rather a garmin "fixed length" buffer that's padded
      * to the end with spaces.  So this is NOT (strlen+1).

--- a/holux.cc
+++ b/holux.cc
@@ -164,7 +164,7 @@ static const char* mknshort(const char* stIn,unsigned int sLen)
   setshort_length(mkshort_handle, sLen);
   setshort_mustuniq(mkshort_handle, 0);
 
-  char* shortstr = mkshort(mkshort_handle, stIn);
+  char* shortstr = mkshort(mkshort_handle, stIn, false);
   strcpy(strTmp,shortstr);
   xfree(shortstr);
 

--- a/mkshort.cc
+++ b/mkshort.cc
@@ -29,7 +29,6 @@
 
 #include "defs.h"
 #include "cet.h"            // for cet_utf8_strdup, cet_utf8_strlen, cet_utf8_strndup
-#include "cet_util.h"       // for cet_cs_vec_utf8
 
 
 #define MYNAME	"mkshort"
@@ -64,7 +63,6 @@ struct  mkshort_handle_imp {
   bool whitespaceok{true};
   bool repeating_whitespaceok{false};
   bool must_uniq{true};
-  bool is_utf8{false};
 };
 
 static struct replacements {
@@ -104,7 +102,6 @@ mkshort_new_handle()
 
   h->badchars = xstrdup(DEFAULT_BADCHARS);
   h->defname = xstrdup("WPT");
-  h->is_utf8 = (global_opts.charset == &cet_cs_vec_utf8);
 
   return h;
 }
@@ -361,18 +358,8 @@ setshort_mustuniq(short_handle h, int i)
   hdl->must_uniq = i;
 }
 
-/*
- *  Declare that actually characters are (or are not) encoded in UTF-8.
- */
-void
-setshort_is_utf8(short_handle h, const int is_utf8)
-{
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
-  hdl->is_utf8 = is_utf8;
-}
-
 char*
-mkshort(short_handle h, const char* istring)
+mkshort(short_handle h, const char* istring, bool is_utf8)
 {
   char* ostring;
   char* tstring;
@@ -380,7 +367,7 @@ mkshort(short_handle h, const char* istring)
   int i, l, replaced;
   mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
 
-  if (hdl->is_utf8) {
+  if (is_utf8) {
     ostring = cet_utf8_strdup(istring);  /* clean UTF-8 string */
   } else {
     ostring = xstrdup(istring);
@@ -529,7 +516,7 @@ mkshort(short_handle h, const char* istring)
    * If the numeric component alone is longer than our target string
    * length, use only what'll fit.
    */
-  if (hdl->is_utf8) {
+  if (is_utf8) {
     /* ToDo: Keep trailing numeric data as described above! */
     if (cet_utf8_strlen(ostring) > hdl->target_len) {
       char* tmp = cet_utf8_strndup(ostring, hdl->target_len);
@@ -564,7 +551,7 @@ mkshort(short_handle h, const char* istring)
 QString
 mkshort(short_handle h, const QString& istring)
 {
-  char* t =  mkshort(h, CSTR(istring));
+  char* t =  mkshort(h, CSTR(istring), true);
   QString r(t);
   xfree(t);
   return r;

--- a/psitrex.cc
+++ b/psitrex.cc
@@ -343,8 +343,6 @@ psit_waypoint_r(gbfile* psit_file, Waypoint**)
 static void
 psit_waypoint_w(gbfile* psit_file, const Waypoint* wpt)
 {
-  char* src = nullptr;  /* BUGBUG Passed to mkshort */
-
   gbfprintf(psit_file, "%11.6f,%11.6f,",
             wpt->latitude,
             wpt->longitude);
@@ -356,7 +354,7 @@ psit_waypoint_w(gbfile* psit_file, const Waypoint* wpt)
               wpt->altitude);
 
   const char* ident = global_opts.synthesize_shortnames ?
-                         mkshort(mkshort_handle, src) :
+                         mkshort(mkshort_handle, "WPT", false) :
                          xstrdup(wpt->shortname);
 
   gbfprintf(psit_file, " %-6s, ", ident);

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -299,7 +299,7 @@ register_waypt(const Waypoint* ref, const char)
     }
   }
 
-  wpt->extra_data = (void*)mkshort(hshort_wpt, CSTRc(wpt->shortname));
+  wpt->extra_data = (void*)mkshort(hshort_wpt, CSTRc(wpt->shortname), false);
 
   waypt_table[waypt_table_ct] = wpt;
   waypt_table_ct++;

--- a/reference/gc/maggeo.gs
+++ b/reference/gc/maggeo.gs
@@ -1,3 +1,3 @@
-$PMGNGEO,4608.000,N,7300.000,W,0000,F,GC7FA4,Points godsiques,Sverdrup2,,Locationless (Reverse) Cache,1508102,1207105,1.0,1.0*7A
+$PMGNGEO,4608.000,N,7300.000,W,0000,F,GC7FA4,Points godsiques d,Sverdrup2,,Locationless (Reverse) Cache,1508102,1207105,1.0,1.0*3E
 $PMGNGEO,3555.300,N,8651.700,W,0000,F,GCGCA8,Oozy rat in a sanita,robertlipe,There Is No Hint,Mystery Cache,2906103,0307105,3.0,2.0*04
 $PMGNCMD,END*3D


### PR DESCRIPTION
Pass a flag indicating utf8 on every call to mkshort, instead of
setting it up in the handle.  This is much more likely to be correct
as the string and the flag are passed together.  The old method was
often incorrect as it was based on global_opts.charset, which was
often unrelated to the string that was passed to mkshort.

This also resolved an apparent bug in psitrex.  It was thought
that passing a nullptr to mkshort was a bug, but this results in
the result being generated from the default name.  It is assumed
that this is what was originally intended, and this was never a bug.

An additional issue was that main calls waypt_init, which calls mkshort_new_handle, which 
reads global_opts.charset, which hasn't been set yet.