### PR TITLE
gpsbabel::textstream now accepts open mode flags

### DIFF
--- a/src/core/textstream.cc
+++ b/src/core/textstream.cc
@@ -18,16 +18,18 @@
  */
 
 #include <QtCore/QFile>        // for QFile
+#include <QtCore/QFlags>     // for QFlags
+#include <QtCore/QIODevice>  // for QIODevice, QIODevice::OpenMode, QIODevice::ReadOnly, QIODevice::WriteOnly
 
+#include "defs.h"              // for fatal, list_codecs
 #include "src/core/textstream.h"
-#include "defs.h"              // for fatal
 #include "src/core/file.h"     // for File
 
 
 namespace gpsbabel
 {
 
-void TextStream::open(const QString& fname, QIODevice::OpenModeFlag mode, const char* module, const char* codec_name)
+void TextStream::open(const QString& fname, QIODevice::OpenMode mode, const char* module, const char* codec_name)
 {
   codec_ = QTextCodec::codecForName(codec_name);
   if (codec_ == nullptr) {

--- a/src/core/textstream.h
+++ b/src/core/textstream.h
@@ -16,9 +16,10 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
+#ifndef SRC_CORE_TEXTSTREAM_INCLUDED_H_
+#define SRC_CORE_TEXTSTREAM_INCLUDED_H_
 
-#include <QtCore/QByteArray>   // for QByteArray
-#include <QtCore/QIODevice>    // for QIODevice, QIODevice::OpenModeFlag
+#include <QtCore/QIODevice>    // for QIODevice, QIODevice::OpenMode
 #include <QtCore/QString>      // for QString
 #include <QtCore/QTextCodec>   // for QTextCodec
 #include <QtCore/QTextStream>  // for QTextStream
@@ -32,7 +33,7 @@ namespace gpsbabel
 class TextStream : public QTextStream
 {
 public:
-  void open(const QString& fname, QIODevice::OpenModeFlag mode, const char* module, const char* codec = "UTF-8");
+  void open(const QString& fname, QIODevice::OpenMode mode, const char* module, const char* codec = "UTF-8");
   void close();
 
 private:
@@ -41,3 +42,4 @@ private:
 };
 
 } // namespace
+#endif // SRC_CORE_TEXTSTREAM_INCLUDED_H_


### PR DESCRIPTION
Previously only an open mode flag was accepted, now a combination
of flags will be accepted.