### PR TITLE
try to get codacy cppcheck running without height.cc

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -5,6 +5,7 @@ exclude_paths:
   - 'shapelib/**'
   - 'zlib/**'
   - coverity_model.cc
+  - height.cc # It takes newer cppcheck versions, somewhere > 1.82, an excessive amount of time to analyze heightgrid.h
   - strptime.[ch]
   - jeeps/gpsproj.cc
   - jeeps/gpsproj.h


### PR DESCRIPTION
At some point after version 1.82 cppcheck started taking a long time to analyze heightgrid.h which is included by heightgrid.cc.  This PR excludes heightgrid.cc from codacy analysis to work around these performance problems.

Another performance issue with codacy cppcheck is that any cppcheck addons are very slow.  In Dec 2019 there was a commit to codacy-cppcheck to not use the addons if none of the corresponding code patterns were enabled (https://github.com/codacy/codacy-cppcheck/commit/f6f37d93934a57b0d8cc1381cf62cc1dbbcab19e).  All the patterns can be seen at https://github.com/codacy/codacy-cppcheck/blob/master/src/main/resources/docs/patterns.json.  The patterns that use addons can be found at https://github.com/codacy/codacy-cppcheck/blob/master/src/main/resources/addons/patterns.json, except for the misra patterns which all start with misra.
