### PR TITLE
clang-tidy modernize-use-auto, but

### DIFF
--- a/alan.cc
+++ b/alan.cc
@@ -484,7 +484,7 @@ static Waypoint* get_wpt(struct wprdata* wprdata, unsigned n)
   }
   struct wpt* wpt = &(wprdata->wpt[idx]);
 
-  Waypoint* WP = new Waypoint;
+  auto* WP = new Waypoint;
   WP->latitude  = -pt2deg(wpt->pt.y);
   WP->longitude =  pt2deg(wpt->pt.x);
   WP->SetCreationTime(unpack_time(wpt->date, wpt->time));
@@ -612,7 +612,7 @@ static void trl_read()
     /* track points */
     struct trklog* trklog = &(trldata.trklog[i]);
     for (j=0; j<trkhdr->totalpt; j++) {
-      Waypoint* WP = new Waypoint;
+      auto* WP = new Waypoint;
       WP->latitude  = -pt2deg(trklog->pt[j].y);
       WP->longitude =  pt2deg(trklog->pt[j].x);
       WP->altitude  =  hgt2m(trklog->sh[j].height);

--- a/an1.cc
+++ b/an1.cc
@@ -662,7 +662,7 @@ static void Read_AN1_Waypoints(gbfile* f)
   for (unsigned long i = 0; i < count; i++) {
     an1_waypoint_record* rec = Alloc_AN1_Waypoint();
     Read_AN1_Waypoint(f, rec);
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     if (rec->creation_time) {
       wpt_tmp->SetCreationTime(rec->creation_time);
@@ -822,7 +822,7 @@ static void Read_AN1_Lines(gbfile* f)
       Read_AN1_Vertex(f, vert);
 
       /* create route point */
-      Waypoint* wpt_tmp = new Waypoint;
+      auto* wpt_tmp = new Waypoint;
       wpt_tmp->latitude = DecodeOrd(vert->lat);
       wpt_tmp->longitude = -DecodeOrd(vert->lon);
       wpt_tmp->shortname = QString::asprintf("\\%5.5lx", rtserial++);

--- a/arcdist.cc
+++ b/arcdist.cc
@@ -114,8 +114,8 @@ void ArcDistanceFilter::process()
 
     gbfile* file_in = gbfopen(arcfileopt, "r", MYNAME);
 
-    Waypoint* arcpt1 = new Waypoint;
-    Waypoint* arcpt2 = new Waypoint;
+    auto* arcpt1 = new Waypoint;
+    auto* arcpt2 = new Waypoint;
     arcdist_arc_disp_hdr_cb(nullptr);
 
     arcpt2->latitude = arcpt2->longitude = BADVAL;

--- a/bcr.cc
+++ b/bcr.cc
@@ -271,7 +271,7 @@ bcr_data_read()
       fatal(MYNAME ": structure error at %s (Coordinates)!\n", station);
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->shortname = station;
     bcr_mercator_to_wgs84(mlat, mlon, &wpt->latitude, &wpt->longitude);

--- a/bend.cc
+++ b/bend.cc
@@ -68,7 +68,7 @@ Waypoint* BendFilter::create_wpt_dest(const Waypoint* wpt_orig, double lat_orig,
   linepart(lat_orig, long_orig, lat_orig_adj, long_orig_adj, frac,
            &lat_dest, &long_dest);
 
-  Waypoint* wpt_dest = new Waypoint(*wpt_orig);
+  auto* wpt_dest = new Waypoint(*wpt_orig);
   wpt_dest->latitude = DEG(lat_dest);
   wpt_dest->longitude = DEG(long_dest);
 
@@ -100,7 +100,7 @@ void BendFilter::process_route(const route_head* route_orig, route_head* route_d
 
     if (wpt_orig_prev == nullptr) {
       if (wpt_orig != nullptr) {
-        Waypoint* waypoint_dest = new Waypoint(*wpt_orig);
+        auto* waypoint_dest = new Waypoint(*wpt_orig);
         route_add_wpt(route_dest, waypoint_dest);
       }
     } else {
@@ -115,7 +115,7 @@ void BendFilter::process_route(const route_head* route_orig, route_head* route_d
 
       if (is_small_angle(lat_orig, long_orig, lat_orig_prev,
                          long_orig_prev, lat_orig_next, long_orig_next)) {
-        Waypoint* waypoint_dest = new Waypoint(*wpt_orig);
+        auto* waypoint_dest = new Waypoint(*wpt_orig);
         route_add_wpt(route_dest, waypoint_dest);
       } else {
         Waypoint* wpt_dest_prev = create_wpt_dest(wpt_orig,
@@ -139,7 +139,7 @@ void BendFilter::process_route(const route_head* route_orig, route_head* route_d
   }
 
   if (wpt_orig != nullptr) {
-    Waypoint* waypoint_dest = new Waypoint(*wpt_orig);
+    auto* waypoint_dest = new Waypoint(*wpt_orig);
     route_add_wpt(route_dest, waypoint_dest);
   }
 }

--- a/bushnell.cc
+++ b/bushnell.cc
@@ -197,7 +197,7 @@ wr_deinit()
 static void
 bushnell_read()
 {
-  Waypoint* wpt_tmp = new Waypoint;
+  auto* wpt_tmp = new Waypoint;
 
   int32_t lat_tmp = gbfgetint32(file_in);
   int32_t lon_tmp = gbfgetint32(file_in);

--- a/bushnell_trl.cc
+++ b/bushnell_trl.cc
@@ -102,7 +102,7 @@ bushnell_read()
       break;
     }
 
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
     wpt_tmp->latitude  = lat_tmp / 10000000.0;
     wpt_tmp->longitude = lon_tmp / 10000000.0;
 

--- a/compegps.cc
+++ b/compegps.cc
@@ -155,7 +155,7 @@ parse_wpt(char* buff)
 {
   int col = -1;
   char* cx;
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   struct tm tm;
   int has_time = 0;
   memset(&tm, 0, sizeof(tm));
@@ -272,7 +272,7 @@ parse_trkpt(char* buff)
 {
   int col = -1;
   struct tm tm;
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   char* c = strstr(buff, "A ");
   if (c == buff) {

--- a/delgpl.cc
+++ b/delgpl.cc
@@ -57,7 +57,7 @@ gpl_read()
   track_add_head(track_head);
 
   while (gbfread(&gp, sizeof(gp), 1, gplfile_in) > 0) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
     wpt_tmp->latitude = le_read_double(&gp.lat);
     wpt_tmp->longitude = le_read_double(&gp.lon);
     double alt_feet = le_read_double(&gp.alt);

--- a/destinator.cc
+++ b/destinator.cc
@@ -159,7 +159,7 @@ destinator_read_poi()
 
     count++;
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->shortname = read_wcstr();
     wpt->notes = read_wcstr();		/* comment */
@@ -231,7 +231,7 @@ destinator_read_rte()
 
     count++;
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->shortname = read_wcstr();
     wpt->notes = read_wcstr();
@@ -279,7 +279,7 @@ destinator_read_trk()
       break;
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->longitude = gbfgetdbl(fin);
     wpt->latitude = gbfgetdbl(fin);

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -270,7 +270,7 @@ process_gpsfile(uint8_t data[], route_head** track)
       track_add_head(*track);
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     float latitude = bin2deg(lat);
     if (latitude >= 100) {
       manual_point = 1;

--- a/dmtlog.cc
+++ b/dmtlog.cc
@@ -449,7 +449,7 @@ read_CTrackFile(const int version)
       datum = read_datum(fin);
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->latitude = gbfgetdbl(fin);
     wpt->longitude = gbfgetdbl(fin);
@@ -496,7 +496,7 @@ read_CTrackFile(const int version)
       gbfungetc(i, fin);
       datum = read_datum(fin);
 
-      Waypoint* wpt = new Waypoint;
+      auto* wpt = new Waypoint;
 
       wpt->latitude = gbfgetdbl(fin);
       wpt->longitude = gbfgetdbl(fin);
@@ -523,7 +523,7 @@ read_CTrackFile(const int version)
   while (wcount > 0) {
     wcount--;
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->latitude = gbfgetdbl(fin);
     wpt->longitude = gbfgetdbl(fin);

--- a/easygps.cc
+++ b/easygps.cc
@@ -78,7 +78,7 @@ data_read()
   int p;
   char ibuf[10];
   do {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
     UrlLink link;
 
     for (int tag = gbfgetc(file_in); tag != 0xff; tag = gbfgetc(file_in)) {

--- a/enigma.cc
+++ b/enigma.cc
@@ -108,7 +108,7 @@ data_read()
   route_add_head(route);
 
   while (1 == gbfread(&ewpt, sizeof(ewpt), 1, file_in)) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     wpt->latitude = enigmaPositionToDec(le_read32(&ewpt.latitude));
     wpt->longitude = enigmaPositionToDec(le_read32(&ewpt.longitude));
     char*sn = xstrndup(ewpt.shortname, ewpt.shortname_len);

--- a/exif.cc
+++ b/exif.cc
@@ -805,7 +805,7 @@ exif_waypt_from_exif_app(ExifApp* app)
     return nullptr;
   }
 
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   wpt->latitude = unknown_alt;
   wpt->longitude = unknown_alt;

--- a/f90g_track.cc
+++ b/f90g_track.cc
@@ -118,7 +118,7 @@ f90g_track_read()
         && velocityMark == 'M') {
 
       // create the Waypoint and fill it in
-      Waypoint* readWaypoint = new Waypoint;
+      auto* readWaypoint = new Waypoint;
       QDateTime dt = QDateTime(QDate(year, mon, mday), QTime(hour, min, sec), Qt::UTC);
 
       readWaypoint->SetCreationTime(dt);

--- a/g7towin.cc
+++ b/g7towin.cc
@@ -272,7 +272,7 @@ parse_waypt(char* buff)
   char* cin;
   struct tm tm;
 
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   garmin_fs_p gmsd = garmin_fs_alloc(-1);
   fs_chain_add(&wpt->fs, (format_specific_data*) gmsd);
 
@@ -343,7 +343,7 @@ parse_waypt(char* buff)
 static Waypoint*
 parse_trkpt(char* buff)
 {
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   garmin_fs_p gmsd = garmin_fs_alloc(-1);
   fs_chain_add(&wpt->fs, (format_specific_data*) gmsd);
 

--- a/garmin.cc
+++ b/garmin.cc
@@ -385,7 +385,7 @@ waypt_read()
   GPS_PWay* way = nullptr;
 
   if (getposn) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     wpt->latitude = gps_save_lat;
     wpt->longitude = gps_save_lon;
     wpt->shortname = "Position";
@@ -401,7 +401,7 @@ waypt_read()
   }
 
   for (int i = 0; i < n; i++) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     wpt_tmp->shortname = QString::fromLatin1(way[i]->ident);
     wpt_tmp->description = QString::fromLatin1(way[i]->cmnt);
@@ -532,7 +532,7 @@ track_read()
     if (array[i]->no_latlon || array[i]->ishdr) {
       continue;
     }
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->longitude = array[i]->lon;
     wpt->latitude = array[i]->lat;
@@ -602,7 +602,7 @@ route_read()
       if (array[i]->islink)  {
         continue;
       } else {
-        Waypoint* wpt_tmp = new Waypoint;
+        auto* wpt_tmp = new Waypoint;
         wpt_tmp->latitude = array[i]->lat;
         wpt_tmp->longitude = array[i]->lon;
         wpt_tmp->shortname = array[i]->ident;
@@ -786,7 +786,7 @@ pvt_init(const QString& fname)
 static Waypoint*
 pvt_read(posn_status* posn_status)
 {
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   GPS_PPvt_Data pvt = GPS_Pvt_New();
 
   if (GPS_Command_Pvt_Get(&pvt_fd, &pvt)) {

--- a/garmin_fs.cc
+++ b/garmin_fs.cc
@@ -37,7 +37,7 @@
 garmin_fs_t*
 garmin_fs_alloc(const int protocol)
 {
-  garmin_fs_t* result = new garmin_fs_t;
+  auto* result = new garmin_fs_t;
   result->fs.type = FS_GMSD;
   result->fs.copy = (fs_copy) garmin_fs_copy;
   result->fs.destroy = garmin_fs_destroy;

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -918,7 +918,7 @@ wdata_compute_size(writer_data_t* data)
       res += 10;  /* tag(4) */
     }
 
-    gpi_waypt_t* dt = new gpi_waypt_t;
+    auto* dt = new gpi_waypt_t;
     wpt->extra_data = dt;
 
     if (alerts) {
@@ -1261,7 +1261,7 @@ enum_waypt_cb(const Waypoint* ref)
     }
   }
 
-  Waypoint* wpt = new Waypoint(*ref);
+  auto* wpt = new Waypoint(*ref);
 
   if (*opt_unique == '1') {
     wpt->shortname = mkshort(short_h, wpt->shortname);

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -1089,7 +1089,7 @@ parse_waypoint()
 
   bind_fields(waypt_header);
 
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   garmin_fs_p gmsd = garmin_fs_alloc(-1);
   fs_chain_add(&wpt->fs, (format_specific_data*) gmsd);
 
@@ -1262,7 +1262,7 @@ parse_track_waypoint()
   int column = -1;
 
   bind_fields(trkpt_header);
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   while ((str = csv_lineparse(nullptr, "\t", "", column++))) {
     double x;

--- a/garmin_xt.cc
+++ b/garmin_xt.cc
@@ -372,7 +372,7 @@ format_garmin_xt_proc_atrk()
     double AltF = (double)uu * GARMIN_XT_ELE - 1500;
 
     //create new waypoint
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     //populate wpt;
     wpt->latitude = LatF*180/16777216;	/* Degrees */

--- a/gdb.cc
+++ b/gdb.cc
@@ -690,7 +690,7 @@ read_route()
   for (int i = 0; i < points; i++) {
     char buf[128];
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     rtept_ct++;
 
     wpt->shortname = fread_cstr();	/* shortname */
@@ -875,7 +875,7 @@ read_track()
   int points = FREAD_i32;
 
   for (int index = 0; index < points; index++) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     trkpt_ct++;
 
@@ -989,7 +989,7 @@ read_data()
       wpt = read_waypoint(&wpt_class);
       if ((gdb_via == 0) || (wpt_class == 0)) {
         waypt_add(wpt);
-        Waypoint* dupe = new Waypoint(*wpt);
+        auto* dupe = new Waypoint(*wpt);
         wayptq_in.append(dupe);
       } else {
         wayptq_in_hidden.append(wpt);
@@ -1553,7 +1553,7 @@ write_waypoint_cb(const Waypoint* refpt)
 
   if (test == nullptr) {
     int display;
-    Waypoint* wpt = new Waypoint(*refpt);
+    auto* wpt = new Waypoint(*refpt);
 
     gdb_check_waypt(wpt);
     wayptq_out.append(wpt);

--- a/ggv_log.cc
+++ b/ggv_log.cc
@@ -124,7 +124,7 @@ ggv_log_read()
 
     memset(&tm, 0, sizeof(tm));
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     int deg = (int16_t) le_read16(&buf[0]);
     int min = le_read16(&buf[2]);

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -751,7 +751,7 @@ track_read()
                 printf(" PwrCadense:%d Power:%d\n", point.PwrCadence,point.Power);
               }
 
-              Waypoint* wpt = new Waypoint(); // waypt_new();
+              auto* wpt = new Waypoint(); // waypt_new();
               //wpt->creation_time = mkgmtime(&gpstime);
               wpt->SetCreationTime(gpsbabeltime);
               wpt->longitude = ((int32_t) point.Longitude) / 1000000.0;

--- a/gnav_trl.cc
+++ b/gnav_trl.cc
@@ -95,7 +95,7 @@ gnav_trl_read()
       fatal(MYNAME ": Unexpected EOF (end of file)!\n");
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->SetCreationTime(le_read32(&rec.time));
     wpt->latitude = le_read_float(&rec.lat);

--- a/googledir.cc
+++ b/googledir.cc
@@ -117,7 +117,7 @@ goog_poly_e(xg_string args, const QXmlStreamAttributes*)
     lon += decode_goog64(qbstr, qbpos);
 
     {
-      Waypoint* wpt_tmp = new Waypoint;
+      auto* wpt_tmp = new Waypoint;
       wpt_tmp->latitude = lat / 100000.0;
       wpt_tmp->longitude = lon / 100000.0;
       route_add_wpt(routehead, wpt_tmp);

--- a/gopal.cc
+++ b/gopal.cc
@@ -200,7 +200,7 @@ gopal_read()
     if ((nfields == 8) && (tx == 0)) {
       // fatal(MYNAME ": Invalid date in filename \"%s\", try to set manually using \"date\" switch!\n", buff);
     }
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     int column = -1;
     // the format of gopal is quite simple. Unfortunately the developers forgot the date as the first element...

--- a/gpsutil.cc
+++ b/gpsutil.cc
@@ -110,7 +110,7 @@ data_read()
     rtrim(sn);
     rtrim(desc);
     rtrim(icon);
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
     wpt_tmp->altitude = alt;
     wpt_tmp->shortname = sn;
     xfree(sn);

--- a/gtrnctr.cc
+++ b/gtrnctr.cc
@@ -504,7 +504,7 @@ gtc_trk_pnt_e(xg_string, const QXmlStreamAttributes*)
       /* Add the first point of an ActivityLap as
       a waypoint as well as a trackpoint. */
       char cbuf[10];
-      Waypoint* wpt_lap_s = new Waypoint(*wpt_tmp);
+      auto* wpt_lap_s = new Waypoint(*wpt_tmp);
       snprintf(cbuf, sizeof(cbuf), "LAP%03d", lap_ct);
       wpt_lap_s->shortname = cbuf;
       waypt_add(wpt_lap_s);

--- a/holux.cc
+++ b/holux.cc
@@ -97,7 +97,7 @@ static void data_read()
 
   /* Get the waypoints */
   for (int iCount = 0; iCount < iWptNum ; iCount ++) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     int iWptIndex = le_read16(&((WPTHDR*)HxWpt)->idx[iCount]);
     WPT* pWptHxTmp = (WPT*)&HxWpt[OFFS_WPT + (sizeof(WPT) * iWptIndex)];

--- a/humminbird.cc
+++ b/humminbird.cc
@@ -279,7 +279,7 @@ humminbird_read_wpt(gbfile* fin)
 
   /* All right! Copy the data to the gpsbabel struct... */
 
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   // Could probably find a way to eliminate the alloc/copy.
   char* s = xstrndup(w.name, sizeof(w.name));
@@ -422,7 +422,7 @@ humminbird_read_track(gbfile* fin)
 
   /* We create one wpt for the info in the header */
 
-  Waypoint* first_wpt = new Waypoint;
+  auto* first_wpt = new Waypoint;
   double g_lat = gudermannian_i1924(accum_north);
   first_wpt->latitude  = geocentric_to_geodetic_hwr(g_lat);
   first_wpt->longitude = accum_east/EAST_SCALE * 180.0;
@@ -431,7 +431,7 @@ humminbird_read_track(gbfile* fin)
   track_add_wpt(trk, first_wpt);
 
   for (int i = 0 ; i<th.num_points-1 ; i++) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     points[i].depth      = be_read16(&points[i].depth);
     points[i].deltaeast  = be_read16(&points[i].deltaeast);
@@ -532,7 +532,7 @@ humminbird_read_track_old(gbfile* fin)
 
   /* We create one wpt for the info in the header */
 
-  Waypoint* first_wpt = new Waypoint;
+  auto* first_wpt = new Waypoint;
   double g_lat = gudermannian_i1924(accum_north);
   first_wpt->latitude  = geocentric_to_geodetic_hwr(g_lat);
   first_wpt->longitude = accum_east/EAST_SCALE * 180.0;
@@ -540,7 +540,7 @@ humminbird_read_track_old(gbfile* fin)
   track_add_wpt(trk, first_wpt);
 
   for (int i = 0 ; i<th.num_points-1 ; i++) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     points[i].deltaeast  = be_read16(&points[i].deltaeast);
     points[i].deltanorth = be_read16(&points[i].deltanorth);

--- a/igc.cc
+++ b/igc.cc
@@ -215,7 +215,7 @@ static void igc_task_rec(const char* rec)
     fatal(MYNAME ": task waypoint (C) record parse error\n%s", rec);
   }
 
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   wpt->latitude = ('N' == lat_hemi[0] ? 1 : -1) *
                   (lat_deg + (lat_min * 1000 + lat_frac) / 1000.0 / 60);
 

--- a/igo8.cc
+++ b/igo8.cc
@@ -171,7 +171,7 @@ static void igo8_read()
   while (in_point_count &&
          gbfread(&point, sizeof(point), 1, igo8_file_in) > 0) {
     in_point_count--;
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     wpt_tmp->latitude = le_read32(&point.lat) / (double)0x800000;
     wpt_tmp->longitude = le_read32(&point.lon) / (double)0x800000;

--- a/interpolate.cc
+++ b/interpolate.cc
@@ -75,7 +75,7 @@ void InterpolateFilter::process()
           for (unsigned int timen = time1+interval;
                timen < wpt->creation_time.toTime_t();
                timen += interval) {
-            Waypoint* wpt_new = new Waypoint(*wpt);
+            auto* wpt_new = new Waypoint(*wpt);
             wpt_new->SetCreationTime(timen);
             wpt_new->shortname = QString();
             wpt_new->description = QString();
@@ -106,7 +106,7 @@ void InterpolateFilter::process()
             for (double distn = dist;
                  distn < curdist;
                  distn += dist) {
-              Waypoint* wpt_new = new Waypoint(*wpt);
+              auto* wpt_new = new Waypoint(*wpt);
               frac = distn / curdist;
               wpt_new->SetCreationTime(frac * (wpt->creation_time.toTime_t() - time1) + time1);
               wpt_new->shortname = QString();

--- a/itracku.cc
+++ b/itracku.cc
@@ -303,7 +303,7 @@ encode_itracku_time(time_t time)
 static Waypoint*
 to_waypoint(itracku_data_record* d)
 {
-  Waypoint* wp = new Waypoint;
+  auto* wp = new Waypoint;
   wp->longitude = deg_min_to_deg(le_read32(d->longitude));
   wp->latitude = deg_min_to_deg(le_read32(d->latitude));
   wp->SetCreationTime(decode_itracku_time(le_read32(d->creation_time)));
@@ -710,7 +710,7 @@ gprmc_parse(char* ibuf)
   dmy = dmy / 100;
   tm.tm_mday = dmy;
 
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   WAYPT_SET(waypt, speed, KNOTS_TO_MPS(speed));
 

--- a/jogmap.cc
+++ b/jogmap.cc
@@ -51,7 +51,7 @@ jogmap_markers(xg_string, const QXmlStreamAttributes*)
 static void
 jogmap_marker(xg_string, const QXmlStreamAttributes* attrv)
 {
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   if (attrv->hasAttribute("lat")) {
     wpt->latitude = attrv->value("lat").toString().toDouble();

--- a/jtr.cc
+++ b/jtr.cc
@@ -206,7 +206,7 @@ jtr_read()
       continue;
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->latitude = lat;
     wpt->longitude = lon;

--- a/kml.cc
+++ b/kml.cc
@@ -485,7 +485,7 @@ void gx_trk_e(xg_string, const QXmlStreamAttributes*)
   // In gx:Track elements all kml:when elements are required to precede all gx:coord elements.
   // For both we allow any order.  Many writers using gx:Track elements don't adhere to the schema.
   while (!gx_trk_times->isEmpty()) {
-    Waypoint* trkpt = new Waypoint;
+    auto* trkpt = new Waypoint;
     trkpt->SetCreationTime(gx_trk_times->takeFirst());
     double lat, lon, alt;
     int n;

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -1115,7 +1115,7 @@ lowranceusr_parse_waypts()
   }
 
   for (int i = 0; i < NumWaypoints && !gbfeof(file_in); i++) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     switch (reading_version) {
     case 2:
@@ -1163,7 +1163,7 @@ lowranceusr_parse_route()
 
   /* waypoints */
   for (int j = 0; j < num_legs; j++) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
     if (global_opts.debug_level == 99) {
       printf(MYNAME " parse_route:");
     }
@@ -1326,7 +1326,7 @@ lowranceusr_parse_icons()
     int    icon_number = gbfgetint32(file_in);
 
     if (opt_ignoreicons == nullptr) {          /* Option not specified if NULL */
-      Waypoint* wpt_tmp = new Waypoint;
+      auto* wpt_tmp = new Waypoint;
 
       /* position coord lat & long */
       wpt_tmp->latitude = latitude;
@@ -1394,7 +1394,7 @@ lowranceusr_parse_trail(int* trail_num)
       }
 
       for (int j = 0; j < num_section_points && !gbfeof(file_in); j++, num_trail_points--) {
-        Waypoint* wpt_tmp = new Waypoint;
+        auto* wpt_tmp = new Waypoint;
         wpt_tmp->latitude = lat_mm_to_deg(gbfgetint32(file_in));
         wpt_tmp->longitude = lon_mm_to_deg(gbfgetint32(file_in));
 
@@ -1528,7 +1528,7 @@ lowranceusr4_parse_trail(int* trail_num)
     }
   }
   for (int j = 0; j < num_trail_pts; ++j) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     /* Some unknown bytes */
     gbfgetint16(file_in);

--- a/maggeo.cc
+++ b/maggeo.cc
@@ -97,7 +97,7 @@ maggeo_read()
     buff += 9; /* skip field no. 1 */
     int fld = 1;
 
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
     geocache_data* gcdata = wpt_tmp->AllocGCData();
 
     while ((s = csv_lineparse(buff, ",", "", fld++))) {

--- a/magproto.cc
+++ b/magproto.cc
@@ -972,7 +972,7 @@ mag_trkparse(char* trkmsg)
   int fracsecs;
   struct tm tm;
 
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   memset(&tm, 0, sizeof(tm));
 
@@ -1092,7 +1092,7 @@ mag_rteparse(char* rtemsg)
       *p = '\0';
     }
 
-    mag_rte_elem* rte_elem = new mag_rte_elem;
+    auto* rte_elem = new mag_rte_elem;
 
     rte_elem->wpt_name = next_stop;
     rte_elem->wpt_icon = abuf;
@@ -1140,7 +1140,7 @@ mag_rteparse(char* rtemsg)
        */
       foreach (const Waypoint* waypt, rte_wpt_tmp) {
         if (waypt->shortname == re->wpt_name) {
-          Waypoint* wpt = new Waypoint(*waypt);
+          auto* wpt = new Waypoint(*waypt);
           route_add_wpt(rte_head, wpt);
           break;
         }
@@ -1208,7 +1208,7 @@ mag_wptparse(char* trkmsg)
   descr[0] = 0;
   icon_token[0] = 0;
 
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   sscanf(trkmsg,"$PMGNWPL,%lf,%c,%lf,%c,%d,%c,%[^,],%[^,]",
          &latdeg,&latdir,

--- a/mapasia.cc
+++ b/mapasia.cc
@@ -114,7 +114,7 @@ tr7_read()
       continue;
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->latitude = lat;
     wpt->longitude = lon;

--- a/mapbar_track.cc
+++ b/mapbar_track.cc
@@ -69,7 +69,7 @@ read_waypoint()
   int longitude = gbfgetint32(fin);
   int latitude = gbfgetint32(fin);
 
-  Waypoint* ret = new Waypoint;
+  auto* ret = new Waypoint;
 
   ret->latitude = double(latitude)/DIV_RATE;
   ret->longitude = double(longitude)/DIV_RATE;

--- a/mapsend.cc
+++ b/mapsend.cc
@@ -202,7 +202,7 @@ mapsend_track_read()
   unsigned int trk_count = gbfgetuint32(mapsend_file_in);
 
   while (trk_count--) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     wpt_tmp->longitude = gbfgetdbl(mapsend_file_in);
     wpt_tmp->latitude = -gbfgetdbl(mapsend_file_in);

--- a/mapsource.cc
+++ b/mapsource.cc
@@ -153,7 +153,7 @@ mps_find_wpt_q_by_name(const QList<Waypoint *>* whichQueue, const QString& name)
 static void
 mps_wpt_q_add(QList<Waypoint *>* whichQueue, const Waypoint* wpt)
 {
-  Waypoint* written_wpt = new Waypoint(*wpt);
+  auto* written_wpt = new Waypoint(*wpt);
   whichQueue->append(written_wpt);
 }
 
@@ -511,7 +511,7 @@ mps_waypoint_r(gbfile* mps_file, int mps_ver, Waypoint** wpt, unsigned int* mpsc
   double mps_proximity = unknown_alt;
   double mps_depth = unknown_alt;
 
-  Waypoint* thisWaypoint = new Waypoint;
+  auto* thisWaypoint = new Waypoint;
   *wpt = thisWaypoint;
 
   mps_readstr(mps_file, wptname, sizeof(wptname));

--- a/mmo.cc
+++ b/mmo.cc
@@ -647,7 +647,7 @@ mmo_read_CObjTrack(mmo_data_t* data)
   DBG((sobj, "track has %d point(s)\n", tp));
 
   for (int ctp = 0; ctp < tp; ctp++) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->latitude = gbfgetdbl(fin);
     wpt->longitude = gbfgetdbl(fin);

--- a/mtk_logger.cc
+++ b/mtk_logger.cc
@@ -803,7 +803,7 @@ mtk_retry:
 static route_head*  trk_head = nullptr;
 static int add_trackpoint(int idx, unsigned long bmask, struct data_item* itm)
 {
-  Waypoint* trk = new Waypoint;
+  auto* trk = new Waypoint;
 
   if (global_opts.masked_objective& TRKDATAMASK && (trk_head == nullptr || (mtk_info.track_event & MTK_EVT_START))) {
     char spds[50];
@@ -899,7 +899,7 @@ static int add_trackpoint(int idx, unsigned long bmask, struct data_item* itm)
          )
      ) {
     /* Button press -- create waypoint, start count at 1 */
-    Waypoint* w = new Waypoint(*trk);
+    auto* w = new Waypoint(*trk);
 
     w->shortname = QString::asprintf("WP%06d", waypt_count()+1);
     waypt_add(w);

--- a/mynav.cc
+++ b/mynav.cc
@@ -83,7 +83,7 @@ MyNavFormat::read_line(const QString& line, route_head* track)
     return;
   }
 
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   wpt->latitude = val_lat;
   wpt->longitude = val_lon;
 

--- a/navicache.cc
+++ b/navicache.cc
@@ -97,7 +97,7 @@ static void
 NaviReadCache(const QXmlStreamReader& reader)
 {
   const QXmlStreamAttributes a = reader.attributes();
-  Waypoint* wpt_tmp = new Waypoint;
+  auto* wpt_tmp = new Waypoint;
   geocache_data* gc_data = wpt_tmp->AllocGCData();
   if (a.hasAttribute("cache_id")) {
     int n = a.value("cache_id").toString().toInt();

--- a/naviguide.cc
+++ b/naviguide.cc
@@ -368,7 +368,7 @@ data_read()
 
   for (int n = 0; n < nof_wp; ++n) {
 
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     /* Read waypoint data */
 

--- a/navilink.cc
+++ b/navilink.cc
@@ -397,7 +397,7 @@ decode_waypoint_id(const unsigned char* buffer)
 static Waypoint*
 decode_waypoint(const unsigned char* buffer)
 {
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   decode_position(buffer + 12, waypt);
   char* s = xstrdup((char*)buffer + 4);
@@ -429,7 +429,7 @@ encode_waypoint(const Waypoint* waypt, unsigned char* buffer)
 static Waypoint*
 decode_trackpoint(const unsigned char* buffer)
 {
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   decode_position(buffer + 12, waypt);
   waypt->SetCreationTime(decode_datetime(buffer + 22));
@@ -813,7 +813,7 @@ decode_sbp_position(const unsigned char* buffer, Waypoint* waypt)
 Waypoint*
 navilink_decode_logpoint(const unsigned char* buffer)
 {
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   waypt->hdop = (buffer[0]) * 0.2f;
   waypt->sat = buffer[1];

--- a/navitel.cc
+++ b/navitel.cc
@@ -57,7 +57,7 @@ navitel_read_track()
     int lon = gbfgetint32(fin);
     int lat = gbfgetint32(fin);
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     wpt->latitude = GPS_Math_Semi_To_Deg(lat & 0x7FFFFFFF);
     wpt->longitude = GPS_Math_Semi_To_Deg(lon);
 

--- a/netstumbler.cc
+++ b/netstumbler.cc
@@ -219,7 +219,7 @@ data_read()
       continue;
     }
 
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     if (stealth) {
       if (!snmac) {

--- a/nmn4.cc
+++ b/nmn4.cc
@@ -85,7 +85,7 @@ nmn4_read_data()
     /* for a quiet compiler */
     QString zip1 = zip2 = city = street = number = QString();
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     int column = -1;
     QString c = csv_lineparse(str, "|", "", column++);

--- a/osm.cc
+++ b/osm.cc
@@ -591,7 +591,7 @@ osm_way_nd(xg_string, const QXmlStreamAttributes* attrv)
 
     if (waypoints.contains(atstr)) {
       const Waypoint* ctmp = waypoints.value(atstr);
-      Waypoint* tmp = new Waypoint(*ctmp);
+      auto* tmp = new Waypoint(*ctmp);
       route_add_wpt(rte, tmp);
     } else {
       warning(MYNAME ": Way reference id \"%s\" wasn't listed under nodes!\n", qPrintable(atstr));

--- a/ozi.cc
+++ b/ozi.cc
@@ -787,7 +787,7 @@ data_read()
     if (buff.contains(',')) {
       bool ozi_fsdata_used = false;
       ozi_fsdata* fsdata = ozi_alloc_fsdata();
-      Waypoint* wpt_tmp = new Waypoint;
+      auto* wpt_tmp = new Waypoint;
 
       /* data delimited by commas. */
       const QStringList parts = buff.split(',');

--- a/pocketfms_bc.cc
+++ b/pocketfms_bc.cc
@@ -103,7 +103,7 @@ read_tracks()
     tm.tm_min = le_readu16(&bc.minute);
     tm.tm_sec = le_readu16(&bc.second);
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     wpt->latitude = le_read_float(&bc.latitude);
     wpt->longitude = le_read_float(&bc.longitude);
     wpt->altitude = FEET_TO_METERS(le_read_float(&bc.altitude));

--- a/pocketfms_wp.cc
+++ b/pocketfms_wp.cc
@@ -65,7 +65,7 @@ data_read()
       break;
     }
     linecount++;
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     char* s = buff;
     s = csv_lineparse(s, "\\w", "", linecount);
     if (!s) {

--- a/psitrex.cc
+++ b/psitrex.cc
@@ -303,7 +303,7 @@ static void
 psit_waypoint_r(gbfile* psit_file, Waypoint**)
 {
   if (strlen(psit_current_token) > 0) {
-    Waypoint* thisWaypoint = new Waypoint;
+    auto* thisWaypoint = new Waypoint;
 
     thisWaypoint->latitude = atof(psit_current_token);
 
@@ -409,7 +409,7 @@ psit_route_r(gbfile* psit_file, route_head** rte)
 
   while (psit_isKnownToken(psit_current_token) != 0) {
     if (strlen(psit_current_token) > 0) {
-      Waypoint* thisWaypoint = new Waypoint;
+      auto* thisWaypoint = new Waypoint;
 
       thisWaypoint->latitude = atof(psit_current_token);
 
@@ -523,7 +523,7 @@ psit_track_r(gbfile* psit_file, route_head**)
 
   while (psit_isKnownToken(psit_current_token) != 0) {
     if (strlen(psit_current_token) > 0) {
-      Waypoint* thisWaypoint = new Waypoint;
+      auto* thisWaypoint = new Waypoint;
 
       thisWaypoint->latitude = atof(psit_current_token);
 

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -200,7 +200,7 @@ raymarine_read()
       break;
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     wpt->shortname = name;
     wpt->latitude = lat.toDouble();
     wpt->longitude = lon.toDouble();

--- a/sbn.cc
+++ b/sbn.cc
@@ -235,7 +235,7 @@ decode_sbn_position(const unsigned char* buffer, Waypoint* waypt)
 static Waypoint*
 decode_sbn_record(unsigned char* buffer)
 {
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   if (is_sbn_valid(buffer)) {
     waypt->fix = decode_sbn_mode(buffer + 3);

--- a/skyforce.cc
+++ b/skyforce.cc
@@ -47,7 +47,7 @@ skyforce_parse_coords(const char* str)
     fatal(MYNAME ": Incomplete line!\n");
   }
 
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   wpt->latitude = atof(str + 21);
   if (str[20] == 'S') {

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -694,7 +694,7 @@ state_init(struct read_state* pst)
 static Waypoint*
 make_trackpoint(struct read_state* st, double lat, double lon, double alt)
 {
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   wpt->shortname = QString::asprintf("TP%04d", ++st->tpn);
 
@@ -1561,7 +1561,7 @@ static void miniHomer_get_poi()
     } else {
       ECEF_to_LLA(ecef_x, ecef_y, ecef_z, &lat, &lng, &alt);
 
-      Waypoint* wpt = new Waypoint;
+      auto* wpt = new Waypoint;
       wpt->shortname      = QString::asprintf("POI_%s", poinames[poi]);
       wpt->description    = QString::asprintf("miniHomer points to this coordinates if the %s symbol is on", poinames[poi]);
       wpt->latitude       = lat;

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -205,7 +205,7 @@ waypoint_final()
 
   if (route != nullptr) {
     if ((via != 0) || (routevia == nullptr)) {
-      Waypoint* wpt = new Waypoint(*wpt_tmp);
+      auto* wpt = new Waypoint(*wpt_tmp);
       route_add_wpt(route, wpt);
     }
   }

--- a/teletype.cc
+++ b/teletype.cc
@@ -57,7 +57,7 @@ static void
 teletype_read()
 {
   for (uint32_t i = 0; i < tty_wpt_count; i++) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     wpt->shortname = (gbfgetcstr(fin));
     wpt->description = (gbfgetcstr(fin));
 

--- a/tiger.cc
+++ b/tiger.cc
@@ -166,7 +166,7 @@ data_read()
     }
     if (sscanf(ibuf, "%lf,%lf:%100[^:]:%100[^\n]",
                &lon, &lat, icon, desc)) {
-      Waypoint* wpt_tmp = new Waypoint;
+      auto* wpt_tmp = new Waypoint;
 
       wpt_tmp->longitude = lon;
       wpt_tmp->latitude = lat;

--- a/tmpro.cc
+++ b/tmpro.cc
@@ -80,7 +80,7 @@ data_read()
     /* skip the line if it contains "sHyperLink" as it is a header (I hope :) */
     if ((strlen(buff)) && (strstr(buff, "sHyperLink") == nullptr)) {
 
-      Waypoint* wpt_tmp = new Waypoint;
+      auto* wpt_tmp = new Waypoint;
 
       /* data delimited by tabs, not enclosed in quotes.  */
       char* s = buff;

--- a/tpg.cc
+++ b/tpg.cc
@@ -113,7 +113,7 @@ tpg_read()
 
 
   while (pointcount--) {
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     /* pascal-like shortname */
     wpt_tmp->shortname = gbfgetpstr(tpg_file_in);

--- a/tpo.cc
+++ b/tpo.cc
@@ -338,7 +338,7 @@ static void tpo_read_2_x()
     /* multiply all the deltas by the scaling factors to determine the waypoint positions */
     for (int j = 0; j < waypoint_count; j++) {
 
-      Waypoint* waypoint_temp = new Waypoint;
+      auto* waypoint_temp = new Waypoint;
       double amt;
       /* convert incoming NAD27/CONUS coordinates to WGS84 */
       GPS_Math_Known_Datum_To_WGS84_M(
@@ -447,7 +447,7 @@ static int tpo_find_block(unsigned int block_desired)
 //
 static Waypoint* tpo_convert_ll(int lat, int lon)
 {
-  Waypoint* waypoint_temp = new Waypoint;
+  auto* waypoint_temp = new Waypoint;
 
   double latitude = (double)lat / 0x800000;
   double longitude = (double)lon / 0x800000;
@@ -857,7 +857,7 @@ static void tpo_process_waypoints()
 
     // For routes (later), we need a duplicate of each waypoint
     // indexed by the order we read them in.
-    Waypoint* waypoint_temp2 = new Waypoint(*waypoint_temp);
+    auto* waypoint_temp2 = new Waypoint(*waypoint_temp);
 
     // Attach the copy to our index
     tpo_wp_index[tpo_index_ptr++] = waypoint_temp2;
@@ -1162,7 +1162,7 @@ static void tpo_process_routes()
 //printf("val: %x\t\t", val);
 
       // Duplicate a waypoint from our index of waypoints.
-      Waypoint* waypoint_temp = new Waypoint(*tpo_wp_index[val-1]);
+      auto* waypoint_temp = new Waypoint(*tpo_wp_index[val-1]);
 
       // Add the waypoint to the route
       route_add_wpt(route_temp, waypoint_temp);

--- a/transform.cc
+++ b/transform.cc
@@ -95,7 +95,7 @@ void TransformFilter::transform_trk_disp_hdr_cb(const route_head* trk)
 
 void TransformFilter::transform_any_disp_wpt_cb(const Waypoint* wpt)
 {
-  Waypoint* temp = new Waypoint(*wpt);
+  auto* temp = new Waypoint(*wpt);
   if (current_target == 'R') {
     route_add_wpt(current_rte, temp, current_namepart, name_digits);
   } else if (current_target == 'T') {

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -624,7 +624,7 @@ unicsv_parse_one_line(const QString& ibuf)
   int ns = 1;
   int ew = 1;
   geocache_data* gc_data = nullptr;
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   wpt->latitude = unicsv_unknown;
   wpt->longitude = unicsv_unknown;
   memset(&ymd, 0, sizeof(ymd));

--- a/v900.cc
+++ b/v900.cc
@@ -288,7 +288,7 @@ v900_read()
       line.bas.cr = 0;	/* null terminate vox field */
     }
 
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     /* lat is a string in the form: 31.768380N */
     char c = line.bas.common.latitude_NS;	/* N/S */
@@ -348,7 +348,7 @@ v900_read()
       // thread on gpsbabel-misc with Jamie Robertson.
       assert(line.bas.common.tag == 'C' || line.bas.common.tag == 'G' ||
              line.bas.common.tag == 'V');
-      Waypoint* wpt2 = new Waypoint(*wpt);
+      auto* wpt2 = new Waypoint(*wpt);
       if (line.bas.common.tag == 'V') {	// waypoint with voice recording?
         char vox_file_name[sizeof(line.adv.vox)+5];
         const char* vox = is_advanced_mode ? line.adv.vox : line.bas.vox;

--- a/vidaone.cc
+++ b/vidaone.cc
@@ -76,7 +76,7 @@ vidaone_read()
   route_head* trk = nullptr;
 
   while (! gbfeof(fin)) {
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
 
     wpt->latitude = gbfgetdbl(fin);
     wpt->longitude = gbfgetdbl(fin);

--- a/vitosmt.cc
+++ b/vitosmt.cc
@@ -126,7 +126,7 @@ vitosmt_read()
     unsigned char gpsvalid = gbfgetc(infile); /* fix is valid */
     unsigned char gpssats = gbfgetc(infile); /* number of sats */
 
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     wpt_tmp->latitude =DEG(latrad);
     wpt_tmp->longitude =DEG(lonrad);

--- a/vitovtt.cc
+++ b/vitovtt.cc
@@ -88,7 +88,7 @@ vitovtt_read()
     int course = gbfgetint16(infile);
     int status = gbfgetint32(infile);
 
-    Waypoint* wpt_tmp = new Waypoint;
+    auto* wpt_tmp = new Waypoint;
 
     wpt_tmp->latitude= scaled_lat / vitovtt_latitudescale;
     wpt_tmp->longitude= scaled_lon / vitovtt_longitudescale;

--- a/vpl.cc
+++ b/vpl.cc
@@ -186,7 +186,7 @@ vpl_parse_75_sentence(const char* ibuf)
   ymd /= 100;
   tm.tm_year = ymd % 100 + 100;
 
-  Waypoint* waypt = new Waypoint;
+  auto* waypt = new Waypoint;
 
   // Lat/Lon are both stored *0xE1000 which we have to divide out
   // for decimal degrees

--- a/wbt-200.cc
+++ b/wbt-200.cc
@@ -537,7 +537,7 @@ static int check_date(uint32_t tim)
 static Waypoint* make_point(double lat, double lon, double alt, time_t tim, const char* fmt, int index)
 {
   char     wp_name[20];
-  Waypoint* wpt = new Waypoint;
+  auto* wpt = new Waypoint;
 
   sprintf(wp_name, fmt, index);
 

--- a/wfff_xml.cc
+++ b/wfff_xml.cc
@@ -152,7 +152,7 @@ void wfff_e(xg_string, const QXmlStreamAttributes*)
   char		desc[255]	="\0";
 
   if ((ap_hdop>=1)&&(ap_hdop<50)) { // Discard invalid GPS fix
-    Waypoint*	wpt_tmp = new Waypoint;
+    auto*	wpt_tmp = new Waypoint;
 
     if (snmac) {
       wpt_tmp->shortname = ap_mac;

--- a/wintec_tes.cc
+++ b/wintec_tes.cc
@@ -67,7 +67,7 @@ wintec_tes_read()
     int16_t alt = gbfgetint16(fin);  // Signed.  Meters.
 
     (void) flags; // Silence 'unused' warning until we use flags.
-    Waypoint* wpt = new Waypoint;
+    auto* wpt = new Waypoint;
     wpt->latitude = latitude / 1.0e7;
     wpt->longitude = longitude / 1.0e7;
     wpt->SetCreationTime(wintec_date_to_time(date));
@@ -84,7 +84,7 @@ wintec_tes_read()
     //  Wintec's software puts a waypoint in the track, so we
     //  mock that.
     if (flags &  0x02) {
-      Waypoint* temp = new Waypoint(*wpt);
+      auto* temp = new Waypoint(*wpt);
       waypt_add(temp);
     }
 

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -953,7 +953,7 @@ xcsv_data_read()
        }
     }
     if (!buff.isEmpty()) {
-      Waypoint* wpt_tmp = new Waypoint;
+      auto* wpt_tmp = new Waypoint;
       // initialize parse data for accumulation of line results from all fields in this line.
       xcsv_parse_data parse_data;
       const QStringList values = csv_linesplit(buff, xcsv_style->field_delimiter,

--- a/xmltag.cc
+++ b/xmltag.cc
@@ -48,7 +48,7 @@ copy_xml_tag(xml_tag** copy, xml_tag* src, xml_tag* parent)
     return;
   }
 
-  xml_tag* res = new xml_tag;
+  auto* res = new xml_tag;
   *copy = res;
 
   res->tagname = (src->tagname);
@@ -78,7 +78,7 @@ fs_xml_copy(void** copy, void* source)
     *copy = nullptr;
     return;
   }
-  fs_xml* res = new fs_xml;
+  auto* res = new fs_xml;
   *copy = res;
 
   res->fs = src->fs;
@@ -87,7 +87,7 @@ fs_xml_copy(void** copy, void* source)
 
 fs_xml* fs_xml_alloc(long type)
 {
-  fs_xml* result = new fs_xml;
+  auto* result = new fs_xml;
   result->fs.type = type;
   result->fs.copy = fs_xml_copy;
   result->fs.destroy = fs_xml_destroy;


### PR DESCRIPTION
only on:
Message: use auto when initializing with new to avoid duplicating the type name

not on:
Message: use auto when initializing with a cast to avoid duplicating the type name
Message: use auto when initializing with a template cast to avoid duplicating the

The later two left me wondering what type I had, while it is obvious with the first
one.  Some of this is due to our macro defines for gbffetuint*, gbfputuint*.

This required a edit of the fixes file produced by clang-tidy:
export PAT='with a template' A=3 B=3
vim -Nes "+g/${PAT}/.-${B},.+${A}d" '+w !tee' '+q!' ct8fixes.yaml > tmp1.yaml
export PAT='with a cast' A=2 B=3
vim -Nes "+g/${PAT}/.-${B},.+${A}d" '+w !tee' '+q!' tmp1.yaml > myfixes.yaml
rm ct8fixes.yaml
rm tmp1.yaml