### PR TITLE
fix some xcsv bugs.

### DIFF
--- a/xcsv.cc
+++ b/xcsv.cc
@@ -1539,7 +1539,7 @@ xcsv_waypt_pr(const Waypoint* wpt)
 
     case XT_TIMET_TIME_MS: {
       /* time as a time_t variable in milliseconds */
-      buff = writetime("%ld", wpt->GetCreationTime().toTime_t(), false);
+      buff = writetime("%s", wpt->GetCreationTime().toTime_t(), false);
       buff += QString::asprintf("%03d", wpt->GetCreationTime().time().msec());
 
     }
@@ -1747,7 +1747,7 @@ xcsv_waypt_pr(const Waypoint* wpt)
 
     if (!xcsv_file.field_encloser.isEmpty()) {
       /* print the enclosing character(s) */
-      *xcsv_file.stream << xcsv_file.record_delimiter;
+      *xcsv_file.stream << xcsv_file.field_encloser;
     }
 
     /* As a special case (pronounced "horrible hack") we allow
@@ -1760,7 +1760,7 @@ xcsv_waypt_pr(const Waypoint* wpt)
 
     if (!xcsv_file.field_encloser.isEmpty()) {
       /* print the enclosing character(s) */
-      *xcsv_file.stream << xcsv_file.record_delimiter;
+      *xcsv_file.stream << xcsv_file.field_encloser;
     }
     buff.clear();
   }


### PR DESCRIPTION
These led to non-sensical motoactv files in test-all.  These
non-sensical files lead to the discovery of a holux write passed
end of buffer bug.

1. fea062ee7 writtime expects a strftime format specification.
When writing XT_TIMET_TIME_MS with writtime the strpftime format
specification ("%s") that was previously used was replaced by a printf
format specification ("%ld").  Thus the twelve hour clock followed by
a 'd' character was printed instead of the number of seconds since the Epoch.

2. 172073cdb When intending to print the field encloser the record
delimiter printed instead.