### PR TITLE
Improve xcsv modularization, fix some xcsv end cases. 

### DIFF
--- a/holux.cc
+++ b/holux.cc
@@ -191,6 +191,11 @@ static void holux_disp(const Waypoint* wpt)
   }
 
   short sIndex = le_read16(&((WPTHDR*)HxWFile)->num);
+
+  if (sIndex >= MAXWPT) {
+    fatal(MYNAME ": too many waypoints.  Max is %d.\n", MAXWPT);
+  }
+
   ((WPTHDR*)HxWFile)->idx[sIndex] = sIndex;          /* set the waypoint index  */
   le_write16(&((WPTHDR*)HxWFile)->idx[sIndex], sIndex);          /* set the waypoint index  */
   ((WPTHDR*)HxWFile)->used[sIndex] = 0xff;            /* Waypoint used */

--- a/main.cc
+++ b/main.cc
@@ -488,6 +488,9 @@ run(const char* prog_name)
       global_opts.masked_objective |= WPTDATAMASK;
     }
 
+    /* reinitialize xcsv in case two formats that use xcsv were given */
+    (void) Vecs::Instance().find_vec(ivecs->get_name());
+
     cet_convert_init(ivecs->get_encode(), 1);
 
     start_session(ivecs->get_name(), qargs.at(0));
@@ -498,6 +501,9 @@ run(const char* prog_name)
     cet_convert_deinit();
 
     if (qargs.size() == 2 && ovecs) {
+      /* reinitialize xcsv in case two formats that use xcsv were given */
+      (void) Vecs::Instance().find_vec(ovecs->get_name());
+
       cet_convert_init(ovecs->get_encode(), 1);
 
       ovecs->wr_init(qargs.at(1));

--- a/reference/csv_csv.gpx
+++ b/reference/csv_csv.gpx
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
+  <time>1970-01-01T00:00:00Z</time>
+  <bounds minlat="35.972030000" minlon="-87.134700000" maxlat="36.112180000" maxlon="-86.620120000"/>
+  <wpt lat="35.972030000" lon="-87.134700000">
+    <name>Mountain Bike Heaven by susy1313</name>
+    <cmt>Mountain Bike Heaven by susy1313</cmt>
+    <desc>Mountain Bike Heaven by susy1313</desc>
+  </wpt>
+  <wpt lat="36.090680000" lon="-86.679550000">
+    <name>The Troll by a182pilot &amp; Family</name>
+    <cmt>The Troll by a182pilot &amp; Family</cmt>
+    <desc>The Troll by a182pilot &amp; Family</desc>
+  </wpt>
+  <wpt lat="35.996270000" lon="-86.620120000">
+    <name>Dive Bomber by JoGPS &amp; family</name>
+    <cmt>Dive Bomber by JoGPS &amp; family</cmt>
+    <desc>Dive Bomber by JoGPS &amp; family</desc>
+  </wpt>
+  <wpt lat="36.038480000" lon="-86.648620000">
+    <name>FOSTER by JoGPS &amp; Family</name>
+    <cmt>FOSTER by JoGPS &amp; Family</cmt>
+    <desc>FOSTER by JoGPS &amp; Family</desc>
+  </wpt>
+  <wpt lat="36.112180000" lon="-86.741770000">
+    <name>Logan Lighthouse by JoGps &amp; Family</name>
+    <cmt>Logan Lighthouse by JoGps &amp; Family</cmt>
+    <desc>Logan Lighthouse by JoGps &amp; Family</desc>
+  </wpt>
+  <wpt lat="36.064080000" lon="-86.790520000">
+    <name>Ganier Cache by Susy1313</name>
+    <cmt>Ganier Cache by Susy1313</cmt>
+    <desc>Ganier Cache by Susy1313</desc>
+  </wpt>
+  <wpt lat="36.087770000" lon="-86.809730000">
+    <name>Shy's Hill by FireFighterEng33</name>
+    <cmt>Shy's Hill by FireFighterEng33</cmt>
+    <desc>Shy's Hill by FireFighterEng33</desc>
+  </wpt>
+  <wpt lat="36.057500000" lon="-86.892000000">
+    <name>GittyUp by JoGPS / Warner Parks</name>
+    <cmt>GittyUp by JoGPS / Warner Parks</cmt>
+    <desc>GittyUp by JoGPS / Warner Parks</desc>
+  </wpt>
+  <wpt lat="36.082800000" lon="-86.867280000">
+    <name>Inlighting by JoGPS / Warner Parks</name>
+    <cmt>Inlighting by JoGPS / Warner Parks</cmt>
+    <desc>Inlighting by JoGPS / Warner Parks</desc>
+  </wpt>
+  <wpt lat="35.972030000" lon="-87.134700000">
+    <name>Mountain Bike Heaven by susy1313</name>
+    <cmt>Mountain Bike Heaven by susy1313</cmt>
+    <desc>Mountain Bike Heaven by susy1313</desc>
+  </wpt>
+  <wpt lat="36.090680000" lon="-86.679550000">
+    <name>The Troll by a182pilot &amp; Family</name>
+    <cmt>The Troll by a182pilot &amp; Family</cmt>
+    <desc>The Troll by a182pilot &amp; Family</desc>
+  </wpt>
+  <wpt lat="35.996270000" lon="-86.620120000">
+    <name>Dive Bomber by JoGPS &amp; family</name>
+    <cmt>Dive Bomber by JoGPS &amp; family</cmt>
+    <desc>Dive Bomber by JoGPS &amp; family</desc>
+  </wpt>
+  <wpt lat="36.038480000" lon="-86.648620000">
+    <name>FOSTER by JoGPS &amp; Family</name>
+    <cmt>FOSTER by JoGPS &amp; Family</cmt>
+    <desc>FOSTER by JoGPS &amp; Family</desc>
+  </wpt>
+  <wpt lat="36.112180000" lon="-86.741770000">
+    <name>Logan Lighthouse by JoGps &amp; Family</name>
+    <cmt>Logan Lighthouse by JoGps &amp; Family</cmt>
+    <desc>Logan Lighthouse by JoGps &amp; Family</desc>
+  </wpt>
+  <wpt lat="36.064080000" lon="-86.790520000">
+    <name>Ganier Cache by Susy1313</name>
+    <cmt>Ganier Cache by Susy1313</cmt>
+    <desc>Ganier Cache by Susy1313</desc>
+  </wpt>
+  <wpt lat="36.087770000" lon="-86.809730000">
+    <name>Shy's Hill by FireFighterEng33</name>
+    <cmt>Shy's Hill by FireFighterEng33</cmt>
+    <desc>Shy's Hill by FireFighterEng33</desc>
+  </wpt>
+  <wpt lat="36.057500000" lon="-86.892000000">
+    <name>GittyUp by JoGPS / Warner Parks</name>
+    <cmt>GittyUp by JoGPS / Warner Parks</cmt>
+    <desc>GittyUp by JoGPS / Warner Parks</desc>
+  </wpt>
+  <wpt lat="36.082800000" lon="-86.867280000">
+    <name>Inlighting by JoGPS / Warner Parks</name>
+    <cmt>Inlighting by JoGPS / Warner Parks</cmt>
+    <desc>Inlighting by JoGPS / Warner Parks</desc>
+  </wpt>
+</gpx>

--- a/reference/csv_csvb.gpx
+++ b/reference/csv_csvb.gpx
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
+  <time>1970-01-01T00:00:00Z</time>
+  <bounds minlat="-87.134700000" minlon="-87.134700000" maxlat="36.112180000" maxlon="36.112180000"/>
+  <wpt lat="35.972030000" lon="-87.134700000">
+    <name>Mountain Bike Heaven by susy1313</name>
+    <cmt>Mountain Bike Heaven by susy1313</cmt>
+    <desc>Mountain Bike Heaven by susy1313</desc>
+  </wpt>
+  <wpt lat="36.090680000" lon="-86.679550000">
+    <name>The Troll by a182pilot &amp; Family</name>
+    <cmt>The Troll by a182pilot &amp; Family</cmt>
+    <desc>The Troll by a182pilot &amp; Family</desc>
+  </wpt>
+  <wpt lat="35.996270000" lon="-86.620120000">
+    <name>Dive Bomber by JoGPS &amp; family</name>
+    <cmt>Dive Bomber by JoGPS &amp; family</cmt>
+    <desc>Dive Bomber by JoGPS &amp; family</desc>
+  </wpt>
+  <wpt lat="36.038480000" lon="-86.648620000">
+    <name>FOSTER by JoGPS &amp; Family</name>
+    <cmt>FOSTER by JoGPS &amp; Family</cmt>
+    <desc>FOSTER by JoGPS &amp; Family</desc>
+  </wpt>
+  <wpt lat="36.112180000" lon="-86.741770000">
+    <name>Logan Lighthouse by JoGps &amp; Family</name>
+    <cmt>Logan Lighthouse by JoGps &amp; Family</cmt>
+    <desc>Logan Lighthouse by JoGps &amp; Family</desc>
+  </wpt>
+  <wpt lat="36.064080000" lon="-86.790520000">
+    <name>Ganier Cache by Susy1313</name>
+    <cmt>Ganier Cache by Susy1313</cmt>
+    <desc>Ganier Cache by Susy1313</desc>
+  </wpt>
+  <wpt lat="36.087770000" lon="-86.809730000">
+    <name>Shy's Hill by FireFighterEng33</name>
+    <cmt>Shy's Hill by FireFighterEng33</cmt>
+    <desc>Shy's Hill by FireFighterEng33</desc>
+  </wpt>
+  <wpt lat="36.057500000" lon="-86.892000000">
+    <name>GittyUp by JoGPS / Warner Parks</name>
+    <cmt>GittyUp by JoGPS / Warner Parks</cmt>
+    <desc>GittyUp by JoGPS / Warner Parks</desc>
+  </wpt>
+  <wpt lat="36.082800000" lon="-86.867280000">
+    <name>Inlighting by JoGPS / Warner Parks</name>
+    <cmt>Inlighting by JoGPS / Warner Parks</cmt>
+    <desc>Inlighting by JoGPS / Warner Parks</desc>
+  </wpt>
+  <wpt lat="-87.134700000" lon="35.972030000">
+    <name>Mountain Bike Heaven by susy1313</name>
+    <cmt>Mountain Bike Heaven by susy1313</cmt>
+    <desc>Mountain Bike Heaven by susy1313</desc>
+  </wpt>
+  <wpt lat="-86.679550000" lon="36.090680000">
+    <name>The Troll by a182pilot &amp; Family</name>
+    <cmt>The Troll by a182pilot &amp; Family</cmt>
+    <desc>The Troll by a182pilot &amp; Family</desc>
+  </wpt>
+  <wpt lat="-86.620120000" lon="35.996270000">
+    <name>Dive Bomber by JoGPS &amp; family</name>
+    <cmt>Dive Bomber by JoGPS &amp; family</cmt>
+    <desc>Dive Bomber by JoGPS &amp; family</desc>
+  </wpt>
+  <wpt lat="-86.648620000" lon="36.038480000">
+    <name>FOSTER by JoGPS &amp; Family</name>
+    <cmt>FOSTER by JoGPS &amp; Family</cmt>
+    <desc>FOSTER by JoGPS &amp; Family</desc>
+  </wpt>
+  <wpt lat="-86.741770000" lon="36.112180000">
+    <name>Logan Lighthouse by JoGps &amp; Family</name>
+    <cmt>Logan Lighthouse by JoGps &amp; Family</cmt>
+    <desc>Logan Lighthouse by JoGps &amp; Family</desc>
+  </wpt>
+  <wpt lat="-86.790520000" lon="36.064080000">
+    <name>Ganier Cache by Susy1313</name>
+    <cmt>Ganier Cache by Susy1313</cmt>
+    <desc>Ganier Cache by Susy1313</desc>
+  </wpt>
+  <wpt lat="-86.809730000" lon="36.087770000">
+    <name>Shy's Hill by FireFighterEng33</name>
+    <cmt>Shy's Hill by FireFighterEng33</cmt>
+    <desc>Shy's Hill by FireFighterEng33</desc>
+  </wpt>
+  <wpt lat="-86.892000000" lon="36.057500000">
+    <name>GittyUp by JoGPS / Warner Parks</name>
+    <cmt>GittyUp by JoGPS / Warner Parks</cmt>
+    <desc>GittyUp by JoGPS / Warner Parks</desc>
+  </wpt>
+  <wpt lat="-86.867280000" lon="36.082800000">
+    <name>Inlighting by JoGPS / Warner Parks</name>
+    <cmt>Inlighting by JoGPS / Warner Parks</cmt>
+    <desc>Inlighting by JoGPS / Warner Parks</desc>
+  </wpt>
+</gpx>

--- a/reference/csvb.csv
+++ b/reference/csvb.csv
@@ -1,0 +1,9 @@
+-87.13470, 35.97203, Mountain Bike Heaven by susy1313
+-86.67955, 36.09068, The Troll by a182pilot & Family
+-86.62012, 35.99627, Dive Bomber by JoGPS & family
+-86.64862, 36.03848, FOSTER by JoGPS & Family
+-86.74177, 36.11218, Logan Lighthouse by JoGps & Family
+-86.79052, 36.06408, Ganier Cache by Susy1313
+-86.80973, 36.08777, Shy's Hill by FireFighterEng33
+-86.89200, 36.05750, GittyUp by JoGPS / Warner Parks
+-86.86728, 36.08280, Inlighting by JoGPS / Warner Parks

--- a/reference/filter0.txt
+++ b/reference/filter0.txt
@@ -1,0 +1,18 @@
+bend	Add points before and after bends in routes
+polygon	Include Only Points Inside Polygon
+arc	Include Only Points Within Distance of Arc
+radius	Include Only Points Within Radius
+interpolate	Interpolate between trackpoints
+height	Manipulate altitudes
+track	Manipulate track lists
+sort	Rearrange waypoints, routes and/or tracks by resorting
+nuketypes	Remove all waypoints, tracks, or routes
+duplicate	Remove Duplicates
+position	Remove Points Within Distance
+discard	Remove unreliable points with high hdop or vdop
+reverse	Reverse stops within routes
+stack	Save and restore waypoint lists
+simplify	Simplify routes
+swap	Swap latitude and longitude of all loaded points
+transform	Transform waypoints into a route, tracks into routes, ...
+validate	Validate internal data structures

--- a/reference/filter1.txt
+++ b/reference/filter1.txt
@@ -1,0 +1,112 @@
+bend	Add points before and after bends in routes	https://www.gpsbabel.org/htmldoc-1.6.0/filter_bend.html
+option	bend	distance	Distance to the bend in meters where the new points will be added	float	25			https://www.gpsbabel.org/htmldoc-1.6.0/filter_bend.html#fmt_bend_o_distance
+option	bend	minangle	Minimum bend angle in degrees	float	5			https://www.gpsbabel.org/htmldoc-1.6.0/filter_bend.html#fmt_bend_o_minangle
+polygon	Include Only Points Inside Polygon	https://www.gpsbabel.org/htmldoc-1.6.0/filter_polygon.html
+option	polygon	file	File containing vertices of polygon	file				https://www.gpsbabel.org/htmldoc-1.6.0/filter_polygon.html#fmt_polygon_o_file
+option	polygon	exclude	Exclude points inside the polygon	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_polygon.html#fmt_polygon_o_exclude
+arc	Include Only Points Within Distance of Arc	https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html
+option	arc	file	File containing vertices of arc	file				https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html#fmt_arc_o_file
+option	arc	rte	Route(s) are vertices of arc	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html#fmt_arc_o_rte
+option	arc	trk	Track(s) are vertices of arc	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html#fmt_arc_o_trk
+option	arc	distance	Maximum distance from arc	float				https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html#fmt_arc_o_distance
+option	arc	exclude	Exclude points close to the arc	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html#fmt_arc_o_exclude
+option	arc	points	Use distance from vertices not lines	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html#fmt_arc_o_points
+option	arc	project	Move waypoints to its projection on lines or vertices	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_arc.html#fmt_arc_o_project
+radius	Include Only Points Within Radius	https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html
+option	radius	lat	Latitude for center point (D.DDDDD)	float				https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html#fmt_radius_o_lat
+option	radius	lon	Longitude for center point (D.DDDDD)	float				https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html#fmt_radius_o_lon
+option	radius	distance	Maximum distance from center	float				https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html#fmt_radius_o_distance
+option	radius	exclude	Exclude points close to center	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html#fmt_radius_o_exclude
+option	radius	nosort	Inhibit sort by distance to center	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html#fmt_radius_o_nosort
+option	radius	maxcount	Output no more than this number of points	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html#fmt_radius_o_maxcount
+option	radius	asroute	Put resulting waypoints in route of this name	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_radius.html#fmt_radius_o_asroute
+interpolate	Interpolate between trackpoints	https://www.gpsbabel.org/htmldoc-1.6.0/filter_interpolate.html
+option	interpolate	time	Time interval in seconds	integer		0		https://www.gpsbabel.org/htmldoc-1.6.0/filter_interpolate.html#fmt_interpolate_o_time
+option	interpolate	distance	Distance interval in miles or kilometers	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_interpolate.html#fmt_interpolate_o_distance
+option	interpolate	route	Interpolate routes instead	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_interpolate.html#fmt_interpolate_o_route
+height	Manipulate altitudes	https://www.gpsbabel.org/htmldoc-1.6.0/filter_height.html
+option	height	add	Adds a constant value to every altitude (meter, append "f" (x.xxf) for feet)	float				https://www.gpsbabel.org/htmldoc-1.6.0/filter_height.html#fmt_height_o_add
+option	height	wgs84tomsl	Converts WGS84 ellipsoidal height to orthometric height (MSL)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_height.html#fmt_height_o_wgs84tomsl
+track	Manipulate track lists	https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html
+option	track	move	Correct trackpoint timestamps by a delta	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_move
+option	track	pack	Pack all tracks into one	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_pack
+option	track	split	Split by date or time interval (see README)	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_split
+option	track	sdistance	Split by distance	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_sdistance
+option	track	merge	Merge multiple tracks for the same way	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_merge
+option	track	name	Use only track(s) where title matches given name	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_name
+option	track	start	Use only track points after this timestamp	integer				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_start
+option	track	stop	Use only track points before this timestamp	integer				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_stop
+option	track	title	Basic title for new track(s)	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_title
+option	track	fix	Synthesize GPS fixes (PPS, DGPS, 3D, 2D, NONE)	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_fix
+option	track	course	Synthesize course	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_course
+option	track	speed	Synthesize speed	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_speed
+option	track	seg2trk	Split track at segment boundaries into multiple tracks	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_seg2trk
+option	track	trk2seg	Merge tracks inserting segment separators at boundaries	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_trk2seg
+option	track	segment	segment tracks with abnormally long gaps	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_segment
+option	track	faketime	Add specified timestamp to each trackpoint	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_faketime
+option	track	discard	Discard track points without timestamps during merge	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_discard
+option	track	minimum_points	Discard tracks with fewer than these points	integer		0	50	https://www.gpsbabel.org/htmldoc-1.6.0/filter_track.html#fmt_track_o_minimum_points
+sort	Rearrange waypoints, routes and/or tracks by resorting	https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html
+option	sort	description	Sort waypoints by description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_description
+option	sort	gcid	Sort waypoints by numeric geocache ID	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_gcid
+option	sort	shortname	Sort waypoints by short name	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_shortname
+option	sort	time	Sort waypoints by time	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_time
+option	sort	rtedesc	Sort routes by description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_rtedesc
+option	sort	rtename	Sort routes by name	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_rtename
+option	sort	rtenum	Sort routes by number	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_rtenum
+option	sort	trkdesc	Sort tracks by description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_trkdesc
+option	sort	trkname	Sort tracks by name	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_trkname
+option	sort	trknum	Sort tracks by number	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_sort.html#fmt_sort_o_trknum
+nuketypes	Remove all waypoints, tracks, or routes	https://www.gpsbabel.org/htmldoc-1.6.0/filter_nuketypes.html
+option	nuketypes	waypoints	Remove all waypoints from data stream	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_nuketypes.html#fmt_nuketypes_o_waypoints
+option	nuketypes	tracks	Remove all tracks from data stream	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_nuketypes.html#fmt_nuketypes_o_tracks
+option	nuketypes	routes	Remove all routes from data stream	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_nuketypes.html#fmt_nuketypes_o_routes
+duplicate	Remove Duplicates	https://www.gpsbabel.org/htmldoc-1.6.0/filter_duplicate.html
+option	duplicate	shortname	Suppress duplicate waypoints based on name	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_duplicate.html#fmt_duplicate_o_shortname
+option	duplicate	location	Suppress duplicate waypoint based on coords	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_duplicate.html#fmt_duplicate_o_location
+option	duplicate	all	Suppress all instances of duplicates	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_duplicate.html#fmt_duplicate_o_all
+option	duplicate	correct	Use coords from duplicate points	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_duplicate.html#fmt_duplicate_o_correct
+position	Remove Points Within Distance	https://www.gpsbabel.org/htmldoc-1.6.0/filter_position.html
+option	position	distance	Maximum positional distance	float				https://www.gpsbabel.org/htmldoc-1.6.0/filter_position.html#fmt_position_o_distance
+option	position	all	Suppress all points close to other points	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_position.html#fmt_position_o_all
+option	position	time	Maximum time in seconds between two points	float				https://www.gpsbabel.org/htmldoc-1.6.0/filter_position.html#fmt_position_o_time
+discard	Remove unreliable points with high hdop or vdop	https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html
+option	discard	hdop	Suppress points with higher hdop	float	-1.0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_hdop
+option	discard	vdop	Suppress points with higher vdop	float	-1.0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_vdop
+option	discard	hdopandvdop	Link hdop and vdop suppression with AND	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_hdopandvdop
+option	discard	sat	Minimum sats to keep points	integer	-1.0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_sat
+option	discard	fixnone	Suppress points without fix	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_fixnone
+option	discard	fixunknown	Suppress points with unknown fix	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_fixunknown
+option	discard	elemin	Suppress points below given elevation in meters	integer				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_elemin
+option	discard	elemax	Suppress points above given elevation in meters	integer				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_elemax
+option	discard	matchname	Suppress points where name matches given name	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_matchname
+option	discard	matchdesc	Suppress points where description matches given name	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_matchdesc
+option	discard	matchcmt	Suppress points where comment matches given name	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_matchcmt
+option	discard	matchicon	Suppress points where type matches given name	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_discard.html#fmt_discard_o_matchicon
+reverse	Reverse stops within routes	https://www.gpsbabel.org/htmldoc-1.6.0/filter_reverse.html
+stack	Save and restore waypoint lists	https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html
+option	stack	push	Push waypoint list onto stack	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_push
+option	stack	pop	Pop waypoint list from stack	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_pop
+option	stack	swap	Swap waypoint list with <depth> item on stack	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_swap
+option	stack	copy	(push) Copy waypoint list	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_copy
+option	stack	append	(pop) Append list	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_append
+option	stack	discard	(pop) Discard top of stack	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_discard
+option	stack	replace	(pop) Replace list (default)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_replace
+option	stack	depth	(swap) Item to use (default=1)	integer		0		https://www.gpsbabel.org/htmldoc-1.6.0/filter_stack.html#fmt_stack_o_depth
+simplify	Simplify routes	https://www.gpsbabel.org/htmldoc-1.6.0/filter_simplify.html
+option	simplify	count	Maximum number of points in route	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/filter_simplify.html#fmt_simplify_o_count
+option	simplify	error	Maximum error	string		0		https://www.gpsbabel.org/htmldoc-1.6.0/filter_simplify.html#fmt_simplify_o_error
+option	simplify	crosstrack	Use cross-track error (default)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_simplify.html#fmt_simplify_o_crosstrack
+option	simplify	length	Use arclength error	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_simplify.html#fmt_simplify_o_length
+option	simplify	relative	Use relative error	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/filter_simplify.html#fmt_simplify_o_relative
+swap	Swap latitude and longitude of all loaded points	https://www.gpsbabel.org/htmldoc-1.6.0/filter_swap.html
+transform	Transform waypoints into a route, tracks into routes, ...	https://www.gpsbabel.org/htmldoc-1.6.0/filter_transform.html
+option	transform	wpt	Transform track(s) or route(s) into waypoint(s) [R/T]	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_transform.html#fmt_transform_o_wpt
+option	transform	rte	Transform waypoint(s) or track(s) into route(s) [W/T]	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_transform.html#fmt_transform_o_rte
+option	transform	trk	Transform waypoint(s) or route(s) into tracks(s) [W/R]	string				https://www.gpsbabel.org/htmldoc-1.6.0/filter_transform.html#fmt_transform_o_trk
+option	transform	rptdigits	Number of digits in generated names	integer		2		https://www.gpsbabel.org/htmldoc-1.6.0/filter_transform.html#fmt_transform_o_rptdigits
+option	transform	rptname	Use source name for route point names	boolean	N			https://www.gpsbabel.org/htmldoc-1.6.0/filter_transform.html#fmt_transform_o_rptname
+option	transform	del	Delete source data after transformation	boolean	N			https://www.gpsbabel.org/htmldoc-1.6.0/filter_transform.html#fmt_transform_o_del
+validate	Validate internal data structures	https://www.gpsbabel.org/htmldoc-1.6.0/filter_validate.html
+option	validate	checkempty	Check for empty input	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_validate.html#fmt_validate_o_checkempty
+option	validate	debug	Output debug messages instead of possibly issuing a fatal error	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/filter_validate.html#fmt_validate_o_debug

--- a/reference/filterusage.txt
+++ b/reference/filterusage.txt
@@ -1,0 +1,10 @@
+
+	radius                Include Only Points Within Radius                 
+	  lat                   Latitude for center point (D.DDDDD) (required)
+	  lon                   Longitude for center point (D.DDDDD) (required)
+	  distance              Maximum distance from center (required)
+	  exclude               Exclude points close to center 
+	  nosort                Inhibit sort by distance to center 
+	  maxcount              Output no more than this number of points 
+	  asroute               Put resulting waypoints in route of this name 
+

--- a/reference/format0.txt
+++ b/reference/format0.txt
@@ -1,0 +1,161 @@
+alantrl	trl	Alan Map500 tracklogs (.trl)
+alanwpr	wpr	Alan Map500 waypoints and routes (.wpr)
+baroiq		Brauniger IQ Series Barograph Download
+bushnell_trl	trl	Bushnell GPS Trail file
+bushnell	wpt	Bushnell GPS Waypoint file
+cambridge	dat	Cambridge/Winpilot glider software
+cst	cst	CarteSurTable data file
+v900		Columbus/Visiontac V900 files (.csv)
+csv		Comma separated values
+compegps		CompeGPS data files (.wpt/.trk/.rte)
+iblue747	csv	Data Logger iBlue747 csv
+iblue757	csv	Data Logger iBlue757 csv
+an1	an1	DeLorme .an1 (drawing) file
+gpl	gpl	DeLorme GPL
+saplus		DeLorme Street Atlas Plus
+saroute	anr	DeLorme Street Atlas Route
+xmap	wpt	DeLorme XMap HH Native .WPT
+xmap2006	txt	DeLorme XMap/SAHH 2006 Native .TXT
+xmapwpt		DeLorme XMat HH Street Atlas USA .WPT (PPC)
+destinator_itn	dat	Destinator Itineraries (.dat)
+destinator_poi	dat	Destinator Points of Interest (.dat)
+destinator_trl	dat	Destinator TrackLogs (.dat)
+easygps	loc	EasyGPS binary format
+exif	jpg	Embedded Exif-GPS data (.jpg)
+energympro	cpo	Energympro GPS training watch
+enigma	ert	Enigma binary waypoint file (.ert)
+shape	shp	ESRI shapefile
+f90g	map	F90G Automobile DVR GPS log file
+igc		FAI/IGC Flight Recorder Data Format
+garmin_fit	fit	Flexible and Interoperable Data Transfer (FIT) Activity file
+flysight	csv	FlySight GPS File
+gpssim	gpssim	Franson GPSGate Simulation
+fugawi	txt	Fugawi
+g7towin	g7t	G7ToWin data files (.g7t)
+garmin301		Garmin 301 Custom position and heartrate
+garmin_g1000	csv	Garmin G1000 datalog input filter file
+glogbook	xml	Garmin Logbook XML
+gdb	gdb	Garmin MapSource - gdb
+mapsource	mps	Garmin MapSource - mps
+garmin_txt	txt	Garmin MapSource - txt (tab delimited)
+pcx	pcx	Garmin PCX5
+garmin_poi		Garmin POI database
+garmin_gpi	gpi	Garmin Points of Interest (.gpi)
+garmin		Garmin serial/USB protocol
+gtrnctr	tcx/crs/hst/xml	Garmin Training Center (.tcx/.crs/.hst/.xml)
+geo	loc	Geocaching.com .loc
+ggv_ovl	ovl	Geogrid-Viewer ascii overlay file (.ovl)
+ggv_bin	ovl	Geogrid-Viewer binary overlay file (.ovl)
+ggv_log	log	Geogrid-Viewer tracklogs (.log)
+geojson	json	GeoJson
+geonet	txt	GEOnet Names Server (GNS)
+dg-100		GlobalSat DG-100/BT-335 Download
+dg-200		GlobalSat DG-200 Download
+globalsat		GlobalSat GH625XT GPS training watch
+googledir	xml	Google Directions XML
+kml	kml	Google Earth (Keyhole) Markup Language
+gnav_trl	trl	Google Navigator Tracklines (.trl)
+gopal	trk	GoPal GPS track log (.trk)
+land_air_sea	txt	GPS Tracking Key Pro text
+gtm	gtm	GPS TrackMaker
+arc	txt	GPSBabel arc filter file
+gpsdrive		GpsDrive Format
+gpsdrivetrack		GpsDrive Format for Tracks
+gpsman		GPSman
+gpsutil		gpsutil
+gpx	gpx	GPX XML
+hiketech	gps	HikeTech
+holux	wpo	Holux (gm-100) .wpo Format
+m241-bin	bin	Holux M-241 (MTK based) Binary File Format
+m241		Holux M-241 (MTK based) download
+vpl		Honda/Acura Navigation System VP Log File Format
+html	html	HTML Output
+humminbird_ht	ht	Humminbird tracks (.ht)
+humminbird	hwr	Humminbird waypoints and routes (.hwr)
+ignrando	rdn	IGN Rando track files
+igoprimo_poi	upoi	iGo Primo points of interest (.upoi)
+igo2008_poi	upoi	iGO2008 points of interest (.upoi)
+igo8	trk	IGO8 .trk
+jtr	jtr	Jelbert GeoTagger data file
+jogmap	xml	Jogmap.de XML format
+kompass_tk	wp	Kompass (DAV) Track (.tk)
+kompass_wp	wp	Kompass (DAV) Waypoints (.wp)
+psitrex		KuDaTa PsiTrex text
+lowranceusr	usr	Lowrance USR
+maggeo	gs	Magellan Explorist Geocaching
+mapsend		Magellan Mapsend
+magellanx	upt	Magellan SD files (as for eXplorist)
+magellan		Magellan SD files (as for Meridian)
+magellan		Magellan serial protocol
+ik3d	ikt	MagicMaps IK3D project file (.ikt)
+mainnav	nav	Mainnav
+tef	xml	Map&Guide 'TourExchangeFormat' XML
+mapasia_tr7	tr7	MapAsia track file (.tr7)
+mapbar	trk	Mapbar (China) navigation track for Sonim Xp3300
+mapfactor	xml	Mapfactor Navigator
+mapconverter	txt	Mapopolis.com Mapconverter CSV
+mxf	mxf	MapTech Exchange Format
+mtk_locus		MediaTek Locus
+mmo	mmo	Memory-Map Navigator overlay files (.mmo)
+s_and_t	txt	Microsoft Streets and Trips 2002-2007
+miniHomer		MiniHomer, a skyTraq Venus 6 based logger (download tracks, waypoints and get/set POI)
+garmin_xt		Mobile Garmin XT Track files
+motoactv	csv	Motoactiv CSV
+bcr	bcr	Motorrad Routenplaner (Map&Guide) .bcr files
+mtk-bin	bin	MTK Logger (iBlue 747,...) Binary File Format
+mtk		MTK Logger (iBlue 747,Qstarz BT-1000,...) download
+mynav	trc	MyNav TRC format
+tpg	tpg	National Geographic Topo .tpg (waypoints)
+tpo2	tpo	National Geographic Topo 2.x .tpo
+tpo3	tpo	National Geographic Topo 3.x/4.x .tpo
+navicache		Navicache.com XML
+nmn4	rte	Navigon Mobile Navigator .rte files
+navigonwpt		Navigon Waypoints
+navilink		NaviGPS GT-11/BGT-11 Download
+sbp	sbp	NaviGPS GT-31/BGT-31 datalogger (.sbp)
+sbn	sbn	NaviGPS GT-31/BGT-31 SiRF binary logfile (.sbn)
+naviguide	twl	Naviguide binary route file (.twl)
+navitel_trk	bin	Navitel binary track (.bin)
+dna	dna	Navitrak DNA marker format
+netstumbler		NetStumbler Summary File (text)
+nima		NIMA/GNIS Geographic Names File
+nmea		NMEA 0183 sentences
+lmx		Nokia Landmark Exchange
+osm	osm	OpenStreetMap data files
+ozi		OziExplorer
+pocketfms_bc		PocketFMS breadcrumbs
+pocketfms_fp	xml	PocketFMS flightplan (.xml)
+pocketfms_wp	txt	PocketFMS waypoints (.txt)
+raymarine	rwf	Raymarine Waypoint File (.rwf)
+ricoh	log	Ricoh GPS Log File
+cup	cup	See You flight analysis data
+skyforce		Skymap / KMD150 ascii files
+skytraq		SkyTraq Venus based loggers (download)
+skytraq-bin	bin	SkyTraq Venus based loggers Binary File Format
+subrip	srt	SubRip subtitles for video mapping (.srt)
+stmsdf	sdf	Suunto Trek Manager (STM) .sdf files
+stmwpp	txt	Suunto Trek Manager (STM) WaypointPlus files
+xol	xol	Swiss Map 25/50/100 (.xol)
+openoffice		Tab delimited fields useful for OpenOffice
+teletype		Teletype [ Get Jonathon Johnson to describe
+text	txt	Textual Output
+tomtom_itn	itn	TomTom Itineraries (.itn)
+tomtom_itn_places	itn	TomTom Places Itineraries (.itn)
+tomtom_asc	asc	TomTom POI file (.asc)
+tomtom	ov2	TomTom POI file (.ov2)
+tmpro	tmpro	TopoMapPro Places File
+dmtlog	trl	TrackLogs digital mapping (.trl)
+tiger		U.S. Census Bureau Tiger Mapping Service
+unicsv		Universal csv with field structure in first line
+vcard	vcf	Vcard Output (for iPod)
+vidaone	gpb	VidaOne GPS for Pocket PC (.gpb)
+vitosmt	smt	Vito Navigator II tracks
+vitovtt	vtt	Vito SmartMap tracks (.vtt)
+wfff	xml	WiFiFoFum 2.0 for PocketPC XML
+wintec_tes	tes	Wintec TES file
+wbt-bin	bin	Wintec WBT-100/200 Binary File Format
+wbt		Wintec WBT-100/200 GPS Download
+wbt-tk1	tk1	Wintec WBT-201/G-Rays 2 Binary File Format
+itracku		XAiOX iTrackU Logger
+itracku-bin	bin	XAiOX iTrackU Logger Binary File Format
+yahoo		Yahoo Geocode API data

--- a/reference/format1.txt
+++ b/reference/format1.txt
@@ -1,0 +1,165 @@
+internal	xcsv		? Character Separated Values
+file	alantrl	trl	Alan Map500 tracklogs (.trl)
+file	alanwpr	wpr	Alan Map500 waypoints and routes (.wpr)
+internal	tabsep		All database fields on one tab-separated line
+serial	baroiq		Brauniger IQ Series Barograph Download
+file	bushnell_trl	trl	Bushnell GPS Trail file
+file	bushnell	wpt	Bushnell GPS Waypoint file
+file	cambridge	dat	Cambridge/Winpilot glider software
+file	cst	cst	CarteSurTable data file
+file	v900		Columbus/Visiontac V900 files (.csv)
+file	csv		Comma separated values
+file	compegps		CompeGPS data files (.wpt/.trk/.rte)
+internal	custom		Custom "Everything" Style
+file	iblue747	csv	Data Logger iBlue747 csv
+file	iblue757	csv	Data Logger iBlue757 csv
+file	an1	an1	DeLorme .an1 (drawing) file
+file	gpl	gpl	DeLorme GPL
+file	saplus		DeLorme Street Atlas Plus
+file	saroute	anr	DeLorme Street Atlas Route
+file	xmap	wpt	DeLorme XMap HH Native .WPT
+file	xmap2006	txt	DeLorme XMap/SAHH 2006 Native .TXT
+file	xmapwpt		DeLorme XMat HH Street Atlas USA .WPT (PPC)
+file	destinator_itn	dat	Destinator Itineraries (.dat)
+file	destinator_poi	dat	Destinator Points of Interest (.dat)
+file	destinator_trl	dat	Destinator TrackLogs (.dat)
+file	easygps	loc	EasyGPS binary format
+file	exif	jpg	Embedded Exif-GPS data (.jpg)
+file	energympro	cpo	Energympro GPS training watch
+file	enigma	ert	Enigma binary waypoint file (.ert)
+file	shape	shp	ESRI shapefile
+file	f90g	map	F90G Automobile DVR GPS log file
+file	igc		FAI/IGC Flight Recorder Data Format
+file	garmin_fit	fit	Flexible and Interoperable Data Transfer (FIT) Activity file
+file	flysight	csv	FlySight GPS File
+file	gpssim	gpssim	Franson GPSGate Simulation
+file	fugawi	txt	Fugawi
+file	g7towin	g7t	G7ToWin data files (.g7t)
+file	garmin301		Garmin 301 Custom position and heartrate
+file	garmin_g1000	csv	Garmin G1000 datalog input filter file
+file	glogbook	xml	Garmin Logbook XML
+file	gdb	gdb	Garmin MapSource - gdb
+file	mapsource	mps	Garmin MapSource - mps
+file	garmin_txt	txt	Garmin MapSource - txt (tab delimited)
+file	pcx	pcx	Garmin PCX5
+file	garmin_poi		Garmin POI database
+file	garmin_gpi	gpi	Garmin Points of Interest (.gpi)
+serial	garmin		Garmin serial/USB protocol
+file	gtrnctr	tcx/crs/hst/xml	Garmin Training Center (.tcx/.crs/.hst/.xml)
+file	geo	loc	Geocaching.com .loc
+file	ggv_ovl	ovl	Geogrid-Viewer ascii overlay file (.ovl)
+file	ggv_bin	ovl	Geogrid-Viewer binary overlay file (.ovl)
+file	ggv_log	log	Geogrid-Viewer tracklogs (.log)
+file	geojson	json	GeoJson
+file	geonet	txt	GEOnet Names Server (GNS)
+serial	dg-100		GlobalSat DG-100/BT-335 Download
+serial	dg-200		GlobalSat DG-200 Download
+serial	globalsat		GlobalSat GH625XT GPS training watch
+file	googledir	xml	Google Directions XML
+file	kml	kml	Google Earth (Keyhole) Markup Language
+file	gnav_trl	trl	Google Navigator Tracklines (.trl)
+file	gopal	trk	GoPal GPS track log (.trk)
+file	land_air_sea	txt	GPS Tracking Key Pro text
+file	gtm	gtm	GPS TrackMaker
+file	arc	txt	GPSBabel arc filter file
+file	gpsdrive		GpsDrive Format
+file	gpsdrivetrack		GpsDrive Format for Tracks
+file	gpsman		GPSman
+file	gpsutil		gpsutil
+file	gpx	gpx	GPX XML
+file	hiketech	gps	HikeTech
+file	holux	wpo	Holux (gm-100) .wpo Format
+file	m241-bin	bin	Holux M-241 (MTK based) Binary File Format
+serial	m241		Holux M-241 (MTK based) download
+file	vpl		Honda/Acura Navigation System VP Log File Format
+file	html	html	HTML Output
+file	humminbird_ht	ht	Humminbird tracks (.ht)
+file	humminbird	hwr	Humminbird waypoints and routes (.hwr)
+file	ignrando	rdn	IGN Rando track files
+file	igoprimo_poi	upoi	iGo Primo points of interest (.upoi)
+file	igo2008_poi	upoi	iGO2008 points of interest (.upoi)
+file	igo8	trk	IGO8 .trk
+internal	random		Internal GPS data generator
+file	jtr	jtr	Jelbert GeoTagger data file
+file	jogmap	xml	Jogmap.de XML format
+file	kompass_tk	wp	Kompass (DAV) Track (.tk)
+file	kompass_wp	wp	Kompass (DAV) Waypoints (.wp)
+file	psitrex		KuDaTa PsiTrex text
+file	lowranceusr	usr	Lowrance USR
+file	maggeo	gs	Magellan Explorist Geocaching
+file	mapsend		Magellan Mapsend
+file	magellanx	upt	Magellan SD files (as for eXplorist)
+file	magellan		Magellan SD files (as for Meridian)
+serial	magellan		Magellan serial protocol
+file	ik3d	ikt	MagicMaps IK3D project file (.ikt)
+file	mainnav	nav	Mainnav
+file	tef	xml	Map&Guide 'TourExchangeFormat' XML
+file	mapasia_tr7	tr7	MapAsia track file (.tr7)
+file	mapbar	trk	Mapbar (China) navigation track for Sonim Xp3300
+file	mapfactor	xml	Mapfactor Navigator
+file	mapconverter	txt	Mapopolis.com Mapconverter CSV
+file	mxf	mxf	MapTech Exchange Format
+file	mtk_locus		MediaTek Locus
+file	mmo	mmo	Memory-Map Navigator overlay files (.mmo)
+file	s_and_t	txt	Microsoft Streets and Trips 2002-2007
+serial	miniHomer		MiniHomer, a skyTraq Venus 6 based logger (download tracks, waypoints and get/set POI)
+file	garmin_xt		Mobile Garmin XT Track files
+file	motoactv	csv	Motoactiv CSV
+file	bcr	bcr	Motorrad Routenplaner (Map&Guide) .bcr files
+file	mtk-bin	bin	MTK Logger (iBlue 747,...) Binary File Format
+serial	mtk		MTK Logger (iBlue 747,Qstarz BT-1000,...) download
+file	mynav	trc	MyNav TRC format
+file	tpg	tpg	National Geographic Topo .tpg (waypoints)
+file	tpo2	tpo	National Geographic Topo 2.x .tpo
+file	tpo3	tpo	National Geographic Topo 3.x/4.x .tpo
+file	navicache		Navicache.com XML
+file	nmn4	rte	Navigon Mobile Navigator .rte files
+file	navigonwpt		Navigon Waypoints
+serial	navilink		NaviGPS GT-11/BGT-11 Download
+file	sbp	sbp	NaviGPS GT-31/BGT-31 datalogger (.sbp)
+file	sbn	sbn	NaviGPS GT-31/BGT-31 SiRF binary logfile (.sbn)
+file	naviguide	twl	Naviguide binary route file (.twl)
+file	navitel_trk	bin	Navitel binary track (.bin)
+file	dna	dna	Navitrak DNA marker format
+file	netstumbler		NetStumbler Summary File (text)
+file	nima		NIMA/GNIS Geographic Names File
+file	nmea		NMEA 0183 sentences
+file	lmx		Nokia Landmark Exchange
+file	osm	osm	OpenStreetMap data files
+file	ozi		OziExplorer
+file	pocketfms_bc		PocketFMS breadcrumbs
+file	pocketfms_fp	xml	PocketFMS flightplan (.xml)
+file	pocketfms_wp	txt	PocketFMS waypoints (.txt)
+file	raymarine	rwf	Raymarine Waypoint File (.rwf)
+file	ricoh	log	Ricoh GPS Log File
+file	cup	cup	See You flight analysis data
+file	skyforce		Skymap / KMD150 ascii files
+serial	skytraq		SkyTraq Venus based loggers (download)
+file	skytraq-bin	bin	SkyTraq Venus based loggers Binary File Format
+file	subrip	srt	SubRip subtitles for video mapping (.srt)
+file	stmsdf	sdf	Suunto Trek Manager (STM) .sdf files
+file	stmwpp	txt	Suunto Trek Manager (STM) WaypointPlus files
+file	xol	xol	Swiss Map 25/50/100 (.xol)
+file	openoffice		Tab delimited fields useful for OpenOffice
+file	teletype		Teletype [ Get Jonathon Johnson to describe
+file	text	txt	Textual Output
+file	tomtom_itn	itn	TomTom Itineraries (.itn)
+file	tomtom_itn_places	itn	TomTom Places Itineraries (.itn)
+file	tomtom_asc	asc	TomTom POI file (.asc)
+file	tomtom	ov2	TomTom POI file (.ov2)
+file	tmpro	tmpro	TopoMapPro Places File
+file	dmtlog	trl	TrackLogs digital mapping (.trl)
+file	tiger		U.S. Census Bureau Tiger Mapping Service
+file	unicsv		Universal csv with field structure in first line
+file	vcard	vcf	Vcard Output (for iPod)
+file	vidaone	gpb	VidaOne GPS for Pocket PC (.gpb)
+file	vitosmt	smt	Vito Navigator II tracks
+file	vitovtt	vtt	Vito SmartMap tracks (.vtt)
+file	wfff	xml	WiFiFoFum 2.0 for PocketPC XML
+file	wintec_tes	tes	Wintec TES file
+file	wbt-bin	bin	Wintec WBT-100/200 Binary File Format
+serial	wbt		Wintec WBT-100/200 GPS Download
+file	wbt-tk1	tk1	Wintec WBT-201/G-Rays 2 Binary File Format
+serial	itracku		XAiOX iTrackU Logger
+file	itracku-bin	bin	XAiOX iTrackU Logger Binary File Format
+file	yahoo		Yahoo Geocode API data

--- a/reference/format2.txt
+++ b/reference/format2.txt
@@ -1,0 +1,165 @@
+internal	rw----	xcsv		? Character Separated Values
+file	--rw--	alantrl	trl	Alan Map500 tracklogs (.trl)
+file	rw--rw	alanwpr	wpr	Alan Map500 waypoints and routes (.wpr)
+internal	rw----	tabsep		All database fields on one tab-separated line
+serial	--r---	baroiq		Brauniger IQ Series Barograph Download
+file	--rw--	bushnell_trl	trl	Bushnell GPS Trail file
+file	rw----	bushnell	wpt	Bushnell GPS Waypoint file
+file	rw----	cambridge	dat	Cambridge/Winpilot glider software
+file	r-r-r-	cst	cst	CarteSurTable data file
+file	r-r---	v900		Columbus/Visiontac V900 files (.csv)
+file	rw----	csv		Comma separated values
+file	rwrwrw	compegps		CompeGPS data files (.wpt/.trk/.rte)
+internal	rw----	custom		Custom "Everything" Style
+file	--rw--	iblue747	csv	Data Logger iBlue747 csv
+file	--rw--	iblue757	csv	Data Logger iBlue757 csv
+file	rw-wrw	an1	an1	DeLorme .an1 (drawing) file
+file	--rw--	gpl	gpl	DeLorme GPL
+file	rw----	saplus		DeLorme Street Atlas Plus
+file	--r---	saroute	anr	DeLorme Street Atlas Route
+file	rw----	xmap	wpt	DeLorme XMap HH Native .WPT
+file	rw----	xmap2006	txt	DeLorme XMap/SAHH 2006 Native .TXT
+file	rw----	xmapwpt		DeLorme XMat HH Street Atlas USA .WPT (PPC)
+file	----rw	destinator_itn	dat	Destinator Itineraries (.dat)
+file	rw----	destinator_poi	dat	Destinator Points of Interest (.dat)
+file	--rw--	destinator_trl	dat	Destinator TrackLogs (.dat)
+file	rw----	easygps	loc	EasyGPS binary format
+file	rw----	exif	jpg	Embedded Exif-GPS data (.jpg)
+file	--r---	energympro	cpo	Energympro GPS training watch
+file	----rw	enigma	ert	Enigma binary waypoint file (.ert)
+file	rwrwrw	shape	shp	ESRI shapefile
+file	--r---	f90g	map	F90G Automobile DVR GPS log file
+file	--rwrw	igc		FAI/IGC Flight Recorder Data Format
+file	-wrw--	garmin_fit	fit	Flexible and Interoperable Data Transfer (FIT) Activity file
+file	rw----	flysight	csv	FlySight GPS File
+file	-w-w-w	gpssim	gpssim	Franson GPSGate Simulation
+file	rw----	fugawi	txt	Fugawi
+file	r-r-r-	g7towin	g7t	G7ToWin data files (.g7t)
+file	rw----	garmin301		Garmin 301 Custom position and heartrate
+file	--rw--	garmin_g1000	csv	Garmin G1000 datalog input filter file
+file	--rw--	glogbook	xml	Garmin Logbook XML
+file	rwrwrw	gdb	gdb	Garmin MapSource - gdb
+file	rwrwrw	mapsource	mps	Garmin MapSource - mps
+file	rwrwrw	garmin_txt	txt	Garmin MapSource - txt (tab delimited)
+file	rwrwrw	pcx	pcx	Garmin PCX5
+file	rw----	garmin_poi		Garmin POI database
+file	rw----	garmin_gpi	gpi	Garmin Points of Interest (.gpi)
+serial	rwrwrw	garmin		Garmin serial/USB protocol
+file	r-rw--	gtrnctr	tcx/crs/hst/xml	Garmin Training Center (.tcx/.crs/.hst/.xml)
+file	rw----	geo	loc	Geocaching.com .loc
+file	rwrwrw	ggv_ovl	ovl	Geogrid-Viewer ascii overlay file (.ovl)
+file	--r---	ggv_bin	ovl	Geogrid-Viewer binary overlay file (.ovl)
+file	--rw--	ggv_log	log	Geogrid-Viewer tracklogs (.log)
+file	rwrwrw	geojson	json	GeoJson
+file	rw----	geonet	txt	GEOnet Names Server (GNS)
+serial	r-r---	dg-100		GlobalSat DG-100/BT-335 Download
+serial	r-r---	dg-200		GlobalSat DG-200 Download
+serial	--r---	globalsat		GlobalSat GH625XT GPS training watch
+file	--r---	googledir	xml	Google Directions XML
+file	rwrwrw	kml	kml	Google Earth (Keyhole) Markup Language
+file	--rw--	gnav_trl	trl	Google Navigator Tracklines (.trl)
+file	--rw--	gopal	trk	GoPal GPS track log (.trk)
+file	--rw--	land_air_sea	txt	GPS Tracking Key Pro text
+file	rwrwrw	gtm	gtm	GPS TrackMaker
+file	rw----	arc	txt	GPSBabel arc filter file
+file	rw----	gpsdrive		GpsDrive Format
+file	rw----	gpsdrivetrack		GpsDrive Format for Tracks
+file	rw----	gpsman		GPSman
+file	rw----	gpsutil		gpsutil
+file	rwrwrw	gpx	gpx	GPX XML
+file	rwrw--	hiketech	gps	HikeTech
+file	rw----	holux	wpo	Holux (gm-100) .wpo Format
+file	r-r---	m241-bin	bin	Holux M-241 (MTK based) Binary File Format
+serial	--r---	m241		Holux M-241 (MTK based) download
+file	--r---	vpl		Honda/Acura Navigation System VP Log File Format
+file	-w----	html	html	HTML Output
+file	r-rwr-	humminbird_ht	ht	Humminbird tracks (.ht)
+file	rwr-rw	humminbird	hwr	Humminbird waypoints and routes (.hwr)
+file	--rw--	ignrando	rdn	IGN Rando track files
+file	rw----	igoprimo_poi	upoi	iGo Primo points of interest (.upoi)
+file	rw----	igo2008_poi	upoi	iGO2008 points of interest (.upoi)
+file	--rw--	igo8	trk	IGO8 .trk
+internal	r-r-r-	random		Internal GPS data generator
+file	--rw--	jtr	jtr	Jelbert GeoTagger data file
+file	--r---	jogmap	xml	Jogmap.de XML format
+file	--rw--	kompass_tk	wp	Kompass (DAV) Track (.tk)
+file	rw----	kompass_wp	wp	Kompass (DAV) Waypoints (.wp)
+file	rwrwrw	psitrex		KuDaTa PsiTrex text
+file	rwrwrw	lowranceusr	usr	Lowrance USR
+file	rw----	maggeo	gs	Magellan Explorist Geocaching
+file	rwrwrw	mapsend		Magellan Mapsend
+file	rwrwrw	magellanx	upt	Magellan SD files (as for eXplorist)
+file	rwrwrw	magellan		Magellan SD files (as for Meridian)
+serial	rwrwrw	magellan		Magellan serial protocol
+file	r-r---	ik3d	ikt	MagicMaps IK3D project file (.ikt)
+file	--rw--	mainnav	nav	Mainnav
+file	----r-	tef	xml	Map&Guide 'TourExchangeFormat' XML
+file	--rw--	mapasia_tr7	tr7	MapAsia track file (.tr7)
+file	--r---	mapbar	trk	Mapbar (China) navigation track for Sonim Xp3300
+file	rw----	mapfactor	xml	Mapfactor Navigator
+file	rw----	mapconverter	txt	Mapopolis.com Mapconverter CSV
+file	rw----	mxf	mxf	MapTech Exchange Format
+file	r-r---	mtk_locus		MediaTek Locus
+file	rwrwrw	mmo	mmo	Memory-Map Navigator overlay files (.mmo)
+file	rw----	s_and_t	txt	Microsoft Streets and Trips 2002-2007
+serial	r-r---	miniHomer		MiniHomer, a skyTraq Venus 6 based logger (download tracks, waypoints and get/set POI)
+file	--r---	garmin_xt		Mobile Garmin XT Track files
+file	rw----	motoactv	csv	Motoactiv CSV
+file	----rw	bcr	bcr	Motorrad Routenplaner (Map&Guide) .bcr files
+file	r-r---	mtk-bin	bin	MTK Logger (iBlue 747,...) Binary File Format
+serial	r-r---	mtk		MTK Logger (iBlue 747,Qstarz BT-1000,...) download
+file	--r---	mynav	trc	MyNav TRC format
+file	rw----	tpg	tpg	National Geographic Topo .tpg (waypoints)
+file	--r---	tpo2	tpo	National Geographic Topo 2.x .tpo
+file	r-r-r-	tpo3	tpo	National Geographic Topo 3.x/4.x .tpo
+file	r-----	navicache		Navicache.com XML
+file	----rw	nmn4	rte	Navigon Mobile Navigator .rte files
+file	rw----	navigonwpt		Navigon Waypoints
+serial	rwrwrw	navilink		NaviGPS GT-11/BGT-11 Download
+file	--r---	sbp	sbp	NaviGPS GT-31/BGT-31 datalogger (.sbp)
+file	--r---	sbn	sbn	NaviGPS GT-31/BGT-31 SiRF binary logfile (.sbn)
+file	rw----	naviguide	twl	Naviguide binary route file (.twl)
+file	--rw--	navitel_trk	bin	Navitel binary track (.bin)
+file	rw----	dna	dna	Navitrak DNA marker format
+file	r-----	netstumbler		NetStumbler Summary File (text)
+file	rw----	nima		NIMA/GNIS Geographic Names File
+file	rwrw--	nmea		NMEA 0183 sentences
+file	rw----	lmx		Nokia Landmark Exchange
+file	rw-wrw	osm	osm	OpenStreetMap data files
+file	rwrwrw	ozi		OziExplorer
+file	--rw--	pocketfms_bc		PocketFMS breadcrumbs
+file	r---r-	pocketfms_fp	xml	PocketFMS flightplan (.xml)
+file	rw----	pocketfms_wp	txt	PocketFMS waypoints (.txt)
+file	rw--rw	raymarine	rwf	Raymarine Waypoint File (.rwf)
+file	--rw--	ricoh	log	Ricoh GPS Log File
+file	rw----	cup	cup	See You flight analysis data
+file	rwrwrw	skyforce		Skymap / KMD150 ascii files
+serial	r-r---	skytraq		SkyTraq Venus based loggers (download)
+file	r-r---	skytraq-bin	bin	SkyTraq Venus based loggers Binary File Format
+file	---w--	subrip	srt	SubRip subtitles for video mapping (.srt)
+file	--rwrw	stmsdf	sdf	Suunto Trek Manager (STM) .sdf files
+file	rwrwrw	stmwpp	txt	Suunto Trek Manager (STM) WaypointPlus files
+file	rwrw--	xol	xol	Swiss Map 25/50/100 (.xol)
+file	rw----	openoffice		Tab delimited fields useful for OpenOffice
+file	r-----	teletype		Teletype [ Get Jonathon Johnson to describe
+file	-w----	text	txt	Textual Output
+file	----rw	tomtom_itn	itn	TomTom Itineraries (.itn)
+file	----rw	tomtom_itn_places	itn	TomTom Places Itineraries (.itn)
+file	rw----	tomtom_asc	asc	TomTom POI file (.asc)
+file	rw----	tomtom	ov2	TomTom POI file (.ov2)
+file	rw----	tmpro	tmpro	TopoMapPro Places File
+file	rwrw--	dmtlog	trl	TrackLogs digital mapping (.trl)
+file	rw----	tiger		U.S. Census Bureau Tiger Mapping Service
+file	rwrwrw	unicsv		Universal csv with field structure in first line
+file	-w----	vcard	vcf	Vcard Output (for iPod)
+file	--rw--	vidaone	gpb	VidaOne GPS for Pocket PC (.gpb)
+file	rwrwrw	vitosmt	smt	Vito Navigator II tracks
+file	--r---	vitovtt	vtt	Vito SmartMap tracks (.vtt)
+file	r-----	wfff	xml	WiFiFoFum 2.0 for PocketPC XML
+file	r-r---	wintec_tes	tes	Wintec TES file
+file	--r---	wbt-bin	bin	Wintec WBT-100/200 Binary File Format
+serial	r-r---	wbt		Wintec WBT-100/200 GPS Download
+file	--r---	wbt-tk1	tk1	Wintec WBT-201/G-Rays 2 Binary File Format
+serial	r-r---	itracku		XAiOX iTrackU Logger
+file	rwrw--	itracku-bin	bin	XAiOX iTrackU Logger Binary File Format
+file	r-----	yahoo		Yahoo Geocode API data

--- a/reference/format3.txt
+++ b/reference/format3.txt
@@ -1,0 +1,1474 @@
+internal	rw----	xcsv		? Character Separated Values	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html
+option	xcsv	style	Full path to XCSV style file	file				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_style
+
+option	xcsv	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_snlen
+
+option	xcsv	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_snwhite
+
+option	xcsv	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_snupper
+
+option	xcsv	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_snunique
+
+option	xcsv	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_urlbase
+
+option	xcsv	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_prefer_shortnames
+
+option	xcsv	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xcsv.html#fmt_xcsv_o_datum
+
+file	--rw--	alantrl	trl	Alan Map500 tracklogs (.trl)	alantrl
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_alantrl.html
+file	rw--rw	alanwpr	wpr	Alan Map500 waypoints and routes (.wpr)	alanwpr
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_alanwpr.html
+internal	rw----	tabsep		All database fields on one tab-separated line	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html
+option	tabsep	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html#fmt_tabsep_o_snlen
+
+option	tabsep	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html#fmt_tabsep_o_snwhite
+
+option	tabsep	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html#fmt_tabsep_o_snupper
+
+option	tabsep	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html#fmt_tabsep_o_snunique
+
+option	tabsep	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html#fmt_tabsep_o_urlbase
+
+option	tabsep	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html#fmt_tabsep_o_prefer_shortnames
+
+option	tabsep	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tabsep.html#fmt_tabsep_o_datum
+
+serial	--r---	baroiq		Brauniger IQ Series Barograph Download	baroiq
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_baroiq.html
+file	--rw--	bushnell_trl	trl	Bushnell GPS Trail file	bushnell_trl
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_bushnell_trl.html
+file	rw----	bushnell	wpt	Bushnell GPS Waypoint file	bushnell
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_bushnell.html
+file	rw----	cambridge	dat	Cambridge/Winpilot glider software	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html
+option	cambridge	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html#fmt_cambridge_o_snlen
+
+option	cambridge	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html#fmt_cambridge_o_snwhite
+
+option	cambridge	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html#fmt_cambridge_o_snupper
+
+option	cambridge	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html#fmt_cambridge_o_snunique
+
+option	cambridge	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html#fmt_cambridge_o_urlbase
+
+option	cambridge	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html#fmt_cambridge_o_prefer_shortnames
+
+option	cambridge	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cambridge.html#fmt_cambridge_o_datum
+
+file	r-r-r-	cst	cst	CarteSurTable data file	cst
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cst.html
+file	r-r---	v900		Columbus/Visiontac V900 files (.csv)	v900
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_v900.html
+file	rw----	csv		Comma separated values	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html
+option	csv	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html#fmt_csv_o_snlen
+
+option	csv	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html#fmt_csv_o_snwhite
+
+option	csv	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html#fmt_csv_o_snupper
+
+option	csv	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html#fmt_csv_o_snunique
+
+option	csv	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html#fmt_csv_o_urlbase
+
+option	csv	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html#fmt_csv_o_prefer_shortnames
+
+option	csv	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_csv.html#fmt_csv_o_datum
+
+file	rwrwrw	compegps		CompeGPS data files (.wpt/.trk/.rte)	compegps
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_compegps.html
+option	compegps	deficon	Default icon name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_compegps.html#fmt_compegps_o_deficon
+
+option	compegps	index	Index of route/track to write (if more than one in source)	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_compegps.html#fmt_compegps_o_index
+
+option	compegps	radius	Give points (waypoints/route points) a default radius (proximity)	float		0		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_compegps.html#fmt_compegps_o_radius
+
+option	compegps	snlen	Length of generated shortnames (default 16)	integer	16	1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_compegps.html#fmt_compegps_o_snlen
+
+internal	rw----	custom		Custom "Everything" Style	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html
+option	custom	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html#fmt_custom_o_snlen
+
+option	custom	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html#fmt_custom_o_snwhite
+
+option	custom	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html#fmt_custom_o_snupper
+
+option	custom	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html#fmt_custom_o_snunique
+
+option	custom	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html#fmt_custom_o_urlbase
+
+option	custom	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html#fmt_custom_o_prefer_shortnames
+
+option	custom	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_custom.html#fmt_custom_o_datum
+
+file	--rw--	iblue747	csv	Data Logger iBlue747 csv	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html
+option	iblue747	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html#fmt_iblue747_o_snlen
+
+option	iblue747	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html#fmt_iblue747_o_snwhite
+
+option	iblue747	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html#fmt_iblue747_o_snupper
+
+option	iblue747	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html#fmt_iblue747_o_snunique
+
+option	iblue747	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html#fmt_iblue747_o_urlbase
+
+option	iblue747	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html#fmt_iblue747_o_prefer_shortnames
+
+option	iblue747	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue747.html#fmt_iblue747_o_datum
+
+file	--rw--	iblue757	csv	Data Logger iBlue757 csv	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html
+option	iblue757	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html#fmt_iblue757_o_snlen
+
+option	iblue757	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html#fmt_iblue757_o_snwhite
+
+option	iblue757	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html#fmt_iblue757_o_snupper
+
+option	iblue757	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html#fmt_iblue757_o_snunique
+
+option	iblue757	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html#fmt_iblue757_o_urlbase
+
+option	iblue757	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html#fmt_iblue757_o_prefer_shortnames
+
+option	iblue757	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_iblue757.html#fmt_iblue757_o_datum
+
+file	rw-wrw	an1	an1	DeLorme .an1 (drawing) file	an1
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html
+option	an1	type	Type of .an1 file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_type
+
+option	an1	road	Road type changes	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_road
+
+option	an1	nogc	Do not add geocache data to description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_nogc
+
+option	an1	nourl	Do not add URLs to description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_nourl
+
+option	an1	deficon	Symbol to use for point data	string	Red Flag			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_deficon
+
+option	an1	color	Color for lines or mapnotes	string	red			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_color
+
+option	an1	zoom	Zoom level to reduce points	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_zoom
+
+option	an1	wpt_type	Waypoint type	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_wpt_type
+
+option	an1	radius	Radius for circles	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_an1.html#fmt_an1_o_radius
+
+file	--rw--	gpl	gpl	DeLorme GPL	gpl
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpl.html
+file	rw----	saplus		DeLorme Street Atlas Plus	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html
+option	saplus	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html#fmt_saplus_o_snlen
+
+option	saplus	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html#fmt_saplus_o_snwhite
+
+option	saplus	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html#fmt_saplus_o_snupper
+
+option	saplus	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html#fmt_saplus_o_snunique
+
+option	saplus	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html#fmt_saplus_o_urlbase
+
+option	saplus	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html#fmt_saplus_o_prefer_shortnames
+
+option	saplus	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saplus.html#fmt_saplus_o_datum
+
+file	--r---	saroute	anr	DeLorme Street Atlas Route	saroute
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saroute.html
+option	saroute	turns_important	Keep turns if simplify filter is used	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saroute.html#fmt_saroute_o_turns_important
+
+option	saroute	turns_only	Only read turns; skip all other points	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saroute.html#fmt_saroute_o_turns_only
+
+option	saroute	split	Split into multiple routes at turns	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saroute.html#fmt_saroute_o_split
+
+option	saroute	controls	Read control points as waypoint/route/none	string	none			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saroute.html#fmt_saroute_o_controls
+
+option	saroute	times	Synthesize track times	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_saroute.html#fmt_saroute_o_times
+
+file	rw----	xmap	wpt	DeLorme XMap HH Native .WPT	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html
+option	xmap	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html#fmt_xmap_o_snlen
+
+option	xmap	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html#fmt_xmap_o_snwhite
+
+option	xmap	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html#fmt_xmap_o_snupper
+
+option	xmap	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html#fmt_xmap_o_snunique
+
+option	xmap	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html#fmt_xmap_o_urlbase
+
+option	xmap	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html#fmt_xmap_o_prefer_shortnames
+
+option	xmap	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap.html#fmt_xmap_o_datum
+
+file	rw----	xmap2006	txt	DeLorme XMap/SAHH 2006 Native .TXT	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html
+option	xmap2006	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html#fmt_xmap2006_o_snlen
+
+option	xmap2006	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html#fmt_xmap2006_o_snwhite
+
+option	xmap2006	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html#fmt_xmap2006_o_snupper
+
+option	xmap2006	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html#fmt_xmap2006_o_snunique
+
+option	xmap2006	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html#fmt_xmap2006_o_urlbase
+
+option	xmap2006	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html#fmt_xmap2006_o_prefer_shortnames
+
+option	xmap2006	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmap2006.html#fmt_xmap2006_o_datum
+
+file	rw----	xmapwpt		DeLorme XMat HH Street Atlas USA .WPT (PPC)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html
+option	xmapwpt	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html#fmt_xmapwpt_o_snlen
+
+option	xmapwpt	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html#fmt_xmapwpt_o_snwhite
+
+option	xmapwpt	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html#fmt_xmapwpt_o_snupper
+
+option	xmapwpt	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html#fmt_xmapwpt_o_snunique
+
+option	xmapwpt	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html#fmt_xmapwpt_o_urlbase
+
+option	xmapwpt	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html#fmt_xmapwpt_o_prefer_shortnames
+
+option	xmapwpt	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xmapwpt.html#fmt_xmapwpt_o_datum
+
+file	----rw	destinator_itn	dat	Destinator Itineraries (.dat)	destinator_itn
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_destinator_itn.html
+file	rw----	destinator_poi	dat	Destinator Points of Interest (.dat)	destinator_poi
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_destinator_poi.html
+file	--rw--	destinator_trl	dat	Destinator TrackLogs (.dat)	destinator_trl
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_destinator_trl.html
+file	rw----	easygps	loc	EasyGPS binary format	easygps
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_easygps.html
+file	rw----	exif	jpg	Embedded Exif-GPS data (.jpg)	exif
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_exif.html
+option	exif	filename	Set waypoint name to source filename	boolean	Y			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_exif.html#fmt_exif_o_filename
+
+option	exif	frame	Time-frame (in seconds)	integer	10	0		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_exif.html#fmt_exif_o_frame
+
+option	exif	name	Locate waypoint for tagging by this name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_exif.html#fmt_exif_o_name
+
+option	exif	overwrite	!OVERWRITE! the original file. Default=N	boolean	N			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_exif.html#fmt_exif_o_overwrite
+
+file	--r---	energympro	cpo	Energympro GPS training watch	energympro
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_energympro.html
+file	----rw	enigma	ert	Enigma binary waypoint file (.ert)	enigma
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_enigma.html
+file	rwrwrw	shape	shp	ESRI shapefile	shape
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_shape.html
+option	shape	name	Source for name field in .dbf	string		0		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_shape.html#fmt_shape_o_name
+
+option	shape	url	Source for URL field in .dbf	string		0		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_shape.html#fmt_shape_o_url
+
+file	--r---	f90g	map	F90G Automobile DVR GPS log file	f90g
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_f90g.html
+file	--rwrw	igc		FAI/IGC Flight Recorder Data Format	igc
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igc.html
+option	igc	timeadj	(integer sec or 'auto') Barograph to GPS time diff	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igc.html#fmt_igc_o_timeadj
+
+file	-wrw--	garmin_fit	fit	Flexible and Interoperable Data Transfer (FIT) Activity file	garmin_fit
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_fit.html
+option	garmin_fit	allpoints	Read all points even if latitude or longitude is missing	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_fit.html#fmt_garmin_fit_o_allpoints
+
+file	rw----	flysight	csv	FlySight GPS File	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html
+option	flysight	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html#fmt_flysight_o_snlen
+
+option	flysight	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html#fmt_flysight_o_snwhite
+
+option	flysight	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html#fmt_flysight_o_snupper
+
+option	flysight	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html#fmt_flysight_o_snunique
+
+option	flysight	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html#fmt_flysight_o_urlbase
+
+option	flysight	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html#fmt_flysight_o_prefer_shortnames
+
+option	flysight	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_flysight.html#fmt_flysight_o_datum
+
+file	-w-w-w	gpssim	gpssim	Franson GPSGate Simulation	gpssim
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpssim.html
+option	gpssim	wayptspd	Default speed for waypoints (knots/hr)	float				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpssim.html#fmt_gpssim_o_wayptspd
+
+option	gpssim	split	Split input into separate files	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpssim.html#fmt_gpssim_o_split
+
+file	rw----	fugawi	txt	Fugawi	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html
+option	fugawi	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html#fmt_fugawi_o_snlen
+
+option	fugawi	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html#fmt_fugawi_o_snwhite
+
+option	fugawi	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html#fmt_fugawi_o_snupper
+
+option	fugawi	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html#fmt_fugawi_o_snunique
+
+option	fugawi	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html#fmt_fugawi_o_urlbase
+
+option	fugawi	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html#fmt_fugawi_o_prefer_shortnames
+
+option	fugawi	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_fugawi.html#fmt_fugawi_o_datum
+
+file	r-r-r-	g7towin	g7t	G7ToWin data files (.g7t)	g7towin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_g7towin.html
+file	rw----	garmin301		Garmin 301 Custom position and heartrate	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html
+option	garmin301	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html#fmt_garmin301_o_snlen
+
+option	garmin301	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html#fmt_garmin301_o_snwhite
+
+option	garmin301	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html#fmt_garmin301_o_snupper
+
+option	garmin301	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html#fmt_garmin301_o_snunique
+
+option	garmin301	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html#fmt_garmin301_o_urlbase
+
+option	garmin301	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html#fmt_garmin301_o_prefer_shortnames
+
+option	garmin301	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin301.html#fmt_garmin301_o_datum
+
+file	--rw--	garmin_g1000	csv	Garmin G1000 datalog input filter file	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html
+option	garmin_g1000	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html#fmt_garmin_g1000_o_snlen
+
+option	garmin_g1000	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html#fmt_garmin_g1000_o_snwhite
+
+option	garmin_g1000	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html#fmt_garmin_g1000_o_snupper
+
+option	garmin_g1000	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html#fmt_garmin_g1000_o_snunique
+
+option	garmin_g1000	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html#fmt_garmin_g1000_o_urlbase
+
+option	garmin_g1000	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html#fmt_garmin_g1000_o_prefer_shortnames
+
+option	garmin_g1000	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_g1000.html#fmt_garmin_g1000_o_datum
+
+file	--rw--	glogbook	xml	Garmin Logbook XML	glogbook
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_glogbook.html
+file	rwrwrw	gdb	gdb	Garmin MapSource - gdb	gdb
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gdb.html
+option	gdb	cat	Default category on output (1..16)	integer		1	16	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gdb.html#fmt_gdb_o_cat
+
+option	gdb	bitscategory	Bitmap of categories	integer		1	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gdb.html#fmt_gdb_o_bitscategory
+
+option	gdb	ver	Version of gdb file to generate (1..3)	integer	2	1	3	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gdb.html#fmt_gdb_o_ver
+
+option	gdb	via	Drop route points that do not have an equivalent waypoint (hidden points)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gdb.html#fmt_gdb_o_via
+
+option	gdb	roadbook	Include major turn points (with description) from calculated route	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gdb.html#fmt_gdb_o_roadbook
+
+file	rwrwrw	mapsource	mps	Garmin MapSource - mps	mapsource
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsource.html
+option	mapsource	snlen	Length of generated shortnames	integer	10	1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsource.html#fmt_mapsource_o_snlen
+
+option	mapsource	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsource.html#fmt_mapsource_o_snwhite
+
+option	mapsource	mpsverout	Version of mapsource file to generate (3,4,5)	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsource.html#fmt_mapsource_o_mpsverout
+
+option	mapsource	mpsmergeout	Merge output with existing file	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsource.html#fmt_mapsource_o_mpsmergeout
+
+option	mapsource	mpsusedepth	Use depth values on output (default is ignore)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsource.html#fmt_mapsource_o_mpsusedepth
+
+option	mapsource	mpsuseprox	Use proximity values on output (default is ignore)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsource.html#fmt_mapsource_o_mpsuseprox
+
+file	rwrwrw	garmin_txt	txt	Garmin MapSource - txt (tab delimited)	garmin_txt
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html
+option	garmin_txt	date	Read/Write date format (i.e. yyyy/mm/dd)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_date
+
+option	garmin_txt	datum	GPS datum (def. WGS 84)	string	WGS 84			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_datum
+
+option	garmin_txt	dist	Distance unit [m=metric, s=statute]	string	m			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_dist
+
+option	garmin_txt	grid	Write position using this grid.	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_grid
+
+option	garmin_txt	prec	Precision of coordinates	integer	3			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_prec
+
+option	garmin_txt	temp	Temperature unit [c=Celsius, f=Fahrenheit]	string	c			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_temp
+
+option	garmin_txt	time	Read/Write time format (i.e. HH:mm:ss xx)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_time
+
+option	garmin_txt	utc	Write timestamps with offset x to UTC time	integer		-23	+23	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_txt.html#fmt_garmin_txt_o_utc
+
+file	rwrwrw	pcx	pcx	Garmin PCX5	pcx
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_pcx.html
+option	pcx	deficon	Default icon name	string	Waypoint			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_pcx.html#fmt_pcx_o_deficon
+
+option	pcx	cartoexploreur	Write tracks compatible with Carto Exploreur	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_pcx.html#fmt_pcx_o_cartoexploreur
+
+file	rw----	garmin_poi		Garmin POI database	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html
+option	garmin_poi	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html#fmt_garmin_poi_o_snlen
+
+option	garmin_poi	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html#fmt_garmin_poi_o_snwhite
+
+option	garmin_poi	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html#fmt_garmin_poi_o_snupper
+
+option	garmin_poi	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html#fmt_garmin_poi_o_snunique
+
+option	garmin_poi	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html#fmt_garmin_poi_o_urlbase
+
+option	garmin_poi	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html#fmt_garmin_poi_o_prefer_shortnames
+
+option	garmin_poi	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_poi.html#fmt_garmin_poi_o_datum
+
+file	rw----	garmin_gpi	gpi	Garmin Points of Interest (.gpi)	garmin_gpi
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html
+option	garmin_gpi	alerts	Enable alerts on speed or proximity distance	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_alerts
+
+option	garmin_gpi	bitmap	Use specified bitmap on output	file				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_bitmap
+
+option	garmin_gpi	category	Default category on output	string	My points			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_category
+
+option	garmin_gpi	hide	Don't show gpi bitmap on device	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_hide
+
+option	garmin_gpi	descr	Write description to address field	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_descr
+
+option	garmin_gpi	notes	Write notes to address field	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_notes
+
+option	garmin_gpi	position	Write position to address field	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_position
+
+option	garmin_gpi	proximity	Default proximity	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_proximity
+
+option	garmin_gpi	sleep	After output job done sleep n second(s)	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_sleep
+
+option	garmin_gpi	speed	Default speed	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_speed
+
+option	garmin_gpi	unique	Create unique waypoint names (default = yes)	boolean	Y			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_unique
+
+option	garmin_gpi	units	Units used for names with @speed ('s'tatute or 'm'etric)	string	m			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_units
+
+option	garmin_gpi	writecodec	codec to use for writing strings	string	windows-1252			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_writecodec
+
+option	garmin_gpi	languagecode	language code to use for reading dual language files	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_gpi.html#fmt_garmin_gpi_o_languagecode
+
+serial	rwrwrw	garmin		Garmin serial/USB protocol	garmin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html
+option	garmin	snlen	Length of generated shortnames	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_snlen
+
+option	garmin	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_snwhite
+
+option	garmin	deficon	Default icon name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_deficon
+
+option	garmin	get_posn	Return current position as a waypoint	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_get_posn
+
+option	garmin	power_off	Command unit to power itself down	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_power_off
+
+option	garmin	erase_t	Erase existing courses when writing new ones	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_erase_t
+
+option	garmin	resettime	Sync GPS time to computer time	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_resettime
+
+option	garmin	category	Category number to use for written waypoints	integer		1	16	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_category
+
+option	garmin	bitscategory	Bitmap of categories	integer		1	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_bitscategory
+
+option	garmin	baud	Speed in bits per second of serial port (baud=9600)	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin.html#fmt_garmin_o_baud
+
+file	r-rw--	gtrnctr	tcx/crs/hst/xml	Garmin Training Center (.tcx/.crs/.hst/.xml)	gtrnctr
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gtrnctr.html
+option	gtrnctr	course	Write course rather than history, default yes	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gtrnctr.html#fmt_gtrnctr_o_course
+
+option	gtrnctr	sport	Sport: Biking (deflt), Running, MultiSport, Other	string	Biking			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gtrnctr.html#fmt_gtrnctr_o_sport
+
+file	rw----	geo	loc	Geocaching.com .loc	geo
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geo.html
+option	geo	deficon	Default icon name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geo.html#fmt_geo_o_deficon
+
+option	geo	nuke_placer	Omit Placer name	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geo.html#fmt_geo_o_nuke_placer
+
+file	rwrwrw	ggv_ovl	ovl	Geogrid-Viewer ascii overlay file (.ovl)	ggv_ovl
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ggv_ovl.html
+file	--r---	ggv_bin	ovl	Geogrid-Viewer binary overlay file (.ovl)	ggv_bin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ggv_bin.html
+file	--rw--	ggv_log	log	Geogrid-Viewer tracklogs (.log)	ggv_log
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ggv_log.html
+file	rwrwrw	geojson	json	GeoJson	geojson
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geojson.html
+option	geojson	compact	Compact Output. Default is off.	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geojson.html#fmt_geojson_o_compact
+
+file	rw----	geonet	txt	GEOnet Names Server (GNS)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html
+option	geonet	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html#fmt_geonet_o_snlen
+
+option	geonet	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html#fmt_geonet_o_snwhite
+
+option	geonet	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html#fmt_geonet_o_snupper
+
+option	geonet	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html#fmt_geonet_o_snunique
+
+option	geonet	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html#fmt_geonet_o_urlbase
+
+option	geonet	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html#fmt_geonet_o_prefer_shortnames
+
+option	geonet	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_geonet.html#fmt_geonet_o_datum
+
+serial	r-r---	dg-100		GlobalSat DG-100/BT-335 Download	dg-100
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dg-100.html
+option	dg-100	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dg-100.html#fmt_dg-100_o_erase
+
+option	dg-100	erase_only	Only erase device data, do not download anything	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dg-100.html#fmt_dg-100_o_erase_only
+
+serial	r-r---	dg-200		GlobalSat DG-200 Download	dg-200
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dg-200.html
+option	dg-200	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dg-200.html#fmt_dg-200_o_erase
+
+option	dg-200	erase_only	Only erase device data, do not download anything	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dg-200.html#fmt_dg-200_o_erase_only
+
+serial	--r---	globalsat		GlobalSat GH625XT GPS training watch	globalsat
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_globalsat.html
+option	globalsat	showlist	list tracks	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_globalsat.html#fmt_globalsat_o_showlist
+
+option	globalsat	track	get track	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_globalsat.html#fmt_globalsat_o_track
+
+option	globalsat	dump-file	Dump raw data to this file	outfile				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_globalsat.html#fmt_globalsat_o_dump-file
+
+option	globalsat	input-is-dump-file	Dump raw data to this file	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_globalsat.html#fmt_globalsat_o_input-is-dump-file
+
+file	--r---	googledir	xml	Google Directions XML	googledir
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_googledir.html
+file	rwrwrw	kml	kml	Google Earth (Keyhole) Markup Language	kml
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html
+option	kml	deficon	Default icon name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_deficon
+
+option	kml	lines	Export linestrings for tracks and routes	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_lines
+
+option	kml	points	Export placemarks for tracks and routes	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_points
+
+option	kml	line_width	Width of lines, in pixels	integer	6			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_line_width
+
+option	kml	line_color	Line color, specified in hex AABBGGRR	string	99ffac59			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_line_color
+
+option	kml	floating	Altitudes are absolute and not clamped to ground	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_floating
+
+option	kml	extrude	Draw extrusion line from trackpoint to ground	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_extrude
+
+option	kml	track	Write KML track (default = 0)	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_track
+
+option	kml	trackdata	Include extended data for trackpoints (default = 1)	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_trackdata
+
+option	kml	trackdirection	Indicate direction of travel in track icons (default = 0)	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_trackdirection
+
+option	kml	units	Units used when writing comments ('s'tatute, 'm'etric,' 'n'autical, 'a'viation)	string	s			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_units
+
+option	kml	labels	Display labels on track and routepoints  (default = 1)	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_labels
+
+option	kml	max_position_points	Retain at most this number of position points  (0 = unlimited)	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_max_position_points
+
+option	kml	rotate_colors	Rotate colors for tracks and routes (default automatic)	float		0	360	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_rotate_colors
+
+option	kml	prec	Precision of coordinates, number of decimals	integer	6			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kml.html#fmt_kml_o_prec
+
+file	--rw--	gnav_trl	trl	Google Navigator Tracklines (.trl)	gnav_trl
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gnav_trl.html
+file	--rw--	gopal	trk	GoPal GPS track log (.trk)	gopal
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gopal.html
+option	gopal	date	Complete date-free tracks with given date (YYYYMMDD).	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gopal.html#fmt_gopal_o_date
+
+option	gopal	maxspeed	The maximum speed (km/h) traveling from waypoint to waypoint.	integer	200	1	1000	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gopal.html#fmt_gopal_o_maxspeed
+
+option	gopal	minspeed	The minimum speed (km/h) traveling from waypoint to waypoint. Set >0 to remove duplicate waypoints	integer	0	0	999	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gopal.html#fmt_gopal_o_minspeed
+
+option	gopal	clean	Cleanup common errors in trackdata	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gopal.html#fmt_gopal_o_clean
+
+file	--rw--	land_air_sea	txt	GPS Tracking Key Pro text	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html
+option	land_air_sea	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html#fmt_land_air_sea_o_snlen
+
+option	land_air_sea	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html#fmt_land_air_sea_o_snwhite
+
+option	land_air_sea	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html#fmt_land_air_sea_o_snupper
+
+option	land_air_sea	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html#fmt_land_air_sea_o_snunique
+
+option	land_air_sea	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html#fmt_land_air_sea_o_urlbase
+
+option	land_air_sea	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html#fmt_land_air_sea_o_prefer_shortnames
+
+option	land_air_sea	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_land_air_sea.html#fmt_land_air_sea_o_datum
+
+file	rwrwrw	gtm	gtm	GPS TrackMaker	gtm
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gtm.html
+file	rw----	arc	txt	GPSBabel arc filter file	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html
+option	arc	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html#fmt_arc_o_snlen
+
+option	arc	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html#fmt_arc_o_snwhite
+
+option	arc	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html#fmt_arc_o_snupper
+
+option	arc	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html#fmt_arc_o_snunique
+
+option	arc	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html#fmt_arc_o_urlbase
+
+option	arc	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html#fmt_arc_o_prefer_shortnames
+
+option	arc	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_arc.html#fmt_arc_o_datum
+
+file	rw----	gpsdrive		GpsDrive Format	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html
+option	gpsdrive	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html#fmt_gpsdrive_o_snlen
+
+option	gpsdrive	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html#fmt_gpsdrive_o_snwhite
+
+option	gpsdrive	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html#fmt_gpsdrive_o_snupper
+
+option	gpsdrive	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html#fmt_gpsdrive_o_snunique
+
+option	gpsdrive	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html#fmt_gpsdrive_o_urlbase
+
+option	gpsdrive	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html#fmt_gpsdrive_o_prefer_shortnames
+
+option	gpsdrive	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrive.html#fmt_gpsdrive_o_datum
+
+file	rw----	gpsdrivetrack		GpsDrive Format for Tracks	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html
+option	gpsdrivetrack	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html#fmt_gpsdrivetrack_o_snlen
+
+option	gpsdrivetrack	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html#fmt_gpsdrivetrack_o_snwhite
+
+option	gpsdrivetrack	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html#fmt_gpsdrivetrack_o_snupper
+
+option	gpsdrivetrack	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html#fmt_gpsdrivetrack_o_snunique
+
+option	gpsdrivetrack	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html#fmt_gpsdrivetrack_o_urlbase
+
+option	gpsdrivetrack	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html#fmt_gpsdrivetrack_o_prefer_shortnames
+
+option	gpsdrivetrack	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsdrivetrack.html#fmt_gpsdrivetrack_o_datum
+
+file	rw----	gpsman		GPSman	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html
+option	gpsman	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html#fmt_gpsman_o_snlen
+
+option	gpsman	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html#fmt_gpsman_o_snwhite
+
+option	gpsman	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html#fmt_gpsman_o_snupper
+
+option	gpsman	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html#fmt_gpsman_o_snunique
+
+option	gpsman	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html#fmt_gpsman_o_urlbase
+
+option	gpsman	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html#fmt_gpsman_o_prefer_shortnames
+
+option	gpsman	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsman.html#fmt_gpsman_o_datum
+
+file	rw----	gpsutil		gpsutil	gpsutil
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpsutil.html
+file	rwrwrw	gpx	gpx	GPX XML	gpx
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html
+option	gpx	snlen	Length of generated shortnames	integer	32	1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_snlen
+
+option	gpx	suppresswhite	No whitespace in generated shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_suppresswhite
+
+option	gpx	logpoint	Create waypoints from geocache log entries	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_logpoint
+
+option	gpx	urlbase	Base URL for link tag in output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_urlbase
+
+option	gpx	gpxver	Target GPX version for output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_gpxver
+
+option	gpx	humminbirdextensions	Add info (depth) as Humminbird extension	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_humminbirdextensions
+
+option	gpx	garminextensions	Add info (depth) as Garmin extension	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_garminextensions
+
+option	gpx	elevprec	Precision of elevations, number of decimals	integer	3			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_gpx.html#fmt_gpx_o_elevprec
+
+file	rwrw--	hiketech	gps	HikeTech	hiketech
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_hiketech.html
+file	rw----	holux	wpo	Holux (gm-100) .wpo Format	holux
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_holux.html
+file	r-r---	m241-bin	bin	Holux M-241 (MTK based) Binary File Format	m241-bin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241-bin.html
+option	m241-bin	csv	MTK compatible CSV output file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241-bin.html#fmt_m241-bin_o_csv
+
+serial	--r---	m241		Holux M-241 (MTK based) download	m241
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241.html
+option	m241	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241.html#fmt_m241_o_erase
+
+option	m241	erase_only	Only erase device data, do not download anything	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241.html#fmt_m241_o_erase_only
+
+option	m241	log_enable	Enable logging after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241.html#fmt_m241_o_log_enable
+
+option	m241	csv	MTK compatible CSV output file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241.html#fmt_m241_o_csv
+
+option	m241	block_size_kb	Size of blocks in KB to request from device	integer	1	1	64	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_m241.html#fmt_m241_o_block_size_kb
+
+file	--r---	vpl		Honda/Acura Navigation System VP Log File Format	vpl
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_vpl.html
+file	-w----	html	html	HTML Output	html
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_html.html
+option	html	stylesheet	Path to HTML style sheet	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_html.html#fmt_html_o_stylesheet
+
+option	html	encrypt	Encrypt hints using ROT13	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_html.html#fmt_html_o_encrypt
+
+option	html	logs	Include groundspeak logs if present	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_html.html#fmt_html_o_logs
+
+option	html	degformat	Degrees output as 'ddd', 'dmm'(default) or 'dms'	string	dmm			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_html.html#fmt_html_o_degformat
+
+option	html	altunits	Units for altitude (f)eet or (m)etres	string	m			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_html.html#fmt_html_o_altunits
+
+file	r-rwr-	humminbird_ht	ht	Humminbird tracks (.ht)	humminbird_ht
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_humminbird_ht.html
+file	rwr-rw	humminbird	hwr	Humminbird waypoints and routes (.hwr)	humminbird
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_humminbird.html
+file	--rw--	ignrando	rdn	IGN Rando track files	ignrando
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ignrando.html
+option	ignrando	index	Index of track to write (if more than one in source)	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ignrando.html#fmt_ignrando_o_index
+
+file	rw----	igoprimo_poi	upoi	iGo Primo points of interest (.upoi)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html
+option	igoprimo_poi	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html#fmt_igoprimo_poi_o_snlen
+
+option	igoprimo_poi	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html#fmt_igoprimo_poi_o_snwhite
+
+option	igoprimo_poi	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html#fmt_igoprimo_poi_o_snupper
+
+option	igoprimo_poi	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html#fmt_igoprimo_poi_o_snunique
+
+option	igoprimo_poi	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html#fmt_igoprimo_poi_o_urlbase
+
+option	igoprimo_poi	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html#fmt_igoprimo_poi_o_prefer_shortnames
+
+option	igoprimo_poi	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igoprimo_poi.html#fmt_igoprimo_poi_o_datum
+
+file	rw----	igo2008_poi	upoi	iGO2008 points of interest (.upoi)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html
+option	igo2008_poi	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html#fmt_igo2008_poi_o_snlen
+
+option	igo2008_poi	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html#fmt_igo2008_poi_o_snwhite
+
+option	igo2008_poi	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html#fmt_igo2008_poi_o_snupper
+
+option	igo2008_poi	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html#fmt_igo2008_poi_o_snunique
+
+option	igo2008_poi	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html#fmt_igo2008_poi_o_urlbase
+
+option	igo2008_poi	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html#fmt_igo2008_poi_o_prefer_shortnames
+
+option	igo2008_poi	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo2008_poi.html#fmt_igo2008_poi_o_datum
+
+file	--rw--	igo8	trk	IGO8 .trk	igo8
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo8.html
+option	igo8	tracknum	Track identification number	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo8.html#fmt_igo8_o_tracknum
+
+option	igo8	title	Track title	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo8.html#fmt_igo8_o_title
+
+option	igo8	description	Track description	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_igo8.html#fmt_igo8_o_description
+
+internal	r-r-r-	random		Internal GPS data generator	random
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_random.html
+option	random	points	Generate # points	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_random.html#fmt_random_o_points
+
+option	random	seed	Starting seed of the internal number generator	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_random.html#fmt_random_o_seed
+
+option	random	nodelay	Output realtime points without delay	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_random.html#fmt_random_o_nodelay
+
+file	--rw--	jtr	jtr	Jelbert GeoTagger data file	jtr
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_jtr.html
+file	--r---	jogmap	xml	Jogmap.de XML format	jogmap
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_jogmap.html
+file	--rw--	kompass_tk	wp	Kompass (DAV) Track (.tk)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html
+option	kompass_tk	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html#fmt_kompass_tk_o_snlen
+
+option	kompass_tk	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html#fmt_kompass_tk_o_snwhite
+
+option	kompass_tk	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html#fmt_kompass_tk_o_snupper
+
+option	kompass_tk	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html#fmt_kompass_tk_o_snunique
+
+option	kompass_tk	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html#fmt_kompass_tk_o_urlbase
+
+option	kompass_tk	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html#fmt_kompass_tk_o_prefer_shortnames
+
+option	kompass_tk	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_tk.html#fmt_kompass_tk_o_datum
+
+file	rw----	kompass_wp	wp	Kompass (DAV) Waypoints (.wp)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html
+option	kompass_wp	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html#fmt_kompass_wp_o_snlen
+
+option	kompass_wp	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html#fmt_kompass_wp_o_snwhite
+
+option	kompass_wp	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html#fmt_kompass_wp_o_snupper
+
+option	kompass_wp	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html#fmt_kompass_wp_o_snunique
+
+option	kompass_wp	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html#fmt_kompass_wp_o_urlbase
+
+option	kompass_wp	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html#fmt_kompass_wp_o_prefer_shortnames
+
+option	kompass_wp	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_kompass_wp.html#fmt_kompass_wp_o_datum
+
+file	rwrwrw	psitrex		KuDaTa PsiTrex text	psitrex
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_psitrex.html
+file	rwrwrw	lowranceusr	usr	Lowrance USR	lowranceusr
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html
+option	lowranceusr	ignoreicons	(USR input) Ignore event marker icons on read	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_ignoreicons
+
+option	lowranceusr	writeasicons	(USR output) Treat waypoints as icons on write	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_writeasicons
+
+option	lowranceusr	merge	(USR output) Merge into one segmented trail	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_merge
+
+option	lowranceusr	break	(USR input) Break segments into separate trails	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_break
+
+option	lowranceusr	wversion	(USR output) Write version	integer	2	2	4	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_wversion
+
+option	lowranceusr	title	(USR output) Output file title string	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_title
+
+option	lowranceusr	serialnum	(USR output) Device serial number	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_serialnum
+
+option	lowranceusr	description	(USR output) Output file content description	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lowranceusr.html#fmt_lowranceusr_o_description
+
+file	rw----	maggeo	gs	Magellan Explorist Geocaching	maggeo
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_maggeo.html
+file	rwrwrw	mapsend		Magellan Mapsend	mapsend
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsend.html
+option	mapsend	trkver	MapSend version TRK file to generate (3,4)	integer	4	3	4	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapsend.html#fmt_mapsend_o_trkver
+
+file	rwrwrw	magellanx	upt	Magellan SD files (as for eXplorist)	magellanx
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellanx.html
+option	magellanx	deficon	Default icon name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellanx.html#fmt_magellanx_o_deficon
+
+option	magellanx	maxcmts	Max number of comments to write (maxcmts=200)	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellanx.html#fmt_magellanx_o_maxcmts
+
+file	rwrwrw	magellan		Magellan SD files (as for Meridian)	magellan
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html
+option	magellan	deficon	Default icon name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html#fmt_magellan_o_deficon
+
+option	magellan	maxcmts	Max number of comments to write (maxcmts=200)	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html#fmt_magellan_o_maxcmts
+
+serial	rwrwrw	magellan		Magellan serial protocol	magellan
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html
+option	magellan	deficon	Default icon name	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html#fmt_magellan_o_deficon
+
+option	magellan	maxcmts	Max number of comments to write (maxcmts=200)	integer	200			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html#fmt_magellan_o_maxcmts
+
+option	magellan	baud	Numeric value of bitrate (baud=4800)	integer	4800			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html#fmt_magellan_o_baud
+
+option	magellan	noack	Suppress use of handshaking in name of speed	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html#fmt_magellan_o_noack
+
+option	magellan	nukewpt	Delete all waypoints	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_magellan.html#fmt_magellan_o_nukewpt
+
+file	r-r---	ik3d	ikt	MagicMaps IK3D project file (.ikt)	ik3d
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ik3d.html
+file	--rw--	mainnav	nav	Mainnav	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html
+option	mainnav	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html#fmt_mainnav_o_snlen
+
+option	mainnav	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html#fmt_mainnav_o_snwhite
+
+option	mainnav	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html#fmt_mainnav_o_snupper
+
+option	mainnav	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html#fmt_mainnav_o_snunique
+
+option	mainnav	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html#fmt_mainnav_o_urlbase
+
+option	mainnav	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html#fmt_mainnav_o_prefer_shortnames
+
+option	mainnav	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mainnav.html#fmt_mainnav_o_datum
+
+file	----r-	tef	xml	Map&Guide 'TourExchangeFormat' XML	tef
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tef.html
+option	tef	routevia	Include only via stations in route	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tef.html#fmt_tef_o_routevia
+
+file	--rw--	mapasia_tr7	tr7	MapAsia track file (.tr7)	mapasia_tr7
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapasia_tr7.html
+file	--r---	mapbar	trk	Mapbar (China) navigation track for Sonim Xp3300	mapbar
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapbar.html
+file	rw----	mapfactor	xml	Mapfactor Navigator	mapfactor
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapfactor.html
+file	rw----	mapconverter	txt	Mapopolis.com Mapconverter CSV	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html
+option	mapconverter	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html#fmt_mapconverter_o_snlen
+
+option	mapconverter	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html#fmt_mapconverter_o_snwhite
+
+option	mapconverter	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html#fmt_mapconverter_o_snupper
+
+option	mapconverter	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html#fmt_mapconverter_o_snunique
+
+option	mapconverter	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html#fmt_mapconverter_o_urlbase
+
+option	mapconverter	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html#fmt_mapconverter_o_prefer_shortnames
+
+option	mapconverter	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mapconverter.html#fmt_mapconverter_o_datum
+
+file	rw----	mxf	mxf	MapTech Exchange Format	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html
+option	mxf	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html#fmt_mxf_o_snlen
+
+option	mxf	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html#fmt_mxf_o_snwhite
+
+option	mxf	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html#fmt_mxf_o_snupper
+
+option	mxf	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html#fmt_mxf_o_snunique
+
+option	mxf	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html#fmt_mxf_o_urlbase
+
+option	mxf	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html#fmt_mxf_o_prefer_shortnames
+
+option	mxf	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mxf.html#fmt_mxf_o_datum
+
+file	r-r---	mtk_locus		MediaTek Locus	mtk_locus
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk_locus.html
+option	mtk_locus	baudrate	Speed in bits per second of serial port (autodetect=0)	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk_locus.html#fmt_mtk_locus_o_baudrate
+
+option	mtk_locus	download	Download logged fixes	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk_locus.html#fmt_mtk_locus_o_download
+
+option	mtk_locus	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk_locus.html#fmt_mtk_locus_o_erase
+
+option	mtk_locus	status	Show device status	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk_locus.html#fmt_mtk_locus_o_status
+
+option	mtk_locus	enable	Enable logging after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk_locus.html#fmt_mtk_locus_o_enable
+
+file	rwrwrw	mmo	mmo	Memory-Map Navigator overlay files (.mmo)	mmo
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mmo.html
+option	mmo	locked	Write items 'locked' [default no]	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mmo.html#fmt_mmo_o_locked
+
+option	mmo	visible	Write items 'visible' [default yes]	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mmo.html#fmt_mmo_o_visible
+
+option	mmo	ver	Write files with internal version [n]	integer		17	18	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mmo.html#fmt_mmo_o_ver
+
+file	rw----	s_and_t	txt	Microsoft Streets and Trips 2002-2007	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html
+option	s_and_t	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html#fmt_s_and_t_o_snlen
+
+option	s_and_t	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html#fmt_s_and_t_o_snwhite
+
+option	s_and_t	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html#fmt_s_and_t_o_snupper
+
+option	s_and_t	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html#fmt_s_and_t_o_snunique
+
+option	s_and_t	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html#fmt_s_and_t_o_urlbase
+
+option	s_and_t	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html#fmt_s_and_t_o_prefer_shortnames
+
+option	s_and_t	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_s_and_t.html#fmt_s_and_t_o_datum
+
+serial	r-r---	miniHomer		MiniHomer, a skyTraq Venus 6 based logger (download tracks, waypoints and get/set POI)	miniHomer
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html
+option	miniHomer	baud	Baud rate used for download	integer	115200	0	115200	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_baud
+
+option	miniHomer	dump-file	Dump raw data to this file	outfile				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_dump-file
+
+option	miniHomer	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_erase
+
+option	miniHomer	first-sector	First sector to be read from the device	integer	0	0	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_first-sector
+
+option	miniHomer	initbaud	Baud rate used to init device (0=autodetect)	integer	38400	38400	38400	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_initbaud
+
+option	miniHomer	last-sector	Last sector to be read from the device (-1: smart read everything)	integer	-1	-1	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_last-sector
+
+option	miniHomer	no-output	Disable output (useful with erase)	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_no-output
+
+option	miniHomer	read-at-once	Number of sectors to read at once (0=use single sector mode)	integer	255	0	255	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_read-at-once
+
+option	miniHomer	Home	POI for Home Symbol as lat:lng[:alt]	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_Home
+
+option	miniHomer	Car	POI for Car Symbol as lat:lng[:alt]	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_Car
+
+option	miniHomer	Boat	POI for Boat Symbol as lat:lng[:alt]	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_Boat
+
+option	miniHomer	Heart	POI for Heart Symbol as lat:lng[:alt]	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_Heart
+
+option	miniHomer	Bar	POI for Bar Symbol as lat:lng[:alt]	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_Bar
+
+option	miniHomer	gps-utc-offset	Seconds that GPS time tracks UTC (0: best guess)	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_gps-utc-offset
+
+option	miniHomer	gps-week-rollover	GPS week rollover period we're in (-1: best guess)	integer	-1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_miniHomer.html#fmt_miniHomer_o_gps-week-rollover
+
+file	--r---	garmin_xt		Mobile Garmin XT Track files	garmin_xt
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_xt.html
+option	garmin_xt	ftype	Garmin Mobile XT ([ATRK]/STRK)	string	ATRK			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_xt.html#fmt_garmin_xt_o_ftype
+
+option	garmin_xt	trk_header	Track name processing option ([0]-nrm/1-ign)	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_garmin_xt.html#fmt_garmin_xt_o_trk_header
+
+file	rw----	motoactv	csv	Motoactiv CSV	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html
+option	motoactv	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html#fmt_motoactv_o_snlen
+
+option	motoactv	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html#fmt_motoactv_o_snwhite
+
+option	motoactv	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html#fmt_motoactv_o_snupper
+
+option	motoactv	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html#fmt_motoactv_o_snunique
+
+option	motoactv	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html#fmt_motoactv_o_urlbase
+
+option	motoactv	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html#fmt_motoactv_o_prefer_shortnames
+
+option	motoactv	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_motoactv.html#fmt_motoactv_o_datum
+
+file	----rw	bcr	bcr	Motorrad Routenplaner (Map&Guide) .bcr files	bcr
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_bcr.html
+option	bcr	index	Index of route to write (if more than one in source)	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_bcr.html#fmt_bcr_o_index
+
+option	bcr	name	New name for the route	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_bcr.html#fmt_bcr_o_name
+
+option	bcr	radius	Radius of our big earth (default 6371000 meters)	float	6371000			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_bcr.html#fmt_bcr_o_radius
+
+option	bcr	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_bcr.html#fmt_bcr_o_prefer_shortnames
+
+file	r-r---	mtk-bin	bin	MTK Logger (iBlue 747,...) Binary File Format	mtk-bin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk-bin.html
+option	mtk-bin	csv	MTK compatible CSV output file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk-bin.html#fmt_mtk-bin_o_csv
+
+serial	r-r---	mtk		MTK Logger (iBlue 747,Qstarz BT-1000,...) download	mtk
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk.html
+option	mtk	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk.html#fmt_mtk_o_erase
+
+option	mtk	erase_only	Only erase device data, do not download anything	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk.html#fmt_mtk_o_erase_only
+
+option	mtk	log_enable	Enable logging after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk.html#fmt_mtk_o_log_enable
+
+option	mtk	csv	MTK compatible CSV output file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk.html#fmt_mtk_o_csv
+
+option	mtk	block_size_kb	Size of blocks in KB to request from device	integer	1	1	64	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mtk.html#fmt_mtk_o_block_size_kb
+
+file	--r---	mynav	trc	MyNav TRC format	mynav
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_mynav.html
+file	rw----	tpg	tpg	National Geographic Topo .tpg (waypoints)	tpg
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tpg.html
+option	tpg	datum	Datum (default=NAD27)	string	N. America 1927 mean			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tpg.html#fmt_tpg_o_datum
+
+file	--r---	tpo2	tpo	National Geographic Topo 2.x .tpo	tpo2
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tpo2.html
+file	r-r-r-	tpo3	tpo	National Geographic Topo 3.x/4.x .tpo	tpo3
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tpo3.html
+file	r-----	navicache		Navicache.com XML	navicache
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navicache.html
+option	navicache	noretired	Suppress retired geocaches	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navicache.html#fmt_navicache_o_noretired
+
+file	----rw	nmn4	rte	Navigon Mobile Navigator .rte files	nmn4
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmn4.html
+option	nmn4	index	Index of route to write (if more than one in source)	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmn4.html#fmt_nmn4_o_index
+
+file	rw----	navigonwpt		Navigon Waypoints	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html
+option	navigonwpt	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html#fmt_navigonwpt_o_snlen
+
+option	navigonwpt	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html#fmt_navigonwpt_o_snwhite
+
+option	navigonwpt	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html#fmt_navigonwpt_o_snupper
+
+option	navigonwpt	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html#fmt_navigonwpt_o_snunique
+
+option	navigonwpt	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html#fmt_navigonwpt_o_urlbase
+
+option	navigonwpt	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html#fmt_navigonwpt_o_prefer_shortnames
+
+option	navigonwpt	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navigonwpt.html#fmt_navigonwpt_o_datum
+
+serial	rwrwrw	navilink		NaviGPS GT-11/BGT-11 Download	navilink
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navilink.html
+option	navilink	nuketrk	Delete all track points	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navilink.html#fmt_navilink_o_nuketrk
+
+option	navilink	nukerte	Delete all routes	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navilink.html#fmt_navilink_o_nukerte
+
+option	navilink	nukewpt	Delete all waypoints	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navilink.html#fmt_navilink_o_nukewpt
+
+option	navilink	nukedlg	Clear the datalog	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navilink.html#fmt_navilink_o_nukedlg
+
+option	navilink	datalog	Read from datalogger buffer	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navilink.html#fmt_navilink_o_datalog
+
+option	navilink	power_off	Command unit to power itself down	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navilink.html#fmt_navilink_o_power_off
+
+file	--r---	sbp	sbp	NaviGPS GT-31/BGT-31 datalogger (.sbp)	sbp
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_sbp.html
+file	--r---	sbn	sbn	NaviGPS GT-31/BGT-31 SiRF binary logfile (.sbn)	sbn
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_sbn.html
+file	rw----	naviguide	twl	Naviguide binary route file (.twl)	naviguide
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_naviguide.html
+option	naviguide	output	'wp' - Create waypoint file , 'rte' - Create route file	string	rte			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_naviguide.html#fmt_naviguide_o_output
+
+option	naviguide	reorder	'n' - Keep the existing wp name, 'y' - rename waypoints	string	n			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_naviguide.html#fmt_naviguide_o_reorder
+
+file	--rw--	navitel_trk	bin	Navitel binary track (.bin)	navitel_trk
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_navitel_trk.html
+file	rw----	dna	dna	Navitrak DNA marker format	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html
+option	dna	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html#fmt_dna_o_snlen
+
+option	dna	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html#fmt_dna_o_snwhite
+
+option	dna	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html#fmt_dna_o_snupper
+
+option	dna	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html#fmt_dna_o_snunique
+
+option	dna	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html#fmt_dna_o_urlbase
+
+option	dna	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html#fmt_dna_o_prefer_shortnames
+
+option	dna	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dna.html#fmt_dna_o_datum
+
+file	r-----	netstumbler		NetStumbler Summary File (text)	netstumbler
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_netstumbler.html
+option	netstumbler	nseicon	Non-stealth encrypted icon name	string	Red Square			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_netstumbler.html#fmt_netstumbler_o_nseicon
+
+option	netstumbler	nsneicon	Non-stealth non-encrypted icon name	string	Green Square			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_netstumbler.html#fmt_netstumbler_o_nsneicon
+
+option	netstumbler	seicon	Stealth encrypted icon name	string	Red Diamond			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_netstumbler.html#fmt_netstumbler_o_seicon
+
+option	netstumbler	sneicon	Stealth non-encrypted icon name	string	Green Diamond			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_netstumbler.html#fmt_netstumbler_o_sneicon
+
+option	netstumbler	snmac	Shortname is MAC address	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_netstumbler.html#fmt_netstumbler_o_snmac
+
+file	rw----	nima		NIMA/GNIS Geographic Names File	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html
+option	nima	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html#fmt_nima_o_snlen
+
+option	nima	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html#fmt_nima_o_snwhite
+
+option	nima	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html#fmt_nima_o_snupper
+
+option	nima	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html#fmt_nima_o_snunique
+
+option	nima	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html#fmt_nima_o_urlbase
+
+option	nima	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html#fmt_nima_o_prefer_shortnames
+
+option	nima	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nima.html#fmt_nima_o_datum
+
+file	rwrw--	nmea		NMEA 0183 sentences	nmea
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html
+option	nmea	snlen	Max length of waypoint name to write	integer	6	1	64	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_snlen
+
+option	nmea	gprmc	Read/write GPRMC sentences	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_gprmc
+
+option	nmea	gpgga	Read/write GPGGA sentences	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_gpgga
+
+option	nmea	gpvtg	Read/write GPVTG sentences	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_gpvtg
+
+option	nmea	gpgsa	Read/write GPGSA sentences	boolean	1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_gpgsa
+
+option	nmea	date	Complete date-free tracks with given date (YYYYMMDD).	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_date
+
+option	nmea	get_posn	Return current position as a waypoint	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_get_posn
+
+option	nmea	pause	Decimal seconds to pause between groups of strings	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_pause
+
+option	nmea	append_positioning	Append realtime positioning data to the output file instead of truncating	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_append_positioning
+
+option	nmea	baud	Speed in bits per second of serial port (baud=4800)	integer				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_baud
+
+option	nmea	gisteq	Write tracks for Gisteq Phototracker	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_gisteq
+
+option	nmea	ignore_fix	Accept position fixes in gpgga marked invalid	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_nmea.html#fmt_nmea_o_ignore_fix
+
+file	rw----	lmx		Nokia Landmark Exchange	lmx
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lmx.html
+option	lmx	binary	Compact binary representation	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_lmx.html#fmt_lmx_o_binary
+
+file	rw-wrw	osm	osm	OpenStreetMap data files	osm
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_osm.html
+option	osm	tag	Write additional way tag key/value pairs	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_osm.html#fmt_osm_o_tag
+
+option	osm	tagnd	Write additional node tag key/value pairs	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_osm.html#fmt_osm_o_tagnd
+
+option	osm	created_by	Use this value as custom created_by value	string	GPSBabel			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_osm.html#fmt_osm_o_created_by
+
+file	rwrwrw	ozi		OziExplorer	ozi
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html
+option	ozi	pack	Write all tracks into one file	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_pack
+
+option	ozi	snlen	Max synthesized shortname length	integer	32	1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_snlen
+
+option	ozi	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_snwhite
+
+option	ozi	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_snupper
+
+option	ozi	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_snunique
+
+option	ozi	wptfgcolor	Waypoint foreground color	string	black			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_wptfgcolor
+
+option	ozi	wptbgcolor	Waypoint background color	string	yellow			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_wptbgcolor
+
+option	ozi	proximity	Proximity distance	string	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_proximity
+
+option	ozi	altunit	Unit used in altitude values	string	feet			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_altunit
+
+option	ozi	proxunit	Unit used in proximity values	string	miles			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_proxunit
+
+option	ozi	codec	codec to use for reading and writing strings (default windows-1252)	string	windows-1252			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ozi.html#fmt_ozi_o_codec
+
+file	--rw--	pocketfms_bc		PocketFMS breadcrumbs	pocketfms_bc
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_pocketfms_bc.html
+file	r---r-	pocketfms_fp	xml	PocketFMS flightplan (.xml)	pocketfms_fp
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_pocketfms_fp.html
+file	rw----	pocketfms_wp	txt	PocketFMS waypoints (.txt)	pocketfms_wp
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_pocketfms_wp.html
+file	rw--rw	raymarine	rwf	Raymarine Waypoint File (.rwf)	raymarine
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_raymarine.html
+option	raymarine	location	Default location	string	My Waypoints			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_raymarine.html#fmt_raymarine_o_location
+
+file	--rw--	ricoh	log	Ricoh GPS Log File	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html
+option	ricoh	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html#fmt_ricoh_o_snlen
+
+option	ricoh	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html#fmt_ricoh_o_snwhite
+
+option	ricoh	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html#fmt_ricoh_o_snupper
+
+option	ricoh	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html#fmt_ricoh_o_snunique
+
+option	ricoh	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html#fmt_ricoh_o_urlbase
+
+option	ricoh	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html#fmt_ricoh_o_prefer_shortnames
+
+option	ricoh	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_ricoh.html#fmt_ricoh_o_datum
+
+file	rw----	cup	cup	See You flight analysis data	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html
+option	cup	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html#fmt_cup_o_snlen
+
+option	cup	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html#fmt_cup_o_snwhite
+
+option	cup	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html#fmt_cup_o_snupper
+
+option	cup	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html#fmt_cup_o_snunique
+
+option	cup	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html#fmt_cup_o_urlbase
+
+option	cup	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html#fmt_cup_o_prefer_shortnames
+
+option	cup	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_cup.html#fmt_cup_o_datum
+
+file	rwrwrw	skyforce		Skymap / KMD150 ascii files	skyforce
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skyforce.html
+serial	r-r---	skytraq		SkyTraq Venus based loggers (download)	skytraq
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html
+option	skytraq	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_erase
+
+option	skytraq	targetlocation	Set location finder target location as lat,lng	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_targetlocation
+
+option	skytraq	configlog	Configure logging parameter as tmin:tmax:dmin:dmax	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_configlog
+
+option	skytraq	baud	Baud rate used for download	integer	230400	0	230400	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_baud
+
+option	skytraq	initbaud	Baud rate used to init device (0=autodetect)	integer	0	4800	230400	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_initbaud
+
+option	skytraq	read-at-once	Number of sectors to read at once (0=use single sector mode)	integer	255	0	255	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_read-at-once
+
+option	skytraq	first-sector	First sector to be read from the device	integer	0	0	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_first-sector
+
+option	skytraq	last-sector	Last sector to be read from the device (-1: smart read everything)	integer	-1	-1	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_last-sector
+
+option	skytraq	dump-file	Dump raw data to this file	outfile				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_dump-file
+
+option	skytraq	no-output	Disable output (useful with erase)	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_no-output
+
+option	skytraq	gps-utc-offset	Seconds that GPS time tracks UTC (0: best guess)	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_gps-utc-offset
+
+option	skytraq	gps-week-rollover	GPS week rollover period we're in (-1: best guess)	integer	-1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq.html#fmt_skytraq_o_gps-week-rollover
+
+file	r-r---	skytraq-bin	bin	SkyTraq Venus based loggers Binary File Format	skytraq-bin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq-bin.html
+option	skytraq-bin	first-sector	First sector to be read from the file	integer	0	0	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq-bin.html#fmt_skytraq-bin_o_first-sector
+
+option	skytraq-bin	last-sector	Last sector to be read from the file (-1: read till empty sector)	integer	-1	-1	65535	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq-bin.html#fmt_skytraq-bin_o_last-sector
+
+option	skytraq-bin	gps-utc-offset	Seconds that GPS time tracks UTC (0: best guess)	integer	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq-bin.html#fmt_skytraq-bin_o_gps-utc-offset
+
+option	skytraq-bin	gps-week-rollover	GPS week rollover period we're in (-1: best guess)	integer	-1			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_skytraq-bin.html#fmt_skytraq-bin_o_gps-week-rollover
+
+file	---w--	subrip	srt	SubRip subtitles for video mapping (.srt)	subrip
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_subrip.html
+option	subrip	video_time	Video position for which exact GPS time is known (hhmmss, default is 0:00:00)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_subrip.html#fmt_subrip_o_video_time
+
+option	subrip	gps_time	GPS time at position video_time (hhmmss, default is first timestamp of track)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_subrip.html#fmt_subrip_o_gps_time
+
+option	subrip	gps_date	GPS date at position video_time (hhmmss, default is first timestamp of track)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_subrip.html#fmt_subrip_o_gps_date
+
+option	subrip	format	Format for subtitles	string	%s km/h %e m\n%t %l			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_subrip.html#fmt_subrip_o_format
+
+file	--rwrw	stmsdf	sdf	Suunto Trek Manager (STM) .sdf files	stmsdf
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_stmsdf.html
+option	stmsdf	index	Index of route (if more than one in source)	integer	1	1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_stmsdf.html#fmt_stmsdf_o_index
+
+file	rwrwrw	stmwpp	txt	Suunto Trek Manager (STM) WaypointPlus files	stmwpp
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_stmwpp.html
+option	stmwpp	index	Index of route/track to write (if more than one in source)	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_stmwpp.html#fmt_stmwpp_o_index
+
+file	rwrw--	xol	xol	Swiss Map 25/50/100 (.xol)	xol
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_xol.html
+file	rw----	openoffice		Tab delimited fields useful for OpenOffice	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html
+option	openoffice	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html#fmt_openoffice_o_snlen
+
+option	openoffice	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html#fmt_openoffice_o_snwhite
+
+option	openoffice	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html#fmt_openoffice_o_snupper
+
+option	openoffice	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html#fmt_openoffice_o_snunique
+
+option	openoffice	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html#fmt_openoffice_o_urlbase
+
+option	openoffice	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html#fmt_openoffice_o_prefer_shortnames
+
+option	openoffice	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_openoffice.html#fmt_openoffice_o_datum
+
+file	r-----	teletype		Teletype [ Get Jonathon Johnson to describe	teletype
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_teletype.html
+file	-w----	text	txt	Textual Output	text
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_text.html
+option	text	nosep	Suppress separator lines between waypoints	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_text.html#fmt_text_o_nosep
+
+option	text	encrypt	Encrypt hints using ROT13	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_text.html#fmt_text_o_encrypt
+
+option	text	logs	Include groundspeak logs if present	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_text.html#fmt_text_o_logs
+
+option	text	degformat	Degrees output as 'ddd', 'dmm'(default) or 'dms'	string	dmm			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_text.html#fmt_text_o_degformat
+
+option	text	altunits	Units for altitude (f)eet or (m)etres	string	m			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_text.html#fmt_text_o_altunits
+
+option	text	splitoutput	Write each waypoint in a separate file	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_text.html#fmt_text_o_splitoutput
+
+file	----rw	tomtom_itn	itn	TomTom Itineraries (.itn)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html
+option	tomtom_itn	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html#fmt_tomtom_itn_o_snlen
+
+option	tomtom_itn	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html#fmt_tomtom_itn_o_snwhite
+
+option	tomtom_itn	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html#fmt_tomtom_itn_o_snupper
+
+option	tomtom_itn	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html#fmt_tomtom_itn_o_snunique
+
+option	tomtom_itn	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html#fmt_tomtom_itn_o_urlbase
+
+option	tomtom_itn	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html#fmt_tomtom_itn_o_prefer_shortnames
+
+option	tomtom_itn	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn.html#fmt_tomtom_itn_o_datum
+
+file	----rw	tomtom_itn_places	itn	TomTom Places Itineraries (.itn)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html
+option	tomtom_itn_places	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html#fmt_tomtom_itn_places_o_snlen
+
+option	tomtom_itn_places	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html#fmt_tomtom_itn_places_o_snwhite
+
+option	tomtom_itn_places	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html#fmt_tomtom_itn_places_o_snupper
+
+option	tomtom_itn_places	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html#fmt_tomtom_itn_places_o_snunique
+
+option	tomtom_itn_places	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html#fmt_tomtom_itn_places_o_urlbase
+
+option	tomtom_itn_places	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html#fmt_tomtom_itn_places_o_prefer_shortnames
+
+option	tomtom_itn_places	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_itn_places.html#fmt_tomtom_itn_places_o_datum
+
+file	rw----	tomtom_asc	asc	TomTom POI file (.asc)	xcsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html
+option	tomtom_asc	snlen	Max synthesized shortname length	integer		1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html#fmt_tomtom_asc_o_snlen
+
+option	tomtom_asc	snwhite	Allow whitespace synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html#fmt_tomtom_asc_o_snwhite
+
+option	tomtom_asc	snupper	UPPERCASE synth. shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html#fmt_tomtom_asc_o_snupper
+
+option	tomtom_asc	snunique	Make synth. shortnames unique	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html#fmt_tomtom_asc_o_snunique
+
+option	tomtom_asc	urlbase	Basename prepended to URL on output	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html#fmt_tomtom_asc_o_urlbase
+
+option	tomtom_asc	prefer_shortnames	Use shortname instead of description	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html#fmt_tomtom_asc_o_prefer_shortnames
+
+option	tomtom_asc	datum	GPS datum (def. WGS 84)	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom_asc.html#fmt_tomtom_asc_o_datum
+
+file	rw----	tomtom	ov2	TomTom POI file (.ov2)	tomtom
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tomtom.html
+file	rw----	tmpro	tmpro	TopoMapPro Places File	tmpro
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tmpro.html
+file	rwrw--	dmtlog	trl	TrackLogs digital mapping (.trl)	dmtlog
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dmtlog.html
+option	dmtlog	index	Index of track (if more than one in source)	integer	1	1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_dmtlog.html#fmt_dmtlog_o_index
+
+file	rw----	tiger		U.S. Census Bureau Tiger Mapping Service	tiger
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html
+option	tiger	nolabels	Suppress labels on generated pins	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_nolabels
+
+option	tiger	genurl	Generate file with lat/lon for centering map	outfile				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_genurl
+
+option	tiger	margin	Margin for map.  Degrees or percentage	float	15%			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_margin
+
+option	tiger	snlen	Max shortname length when used with -s	integer	10	1		https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_snlen
+
+option	tiger	oldthresh	Days after which points are considered old	integer	14			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_oldthresh
+
+option	tiger	oldmarker	Marker type for old points	string	redpin			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_oldmarker
+
+option	tiger	newmarker	Marker type for new points	string	greenpin			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_newmarker
+
+option	tiger	suppresswhite	Suppress whitespace in generated shortnames	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_suppresswhite
+
+option	tiger	unfoundmarker	Marker type for unfound points	string	bluepin			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_unfoundmarker
+
+option	tiger	xpixels	Width in pixels of map	integer	768			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_xpixels
+
+option	tiger	ypixels	Height in pixels of map	integer	768			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_ypixels
+
+option	tiger	iconismarker	The icon description is already the marker	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_tiger.html#fmt_tiger_o_iconismarker
+
+file	rwrwrw	unicsv		Universal csv with field structure in first line	unicsv
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html
+option	unicsv	datum	GPS datum (def. WGS 84)	string	WGS 84			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_datum
+
+option	unicsv	grid	Write position using this grid.	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_grid
+
+option	unicsv	utc	Write timestamps with offset x to UTC time	integer		-23	+23	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_utc
+
+option	unicsv	format	Write name(s) of format(s) from input session(s)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_format
+
+option	unicsv	filename	Write filename(s) from input session(s)	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_filename
+
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_prec
+
+option	unicsv	fields	Name and order of input fields, separated by '+'	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_fields
+
+option	unicsv	codec	codec to use for reading and writing strings (default UTF-8)	string	UTF-8			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_unicsv.html#fmt_unicsv_o_codec
+
+file	-w----	vcard	vcf	Vcard Output (for iPod)	vcard
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_vcard.html
+option	vcard	encrypt	Encrypt hints using ROT13	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_vcard.html#fmt_vcard_o_encrypt
+
+file	--rw--	vidaone	gpb	VidaOne GPS for Pocket PC (.gpb)	vidaone
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_vidaone.html
+option	vidaone	ver	Version of VidaOne file to read or write (1 or 2)	integer	1	1	2	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_vidaone.html#fmt_vidaone_o_ver
+
+file	rwrwrw	vitosmt	smt	Vito Navigator II tracks	vitosmt
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_vitosmt.html
+file	--r---	vitovtt	vtt	Vito SmartMap tracks (.vtt)	vitovtt
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_vitovtt.html
+file	r-----	wfff	xml	WiFiFoFum 2.0 for PocketPC XML	wfff
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wfff.html
+option	wfff	aicicon	Infrastructure closed icon name	string	Red Square			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wfff.html#fmt_wfff_o_aicicon
+
+option	wfff	aioicon	Infrastructure open icon name	string	Green Square			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wfff.html#fmt_wfff_o_aioicon
+
+option	wfff	ahcicon	Ad-hoc closed icon name	string	Red Diamond			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wfff.html#fmt_wfff_o_ahcicon
+
+option	wfff	ahoicon	Ad-hoc open icon name	string	Green Diamond			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wfff.html#fmt_wfff_o_ahoicon
+
+option	wfff	snmac	Shortname is MAC address	boolean				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wfff.html#fmt_wfff_o_snmac
+
+file	r-r---	wintec_tes	tes	Wintec TES file	wintec_tes
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wintec_tes.html
+file	--r---	wbt-bin	bin	Wintec WBT-100/200 Binary File Format	wbt-bin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wbt-bin.html
+serial	r-r---	wbt		Wintec WBT-100/200 GPS Download	wbt
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wbt.html
+option	wbt	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wbt.html#fmt_wbt_o_erase
+
+file	--r---	wbt-tk1	tk1	Wintec WBT-201/G-Rays 2 Binary File Format	wbt-tk1
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_wbt-tk1.html
+serial	r-r---	itracku		XAiOX iTrackU Logger	itracku
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_itracku.html
+option	itracku	backup	Appends the input to a backup file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_itracku.html#fmt_itracku_o_backup
+
+option	itracku	new	Only waypoints that are not the backup file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_itracku.html#fmt_itracku_o_new
+
+file	rwrw--	itracku-bin	bin	XAiOX iTrackU Logger Binary File Format	itracku-bin
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_itracku-bin.html
+option	itracku-bin	backup	Appends the input to a backup file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_itracku-bin.html#fmt_itracku-bin_o_backup
+
+option	itracku-bin	new	Only waypoints that are not the backup file	string				https://www.gpsbabel.org/htmldoc-1.6.0/fmt_itracku-bin.html#fmt_itracku-bin_o_new
+
+file	r-----	yahoo		Yahoo Geocode API data	yahoo
+	https://www.gpsbabel.org/htmldoc-1.6.0/fmt_yahoo.html
+option	yahoo	addrsep	String to separate concatenated address fields (default=", ")	string	, 			https://www.gpsbabel.org/htmldoc-1.6.0/fmt_yahoo.html#fmt_yahoo_o_addrsep
+

--- a/reference/formatusage.txt
+++ b/reference/formatusage.txt
@@ -1,0 +1,11 @@
+
+	gpx                   GPX XML
+	  snlen                 Length of generated shortnames 
+	  suppresswhite         (0/1) No whitespace in generated shortnames 
+	  logpoint              (0/1) Create waypoints from geocache log entries 
+	  urlbase               Base URL for link tag in output 
+	  gpxver                Target GPX version for output 
+	  humminbirdextensio    (0/1) Add info (depth) as Humminbird extension 
+	  garminextensions      (0/1) Add info (depth) as Garmin extension 
+	  elevprec              Precision of elevations, number of decimals 
+

--- a/reference/help.txt
+++ b/reference/help.txt
@@ -1,0 +1,855 @@
+GPSBabel Version 1.6.0.  https://www.gpsbabel.org
+
+Usage:
+    ./gpsbabel [options] -i INTYPE -f INFILE [filter] -o OUTTYPE -F OUTFILE
+    ./gpsbabel [options] -i INTYPE -o OUTTYPE INFILE [filter] OUTFILE
+
+    Converts GPS route and waypoint data from one format type to another.
+    The input type and filename are specified with the -i INTYPE
+    and -f INFILE options. The output type and filename are specified
+    with the -o OUTTYPE and -F OUTFILE options.
+    If '-' is used for INFILE or OUTFILE, stdin or stdout will be used.
+
+    In the second form of the command, INFILE and OUTFILE are the
+    first and second positional (non-option) arguments.
+
+    INTYPE and OUTTYPE must be one of the supported file types and
+    may include options valid for that file type.  For example:
+      'gpx', 'gpx,snlen=10' and 'ozi,snlen=10,snwhite=1'
+    (without the quotes) are all valid file type specifications.
+
+Options:
+    -p               Preferences file (gpsbabel.ini)
+    -s               Synthesize shortnames
+    -r               Process route information
+    -t               Process track information
+    -T               Process realtime tracking information
+    -w               Process waypoint information [default]
+    -b               Process command file (batch mode)
+    -x filtername    Invoke filter (placed between inputs and output) 
+    -D level         Set debug level [0]
+    -h, -?           Print detailed help and exit
+    -V               Print GPSBabel version and exit
+
+File Types (-i and -o options):
+	alantrl               Alan Map500 tracklogs (.trl)
+	alanwpr               Alan Map500 waypoints and routes (.wpr)
+	baroiq                Brauniger IQ Series Barograph Download
+	bushnell_trl          Bushnell GPS Trail file
+	bushnell              Bushnell GPS Waypoint file
+	cambridge             Cambridge/Winpilot glider software
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	cst                   CarteSurTable data file
+	v900                  Columbus/Visiontac V900 files (.csv)
+	csv                   Comma separated values
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	compegps              CompeGPS data files (.wpt/.trk/.rte)
+	  deficon               Default icon name 
+	  index                 Index of route/track to write (if more than one in 
+	  radius                Give points (waypoints/route points) a default rad 
+	  snlen                 Length of generated shortnames (default 16) 
+	iblue747              Data Logger iBlue747 csv
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	iblue757              Data Logger iBlue757 csv
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	an1                   DeLorme .an1 (drawing) file
+	  type                  Type of .an1 file 
+	  road                  Road type changes 
+	  nogc                  (0/1) Do not add geocache data to description 
+	  nourl                 (0/1) Do not add URLs to description 
+	  deficon               Symbol to use for point data 
+	  color                 Color for lines or mapnotes 
+	  zoom                  Zoom level to reduce points 
+	  wpt_type              Waypoint type 
+	  radius                Radius for circles 
+	gpl                   DeLorme GPL
+	saplus                DeLorme Street Atlas Plus
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	saroute               DeLorme Street Atlas Route
+	  turns_important       (0/1) Keep turns if simplify filter is used 
+	  turns_only            (0/1) Only read turns; skip all other points 
+	  split                 (0/1) Split into multiple routes at turns 
+	  controls              Read control points as waypoint/route/none 
+	  times                 (0/1) Synthesize track times 
+	xmap                  DeLorme XMap HH Native .WPT
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	xmap2006              DeLorme XMap/SAHH 2006 Native .TXT
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	xmapwpt               DeLorme XMat HH Street Atlas USA .WPT (PPC)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	destinator_itn        Destinator Itineraries (.dat)
+	destinator_poi        Destinator Points of Interest (.dat)
+	destinator_trl        Destinator TrackLogs (.dat)
+	easygps               EasyGPS binary format
+	exif                  Embedded Exif-GPS data (.jpg)
+	  filename              (0/1) Set waypoint name to source filename 
+	  frame                 Time-frame (in seconds) 
+	  name                  Locate waypoint for tagging by this name 
+	  overwrite             (0/1) !OVERWRITE! the original file. Default=N 
+	energympro            Energympro GPS training watch
+	enigma                Enigma binary waypoint file (.ert)
+	shape                 ESRI shapefile
+	  name                  Source for name field in .dbf 
+	  url                   Source for URL field in .dbf 
+	f90g                  F90G Automobile DVR GPS log file
+	igc                   FAI/IGC Flight Recorder Data Format
+	  timeadj               (integer sec or 'auto') Barograph to GPS time diff 
+	garmin_fit            Flexible and Interoperable Data Transfer (FIT) Act
+	  allpoints             (0/1) Read all points even if latitude or longitude is m 
+	flysight              FlySight GPS File
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	gpssim                Franson GPSGate Simulation
+	  wayptspd              Default speed for waypoints (knots/hr) 
+	  split                 (0/1) Split input into separate files 
+	fugawi                Fugawi
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	g7towin               G7ToWin data files (.g7t)
+	garmin301             Garmin 301 Custom position and heartrate
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	garmin_g1000          Garmin G1000 datalog input filter file
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	glogbook              Garmin Logbook XML
+	gdb                   Garmin MapSource - gdb
+	  cat                   Default category on output (1..16) 
+	  bitscategory          Bitmap of categories 
+	  ver                   Version of gdb file to generate (1..3) 
+	  via                   (0/1) Drop route points that do not have an equivalent w 
+	  roadbook              (0/1) Include major turn points (with description) from  
+	mapsource             Garmin MapSource - mps
+	  snlen                 Length of generated shortnames 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  mpsverout             Version of mapsource file to generate (3,4,5) 
+	  mpsmergeout           (0/1) Merge output with existing file 
+	  mpsusedepth           (0/1) Use depth values on output (default is ignore) 
+	  mpsuseprox            (0/1) Use proximity values on output (default is ignore) 
+	garmin_txt            Garmin MapSource - txt (tab delimited)
+	  date                  Read/Write date format (i.e. yyyy/mm/dd) 
+	  datum                 GPS datum (def. WGS 84) 
+	  dist                  Distance unit [m=metric, s=statute] 
+	  grid                  Write position using this grid. 
+	  prec                  Precision of coordinates 
+	  temp                  Temperature unit [c=Celsius, f=Fahrenheit] 
+	  time                  Read/Write time format (i.e. HH:mm:ss xx) 
+	  utc                   Write timestamps with offset x to UTC time 
+	pcx                   Garmin PCX5
+	  deficon               Default icon name 
+	  cartoexploreur        (0/1) Write tracks compatible with Carto Exploreur 
+	garmin_poi            Garmin POI database
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	garmin_gpi            Garmin Points of Interest (.gpi)
+	  alerts                (0/1) Enable alerts on speed or proximity distance 
+	  bitmap                Use specified bitmap on output 
+	  category              Default category on output 
+	  hide                  (0/1) Don't show gpi bitmap on device 
+	  descr                 (0/1) Write description to address field 
+	  notes                 (0/1) Write notes to address field 
+	  position              (0/1) Write position to address field 
+	  proximity             Default proximity 
+	  sleep                 After output job done sleep n second(s) 
+	  speed                 Default speed 
+	  unique                (0/1) Create unique waypoint names (default = yes) 
+	  units                 Units used for names with @speed ('s'tatute or 'm' 
+	  writecodec            codec to use for writing strings 
+	  languagecode          language code to use for reading dual language fil 
+	garmin                Garmin serial/USB protocol
+	  snlen                 Length of generated shortnames 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  deficon               Default icon name 
+	  get_posn              (0/1) Return current position as a waypoint 
+	  power_off             (0/1) Command unit to power itself down 
+	  erase_t               (0/1) Erase existing courses when writing new ones 
+	  resettime             (0/1) Sync GPS time to computer time 
+	  category              Category number to use for written waypoints 
+	  bitscategory          Bitmap of categories 
+	  baud                  Speed in bits per second of serial port (baud=9600 
+	gtrnctr               Garmin Training Center (.tcx/.crs/.hst/.xml)
+	  course                (0/1) Write course rather than history, default yes 
+	  sport                 Sport: Biking (deflt), Running, MultiSport, Other 
+	geo                   Geocaching.com .loc
+	  deficon               Default icon name 
+	  nuke_placer           (0/1) Omit Placer name 
+	ggv_ovl               Geogrid-Viewer ascii overlay file (.ovl)
+	ggv_bin               Geogrid-Viewer binary overlay file (.ovl)
+	ggv_log               Geogrid-Viewer tracklogs (.log)
+	geojson               GeoJson
+	  compact               (0/1) Compact Output. Default is off. 
+	geonet                GEOnet Names Server (GNS)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	dg-100                GlobalSat DG-100/BT-335 Download
+	  erase                 (0/1) Erase device data after download 
+	  erase_only            (0/1) Only erase device data, do not download anything 
+	dg-200                GlobalSat DG-200 Download
+	  erase                 (0/1) Erase device data after download 
+	  erase_only            (0/1) Only erase device data, do not download anything 
+	globalsat             GlobalSat GH625XT GPS training watch
+	  showlist              (0/1) list tracks 
+	  track                 get track 
+	  dump-file             Dump raw data to this file 
+	  input-is-dump-file    (0/1) Dump raw data to this file 
+	googledir             Google Directions XML
+	kml                   Google Earth (Keyhole) Markup Language
+	  deficon               Default icon name 
+	  lines                 (0/1) Export linestrings for tracks and routes 
+	  points                (0/1) Export placemarks for tracks and routes 
+	  line_width            Width of lines, in pixels 
+	  line_color            Line color, specified in hex AABBGGRR 
+	  floating              (0/1) Altitudes are absolute and not clamped to ground 
+	  extrude               (0/1) Draw extrusion line from trackpoint to ground 
+	  track                 (0/1) Write KML track (default = 0) 
+	  trackdata             (0/1) Include extended data for trackpoints (default = 1 
+	  trackdirection        (0/1) Indicate direction of travel in track icons (defau 
+	  units                 Units used when writing comments ('s'tatute, 'm'et 
+	  labels                (0/1) Display labels on track and routepoints  (default  
+	  max_position_point    Retain at most this number of position points  (0  
+	  rotate_colors         Rotate colors for tracks and routes (default autom 
+	  prec                  Precision of coordinates, number of decimals 
+	gnav_trl              Google Navigator Tracklines (.trl)
+	gopal                 GoPal GPS track log (.trk)
+	  date                  Complete date-free tracks with given date (YYYYMMD 
+	  maxspeed              The maximum speed (km/h) traveling from waypoint t 
+	  minspeed              The minimum speed (km/h) traveling from waypoint t 
+	  clean                 (0/1) Cleanup common errors in trackdata 
+	land_air_sea          GPS Tracking Key Pro text
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	gtm                   GPS TrackMaker
+	arc                   GPSBabel arc filter file
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	gpsdrive              GpsDrive Format
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	gpsdrivetrack         GpsDrive Format for Tracks
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	gpsman                GPSman
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	gpsutil               gpsutil
+	gpx                   GPX XML
+	  snlen                 Length of generated shortnames 
+	  suppresswhite         (0/1) No whitespace in generated shortnames 
+	  logpoint              (0/1) Create waypoints from geocache log entries 
+	  urlbase               Base URL for link tag in output 
+	  gpxver                Target GPX version for output 
+	  humminbirdextensio    (0/1) Add info (depth) as Humminbird extension 
+	  garminextensions      (0/1) Add info (depth) as Garmin extension 
+	  elevprec              Precision of elevations, number of decimals 
+	hiketech              HikeTech
+	holux                 Holux (gm-100) .wpo Format
+	m241-bin              Holux M-241 (MTK based) Binary File Format
+	  csv                   MTK compatible CSV output file 
+	m241                  Holux M-241 (MTK based) download
+	  erase                 (0/1) Erase device data after download 
+	  erase_only            (0/1) Only erase device data, do not download anything 
+	  log_enable            (0/1) Enable logging after download 
+	  csv                   MTK compatible CSV output file 
+	  block_size_kb         Size of blocks in KB to request from device 
+	vpl                   Honda/Acura Navigation System VP Log File Format
+	html                  HTML Output
+	  stylesheet            Path to HTML style sheet 
+	  encrypt               (0/1) Encrypt hints using ROT13 
+	  logs                  (0/1) Include groundspeak logs if present 
+	  degformat             Degrees output as 'ddd', 'dmm'(default) or 'dms' 
+	  altunits              Units for altitude (f)eet or (m)etres 
+	humminbird_ht         Humminbird tracks (.ht)
+	humminbird            Humminbird waypoints and routes (.hwr)
+	ignrando              IGN Rando track files
+	  index                 Index of track to write (if more than one in sourc 
+	igoprimo_poi          iGo Primo points of interest (.upoi)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	igo2008_poi           iGO2008 points of interest (.upoi)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	igo8                  IGO8 .trk
+	  tracknum              Track identification number 
+	  title                 Track title 
+	  description           Track description 
+	jtr                   Jelbert GeoTagger data file
+	jogmap                Jogmap.de XML format
+	kompass_tk            Kompass (DAV) Track (.tk)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	kompass_wp            Kompass (DAV) Waypoints (.wp)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	psitrex               KuDaTa PsiTrex text
+	lowranceusr           Lowrance USR
+	  ignoreicons           (0/1) (USR input) Ignore event marker icons on read 
+	  writeasicons          (0/1) (USR output) Treat waypoints as icons on write 
+	  merge                 (0/1) (USR output) Merge into one segmented trail 
+	  break                 (0/1) (USR input) Break segments into separate trails 
+	  wversion              (USR output) Write version 
+	  title                 (USR output) Output file title string 
+	  serialnum             (USR output) Device serial number 
+	  description           (USR output) Output file content description 
+	maggeo                Magellan Explorist Geocaching
+	mapsend               Magellan Mapsend
+	  trkver                MapSend version TRK file to generate (3,4) 
+	magellanx             Magellan SD files (as for eXplorist)
+	  deficon               Default icon name 
+	  maxcmts               Max number of comments to write (maxcmts=200) 
+	magellan              Magellan SD files (as for Meridian)
+	  deficon               Default icon name 
+	  maxcmts               Max number of comments to write (maxcmts=200) 
+	magellan              Magellan serial protocol
+	  deficon               Default icon name 
+	  maxcmts               Max number of comments to write (maxcmts=200) 
+	  baud                  Numeric value of bitrate (baud=4800) 
+	  noack                 (0/1) Suppress use of handshaking in name of speed 
+	  nukewpt               (0/1) Delete all waypoints 
+	ik3d                  MagicMaps IK3D project file (.ikt)
+	mainnav               Mainnav
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	tef                   Map&Guide 'TourExchangeFormat' XML
+	  routevia              (0/1) Include only via stations in route 
+	mapasia_tr7           MapAsia track file (.tr7)
+	mapbar                Mapbar (China) navigation track for Sonim Xp3300
+	mapfactor             Mapfactor Navigator
+	mapconverter          Mapopolis.com Mapconverter CSV
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	mxf                   MapTech Exchange Format
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	mtk_locus             MediaTek Locus
+	  baudrate              Speed in bits per second of serial port (autodetec 
+	  download              (0/1) Download logged fixes 
+	  erase                 (0/1) Erase device data after download 
+	  status                (0/1) Show device status 
+	  enable                (0/1) Enable logging after download 
+	mmo                   Memory-Map Navigator overlay files (.mmo)
+	  locked                (0/1) Write items 'locked' [default no] 
+	  visible               (0/1) Write items 'visible' [default yes] 
+	  ver                   Write files with internal version [n] 
+	s_and_t               Microsoft Streets and Trips 2002-2007
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	miniHomer             MiniHomer, a skyTraq Venus 6 based logger (downloa
+	  baud                  Baud rate used for download 
+	  dump-file             Dump raw data to this file 
+	  erase                 (0/1) Erase device data after download 
+	  first-sector          First sector to be read from the device 
+	  initbaud              Baud rate used to init device (0=autodetect) 
+	  last-sector           Last sector to be read from the device (-1: smart  
+	  no-output             (0/1) Disable output (useful with erase) 
+	  read-at-once          Number of sectors to read at once (0=use single se 
+	  Home                  POI for Home Symbol as lat:lng[:alt] 
+	  Car                   POI for Car Symbol as lat:lng[:alt] 
+	  Boat                  POI for Boat Symbol as lat:lng[:alt] 
+	  Heart                 POI for Heart Symbol as lat:lng[:alt] 
+	  Bar                   POI for Bar Symbol as lat:lng[:alt] 
+	  gps-utc-offset        Seconds that GPS time tracks UTC (0: best guess) 
+	  gps-week-rollover     GPS week rollover period we're in (-1: best guess) 
+	garmin_xt             Mobile Garmin XT Track files
+	  ftype                 Garmin Mobile XT ([ATRK]/STRK) (required)
+	  trk_header            Track name processing option ([0]-nrm/1-ign) 
+	motoactv              Motoactiv CSV
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	bcr                   Motorrad Routenplaner (Map&Guide) .bcr files
+	  index                 Index of route to write (if more than one in sourc 
+	  name                  New name for the route 
+	  radius                Radius of our big earth (default 6371000 meters) 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	mtk-bin               MTK Logger (iBlue 747,...) Binary File Format
+	  csv                   MTK compatible CSV output file 
+	mtk                   MTK Logger (iBlue 747,Qstarz BT-1000,...) download
+	  erase                 (0/1) Erase device data after download 
+	  erase_only            (0/1) Only erase device data, do not download anything 
+	  log_enable            (0/1) Enable logging after download 
+	  csv                   MTK compatible CSV output file 
+	  block_size_kb         Size of blocks in KB to request from device 
+	mynav                 MyNav TRC format
+	tpg                   National Geographic Topo .tpg (waypoints)
+	  datum                 Datum (default=NAD27) 
+	tpo2                  National Geographic Topo 2.x .tpo
+	tpo3                  National Geographic Topo 3.x/4.x .tpo
+	navicache             Navicache.com XML
+	  noretired             (0/1) Suppress retired geocaches 
+	nmn4                  Navigon Mobile Navigator .rte files
+	  index                 Index of route to write (if more than one in sourc 
+	navigonwpt            Navigon Waypoints
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	navilink              NaviGPS GT-11/BGT-11 Download
+	  nuketrk               (0/1) Delete all track points 
+	  nukerte               (0/1) Delete all routes 
+	  nukewpt               (0/1) Delete all waypoints 
+	  nukedlg               (0/1) Clear the datalog 
+	  datalog               (0/1) Read from datalogger buffer 
+	  power_off             (0/1) Command unit to power itself down 
+	sbp                   NaviGPS GT-31/BGT-31 datalogger (.sbp)
+	sbn                   NaviGPS GT-31/BGT-31 SiRF binary logfile (.sbn)
+	naviguide             Naviguide binary route file (.twl)
+	  output                'wp' - Create waypoint file , 'rte' - Create route 
+	  reorder               'n' - Keep the existing wp name, 'y' - rename wayp 
+	navitel_trk           Navitel binary track (.bin)
+	dna                   Navitrak DNA marker format
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	netstumbler           NetStumbler Summary File (text)
+	  nseicon               Non-stealth encrypted icon name 
+	  nsneicon              Non-stealth non-encrypted icon name 
+	  seicon                Stealth encrypted icon name 
+	  sneicon               Stealth non-encrypted icon name 
+	  snmac                 (0/1) Shortname is MAC address 
+	nima                  NIMA/GNIS Geographic Names File
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	nmea                  NMEA 0183 sentences
+	  snlen                 Max length of waypoint name to write 
+	  gprmc                 (0/1) Read/write GPRMC sentences 
+	  gpgga                 (0/1) Read/write GPGGA sentences 
+	  gpvtg                 (0/1) Read/write GPVTG sentences 
+	  gpgsa                 (0/1) Read/write GPGSA sentences 
+	  date                  Complete date-free tracks with given date (YYYYMMD 
+	  get_posn              (0/1) Return current position as a waypoint 
+	  pause                 Decimal seconds to pause between groups of strings 
+	  append_positioning    (0/1) Append realtime positioning data to the output fil 
+	  baud                  Speed in bits per second of serial port (baud=4800 
+	  gisteq                (0/1) Write tracks for Gisteq Phototracker 
+	  ignore_fix            (0/1) Accept position fixes in gpgga marked invalid 
+	lmx                   Nokia Landmark Exchange
+	  binary                (0/1) Compact binary representation 
+	osm                   OpenStreetMap data files
+	  tag                   Write additional way tag key/value pairs 
+	  tagnd                 Write additional node tag key/value pairs 
+	  created_by            Use this value as custom created_by value 
+	ozi                   OziExplorer
+	  pack                  (0/1) Write all tracks into one file 
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  wptfgcolor            Waypoint foreground color 
+	  wptbgcolor            Waypoint background color 
+	  proximity             Proximity distance 
+	  altunit               Unit used in altitude values 
+	  proxunit              Unit used in proximity values 
+	  codec                 codec to use for reading and writing strings (defa 
+	pocketfms_bc          PocketFMS breadcrumbs
+	pocketfms_fp          PocketFMS flightplan (.xml)
+	pocketfms_wp          PocketFMS waypoints (.txt)
+	raymarine             Raymarine Waypoint File (.rwf)
+	  location              Default location 
+	ricoh                 Ricoh GPS Log File
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	cup                   See You flight analysis data
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	skyforce              Skymap / KMD150 ascii files
+	skytraq               SkyTraq Venus based loggers (download)
+	  erase                 (0/1) Erase device data after download 
+	  targetlocation        Set location finder target location as lat,lng 
+	  configlog             Configure logging parameter as tmin:tmax:dmin:dmax 
+	  baud                  Baud rate used for download 
+	  initbaud              Baud rate used to init device (0=autodetect) 
+	  read-at-once          Number of sectors to read at once (0=use single se 
+	  first-sector          First sector to be read from the device 
+	  last-sector           Last sector to be read from the device (-1: smart  
+	  dump-file             Dump raw data to this file 
+	  no-output             (0/1) Disable output (useful with erase) 
+	  gps-utc-offset        Seconds that GPS time tracks UTC (0: best guess) 
+	  gps-week-rollover     GPS week rollover period we're in (-1: best guess) 
+	skytraq-bin           SkyTraq Venus based loggers Binary File Format
+	  first-sector          First sector to be read from the file 
+	  last-sector           Last sector to be read from the file (-1: read til 
+	  gps-utc-offset        Seconds that GPS time tracks UTC (0: best guess) 
+	  gps-week-rollover     GPS week rollover period we're in (-1: best guess) 
+	subrip                SubRip subtitles for video mapping (.srt)
+	  video_time            Video position for which exact GPS time is known ( 
+	  gps_time              GPS time at position video_time (hhmmss, default i 
+	  gps_date              GPS date at position video_time (hhmmss, default i 
+	  format                Format for subtitles 
+	stmsdf                Suunto Trek Manager (STM) .sdf files
+	  index                 Index of route (if more than one in source) 
+	stmwpp                Suunto Trek Manager (STM) WaypointPlus files
+	  index                 Index of route/track to write (if more than one in 
+	xol                   Swiss Map 25/50/100 (.xol)
+	openoffice            Tab delimited fields useful for OpenOffice
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	teletype              Teletype [ Get Jonathon Johnson to describe
+	text                  Textual Output
+	  nosep                 (0/1) Suppress separator lines between waypoints 
+	  encrypt               (0/1) Encrypt hints using ROT13 
+	  logs                  (0/1) Include groundspeak logs if present 
+	  degformat             Degrees output as 'ddd', 'dmm'(default) or 'dms' 
+	  altunits              Units for altitude (f)eet or (m)etres 
+	  splitoutput           (0/1) Write each waypoint in a separate file 
+	tomtom_itn            TomTom Itineraries (.itn)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	tomtom_itn_places     TomTom Places Itineraries (.itn)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	tomtom_asc            TomTom POI file (.asc)
+	  snlen                 Max synthesized shortname length 
+	  snwhite               (0/1) Allow whitespace synth. shortnames 
+	  snupper               (0/1) UPPERCASE synth. shortnames 
+	  snunique              (0/1) Make synth. shortnames unique 
+	  urlbase               Basename prepended to URL on output 
+	  prefer_shortnames     (0/1) Use shortname instead of description 
+	  datum                 GPS datum (def. WGS 84) 
+	tomtom                TomTom POI file (.ov2)
+	tmpro                 TopoMapPro Places File
+	dmtlog                TrackLogs digital mapping (.trl)
+	  index                 Index of track (if more than one in source) 
+	tiger                 U.S. Census Bureau Tiger Mapping Service
+	  nolabels              (0/1) Suppress labels on generated pins 
+	  genurl                Generate file with lat/lon for centering map 
+	  margin                Margin for map.  Degrees or percentage 
+	  snlen                 Max shortname length when used with -s 
+	  oldthresh             Days after which points are considered old 
+	  oldmarker             Marker type for old points 
+	  newmarker             Marker type for new points 
+	  suppresswhite         (0/1) Suppress whitespace in generated shortnames 
+	  unfoundmarker         Marker type for unfound points 
+	  xpixels               Width in pixels of map 
+	  ypixels               Height in pixels of map 
+	  iconismarker          (0/1) The icon description is already the marker 
+	unicsv                Universal csv with field structure in first line
+	  datum                 GPS datum (def. WGS 84) 
+	  grid                  Write position using this grid. 
+	  utc                   Write timestamps with offset x to UTC time 
+	  format                (0/1) Write name(s) of format(s) from input session(s) 
+	  filename              (0/1) Write filename(s) from input session(s) 
+	  fields                Name and order of input fields, separated by '+' 
+	  codec                 codec to use for reading and writing strings (defa 
+	vcard                 Vcard Output (for iPod)
+	  encrypt               (0/1) Encrypt hints using ROT13 
+	vidaone               VidaOne GPS for Pocket PC (.gpb)
+	  ver                   Version of VidaOne file to read or write (1 or 2) 
+	vitosmt               Vito Navigator II tracks
+	vitovtt               Vito SmartMap tracks (.vtt)
+	wfff                  WiFiFoFum 2.0 for PocketPC XML
+	  aicicon               Infrastructure closed icon name 
+	  aioicon               Infrastructure open icon name 
+	  ahcicon               Ad-hoc closed icon name 
+	  ahoicon               Ad-hoc open icon name 
+	  snmac                 (0/1) Shortname is MAC address 
+	wintec_tes            Wintec TES file
+	wbt-bin               Wintec WBT-100/200 Binary File Format
+	wbt                   Wintec WBT-100/200 GPS Download
+	  erase                 (0/1) Erase device data after download 
+	wbt-tk1               Wintec WBT-201/G-Rays 2 Binary File Format
+	itracku               XAiOX iTrackU Logger
+	  backup                Appends the input to a backup file 
+	  new                   Only waypoints that are not the backup file 
+	itracku-bin           XAiOX iTrackU Logger Binary File Format
+	  backup                Appends the input to a backup file 
+	  new                   Only waypoints that are not the backup file 
+	yahoo                 Yahoo Geocode API data
+	  addrsep               String to separate concatenated address fields (de 
+
+Supported data filters:
+	arc                   Include Only Points Within Distance of Arc        
+	  file                  File containing vertices of arc 
+	  rte                   Route(s) are vertices of arc 
+	  trk                   Track(s) are vertices of arc 
+	  distance              Maximum distance from arc (required)
+	  exclude               Exclude points close to the arc 
+	  points                Use distance from vertices not lines 
+	  project               Move waypoints to its projection on lines or verti 
+	bend                  Add points before and after bends in routes       
+	  distance              Distance to the bend in meters where the new point 
+	  minangle              Minimum bend angle in degrees 
+	discard               Remove unreliable points with high hdop or vdop   
+	  hdop                  Suppress points with higher hdop 
+	  vdop                  Suppress points with higher vdop 
+	  hdopandvdop           Link hdop and vdop suppression with AND 
+	  sat                   Minimum sats to keep points 
+	  fixnone               Suppress points without fix 
+	  fixunknown            Suppress points with unknown fix 
+	  elemin                Suppress points below given elevation in meters 
+	  elemax                Suppress points above given elevation in meters 
+	  matchname             Suppress points where name matches given name 
+	  matchdesc             Suppress points where description matches given na 
+	  matchcmt              Suppress points where comment matches given name 
+	  matchicon             Suppress points where type matches given name 
+	duplicate             Remove Duplicates                                 
+	  shortname             Suppress duplicate waypoints based on name 
+	  location              Suppress duplicate waypoint based on coords 
+	  all                   Suppress all instances of duplicates 
+	  correct               Use coords from duplicate points 
+	interpolate           Interpolate between trackpoints                   
+	  time                  Time interval in seconds 
+	  distance              Distance interval in miles or kilometers 
+	  route                 Interpolate routes instead 
+	nuketypes             Remove all waypoints, tracks, or routes           
+	  waypoints             Remove all waypoints from data stream 
+	  tracks                Remove all tracks from data stream 
+	  routes                Remove all routes from data stream 
+	polygon               Include Only Points Inside Polygon                
+	  file                  File containing vertices of polygon (required)
+	  exclude               Exclude points inside the polygon 
+	position              Remove Points Within Distance                     
+	  distance              Maximum positional distance (required)
+	  all                   Suppress all points close to other points 
+	  time                  Maximum time in seconds between two points (required)
+	radius                Include Only Points Within Radius                 
+	  lat                   Latitude for center point (D.DDDDD) (required)
+	  lon                   Longitude for center point (D.DDDDD) (required)
+	  distance              Maximum distance from center (required)
+	  exclude               Exclude points close to center 
+	  nosort                Inhibit sort by distance to center 
+	  maxcount              Output no more than this number of points 
+	  asroute               Put resulting waypoints in route of this name 
+	simplify              Simplify routes                                   
+	  count                 Maximum number of points in route 
+	  error                 Maximum error 
+	  crosstrack            Use cross-track error (default) 
+	  length                Use arclength error 
+	  relative              Use relative error 
+	sort                  Rearrange waypoints, routes and/or tracks by resor
+	  description           Sort waypoints by description 
+	  gcid                  Sort waypoints by numeric geocache ID 
+	  shortname             Sort waypoints by short name 
+	  time                  Sort waypoints by time 
+	  rtedesc               Sort routes by description 
+	  rtename               Sort routes by name 
+	  rtenum                Sort routes by number 
+	  trkdesc               Sort tracks by description 
+	  trkname               Sort tracks by name 
+	  trknum                Sort tracks by number 
+	stack                 Save and restore waypoint lists                   
+	  push                  Push waypoint list onto stack 
+	  pop                   Pop waypoint list from stack 
+	  swap                  Swap waypoint list with <depth> item on stack 
+	  copy                  (push) Copy waypoint list 
+	  append                (pop) Append list 
+	  discard               (pop) Discard top of stack 
+	  replace               (pop) Replace list (default) 
+	  depth                 (swap) Item to use (default=1) 
+	reverse               Reverse stops within routes                       
+	track                 Manipulate track lists                            
+	  move                  Correct trackpoint timestamps by a delta 
+	  pack                  Pack all tracks into one 
+	  split                 Split by date or time interval (see README) 
+	  sdistance             Split by distance 
+	  merge                 Merge multiple tracks for the same way 
+	  name                  Use only track(s) where title matches given name 
+	  start                 Use only track points after this timestamp 
+	  stop                  Use only track points before this timestamp 
+	  title                 Basic title for new track(s) 
+	  fix                   Synthesize GPS fixes (PPS, DGPS, 3D, 2D, NONE) 
+	  course                Synthesize course 
+	  speed                 Synthesize speed 
+	  seg2trk               Split track at segment boundaries into multiple tr 
+	  trk2seg               Merge tracks inserting segment separators at bound 
+	  segment               segment tracks with abnormally long gaps 
+	  faketime              Add specified timestamp to each trackpoint 
+	  discard               Discard track points without timestamps during mer 
+	  minimum_points        Discard tracks with fewer than these points 
+	transform             Transform waypoints into a route, tracks into rout
+	  wpt                   Transform track(s) or route(s) into waypoint(s) [R 
+	  rte                   Transform waypoint(s) or track(s) into route(s) [W 
+	  trk                   Transform waypoint(s) or route(s) into tracks(s) [ 
+	  rptdigits             Number of digits in generated names 
+	  rptname               Use source name for route point names 
+	  del                   Delete source data after transformation 
+	height                Manipulate altitudes                              
+	  add                   Adds a constant value to every altitude (meter, ap 
+	  wgs84tomsl            Converts WGS84 ellipsoidal height to orthometric h 
+	swap                  Swap latitude and longitude of all loaded points  
+	validate              Validate internal data structures                 
+	  checkempty            Check for empty input 
+	  debug                 Output debug messages instead of possibly issuing  

--- a/reference/usage.txt
+++ b/reference/usage.txt
@@ -1,0 +1,36 @@
+GPSBabel Version 1.6.0.  https://www.gpsbabel.org
+
+Usage:
+    ./gpsbabel [options] -i INTYPE -f INFILE [filter] -o OUTTYPE -F OUTFILE
+    ./gpsbabel [options] -i INTYPE -o OUTTYPE INFILE [filter] OUTFILE
+
+    Converts GPS route and waypoint data from one format type to another.
+    The input type and filename are specified with the -i INTYPE
+    and -f INFILE options. The output type and filename are specified
+    with the -o OUTTYPE and -F OUTFILE options.
+    If '-' is used for INFILE or OUTFILE, stdin or stdout will be used.
+
+    In the second form of the command, INFILE and OUTFILE are the
+    first and second positional (non-option) arguments.
+
+    INTYPE and OUTTYPE must be one of the supported file types and
+    may include options valid for that file type.  For example:
+      'gpx', 'gpx,snlen=10' and 'ozi,snlen=10,snwhite=1'
+    (without the quotes) are all valid file type specifications.
+
+Options:
+    -p               Preferences file (gpsbabel.ini)
+    -s               Synthesize shortnames
+    -r               Process route information
+    -t               Process track information
+    -T               Process realtime tracking information
+    -w               Process waypoint information [default]
+    -b               Process command file (batch mode)
+    -x filtername    Invoke filter (placed between inputs and output) 
+    -D level         Set debug level [0]
+    -h, -?           Print detailed help and exit
+    -V               Print GPSBabel version and exit
+
+
+
+[Press enter]

--- a/testo
+++ b/testo
@@ -52,6 +52,15 @@ compare()
 	}
 }
 
+compare_nole()
+{
+	${DIFF} -u --strip-trailing-cr $* ||  {
+		echo ERROR comparing $*
+		errorcount=`expr $errorcount + 1`
+		#exit 1
+	}
+}
+
 compare_with_alternate()
 {
 	${DIFF} -u -b -w $1 $3 1>${TMPDIR}/compare.log ||  {

--- a/testo.d/csv.test
+++ b/testo.d/csv.test
@@ -8,3 +8,44 @@ compare ${TMPDIR}/csv2.csv ${TMPDIR}/csv.csv
 gpsbabel -i csv -o gpx ${TMPDIR}/csv.csv ${TMPDIR}/csv3.gpx
 gpsbabel -i gpx -o csv ${TMPDIR}/csv3.gpx ${TMPDIR}/csv4.csv
 compare ${TMPDIR}/csv.csv ${TMPDIR}/csv4.csv 
+
+# flip lat and lon so we can distiguish which style file got used.
+echo '# and an internal xcsv and external xcsv.' >> ${TMPDIR}/csvb.style
+echo '# gpsbabel XCSV style file' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo '# Format: DeLorme SA 9.0 CSV' >> ${TMPDIR}/csvb.style
+echo '# Author: Alex Mottram' >> ${TMPDIR}/csvb.style
+echo '#   Date: 12/09/2002' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo 'DESCRIPTION	Comma separated values' >> ${TMPDIR}/csvb.style
+echo 'SHORTLEN	8' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo '# FILE LAYOUT DEFINITIIONS:' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo 'FIELD_DELIMITER		COMMASPACE' >> ${TMPDIR}/csvb.style
+echo 'RECORD_DELIMITER	NEWLINE' >> ${TMPDIR}/csvb.style
+echo 'BADCHARS		COMMA' >> ${TMPDIR}/csvb.style
+echo '' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo '# INDIVIDUAL DATA FIELDS, IN ORDER OF APPEARANCE:' >> ${TMPDIR}/csvb.style
+echo '#' >> ${TMPDIR}/csvb.style
+echo 'IFIELD	LON_HUMAN_READABLE, "", "%08.5f"' >> ${TMPDIR}/csvb.style
+echo 'IFIELD	LAT_HUMAN_READABLE, "", "%08.5f"' >> ${TMPDIR}/csvb.style
+echo 'IFIELD	DESCRIPTION, "", "%s"' >> ${TMPDIR}/csvb.style
+echo '' >> ${TMPDIR}/csvb.style
+echo 'OFIELD	LON_DECIMAL, "", "%08.5f"' >> ${TMPDIR}/csvb.style
+echo 'OFIELD	LAT_DECIMAL, "", "%08.5f"' >> ${TMPDIR}/csvb.style
+echo 'OFIELD	DESCRIPTION, "", "%s"' >> ${TMPDIR}/csvb.style
+
+# make sure we can follow an internal format with an explict style on read.
+gpsbabel -i csv -f ${TMPDIR}/csv.csv -i xcsv,style=${TMPDIR}/csvb.style  -f ${TMPDIR}/csv.csv -o gpx -F ${TMPDIR}/csv_csvb.gpx
+compare ${REFERENCE}/csv_csvb.gpx ${TMPDIR}/csv_csvb.gpx
+# make sure we remember the style file if we don't give a second -i.
+gpsbabel -i csv -f ${TMPDIR}/csv.csv -f ${TMPDIR}/csv.csv -o gpx -F ${TMPDIR}/csv_csv.gpx
+compare ${REFERENCE}/csv_csv.gpx ${TMPDIR}/csv_csv.gpx
+# make sure we can follow a internal format with an explict style on write.
+gpsbabel -i csv -f ${TMPDIR}/csv.csv -o xcsv,style=${TMPDIR}/csvb.style -F ${TMPDIR}/csvb.csv
+compare ${REFERENCE}/csvb.csv ${TMPDIR}/csvb.csv
+

--- a/testo.d/serialization.test
+++ b/testo.d/serialization.test
@@ -1,0 +1,33 @@
+# These outputs will change with any new format or changed format option.
+# Format options should be automatically handled by the GUI.
+# These outputs will change with any new filter or changed filter option.
+# Filter options must be hand coded in the GUI.
+#
+# These are primarily meant to serialize the interface specification to
+# the GUI and the document.
+# We do a bincompare as specific whitespace is part of deserialization.
+gpsbabel -^3 > ${TMPDIR}/format3.txt
+bincompare ${REFERENCE}/format3.txt ${TMPDIR}/format3.txt
+gpsbabel -^2 > ${TMPDIR}/format2.txt
+bincompare ${REFERENCE}/format2.txt ${TMPDIR}/format2.txt
+gpsbabel -^1 > ${TMPDIR}/format1.txt
+bincompare ${REFERENCE}/format1.txt ${TMPDIR}/format1.txt
+gpsbabel -^0 > ${TMPDIR}/format0.txt
+bincompare ${REFERENCE}/format0.txt ${TMPDIR}/format0.txt
+gpsbabel -%1 > ${TMPDIR}/filter1.txt
+bincompare ${REFERENCE}/filter1.txt ${TMPDIR}/filter1.txt
+gpsbabel -%0 > ${TMPDIR}/filter0.txt
+bincompare ${REFERENCE}/filter0.txt ${TMPDIR}/filter0.txt
+
+# These are primarily meant for a user
+gpsbabel -h > ${TMPDIR}/help.txt
+compare ${REFERENCE}/help.txt ${TMPDIR}/help.txt
+gpsbabel -h gpx > ${TMPDIR}/formatusage.txt
+compare ${REFERENCE}/formatusage.txt ${TMPDIR}/formatusage.txt
+gpsbabel -h radius > ${TMPDIR}/filterusage.txt
+compare ${REFERENCE}/filterusage.txt ${TMPDIR}/filterusage.txt
+gpsbabel > ${TMPDIR}/usage.txt << EOJ
+
+EOJ
+compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.txt
+

--- a/testo.d/serialization.test
+++ b/testo.d/serialization.test
@@ -5,19 +5,19 @@
 #
 # These are primarily meant to serialize the interface specification to
 # the GUI and the document.
-# We do a bincompare as specific whitespace is part of deserialization.
+# We do a compare_nole as specific whitespace is part of deserialization.
 gpsbabel -^3 > ${TMPDIR}/format3.txt
-bincompare ${REFERENCE}/format3.txt ${TMPDIR}/format3.txt
+compare_nole ${REFERENCE}/format3.txt ${TMPDIR}/format3.txt
 gpsbabel -^2 > ${TMPDIR}/format2.txt
-bincompare ${REFERENCE}/format2.txt ${TMPDIR}/format2.txt
+compare_nole ${REFERENCE}/format2.txt ${TMPDIR}/format2.txt
 gpsbabel -^1 > ${TMPDIR}/format1.txt
-bincompare ${REFERENCE}/format1.txt ${TMPDIR}/format1.txt
+compare_nole ${REFERENCE}/format1.txt ${TMPDIR}/format1.txt
 gpsbabel -^0 > ${TMPDIR}/format0.txt
-bincompare ${REFERENCE}/format0.txt ${TMPDIR}/format0.txt
+compare_nole ${REFERENCE}/format0.txt ${TMPDIR}/format0.txt
 gpsbabel -%1 > ${TMPDIR}/filter1.txt
-bincompare ${REFERENCE}/filter1.txt ${TMPDIR}/filter1.txt
+compare_nole ${REFERENCE}/filter1.txt ${TMPDIR}/filter1.txt
 gpsbabel -%0 > ${TMPDIR}/filter0.txt
-bincompare ${REFERENCE}/filter0.txt ${TMPDIR}/filter0.txt
+compare_nole ${REFERENCE}/filter0.txt ${TMPDIR}/filter0.txt
 
 # These are primarily meant for a user
 gpsbabel -h > ${TMPDIR}/help.txt
@@ -29,5 +29,7 @@ compare ${REFERENCE}/filterusage.txt ${TMPDIR}/filterusage.txt
 gpsbabel > ${TMPDIR}/usage.txt << EOJ
 
 EOJ
-compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.txt
+# ahh shucks, the executable changes based on OS, and the path can change as well.
+sed 's/.*\[options\]/    .\/gpsbabel [options]/' ${TMPDIR}/usage.txt > ${TMPDIR}/usage.stripped.txt
+compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.stripped.txt
 

--- a/testo.d/serialization.test
+++ b/testo.d/serialization.test
@@ -23,7 +23,9 @@ if [ ${RUNNINGVALGRIND} -ne  0 ]; then
   
   # These are primarily meant for a user
   gpsbabel -h > ${TMPDIR}/help.txt
-  compare ${REFERENCE}/help.txt ${TMPDIR}/help.txt
+  # ahh shucks, the executable changes based on OS, and the path can change as well.
+  sed 's/.*\[options\]/    .\/gpsbabel [options]/' ${TMPDIR}/help.txt > ${TMPDIR}/help.stripped.txt
+  compare ${REFERENCE}/help.txt ${TMPDIR}/help.stripped.txt
   gpsbabel -h gpx > ${TMPDIR}/formatusage.txt
   compare ${REFERENCE}/formatusage.txt ${TMPDIR}/formatusage.txt
   gpsbabel -h radius > ${TMPDIR}/filterusage.txt
@@ -32,9 +34,7 @@ if [ ${RUNNINGVALGRIND} -ne  0 ]; then
   
 EOJ
   # ahh shucks, the executable changes based on OS, and the path can change as well.
-  # sed command fails to change anything on appveyor???
-  # works ok on macos.
   sed 's/.*\[options\]/    .\/gpsbabel [options]/' ${TMPDIR}/usage.txt > ${TMPDIR}/usage.stripped.txt
-  #compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.stripped.txt
+  compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.stripped.txt
 fi
 

--- a/testo.d/serialization.test
+++ b/testo.d/serialization.test
@@ -3,33 +3,38 @@
 # These outputs will change with any new filter or changed filter option.
 # Filter options must be hand coded in the GUI.
 #
-# These are primarily meant to serialize the interface specification to
-# the GUI and the document.
-# We do a compare_nole as specific whitespace is part of deserialization.
-gpsbabel -^3 > ${TMPDIR}/format3.txt
-compare_nole ${REFERENCE}/format3.txt ${TMPDIR}/format3.txt
-gpsbabel -^2 > ${TMPDIR}/format2.txt
-compare_nole ${REFERENCE}/format2.txt ${TMPDIR}/format2.txt
-gpsbabel -^1 > ${TMPDIR}/format1.txt
-compare_nole ${REFERENCE}/format1.txt ${TMPDIR}/format1.txt
-gpsbabel -^0 > ${TMPDIR}/format0.txt
-compare_nole ${REFERENCE}/format0.txt ${TMPDIR}/format0.txt
-gpsbabel -%1 > ${TMPDIR}/filter1.txt
-compare_nole ${REFERENCE}/filter1.txt ${TMPDIR}/filter1.txt
-gpsbabel -%0 > ${TMPDIR}/filter0.txt
-compare_nole ${REFERENCE}/filter0.txt ${TMPDIR}/filter0.txt
-
-# These are primarily meant for a user
-gpsbabel -h > ${TMPDIR}/help.txt
-compare ${REFERENCE}/help.txt ${TMPDIR}/help.txt
-gpsbabel -h gpx > ${TMPDIR}/formatusage.txt
-compare ${REFERENCE}/formatusage.txt ${TMPDIR}/formatusage.txt
-gpsbabel -h radius > ${TMPDIR}/filterusage.txt
-compare ${REFERENCE}/filterusage.txt ${TMPDIR}/filterusage.txt
-gpsbabel > ${TMPDIR}/usage.txt << EOJ
-
+# we have memory leaks in sort_and_unify.
+if [ ${RUNNINGVALGRIND} -ne  0 ]; then
+  # These are primarily meant to serialize the interface specification to
+  # the GUI and the document.
+  # We do a compare_nole as specific whitespace is part of deserialization.
+  gpsbabel -^3 > ${TMPDIR}/format3.txt
+  compare_nole ${REFERENCE}/format3.txt ${TMPDIR}/format3.txt
+  gpsbabel -^2 > ${TMPDIR}/format2.txt
+  compare_nole ${REFERENCE}/format2.txt ${TMPDIR}/format2.txt
+  gpsbabel -^1 > ${TMPDIR}/format1.txt
+  compare_nole ${REFERENCE}/format1.txt ${TMPDIR}/format1.txt
+  gpsbabel -^0 > ${TMPDIR}/format0.txt
+  compare_nole ${REFERENCE}/format0.txt ${TMPDIR}/format0.txt
+  gpsbabel -%1 > ${TMPDIR}/filter1.txt
+  compare_nole ${REFERENCE}/filter1.txt ${TMPDIR}/filter1.txt
+  gpsbabel -%0 > ${TMPDIR}/filter0.txt
+  compare_nole ${REFERENCE}/filter0.txt ${TMPDIR}/filter0.txt
+  
+  # These are primarily meant for a user
+  gpsbabel -h > ${TMPDIR}/help.txt
+  compare ${REFERENCE}/help.txt ${TMPDIR}/help.txt
+  gpsbabel -h gpx > ${TMPDIR}/formatusage.txt
+  compare ${REFERENCE}/formatusage.txt ${TMPDIR}/formatusage.txt
+  gpsbabel -h radius > ${TMPDIR}/filterusage.txt
+  compare ${REFERENCE}/filterusage.txt ${TMPDIR}/filterusage.txt
+  gpsbabel > ${TMPDIR}/usage.txt << EOJ
+  
 EOJ
-# ahh shucks, the executable changes based on OS, and the path can change as well.
-sed 's/.*\[options\]/    .\/gpsbabel [options]/' ${TMPDIR}/usage.txt > ${TMPDIR}/usage.stripped.txt
-compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.stripped.txt
+  # ahh shucks, the executable changes based on OS, and the path can change as well.
+  # sed command fails to change anything on appveyor???
+  # works ok on macos.
+  sed 's/.*\[options\]/    .\/gpsbabel [options]/' ${TMPDIR}/usage.txt > ${TMPDIR}/usage.stripped.txt
+  #compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.stripped.txt
+fi
 

--- a/vecs.h
+++ b/vecs.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 
 #include <QtCore/QString>       // for QString
+#include <QtCore/QStringList>   // for QStringList
 #include <QtCore/QVector>       // for QVector<>::iterator, QVector
 
 #include "defs.h"

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -185,8 +185,8 @@ static double oldlon = 999;
 static double oldlat = 999;
 
 static int waypt_out_count = 0;
-static route_head* csv_track = nullptr;
-static route_head* csv_route = nullptr;
+static const route_head* csv_track = nullptr;
+static const route_head* csv_route = nullptr;
 
 struct xcsv_parse_data {
   QString rte_name;
@@ -1046,10 +1046,10 @@ xcsv_resetpathlen(const route_head* head)
   csv_route = csv_track = nullptr;
   switch (xcsv_style->datatype) {
   case trkdata:
-    csv_track = const_cast<route_head*>(head);
+    csv_track = head;
     break;
   case rtedata:
-    csv_route = const_cast<route_head*>(head);
+    csv_route = head;
     break;
   default:
     break;

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -23,6 +23,7 @@
 
  */
 
+#include <cassert>                 // for assert
 #include <cctype>                  // for isdigit, tolower
 #include <cmath>                   // for fabs, pow
 #include <cstdio>                  // for snprintf, sscanf
@@ -35,17 +36,15 @@
 #include <QtCore/QCharRef>         // for QCharRef
 #include <QtCore/QDate>            // for QDate
 #include <QtCore/QDateTime>        // for QDateTime
-#include <QtCore/QFile>            // for QFile
 #include <QtCore/QHash>            // for QHash
 #include <QtCore/QIODevice>        // for operator|, QIODevice::ReadOnly, QIODevice::Text, QIODevice::WriteOnly
 #include <QtCore/QList>            // for QList
 #include <QtCore/QRegExp>          // for QRegExp
 #include <QtCore/QString>          // for QString, operator+, operator==, QByteArray::append
 #include <QtCore/QStringList>      // for QStringList
-#include <QtCore/QTextCodec>       // for QTextCodec
 #include <QtCore/QTextStream>      // for QTextStream
 #include <QtCore/QTime>            // for QTime
-#include <QtCore/Qt>               // for UTC
+#include <QtCore/QVector>          // for QVector
 #include <QtCore/QtGlobal>         // for qAsConst, QAddConst<>::Type, qPrintable
 
 #include "defs.h"
@@ -57,25 +56,23 @@
 #include "jeeps/gpsport.h"         // for int32
 #include "session.h"               // for session_t
 #include "src/core/datetime.h"     // for DateTime
-#include "src/core/file.h"         // for File
 #include "src/core/logging.h"      // for Warning, Fatal
 #include "src/core/optional.h"     // for optional
+#include "src/core/textstream.h"
 #include "strptime.h"              // for strptime
 #include "xcsv.h"
 
 #define MYNAME	"XCSV"
 
 /* macros */
-#define LAT_DIR(a) a < 0.0 ? 'S' : 'N'
-#define LON_DIR(a) a < 0.0 ? 'W' : 'E'
-#define NONULL(a) a.isNull() ? "" : CSTRc(a)
+constexpr char lat_dir(double a) {return a < 0.0 ? 'S' : 'N';}
+constexpr char lon_dir(double a) {return a < 0.0 ? 'W' : 'E';}
 
 /* convert excel time (days since 1900) to time_t and back again */
-#define EXCEL_TO_TIMET(a) ((a - 25569.0) * 86400.0)
-#define TIMET_TO_EXCEL(a) ((a / 86400.0) + 25569.0)
+constexpr double excel_to_timet(double a) {return (a - 25569.0) * 86400.0;}
+constexpr double timet_to_excel(double a) {return (a / 86400.0) + 25569.0;}
 
-#define GPS_DATUM_WGS84		118
-
+constexpr int gps_datum_wgs84 = 118; // GPS_Lookup_Datum_Index("WGS 84")
 
 /*
  * Internal numeric value to associate with each keyword in a style file.
@@ -181,13 +178,15 @@ enum xcsv_token {
 /* obligatory global struct                                                 */
 /****************************************************************************/
 
-XcsvFile xcsv_file;
+static XcsvFile* xcsv_file;
+static const XcsvStyle* xcsv_style;
 static double pathdist = 0;
 static double oldlon = 999;
 static double oldlat = 999;
 
-static int waypt_out_count;
-static route_head* csv_track, *csv_route;
+static int waypt_out_count = 0;
+static route_head* csv_track = nullptr;
+static route_head* csv_route = nullptr;
 
 struct xcsv_parse_data {
   QString rte_name;
@@ -209,7 +208,7 @@ static char* snupperopt = nullptr;
 static char* snuniqueopt = nullptr;
 static char* prefer_shortnames = nullptr;
 static char* xcsv_urlbase = nullptr;
-static char* opt_datum;
+static char* opt_datum = nullptr;;
 
 static const char* intstylebuf = nullptr;
 
@@ -246,7 +245,7 @@ QVector<arglist_t> xcsv_args = {
   },
   {
     "datum", &opt_datum, "GPS datum (def. WGS 84)",
-    "WGS 84", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
+    nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
   },
 };
 
@@ -276,39 +275,6 @@ char_map_t xcsv_char_table[] = {
   { nullptr, 		nullptr	}
 };
 
-static void
-xcsv_destroy_style()
-{
-
-  /*
-   * If this xcsv_file struct came from a file we can free it all.
-   * If not, we can at least free the queue elements.
-   */
-
-  /* destroy the prologue */
-  xcsv_file.prologue.clear();
-
-  /* destroy the epilogue */
-  xcsv_file.epilogue.clear();
-
-  /* destroy the ifields */
-  xcsv_file.ifields.clear();
-  /* destroy the ofields */
-  xcsv_file.ofields.clear();
-
-  /* other alloc'd glory */
-  xcsv_file.field_delimiter = QString();
-  xcsv_file.field_encloser = QString();
-  xcsv_file.record_delimiter = QString();
-  xcsv_file.badchars = QString();
-  xcsv_file.description = QString();
-  xcsv_file.extension = QString();
-
-  if (xcsv_file.mkshort_handle) {
-    mkshort_del_handle(&xcsv_file.mkshort_handle);
-  }
-}
-
 // Given a keyword of "COMMASPACE", return ", ".
 static QString
 xcsv_get_char_from_constant_table(const QString& key)
@@ -335,43 +301,6 @@ static QString dequote(const QString& in) {
   return r;
 }
 
-/*****************************************************************************/
-/* xcsv_file_init() - prepare xcsv_file for first use.                       */
-/*****************************************************************************/
-void xcsv_file_init()
-{
-  xcsv_file.is_internal = false;
-  xcsv_file.field_delimiter = QString();
-  xcsv_file.field_encloser = QString();
-  xcsv_file.record_delimiter = QString();
-  xcsv_file.badchars = QString();
-  xcsv_file.file = nullptr;
-  xcsv_file.stream = nullptr;
-  xcsv_file.codec = nullptr;
-  xcsv_file.fname = QString();
-  xcsv_file.description = nullptr;
-  xcsv_file.extension = nullptr;
-
-  xcsv_file.prologue.clear();
-  xcsv_file.epilogue.clear();
-
-  xcsv_file.ifields.clear();
-  xcsv_file.ofields.clear();
-  /*
-   * Provide a sane default for CSV _files_.
-   */
-  xcsv_file.type = ff_type_file;
-
-  xcsv_file.mkshort_handle = mkshort_new_handle();
-  xcsv_file.gps_datum = GPS_DATUM_WGS84;
-}
-
-XcsvFile::XcsvFile() {
-  is_internal = false;
-  extension  = nullptr;
-//   xcsv_file_init();
-}
-
 static void validate_fieldmap(const field_map& fmp, bool is_output) {
   if (fmp.key.isEmpty()) {
     Fatal() << MYNAME << ": xcsv style is missing" <<
@@ -390,7 +319,7 @@ static void validate_fieldmap(const field_map& fmp, bool is_output) {
 /* usage: xcsv_ifield_add("DESCRIPTION", "", "%s")                           */
 /*****************************************************************************/
 static void
-xcsv_ifield_add(const QString& qkey, const QString& qval, const QString& qpfc)
+xcsv_ifield_add(XcsvStyle* style, const QString& qkey, const QString& qval, const QString& qpfc)
 {
   QByteArray key = qkey.toUtf8();
   QByteArray val = qval.toUtf8();
@@ -401,7 +330,7 @@ xcsv_ifield_add(const QString& qkey, const QString& qval, const QString& qpfc)
   field_map fmp(key, val, pfc, xm ? xm->xt_token : -1);
   validate_fieldmap(fmp, false);
 
-  xcsv_file.ifields.append(fmp);
+  style->ifields.append(fmp);
 }
 
 /*****************************************************************************/
@@ -409,7 +338,7 @@ xcsv_ifield_add(const QString& qkey, const QString& qval, const QString& qpfc)
 /* usage: xcsv_ofield_add("LAT_DECIMAL", "", "%08.5lf")                      */
 /*****************************************************************************/
 static void
-xcsv_ofield_add(const QString& qkey, const QString& qval, const QString& qpfc, unsigned options)
+xcsv_ofield_add(XcsvStyle* style, const QString& qkey, const QString& qval, const QString& qpfc, unsigned options)
 {
   QByteArray key = qkey.toUtf8();
   QByteArray val = qval.toUtf8();
@@ -420,31 +349,10 @@ xcsv_ofield_add(const QString& qkey, const QString& qval, const QString& qpfc, u
   field_map fmp(key, val, pfc, xm ? xm->xt_token : -1, options);
   validate_fieldmap(fmp, true);
 
-  xcsv_file.ofields.append(fmp);
+  style->ofields.append(fmp);
 }
 
-/*****************************************************************************/
-/* xcsv_prologue_add() - add prologue line to prologue queue                 */
-/* usage: xcsv_prologue_add("Four score and seven years ago today,")         */
-/*****************************************************************************/
-static void
-xcsv_prologue_add(const QString& prologue)
-{
-  xcsv_file.prologue.append(prologue);
-}
-
-/*****************************************************************************/
-/* xcsv_epilogue_add() - add epilogue line to epilogue queue                 */
-/* usage: xcsv_epilogue_add("shall not perish from the earth.")              */
-/*****************************************************************************/
-static void
-xcsv_epilogue_add(const QString& epilogue)
-{
-  xcsv_file.epilogue.append(epilogue);
-}
-
-static
-QDateTime
+static QDateTime
 yyyymmdd_to_time(const char* s)
 {
   QDate d = QDate::fromString(s, "yyyyMMdd");
@@ -455,8 +363,7 @@ yyyymmdd_to_time(const char* s)
 /*
  * sscanftime - Parse a date buffer using strftime format
  */
-static
-time_t
+static time_t
 sscanftime(const char* s, const char* format, const int gmt)
 {
   struct tm stm;
@@ -483,8 +390,7 @@ sscanftime(const char* s, const char* format, const int gmt)
   return 0;
 }
 
-static
-time_t
+static time_t
 addhms(const char* s, const char* format)
 {
   time_t tt = 0;
@@ -506,8 +412,7 @@ addhms(const char* s, const char* format)
   return tt;
 }
 
-static
-QString
+static QString
 writetime(const char* format, time_t t, bool gmt)
 {
   static struct tm* stmp;
@@ -527,14 +432,13 @@ writetime(const char* format, time_t t, bool gmt)
   return QString(tbuff);
 }
 
-static
-QString
+static QString
 writetime(const char* format, const gpsbabel::DateTime& t, bool gmt)
 {
   return writetime(format, t.toTime_t(), gmt);
 }
 
-QString
+static QString
 writehms(const char* format, time_t t, int gmt)
 {
   static struct tm no_time = tm();
@@ -555,14 +459,13 @@ writehms(const char* format, time_t t, int gmt)
                             (stmp->tm_hour >= 12 ? "PM" : "AM"));
 }
 
-QString
+static QString
 writehms(const char* format, const gpsbabel::DateTime& t, int gmt)
 {
   return writehms(format, t.toTime_t(), gmt);
 }
 
-static
-long
+static long
 time_to_yyyymmdd(const QDateTime& t)
 {
   QDate d = t.date();
@@ -797,7 +700,7 @@ xcsv_parse_val(const QString& value, Waypoint* wpt, const field_map& fmp,
     /* TIME CONVERSIONS ***************************************************/
   case XT_EXCEL_TIME:
     /* Time as Excel Time  */
-    wpt->SetCreationTime(EXCEL_TO_TIMET(atof(s)));
+    wpt->SetCreationTime(excel_to_timet(atof(s)));
     break;
   case XT_TIMET_TIME:
     /* Time as time_t */
@@ -1021,7 +924,7 @@ xcsv_data_read()
   route_head* trk = nullptr;
 
   while (true) {
-    QString buff = xcsv_file.stream->readLine();
+    QString buff = xcsv_file->stream.readLine();
     if (buff.isNull()) { 
       break;
     }
@@ -1035,7 +938,7 @@ xcsv_data_read()
     }
 
     /* skip over x many lines on the top for the prologue... */
-    if ((linecount - 1) < xcsv_file.prologue.count()) {
+    if ((linecount - 1) < xcsv_style->prologue.count()) {
       continue;
     }
 
@@ -1043,7 +946,7 @@ xcsv_data_read()
      * pre-read the file to know how many data lines we should be seeing,
      * we take this cheap shot at the data and cross our fingers.
      */
-    for(const auto& ogp : qAsConst(xcsv_file.epilogue)) {
+    for(const auto& ogp : qAsConst(xcsv_style->epilogue)) {
        if (ogp.startsWith(buff)) {
          buff.clear();
          break;
@@ -1053,21 +956,21 @@ xcsv_data_read()
       Waypoint* wpt_tmp = new Waypoint;
       // initialize parse data for accumulation of line results from all fields in this line.
       xcsv_parse_data parse_data;
-      const QStringList values = csv_linesplit(buff, xcsv_file.field_delimiter,
-                        xcsv_file.field_encloser, linecount);
+      const QStringList values = csv_linesplit(buff, xcsv_style->field_delimiter,
+                        xcsv_style->field_encloser, linecount);
 
-      if (xcsv_file.ifields.isEmpty()) {
-        fatal(MYNAME ": attempt to read, but style '%s' has no IFIELDs in it.\n", CSTR(xcsv_file.description)? CSTR(xcsv_file.description) : "unknown");
+      if (xcsv_style->ifields.isEmpty()) {
+        fatal(MYNAME ": attempt to read, but style '%s' has no IFIELDs in it.\n", qPrintable(xcsv_style->description)? qPrintable(xcsv_style->description) : "unknown");
       }
 
       int ifield_idx = 0;
 
       /* now rip the line apart */
       for (const auto& value : values) {
-        const field_map& fmp = xcsv_file.ifields.at(ifield_idx++);
+        const field_map& fmp = xcsv_style->ifields.at(ifield_idx++);
         xcsv_parse_val(value, wpt_tmp, fmp, &parse_data, linecount);
 
-        if (ifield_idx >= xcsv_file.ifields.size()) {
+        if (ifield_idx >= xcsv_style->ifields.size()) {
           /* no more fields, stop parsing! */
           break;
         }
@@ -1082,10 +985,10 @@ xcsv_data_read()
         wpt_tmp->longitude = -wpt_tmp->longitude;
       }
 
-      if ((xcsv_file.gps_datum > -1) && (xcsv_file.gps_datum != GPS_DATUM_WGS84)) {
+      if ((xcsv_file->gps_datum_idx > -1) && (xcsv_file->gps_datum_idx != gps_datum_wgs84)) {
         double alt;
         GPS_Math_Known_Datum_To_WGS84_M(wpt_tmp->latitude, wpt_tmp->longitude, 0.0,
-                                        &wpt_tmp->latitude, &wpt_tmp->longitude, &alt, xcsv_file.gps_datum);
+                                        &wpt_tmp->latitude, &wpt_tmp->longitude, &alt, xcsv_file->gps_datum_idx);
       }
 
       if (parse_data.utm_easting || parse_data.utm_northing) {
@@ -1102,7 +1005,7 @@ xcsv_data_read()
         parse_data.link_ = nullptr;
       }
 
-      switch (xcsv_file.datatype) {
+      switch (xcsv_style->datatype) {
       case unknown_gpsdata:
       case wptdata:
         waypt_add(wpt_tmp);
@@ -1141,7 +1044,7 @@ xcsv_resetpathlen(const route_head* head)
   oldlat = 999;
   oldlon = 999;
   csv_route = csv_track = nullptr;
-  switch (xcsv_file.datatype) {
+  switch (xcsv_style->datatype) {
   case trkdata:
     csv_track = const_cast<route_head*>(head);
     break;
@@ -1176,10 +1079,10 @@ xcsv_waypt_pr(const Waypoint* wpt)
   latitude = oldlat = wpt->latitude;
 
   QString write_delimiter;
-  if (xcsv_file.field_delimiter == "\\w") {
+  if (xcsv_style->field_delimiter == "\\w") {
     write_delimiter = " ";
   } else {
-    write_delimiter = xcsv_file.field_delimiter;
+    write_delimiter = xcsv_style->field_delimiter;
   }
 
   QString description;
@@ -1187,38 +1090,38 @@ xcsv_waypt_pr(const Waypoint* wpt)
   if (wpt->shortname.isEmpty() || global_opts.synthesize_shortnames) {
     if (!wpt->description.isEmpty()) {
       if (global_opts.synthesize_shortnames) {
-        shortname = mkshort_from_wpt(xcsv_file.mkshort_handle, wpt);
+        shortname = mkshort_from_wpt(xcsv_file->mkshort_handle, wpt);
       } else {
-        shortname = csv_stringclean(wpt->description, xcsv_file.badchars);
+        shortname = csv_stringclean(wpt->description, xcsv_style->badchars);
       }
     } else {
       /* no shortname available -- let shortname default on output */
     }
   } else {
-    shortname = csv_stringclean(wpt->shortname, xcsv_file.badchars);
+    shortname = csv_stringclean(wpt->shortname, xcsv_style->badchars);
   }
   if (wpt->description.isEmpty()) {
     if (!shortname.isEmpty()) {
-      description = csv_stringclean(shortname, xcsv_file.badchars);
+      description = csv_stringclean(shortname, xcsv_style->badchars);
     } else {
       /* no description -- let description default on output */
     }
   } else {
-    description = csv_stringclean(wpt->description, xcsv_file.badchars);
+    description = csv_stringclean(wpt->description, xcsv_style->badchars);
   }
 
   if (prefer_shortnames) {
     description = shortname;
   }
 
-  if ((xcsv_file.gps_datum > -1) && (xcsv_file.gps_datum != GPS_DATUM_WGS84)) {
+  if ((xcsv_file->gps_datum_idx > -1) && (xcsv_file->gps_datum_idx != gps_datum_wgs84)) {
     double alt;
     GPS_Math_WGS84_To_Known_Datum_M(latitude, longitude, 0.0,
-                                    &latitude, &longitude, &alt, xcsv_file.gps_datum);
+                                    &latitude, &longitude, &alt, xcsv_file->gps_datum_idx);
   }
 
   int i = 0;
-  for (const auto& fmp : qAsConst(xcsv_file.ofields)) {
+  for (const auto& fmp : qAsConst(xcsv_style->ofields)) {
     double lat = latitude;
     double lon = longitude;
     /*
@@ -1229,11 +1132,11 @@ xcsv_waypt_pr(const Waypoint* wpt)
      */
     int field_is_unknown = 0;
 
-    if ((i != 0) && !(fmp.options & OPTIONS_NODELIM)) {
-      *xcsv_file.stream << write_delimiter;
+    if ((i != 0) && !(fmp.options & options_nodelim)) {
+      xcsv_file->stream << write_delimiter;
     }
 
-    if (fmp.options & OPTIONS_ABSOLUTE) {
+    if (fmp.options & options_absolute) {
       lat = fabs(lat);
       lon = fabs(lon);
     }
@@ -1266,10 +1169,10 @@ xcsv_waypt_pr(const Waypoint* wpt)
       {
       QString anyname = wpt->shortname;
       if (anyname.isEmpty()) {
-        anyname = mkshort(xcsv_file.mkshort_handle, wpt->description);
+        anyname = mkshort(xcsv_file->mkshort_handle, wpt->description);
       }
       if (anyname.isEmpty()) {
-        anyname = mkshort(xcsv_file.mkshort_handle, wpt->description);
+        anyname = mkshort(xcsv_file->mkshort_handle, wpt->description);
       }
       if (anyname.isEmpty()) {
         anyname = wpt->notes;
@@ -1322,12 +1225,12 @@ xcsv_waypt_pr(const Waypoint* wpt)
     case XT_LAT_DECIMALDIR:
       /* latitude as a decimal value with N/S after it */
       buff = QString::asprintf(fmp.printfc.constData(), fabs(lat),
-               LAT_DIR(lat));
+               lat_dir(lat));
       break;
     case XT_LAT_DIRDECIMAL:
       /* latitude as a decimal value with N/S before it */
       buff = QString::asprintf(fmp.printfc.constData(),
-               LAT_DIR(lat),
+               lat_dir(lat),
                fabs(lat));
       break;
     case XT_LAT_INT32DEG:
@@ -1355,12 +1258,12 @@ xcsv_waypt_pr(const Waypoint* wpt)
       /* latitude as a decimal value with N/S after it */
       buff = QString::asprintf(fmp.printfc.constData(),
                fabs(lon),
-               LON_DIR(lon));
+               lon_dir(lon));
       break;
     case XT_LON_DIRDECIMAL:
       /* latitude as a decimal value with N/S before it */
       buff = QString::asprintf(fmp.printfc.constData(),
-               LON_DIR(lon),
+               lon_dir(lon),
                fabs(lon));
       break;
     case XT_LON_INT32DEG:
@@ -1390,12 +1293,12 @@ xcsv_waypt_pr(const Waypoint* wpt)
     case XT_LAT_DIR:
       /* latitude N/S as a char */
       buff = QString::asprintf(fmp.printfc.constData(),
-                LAT_DIR(lat));
+                lat_dir(lat));
       break;
     case XT_LON_DIR:
       /* longitude E/W as a char */
       buff = QString::asprintf(fmp.printfc.constData(),
-                LON_DIR(lon));
+                lon_dir(lon));
       break;
 
       /* SPECIAL COORDINATES */
@@ -1527,7 +1430,7 @@ xcsv_waypt_pr(const Waypoint* wpt)
       /* TIME CONVERSIONS**************************************************/
     case XT_EXCEL_TIME:
       /* creation time as an excel (double) time */
-      buff = QString::asprintf(fmp.printfc.constData(), TIMET_TO_EXCEL(wpt->GetCreationTime().toTime_t()));
+      buff = QString::asprintf(fmp.printfc.constData(), timet_to_excel(wpt->GetCreationTime().toTime_t()));
       break;
     case XT_TIMET_TIME:
       /* time as a time_t variable */
@@ -1627,14 +1530,12 @@ xcsv_waypt_pr(const Waypoint* wpt)
       break;
     case XT_TRACK_NAME:
       if (csv_track) {
-        QString r = csv_track->rte_name;
-        buff = QString::asprintf(fmp.printfc.constData(), NONULL(r));
+        buff = QString::asprintf(fmp.printfc.constData(), CSTR(csv_track->rte_name));
       }
       break;
     case XT_ROUTE_NAME:
       if (csv_route) {
-        QString r = csv_route->rte_name;
-        buff = QString::asprintf(fmp.printfc.constData(), NONULL(r));
+        buff = QString::asprintf(fmp.printfc.constData(), CSTR(csv_route->rte_name));
       }
       break;
 
@@ -1739,15 +1640,15 @@ xcsv_waypt_pr(const Waypoint* wpt)
       warning(MYNAME ": Unknown style directive: %s\n", fmp.key.constData());
       break;
     }
-    QString obuff = csv_stringclean(buff, xcsv_file.badchars);
+    QString obuff = csv_stringclean(buff, xcsv_style->badchars);
 
-    if (field_is_unknown && fmp.options & OPTIONS_OPTIONAL) {
+    if (field_is_unknown && fmp.options & options_optional) {
       continue;
     }
 
-    if (!xcsv_file.field_encloser.isEmpty()) {
+    if (!xcsv_style->field_encloser.isEmpty()) {
       /* print the enclosing character(s) */
-      *xcsv_file.stream << xcsv_file.record_delimiter;
+      xcsv_file->stream << xcsv_style->record_delimiter;
     }
 
     /* As a special case (pronounced "horrible hack") we allow
@@ -1756,16 +1657,16 @@ xcsv_waypt_pr(const Waypoint* wpt)
     if (0 == strcmp(fmp.printfc.constData(), "\"%s\"")) {
       obuff = '"' + obuff + '"';
     }
-    *xcsv_file.stream << obuff;
+    xcsv_file->stream << obuff;
 
-    if (!xcsv_file.field_encloser.isEmpty()) {
+    if (!xcsv_style->field_encloser.isEmpty()) {
       /* print the enclosing character(s) */
-      *xcsv_file.stream << xcsv_file.record_delimiter;
+      xcsv_file->stream << xcsv_style->record_delimiter;
     }
     buff.clear();
   }
 
-  *xcsv_file.stream << xcsv_file.record_delimiter;
+  xcsv_file->stream << xcsv_style->record_delimiter;
 
   /* increment the index counter */
   waypt_out_count++;
@@ -1778,7 +1679,7 @@ xcsv_replace_tokens(const QString& original) {
     // Don't do potentially expensive replacements if token prefix
     // isn't present;
     if (original.contains("__")) {
-      replacement.replace("__FILE__", xcsv_file.fname);
+      replacement.replace("__FILE__", xcsv_file->fname);
       replacement.replace("__VERSION__", gpsbabel_testmode()? "" : gpsbabel_version);
 
       QDateTime dt = current_time().toUTC();
@@ -1806,30 +1707,30 @@ xcsv_data_write()
   waypt_out_count = 0;
 
   /* output prologue lines, if any. */
-  for (const auto& line : qAsConst(xcsv_file.prologue)) {
+  for (const auto& line : qAsConst(xcsv_style->prologue)) {
    QString line_to_write = xcsv_replace_tokens(line);
-    *xcsv_file.stream << line_to_write <<  xcsv_file.record_delimiter;
+    xcsv_file->stream << line_to_write <<  xcsv_style->record_delimiter;
   }
 
-  if ((xcsv_file.datatype == 0) || (xcsv_file.datatype == wptdata)) {
+  if ((xcsv_style->datatype == 0) || (xcsv_style->datatype == wptdata)) {
     waypt_disp_all(xcsv_waypt_pr);
   }
-  if ((xcsv_file.datatype == 0) || (xcsv_file.datatype == rtedata)) {
+  if ((xcsv_style->datatype == 0) || (xcsv_style->datatype == rtedata)) {
     route_disp_all(xcsv_resetpathlen, nullptr, xcsv_waypt_pr);
   }
-  if ((xcsv_file.datatype == 0) || (xcsv_file.datatype == trkdata)) {
+  if ((xcsv_style->datatype == 0) || (xcsv_style->datatype == trkdata)) {
     track_disp_all(xcsv_resetpathlen, nullptr, xcsv_waypt_pr);
   }
 
   /* output epilogue lines, if any. */
-  for (const auto& line : qAsConst(xcsv_file.epilogue)) {
+  for (const auto& line : qAsConst(xcsv_style->epilogue)) {
     QString line_to_write = xcsv_replace_tokens(line);
-    *xcsv_file.stream << line_to_write << xcsv_file.record_delimiter;
+    xcsv_file->stream << line_to_write << xcsv_style->record_delimiter;
   }
 }
 
 static void
-xcsv_parse_style_line(QString line)
+xcsv_parse_style_line(XcsvStyle* style, QString line)
 {
   // The lines to be parsed have a leading operation |op| that is
   // separated by whitespace from the rest. Each op may have zero or
@@ -1854,14 +1755,14 @@ xcsv_parse_style_line(QString line)
 
   if (op == "FIELD_DELIMITER") {
     auto cp = xcsv_get_char_from_constant_table(tokens[0]);
-    xcsv_file.field_delimiter = cp;
+    style->field_delimiter = cp;
 
-    char* p = csv_stringtrim(CSTR(xcsv_file.field_delimiter), " ", 0);
+    char* p = csv_stringtrim(CSTR(style->field_delimiter), " ", 0);
       /* field delimiters are always bad characters */
     if (0 == strcmp(p, "\\w")) {
-      xcsv_file.badchars = " \n\r";
+      style->badchars = " \n\r";
     } else {
-      xcsv_file.badchars += p;
+      style->badchars += p;
     }
     xfree(p);
 
@@ -1869,91 +1770,81 @@ xcsv_parse_style_line(QString line)
 
   if (op == "FIELD_ENCLOSER") {
     auto cp = xcsv_get_char_from_constant_table(tokens[0]);
-    xcsv_file.field_encloser = cp;
+    style->field_encloser = cp;
 
-    char* p = csv_stringtrim(CSTR(xcsv_file.field_encloser), " ", 0);
-    xcsv_file.badchars += p;
+    char* p = csv_stringtrim(CSTR(style->field_encloser), " ", 0);
+    style->badchars += p;
     xfree(p);
   } else
 
   if (op == "RECORD_DELIMITER") {
     auto cp = xcsv_get_char_from_constant_table(tokens[0]);
-    xcsv_file.record_delimiter = cp;
+    style->record_delimiter = cp;
 
       // Record delimiters are always bad characters.
-    auto p = csv_stringtrim(CSTR(xcsv_file.record_delimiter), " ", 0);
-    xcsv_file.badchars += p;
+    auto p = csv_stringtrim(CSTR(style->record_delimiter), " ", 0);
+    style->badchars += p;
     xfree(p);
 
   } else
 
   if (op == "FORMAT_TYPE") {
     if (tokens[0] == "INTERNAL") {
-      xcsv_file.type = ff_type_internal;
+      style->type = ff_type_internal;
     }
       // this is almost inconceivable...
     if (tokens[0] == "SERIAL") {
-      xcsv_file.type = ff_type_serial;
+      style->type = ff_type_serial;
     }
   } else
 
   if (op == "DESCRIPTION") {
-    xcsv_file.description = tokens[0];
+    style->description = tokens[0];
   } else
 
   if (op == "EXTENSION") {
-    xcsv_file.extension = tokens[0];
+    style->extension = tokens[0];
   } else
 
   if (op == "SHORTLEN") {
-    if (xcsv_file.mkshort_handle) {
-      setshort_length(xcsv_file.mkshort_handle, tokens[0].toInt());
-    }
+    style->shortlen = tokens[0].toInt();
   } else
 
   if (op == "SHORTWHITE") {
-    if (xcsv_file.mkshort_handle) {
-      setshort_whitespace_ok(xcsv_file.mkshort_handle, tokens[0].toInt());
-    }
+    style->whitespace_ok = tokens[0].toInt();
   } else
 
   if (op == "BADCHARS") {
     char* sp = csv_stringtrim(CSTR(tokenstr), "\"", 1);
     QString cp = xcsv_get_char_from_constant_table(sp);
-    xcsv_file.badchars += cp;
+    style->badchars += cp;
     xfree(sp);
   } else
 
   if (op =="PROLOGUE") {
-    xcsv_prologue_add(tokenstr);
+    style->prologue.append(tokenstr);
   } else
 
   if (op == "EPILOGUE") {
-    xcsv_epilogue_add(tokenstr);
+    style->epilogue.append(tokenstr);
   } else
 
   if (op == "ENCODING") {
-    QByteArray ba;
-    ba.append(tokens[0]);
-    xcsv_file.codec = QTextCodec::codecForName(ba);
-    if (!xcsv_file.codec) {
-      Fatal() << "Unsupported character set '" << QString(tokens[0]) << "'.";
-    }
+    style->codecname = tokens[0];
   } else
 
   if (op == "DATUM") {
-    xcsv_file.gps_datum = GPS_Lookup_Datum_Index(tokens[0]);
-    is_fatal(xcsv_file.gps_datum < 0, MYNAME ": datum \"%s\" is not supported.", CSTR(tokens[0]));
+    style->gps_datum_name = tokens[0];
   } else
 
   if (op == "DATATYPE") {
     QString p = tokens[0].toUpper();
     if (p == "TRACK") {
-      xcsv_file.datatype = trkdata;
+      style->datatype = trkdata;
     } else if (p == "ROUTE") {
-      xcsv_file.datatype = rtedata;
+      style->datatype = rtedata;
     } else if (p == "WAYPOINT") {
-      xcsv_file.datatype = wptdata;
+      style->datatype = wptdata;
     } else {
       Fatal() << MYNAME << ": Unknown data type" << p;
     }
@@ -1969,7 +1860,7 @@ xcsv_parse_style_line(QString line)
     const QString key = tokens[0].simplified();
     const QString val = dequote(tokens[1]);
     const QString pfc = dequote(tokens[2]);
-    xcsv_ifield_add(key, val, pfc);
+    xcsv_ifield_add(style, key, val, pfc);
   } else
 
       //
@@ -1996,16 +1887,16 @@ xcsv_parse_style_line(QString line)
     for (int token_idx = 3; token_idx < tokens.size(); ++token_idx) {
       QString options_string = tokens[token_idx].simplified();
       if (options_string.contains("no_delim_before")) {
-        options |= OPTIONS_NODELIM;
+        options |= options_nodelim;
       }
       if (options_string.contains("absolute")) {
-        options |= OPTIONS_ABSOLUTE;
+        options |= options_absolute;
       }
       if (options_string.contains("optional")) {
-        options |= OPTIONS_OPTIONAL;
+        options |= options_optional;
       }
     }
-    xcsv_ofield_add(key, val, pfc, options);
+    xcsv_ofield_add(style, key, val, pfc, options);
   }
 }
 
@@ -2015,31 +1906,34 @@ xcsv_parse_style_line(QString line)
  * a terminating null.   Makes multiple calls to that function so
  * that "ignore to end of line" comments work right.
  */
-static void
+static XcsvStyle
 xcsv_parse_style_buff(const char* sbuff)
 {
+  XcsvStyle style;
   const QStringList lines = QString(sbuff).split('\n');
   for (const auto& line : lines) {
-    xcsv_parse_style_line(line);
+    xcsv_parse_style_line(&style, line);
   }
+  return style;
 }
 
-static void
+static XcsvStyle
 xcsv_read_style(const char* fname)
 {
-  xcsv_file_init();
-
   gbfile* fp = gbfopen(fname, "rb", MYNAME);
+  XcsvStyle style;
   for  (QString sbuff = gbfgetstr(fp); !sbuff.isNull(); sbuff = gbfgetstr(fp)) {
     sbuff = sbuff.trimmed();
-    xcsv_parse_style_line(sbuff);
+    xcsv_parse_style_line(&style, sbuff);
   }
 
   /* if we have no output fields, use input fields as output fields */
-  if (xcsv_file.ofields.isEmpty()) {
-    xcsv_file.ofields = xcsv_file.ifields;
+  if (style.ofields.isEmpty()) {
+    style.ofields = style.ifields;
   }
   gbfclose(fp);
+
+  return style;
 }
 
 /*
@@ -2047,139 +1941,146 @@ xcsv_read_style(const char* fname)
  * to the series of bytes that would be in a style file, we set up
  * the xcsv parser and make it ready for general use.
  */
-void
+XcsvStyle
 xcsv_read_internal_style(const char* style_buf)
 {
-  xcsv_file_init();
-  xcsv_file.is_internal = true;
-
-  xcsv_parse_style_buff(style_buf);
+  XcsvStyle style = xcsv_parse_style_buff(style_buf);
 
   /* if we have no output fields, use input fields as output fields */
-  if (xcsv_file.ofields.isEmpty()) {
-    xcsv_file.ofields = xcsv_file.ifields;
+  if (style.ofields.isEmpty()) {
+    style.ofields = style.ifields;
   }
+
+  return style;
 }
 
 void
 xcsv_setup_internal_style(const char* style_buf)
 {
-  xcsv_file_init();
-  xcsv_destroy_style();
-  xcsv_file.is_internal = !!style_buf;
   intstylebuf = style_buf;
 }
-
 
 static void
 xcsv_rd_init(const QString& fname)
 {
-
   /*
    * if we don't have an internal style defined, we need to
    * read it from a user-supplied style file, or die trying.
    */
-  if (xcsv_file.is_internal) {
-    xcsv_read_internal_style(intstylebuf);
+  if (intstylebuf != nullptr) {
+    xcsv_style = new XcsvStyle(xcsv_read_internal_style(intstylebuf));
   } else {
     if (!styleopt) {
       fatal(MYNAME ": XCSV input style not declared.  Use ... -i xcsv,style=path/to/file.style\n");
     }
 
-    xcsv_read_style(styleopt);
+    xcsv_style = new XcsvStyle(xcsv_read_style(styleopt));
   }
 
-  if ((xcsv_file.datatype == 0) || (xcsv_file.datatype == wptdata)) {
+  if ((xcsv_style->datatype == 0) || (xcsv_style->datatype == wptdata)) {
     if (global_opts.masked_objective & (TRKDATAMASK|RTEDATAMASK)) {
       warning(MYNAME " attempt to read %s as a track or route, but this format only supports waypoints on read.  Reading as waypoints instead.\n", qPrintable(fname));
     }
   }
 
-  xcsv_file.file = new gpsbabel::File(fname);
-  xcsv_file.file->open(QFile::ReadOnly);
-  xcsv_file.stream = new QTextStream(xcsv_file.file);
-  if (xcsv_file.codec) {
-    xcsv_file.stream->setCodec(xcsv_file.codec);
+  xcsv_file = new XcsvFile;
+  if (xcsv_style->codecname.isEmpty()) {
+    xcsv_file->stream.open(fname, QIODevice::ReadOnly, MYNAME);
   } else {
-    // default to UTF-8.
-    xcsv_file.stream->setCodec("UTF-8");
-    xcsv_file.stream->setAutoDetectUnicode(true);
+    xcsv_file->stream.open(fname, QIODevice::ReadOnly, MYNAME, CSTR(xcsv_style->codecname));
   }
-  xcsv_file.gps_datum = GPS_Lookup_Datum_Index(opt_datum);
-  is_fatal(xcsv_file.gps_datum < 0, MYNAME ": datum \"%s\" is not supported.", opt_datum);
+  xcsv_file->fname = fname;
+
+  QString datum_name;
+  if (opt_datum != nullptr) {
+    datum_name = opt_datum;
+  } else if (!xcsv_style->gps_datum_name.isEmpty()) {
+    datum_name = xcsv_style->gps_datum_name;
+  } else {
+    datum_name = "WGS 84";
+  }
+  xcsv_file->gps_datum_idx = GPS_Lookup_Datum_Index(datum_name);
+  is_fatal(xcsv_file->gps_datum_idx < 0, MYNAME ": datum \"%s\" is not supported.", qPrintable(datum_name));
+  assert(gps_datum_wgs84 == GPS_Lookup_Datum_Index("WGS 84"));
 }
 
 static void
 xcsv_rd_deinit()
 {
-  xcsv_file.file->close();
-  delete xcsv_file.file;
-  xcsv_file.file = nullptr;
-  delete xcsv_file.stream;
-  xcsv_file.stream = nullptr;
-  xcsv_file.codec = nullptr;
+  xcsv_file->stream.close();
+  delete xcsv_file;
+  xcsv_file = nullptr;
 
-  xcsv_destroy_style();
+  delete xcsv_style;
+  xcsv_style = nullptr;
 }
 
 static void
 xcsv_wr_init(const QString& fname)
 {
-  /* if we don't have an internal style defined, we need to
+  /*
+   * if we don't have an internal style defined, we need to
    * read it from a user-supplied style file, or die trying.
-   * 8/19 - add test for styleopt to ensure that a write of a style
-   * after a read of a style works.
    */
-  if (xcsv_file.is_internal && !styleopt) {
-    xcsv_read_internal_style(intstylebuf);
+  if (intstylebuf != nullptr) {
+    xcsv_style = new XcsvStyle(xcsv_read_internal_style(intstylebuf));
   } else {
-
     if (!styleopt) {
       fatal(MYNAME ": XCSV output style not declared.  Use ... -o xcsv,style=path/to/file.style\n");
     }
 
-    xcsv_read_style(styleopt);
+    xcsv_style = new XcsvStyle(xcsv_read_style(styleopt));
   }
 
-  xcsv_file.file = new gpsbabel::File(fname);
-  xcsv_file.file->open(QFile::WriteOnly | QFile::Text);
-  xcsv_file.stream = new QTextStream(xcsv_file.file);
-  if (xcsv_file.codec) {
-    xcsv_file.stream->setCodec(xcsv_file.codec);
-    // enable bom for all UTF codecs except UTF-8
-    if (xcsv_file.codec->mibEnum() != 106) {
-      xcsv_file.stream->setGenerateByteOrderMark(true);
-    }
+  xcsv_file = new XcsvFile;
+  if (xcsv_style->codecname.isEmpty()) {
+    xcsv_file->stream.open(fname, QIODevice::WriteOnly | QIODevice::Text, MYNAME);
   } else {
-    // emulate gbfputs which assumes UTF-8.
-    xcsv_file.stream->setCodec("UTF-8");
+    xcsv_file->stream.open(fname, QIODevice::WriteOnly | QIODevice::Text, MYNAME, CSTR(xcsv_style->codecname));
   }
-  xcsv_file.fname = fname;
+  xcsv_file->fname = fname;
+
+  if (xcsv_style->shortlen) {
+    setshort_length(xcsv_file->mkshort_handle, *xcsv_style->shortlen);
+  }
+  if (xcsv_style->whitespace_ok) {
+    setshort_whitespace_ok(xcsv_file->mkshort_handle, *xcsv_style->whitespace_ok);
+  }
 
   /* set mkshort options from the command line */
   if (global_opts.synthesize_shortnames) {
 
     if (snlenopt) {
-      setshort_length(xcsv_file.mkshort_handle, atoi(snlenopt));
+      setshort_length(xcsv_file->mkshort_handle, atoi(snlenopt));
     }
 
     if (snwhiteopt) {
-      setshort_whitespace_ok(xcsv_file.mkshort_handle, atoi(snwhiteopt));
+      setshort_whitespace_ok(xcsv_file->mkshort_handle, atoi(snwhiteopt));
     }
 
     if (snupperopt) {
-      setshort_mustupper(xcsv_file.mkshort_handle, atoi(snupperopt));
+      setshort_mustupper(xcsv_file->mkshort_handle, atoi(snupperopt));
     }
 
     if (snuniqueopt) {
-      setshort_mustuniq(xcsv_file.mkshort_handle, atoi(snuniqueopt));
+      setshort_mustuniq(xcsv_file->mkshort_handle, atoi(snuniqueopt));
     }
 
-    setshort_badchars(xcsv_file.mkshort_handle, CSTR(xcsv_file.badchars));
+    setshort_badchars(xcsv_file->mkshort_handle, CSTR(xcsv_style->badchars));
 
   }
-  xcsv_file.gps_datum = GPS_Lookup_Datum_Index(opt_datum);
-  is_fatal(xcsv_file.gps_datum < 0, MYNAME ": datum \"%s\" is not supported.", opt_datum);
+
+  QString datum_name;
+  if (opt_datum != nullptr) {
+    datum_name = opt_datum;
+  } else if (!xcsv_style->gps_datum_name.isEmpty()) {
+    datum_name = xcsv_style->gps_datum_name;
+  } else {
+    datum_name = "WGS 84";
+  }
+  xcsv_file->gps_datum_idx = GPS_Lookup_Datum_Index(datum_name);
+  is_fatal(xcsv_file->gps_datum_idx < 0, MYNAME ": datum \"%s\" is not supported.", qPrintable(datum_name));
+  assert(gps_datum_wgs84 == GPS_Lookup_Datum_Index("WGS 84"));
 }
 
 static void
@@ -2191,15 +2092,12 @@ xcsv_wr_position_init(const QString& fname)
 static void
 xcsv_wr_deinit()
 {
-  xcsv_file.stream->flush();
-  xcsv_file.file->close();
-  delete xcsv_file.file;
-  xcsv_file.file = nullptr;
-  delete xcsv_file.stream;
-  xcsv_file.stream = nullptr;
-  xcsv_file.codec = nullptr;
+  xcsv_file->stream.close();
+  delete xcsv_file;
+  xcsv_file = nullptr;
 
-  xcsv_destroy_style();
+  delete xcsv_style;
+  xcsv_style = nullptr;
 }
 
 static void
@@ -2207,7 +2105,6 @@ xcsv_wr_position_deinit()
 {
   xcsv_wr_deinit();
 }
-
 
 static void
 xcsv_wr_position(Waypoint* wpt)
@@ -2225,7 +2122,7 @@ xcsv_wr_position(Waypoint* wpt)
   xcsv_data_write();
   waypt_del(wpt);
 
-  xcsv_file.stream->flush();
+  xcsv_file->stream.flush();
 }
 
 ff_vecs_t xcsv_vecs = {
@@ -2244,7 +2141,4 @@ ff_vecs_t xcsv_vecs = {
   nullptr
 
 };
-#else
-void xcsv_read_internal_style(const char* style_buf) {}
-void xcsv_setup_internal_style(const char* style_buf) {}
 #endif //CSVFMTS_ENABLED


### PR DESCRIPTION
Add a test for various textual outputs from main.  Some of these are
for the user, and some of these are primarly for passing information
to the doc or the GUI.  While the reference files will have to change
anytime we add/delete a filter or format, or anytime a filter or format
has an arugment change, this test prevents bugs from unintentionally
changing the information passed to the GUI.  As the GUI has no automated
test those types of bugs are difficult to find.

Enhance csv test to cover more end cases with the xcsv format. Historically
these cases have involved a series of xcsv format operations.  These operations
may be using internal style files or passed style files.  These operations may
or may not involve postional arugments on the command line.  Some of these end
cases represented bugs previous to this PR, e.g. a series of input operations
where a xcsv format using an internal style is followed by an xcsv format using
a passsed style file.

Refactor XcsvFile, splitting sytle information into XcsvStyle.  This allows
xcsv_file to be private.  A XcsvStyle object is returned to Vecs by
xcsv_read_internalstyle that can Vecs can parse to build vectors containing
the real formats and the style based formats.  This also eliminates bugs as
we build a new XcsvFile object every time we parse an external or internal
style file so we don't have any accidental dependiencies on previous operations.

Some other xcsv bugs are fixed:
  DATUM was always ignored in a style file.
  #474 xcsv style derived formats may have wrong GUI and/or CLI capability.
    Behavoir now matches the document, which is likely not to be what some of
    the style file authors intended!  E.g. should gpsdrivetrack really be
    working with waypoints as they do after this PR and as is documented,
    or was the accidental operation with tracks desired?

Use gpsbabel::textstream in xcsv.
