### PR TITLE
clang-tidy modernize-use-auto, part 2, but

### DIFF
--- a/alan.cc
+++ b/alan.cc
@@ -197,7 +197,7 @@ static unsigned int byte_order()
 {
   unsigned long test = BYTEORDER_TEST;
 
-  unsigned char* ptr = (unsigned char*)(&test);
+  auto* ptr = (unsigned char*)(&test);
   unsigned int order = (ptr[0] << 12) | (ptr[1] << 8) | (ptr[2] << 4) | ptr[3];
 
   return order;
@@ -205,22 +205,22 @@ static unsigned int byte_order()
 
 static void sw_bytes(void* word)
 {
-  uint8_t* p = (uint8_t*) word;
-  uint16_t* r = (uint16_t*) word;
+  auto* p = (uint8_t*) word;
+  auto* r = (uint16_t*) word;
 
   *r = (uint16_t)(p[1] << 8 | p[0]);
 }
 static void sw_words(void* dword)
 {
-  uint16_t* p = (uint16_t*) dword;
-  uint32_t* r = (uint32_t*) dword;
+  auto* p = (uint16_t*) dword;
+  auto* r = (uint32_t*) dword;
 
   *r = (uint32_t)(p[0] << 16 | p[1]);
 }
 static void rev_bytes(void* dword)
 {
-  uint8_t* p = (uint8_t*) dword;
-  uint32_t* r = (uint32_t*) dword;
+  auto* p = (uint8_t*) dword;
+  auto* r = (uint32_t*) dword;
 
   *r = (uint32_t)(p[3] << 24 | p[2] << 16 | p[1] << 8 | p[0]);
 }

--- a/an1.cc
+++ b/an1.cc
@@ -280,7 +280,7 @@ static void Copy_AN1_Waypoint(void** vdwpt, void* vwpt)
 
 static an1_waypoint_record* Alloc_AN1_Waypoint()
 {
-  auto* result = (an1_waypoint_record*)xcalloc(sizeof(*result), 1);
+  auto* result = (an1_waypoint_record*)xcalloc(1, sizeof(an1_waypoint_record));
   result->fs.type = FS_AN1W;
   result->fs.copy = Copy_AN1_Waypoint;
   result->fs.destroy = Destroy_AN1_Waypoint;
@@ -304,7 +304,7 @@ static void Copy_AN1_Vertex(void** vdvert, void* vvert)
 
 static an1_vertex_record* Alloc_AN1_Vertex()
 {
-  auto* result = (an1_vertex_record*)xcalloc(sizeof(*result), 1);
+  auto* result = (an1_vertex_record*)xcalloc(1, sizeof(an1_vertex_record));
   result->fs.type = FS_AN1V;
   result->fs.copy = Copy_AN1_Vertex;
   result->fs.destroy = Destroy_AN1_Vertex;
@@ -332,7 +332,7 @@ static void Copy_AN1_Line(void** vdline, void* vline)
 
 static an1_line_record* Alloc_AN1_Line()
 {
-  auto* result = (an1_line_record*)xcalloc(sizeof(*result), 1);
+  auto* result = (an1_line_record*)xcalloc(1, sizeof(an1_line_record));
   result->fs.type = FS_AN1L;
   result->fs.copy = Copy_AN1_Line;
   result->fs.destroy = Destroy_AN1_Line;

--- a/an1.cc
+++ b/an1.cc
@@ -249,7 +249,7 @@ static an1_waypoint_record* Alloc_AN1_Waypoint();
 static void Destroy_AN1_Waypoint(void* vwpt)
 {
 
-  an1_waypoint_record* wpt = (an1_waypoint_record*)vwpt;
+  auto* wpt = (an1_waypoint_record*)vwpt;
   xfree(wpt->name);
   xfree(wpt->fontname);
 
@@ -267,7 +267,7 @@ static void Destroy_AN1_Waypoint(void* vwpt)
 
 static void Copy_AN1_Waypoint(void** vdwpt, void* vwpt)
 {
-  an1_waypoint_record* wpt = (an1_waypoint_record*)vwpt;
+  auto* wpt = (an1_waypoint_record*)vwpt;
   an1_waypoint_record* dwpt = Alloc_AN1_Waypoint();
   memcpy(dwpt, wpt, sizeof(an1_waypoint_record));
   dwpt->name = xstrdup(wpt->name);
@@ -280,7 +280,7 @@ static void Copy_AN1_Waypoint(void** vdwpt, void* vwpt)
 
 static an1_waypoint_record* Alloc_AN1_Waypoint()
 {
-  an1_waypoint_record* result = (an1_waypoint_record*)xcalloc(sizeof(*result), 1);
+  auto* result = (an1_waypoint_record*)xcalloc(sizeof(*result), 1);
   result->fs.type = FS_AN1W;
   result->fs.copy = Copy_AN1_Waypoint;
   result->fs.destroy = Destroy_AN1_Waypoint;
@@ -296,7 +296,7 @@ static void Destroy_AN1_Vertex(void* vvertex)
 
 static void Copy_AN1_Vertex(void** vdvert, void* vvert)
 {
-  an1_vertex_record* vert = (an1_vertex_record*)vvert;
+  auto* vert = (an1_vertex_record*)vvert;
   an1_vertex_record* dvert = Alloc_AN1_Vertex();
   memcpy(dvert, vert, sizeof(an1_vertex_record));
   *vdvert = (void*)dvert;
@@ -304,7 +304,7 @@ static void Copy_AN1_Vertex(void** vdvert, void* vvert)
 
 static an1_vertex_record* Alloc_AN1_Vertex()
 {
-  an1_vertex_record* result = (an1_vertex_record*)xcalloc(sizeof(*result), 1);
+  auto* result = (an1_vertex_record*)xcalloc(sizeof(*result), 1);
   result->fs.type = FS_AN1V;
   result->fs.copy = Copy_AN1_Vertex;
   result->fs.destroy = Destroy_AN1_Vertex;
@@ -316,14 +316,14 @@ static an1_line_record* Alloc_AN1_Line();
 
 static void Destroy_AN1_Line(void* vline)
 {
-  an1_line_record* line = (an1_line_record*)vline;
+  auto* line = (an1_line_record*)vline;
   xfree(line->name);
   xfree(vline);
 }
 
 static void Copy_AN1_Line(void** vdline, void* vline)
 {
-  an1_line_record* line = (an1_line_record*)vline;
+  auto* line = (an1_line_record*)vline;
   an1_line_record* dline = Alloc_AN1_Line();
   memcpy(dline, line, sizeof(an1_line_record));
   dline->name = xstrdup(line->name);
@@ -332,7 +332,7 @@ static void Copy_AN1_Line(void** vdline, void* vline)
 
 static an1_line_record* Alloc_AN1_Line()
 {
-  an1_line_record* result = (an1_line_record*)xcalloc(sizeof(*result), 1);
+  auto* result = (an1_line_record*)xcalloc(sizeof(*result), 1);
   result->fs.type = FS_AN1L;
   result->fs.copy = Copy_AN1_Line;
   result->fs.destroy = Destroy_AN1_Line;

--- a/arcdist.cc
+++ b/arcdist.cc
@@ -154,7 +154,7 @@ void ArcDistanceFilter::process()
 
   unsigned removed = 0;
   foreach (Waypoint* wp, *global_waypoint_list) {
-    extra_data* ed = (extra_data*) wp->extra_data;
+    auto* ed = (extra_data*) wp->extra_data;
     wp->extra_data = nullptr;
     if (ed) {
       if ((ed->distance >= pos_dist) == (exclopt == nullptr)) {

--- a/cet.cc
+++ b/cet.cc
@@ -113,7 +113,7 @@ cet_ucs4_to_utf8(char* dest, size_t dest_size, int value)
 int
 cet_utf8_to_ucs4(const char* str, int* bytes, int* value)
 {
-  unsigned char* cp = (unsigned char*)str;
+  auto* cp = (unsigned char*)str;
 
   if (*cp < 0x80) {
     if (bytes != nullptr) {

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -550,7 +550,7 @@ dg100_request(uint8_t cmd, const void* sendbuf, void* recvbuf, size_t count)
   /* the number of frames the answer will comprise */
   int frames = (cmd == dg100cmd_getfile) ? 2 : 1;
   /* alias pointer for easy typecasting */
-  uint8_t* buf = (uint8_t*) recvbuf;
+  auto* buf = (uint8_t*) recvbuf;
   int fill = 0;
   for (int i = 0; i < frames; i++) {
     int n = dg100_recv(cmd, buf + fill, count - fill);

--- a/discard.cc
+++ b/discard.cc
@@ -38,7 +38,7 @@ void DiscardFilter::fix_process_wpt(const Waypoint* wpt)
   int delh = 0;
   int delv = 0;
 
-  Waypoint* waypointp = const_cast<Waypoint*>(wpt);
+  auto* waypointp = const_cast<Waypoint*>(wpt);
 
   if ((hdopf >= 0.0) && (waypointp->hdop > hdopf)) {
     delh = 1;

--- a/duplicate.cc
+++ b/duplicate.cc
@@ -153,7 +153,7 @@ void DuplicateFilter::process()
 
   int ct = waypt_count();
 
-  auto* htable = (wpt_ptr*) xmalloc(ct * sizeof(*htable));
+  auto* htable = (wpt_ptr*) xmalloc(ct * sizeof(wpt_ptr));
   wpt_ptr* bh = htable;
 
   int i = 0;

--- a/duplicate.cc
+++ b/duplicate.cc
@@ -153,7 +153,7 @@ void DuplicateFilter::process()
 
   int ct = waypt_count();
 
-  wpt_ptr* htable = (wpt_ptr*) xmalloc(ct * sizeof(*htable));
+  auto* htable = (wpt_ptr*) xmalloc(ct * sizeof(*htable));
   wpt_ptr* bh = htable;
 
   int i = 0;

--- a/explorist_ini.cc
+++ b/explorist_ini.cc
@@ -25,7 +25,7 @@ explorist_ini_try(const char* path)
     return nullptr;
   }
 
-  mag_info* info = (mag_info*) xmalloc(sizeof(mag_info));
+  auto* info = (mag_info*) xmalloc(sizeof(mag_info));
   info->geo_path = nullptr;
   info->track_path = nullptr;
   info->waypoint_path = nullptr;

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -801,7 +801,7 @@ wdata_free(writer_data_t* data)
   foreach (Waypoint* wpt, data->waypt_list) {
 
     if (wpt->extra_data) {
-      gpi_waypt_t* dt = (gpi_waypt_t*) wpt->extra_data;
+      auto* dt = (gpi_waypt_t*) wpt->extra_data;
       delete dt;
     }
     delete wpt;
@@ -1066,7 +1066,7 @@ wdata_write(const writer_data_t* data)
 
   foreach (const Waypoint* wpt, data->waypt_list) {
     int s1;
-    gpi_waypt_t* dt = (gpi_waypt_t*) wpt->extra_data;
+    auto* dt = (gpi_waypt_t*) wpt->extra_data;
 
     QString str = wpt->description;
     if (str.isEmpty()) {

--- a/garmin_xt.cc
+++ b/garmin_xt.cc
@@ -180,7 +180,7 @@ format_garmin_xt_decomp_trk_blk(uint8_t ii, const uint8_t TrackBlock[], double* 
   LatLW = LatLW + TrackBlock[(ii - 1) * 12 + 3];
   LatLW = LatLW << 8;
   LatLW = LatLW + TrackBlock[(ii - 1) * 12 + 2];
-  double LatF = (double)LatLW;
+  auto LatF = (double)LatLW;
   if (LatF > 8388608) {
     LatF = LatF - 16777216;
   }
@@ -191,7 +191,7 @@ format_garmin_xt_decomp_trk_blk(uint8_t ii, const uint8_t TrackBlock[], double* 
   LonLW = LonLW+TrackBlock[(ii-1)*12+6];
   LonLW = LonLW << 8;
   LonLW = LonLW+TrackBlock[(ii-1)*12+5];
-  double LonF = (double)LonLW;
+  auto LonF = (double)LonLW;
   if (LonF>8388608) {
     LonF = LonF - 16777216;
   }

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -502,7 +502,7 @@ memapi_error(gbfile* self)
 gbfile*
 gbfopen(const QString& filename, const char* mode, const char* module)
 {
-  auto* file = (gbfile*) xcalloc(1, sizeof(*file));
+  auto* file = (gbfile*) xcalloc(1, sizeof(gbfile));
 
   file->module = xstrdup(module);
   file->mode = 'r'; // default

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -502,7 +502,7 @@ memapi_error(gbfile* self)
 gbfile*
 gbfopen(const QString& filename, const char* mode, const char* module)
 {
-  gbfile* file = (gbfile*) xcalloc(1, sizeof(*file));
+  auto* file = (gbfile*) xcalloc(1, sizeof(*file));
 
   file->module = xstrdup(module);
   file->mode = 'r'; // default

--- a/gbfile.h
+++ b/gbfile.h
@@ -88,7 +88,10 @@ struct gbfile {
 
 gbfile* gbfopen(const QString& filename, const char* mode, const char* module);
 gbfile* gbfopen_be(const QString& filename, const char* mode, const char* module);
-#define gbfopen_le gbfopen
+inline gbfile* gbfopen_le(const QString& filename, const char* mode, const char* module)
+{
+  return gbfopen(filename, mode, module);
+}
 void gbfclose(gbfile* file);
 
 gbsize_t gbfread(void* buf, gbsize_t size, gbsize_t members, gbfile* file);
@@ -114,9 +117,15 @@ int gbfeof(gbfile* file);
 int gbfungetc(int c, gbfile* file);
 
 int32_t gbfgetint32(gbfile* file);
-#define gbfgetuint32 (uint32_t)gbfgetint32
+inline uint32_t gbfgetuint32(gbfile* file)
+{
+  return gbfgetint32(file);
+}
 int16_t gbfgetint16(gbfile* file);
-#define gbfgetuint16 (uint16_t)gbfgetint16
+inline uint16_t gbfgetuint16(gbfile* file)
+{
+  return gbfgetint16(file);
+}
 double gbfgetdbl(gbfile* file);			// read a double value
 float gbfgetflt(gbfile* file);			// read a float value
 char* gbfgetstr(gbfile* file);			// read until any type of line-breaks or EOF
@@ -126,9 +135,15 @@ QByteArray gbfgetnativecstr(gbfile* file);  // read a null terminated string
 char* gbfgetcstr_old(gbfile* file);		// read a null terminated string
 
 int gbfputint16(int16_t i, gbfile* file);
-#define gbfputuint16(a,b) gbfputint16((uint16_t)(a),(b))
+inline int gbfputuint16(uint16_t i, gbfile* file)
+{
+  return gbfputint16(i, file);
+}
 int gbfputint32(int32_t i, gbfile* file);
-#define gbfputuint32(a,b) gbfputint32((uint32_t)(a),(b))
+inline int gbfputuint32(uint32_t i, gbfile* file)
+{
+  return gbfputint32(i, file);
+}
 
 int gbfputdbl(double d, gbfile* file);	// write a double value
 int gbfputflt(float f, gbfile* file);	// write a float value

--- a/gbser_posix.cc
+++ b/gbser_posix.cc
@@ -46,7 +46,7 @@ struct gbser_handle {
 /* Wrapper to safely cast a void * into a gbser_handle */
 static gbser_handle* gbser__get_handle(void* p)
 {
-  gbser_handle* h = (gbser_handle*) p;
+  auto* h = (gbser_handle*) p;
   assert(h->magic == MYMAGIC);
   return h;
 }
@@ -255,7 +255,7 @@ unsigned gbser__read_buffer(void* handle, void** buf, unsigned* len)
 {
   gbser_handle* h = gbser__get_handle(handle);
   unsigned count = *len;
-  unsigned char* cp = (unsigned char*) *buf;
+  auto* cp = (unsigned char*) *buf;
   if (count > h->inbuf_used) {
     count = h->inbuf_used;
   }

--- a/gdb.cc
+++ b/gdb.cc
@@ -730,7 +730,7 @@ read_route()
            qPrintable(wpt->shortname), wpt_class, links);
 #endif
     for (int j = 0; j < links; j++) {
-      auto* il_step = (garmin_ilink_t*) xmalloc(sizeof(*il_step));
+      auto* il_step = (garmin_ilink_t*) xmalloc(sizeof(garmin_ilink_t));
 
       il_step->ref_count = 1;
 

--- a/gdb.cc
+++ b/gdb.cc
@@ -730,7 +730,7 @@ read_route()
            qPrintable(wpt->shortname), wpt_class, links);
 #endif
     for (int j = 0; j < links; j++) {
-      garmin_ilink_t* il_step = (garmin_ilink_t*) xmalloc(sizeof(*il_step));
+      auto* il_step = (garmin_ilink_t*) xmalloc(sizeof(*il_step));
 
       il_step->ref_count = 1;
 

--- a/ggv_log.cc
+++ b/ggv_log.cc
@@ -108,7 +108,7 @@ ggv_log_read()
     break;
   }
 
-  signed char* buf = (signed char*) xmalloc(bufsz);
+  auto* buf = (signed char*) xmalloc(bufsz);
 
   while ((len = gbfread(buf, 1, bufsz, fin))) {
     struct tm tm;

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -335,7 +335,7 @@ globalsat_read_package(int* out_length, uint8_t* out_DeviceCommand)
     printf("len=%d Payload:", length);
   }
 
-  uint8_t* payload = (uint8_t*) malloc(length);
+  auto* payload = (uint8_t*) malloc(length);
   if (payload == nullptr) {
     goto error_out;
   }

--- a/gnav_trl.cc
+++ b/gnav_trl.cc
@@ -68,7 +68,7 @@ gnav_trl_rw_deinit()
 static double
 read_altitude(void* ptr)
 {
-  unsigned char* i = (unsigned char*) ptr;
+  auto* i = (unsigned char*) ptr;
   char buf[sizeof(float)];
   le_write32(&buf, i[2] << 24 | i[1] << 16 | i[0] <<8 | i[3]);
   return le_read_float(&buf);
@@ -78,7 +78,7 @@ static void
 write_altitude(void* ptr, const float alt)
 {
   char buf[sizeof(float)];
-  unsigned char* i = (unsigned char*) &buf;
+  auto* i = (unsigned char*) &buf;
   le_write_float(&buf, alt);
   le_write32(ptr, i[0] << 24 | i[3] << 16 | i[2] << 8 | i[1]);
 }

--- a/holux.cc
+++ b/holux.cc
@@ -84,7 +84,7 @@ static void data_read()
 
   memset(&tm, 0, sizeof(tm));
 
-  unsigned char* HxWpt = (unsigned char*) xcalloc(GM100_WPO_FILE_SIZE, 1);
+  auto* HxWpt = (unsigned char*) xcalloc(GM100_WPO_FILE_SIZE, 1);
 
   /* read the wpo file to the data-array */
   int iDataRead = gbfread(HxWpt, 1, GM100_WPO_FILE_SIZE, file_in);

--- a/humminbird.cc
+++ b/humminbird.cc
@@ -403,7 +403,7 @@ humminbird_read_track(gbfile* fin)
   /* num_points is actually one too big, because it includes the value in
      the header. But we want the extra point at the end because the
      freak-value filter below looks at points[i+1] */
-  humminbird_trk_point_t* points = (humminbird_trk_point_t*) xcalloc(th.num_points, sizeof(humminbird_trk_point_t));
+  auto* points = (humminbird_trk_point_t*) xcalloc(th.num_points, sizeof(humminbird_trk_point_t));
   if (! gbfread(points, sizeof(humminbird_trk_point_t), th.num_points-1, fin)) {
     fatal(MYNAME ": Unexpected end of file reading points!\n");
   }
@@ -510,7 +510,7 @@ humminbird_read_track_old(gbfile* fin)
   /* num_points is actually one too big, because it includes the value in
      the header. But we want the extra point at the end because the
      freak-value filter below looks at points[i+1] */
-  humminbird_trk_point_old_t* points = (humminbird_trk_point_old_t*)xcalloc(th.num_points, sizeof(humminbird_trk_point_old_t));
+  auto* points = (humminbird_trk_point_old_t*)xcalloc(th.num_points, sizeof(humminbird_trk_point_old_t));
   if (! gbfread(points, sizeof(humminbird_trk_point_old_t), th.num_points-1, fin)) {
     fatal(MYNAME ": Unexpected end of file reading points!\n");
   }

--- a/igo8.cc
+++ b/igo8.cc
@@ -275,7 +275,7 @@ static void write_header()
 {
   char header[IGO8_HEADER_SIZE] = {};
   igo8_id_block tmp_id_block;
-  p_igo8_id_block id_block = (p_igo8_id_block)header;
+  auto id_block = (p_igo8_id_block)header;
   uint32_t current_position = 0;
   const char* title = "Title";
   const char* description = "Description";

--- a/jeeps/gpssend.cc
+++ b/jeeps/gpssend.cc
@@ -89,7 +89,7 @@ Build_Serial_Packet(GPS_PPacket in, GPS_Serial_PPacket out)
 void
 Diag(void* buf, size_t sz)
 {
-  unsigned char* cbuf = (unsigned char*) buf;
+  auto* cbuf = (unsigned char*) buf;
   while (sz--) {
     GPS_Diag("%02x ", *cbuf++);
   }
@@ -98,7 +98,7 @@ Diag(void* buf, size_t sz)
 void
 DiagS(void* buf, size_t sz)
 {
-  unsigned char* cbuf = (unsigned char*) buf;
+  auto* cbuf = (unsigned char*) buf;
 
   while (sz--) {
     unsigned char c = *cbuf++;

--- a/jeeps/gpsserial.cc
+++ b/jeeps/gpsserial.cc
@@ -336,7 +336,7 @@ int32 GPS_Serial_Open(gpsdevh* dh, const char* port)
   struct termios tty;
   if (global_opts.debug_level >= 2) fprintf(stderr, "GPS Serial Open at %d\n", gps_baud_rate);
   speed_t baud = mkspeed(gps_baud_rate);
-  posix_serial_data* psd = (posix_serial_data*)dh;
+  auto* psd = (posix_serial_data*)dh;
 
   /*
    * This originally had O_NDELAY | O_NOCTTY in here, but this
@@ -402,7 +402,7 @@ void GPS_Serial_Error(const char* mb, ...)
 
 int32 GPS_Serial_Read(gpsdevh* dh, void* ibuf, int size)
 {
-  posix_serial_data* psd = (posix_serial_data*)dh;
+  auto* psd = (posix_serial_data*)dh;
 #if GARMULATOR
   static int l;
   static char* rp;
@@ -434,7 +434,7 @@ int32 GPS_Serial_Read(gpsdevh* dh, void* ibuf, int size)
 
 int32 GPS_Serial_Write(gpsdevh* dh, const void* obuf, int size)
 {
-  posix_serial_data* psd = (posix_serial_data*)dh;
+  auto* psd = (posix_serial_data*)dh;
   return write(psd->fd, obuf, size);
 }
 
@@ -449,7 +449,7 @@ int32 GPS_Serial_Write(gpsdevh* dh, const void* obuf, int size)
 ************************************************************************/
 int32 GPS_Serial_Flush(gpsdevh* fd)
 {
-  posix_serial_data* psd = (posix_serial_data*)fd;
+  auto* psd = (posix_serial_data*)fd;
 
   if (tcflush(psd->fd,TCIOFLUSH)) {
     GPS_Serial_Error("SERIAL: tcflush error");
@@ -474,7 +474,7 @@ int32 GPS_Serial_Flush(gpsdevh* fd)
 
 int32 GPS_Serial_Close(gpsdevh* fd)
 {
-  posix_serial_data* psd = (posix_serial_data*)fd;
+  auto* psd = (posix_serial_data*)fd;
 
   if (tcsetattr(psd->fd, TCSAFLUSH, &psd->gps_ttysave)==-1) {
     gps_errno = HARDWARE_ERROR;
@@ -505,7 +505,7 @@ int32 GPS_Serial_Chars_Ready(gpsdevh* dh)
 {
   fd_set rec;
   struct timeval t;
-  posix_serial_data* psd = (posix_serial_data*)dh;
+  auto* psd = (posix_serial_data*)dh;
   int32 fd = psd->fd;
 
 #if GARMULATOR
@@ -548,7 +548,7 @@ int32 GPS_Serial_Wait(gpsdevh* dh)
 {
   fd_set rec;
   struct timeval t;
-  posix_serial_data* psd = (posix_serial_data*)dh;
+  auto* psd = (posix_serial_data*)dh;
 
   FD_ZERO(&rec);
   FD_SET(psd->fd,&rec);
@@ -578,7 +578,7 @@ int32 GPS_Serial_Wait(gpsdevh* dh)
 
 int32 GPS_Serial_On(const char* port, gpsdevh** dh)
 {
-  posix_serial_data* psd = (posix_serial_data*) xcalloc(sizeof(posix_serial_data), 1);
+  auto* psd = (posix_serial_data*) xcalloc(sizeof(posix_serial_data), 1);
   *dh = (gpsdevh*) psd;
 
   if (!GPS_Serial_Open((gpsdevh*) psd,port)) {
@@ -661,7 +661,7 @@ int32 GPS_Serial_Set_Baud_Rate(gpsdevh* fd, int br)
     QThread::usleep(100000);
 
   // Change port speed
-  posix_serial_data* psd = (posix_serial_data*)fd;
+  auto* psd = (posix_serial_data*)fd;
   tty = psd->gps_ttysave;
 
   cfsetospeed(&tty,speed);

--- a/jeeps/gpsusbcommon.cc
+++ b/jeeps/gpsusbcommon.cc
@@ -82,7 +82,7 @@ int
 gusb_cmd_get(garmin_usb_packet* ibuf, size_t sz)
 {
   int rv;
-  unsigned char* buf = (unsigned char*) &ibuf->dbuf;
+  auto* buf = (unsigned char*) &ibuf->dbuf;
   unsigned short pkt_id;
 top:
   switch (receive_state) {
@@ -155,7 +155,7 @@ gusb_cmd_send(const garmin_usb_packet* opkt, size_t sz)
 {
   unsigned int rv, i;
 
-  unsigned char* obuf = (unsigned char*) &opkt->dbuf;
+  auto* obuf = (unsigned char*) &opkt->dbuf;
   const char* m1, *m2;
 
   rv = gusb_llops->llop_send(opkt, sz);

--- a/kml.cc
+++ b/kml.cc
@@ -1433,7 +1433,7 @@ static QString kml_geocache_get_logs(const Waypoint* wpt)
 {
   QString r;
 
-  fs_xml* fs_gpx = (fs_xml*)fs_chain_find(wpt->fs, FS_GPX);
+  auto* fs_gpx = (fs_xml*)fs_chain_find(wpt->fs, FS_GPX);
 
   if (!fs_gpx) {
     return r;

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -413,7 +413,7 @@ static
 lowranceusr4_fsdata*
 lowranceusr4_alloc_fsdata()
 {
-  lowranceusr4_fsdata* fsdata = (lowranceusr4_fsdata*) xcalloc(sizeof(*fsdata), 1);
+  auto* fsdata = (lowranceusr4_fsdata*) xcalloc(sizeof(*fsdata), 1);
   fsdata->fs.type = FS_LOWRANCEUSR4;
   fsdata->fs.copy = (fs_copy) lowranceusr4_copy_fsdata;
   fsdata->fs.destroy = lowranceusr4_free_fsdata;
@@ -1791,7 +1791,7 @@ lowranceusr_waypt_disp(const Waypoint* wpt)
 static void
 lowranceusr4_waypt_disp(const Waypoint* wpt)
 {
-  lowranceusr4_fsdata* fs = (lowranceusr4_fsdata*) fs_chain_find(wpt->fs, FS_LOWRANCEUSR4);
+  auto* fs = (lowranceusr4_fsdata*) fs_chain_find(wpt->fs, FS_LOWRANCEUSR4);
 
   /* UID unit number */
   if (opt_serialnum_i > 0) {
@@ -1979,7 +1979,7 @@ lowranceusr_trail_hdr(const route_head* trk)
   gbfputint32(text_len, file_out);
   gbfwrite(CSTR(name), 1, text_len, file_out);
 
-  short num_trail_points = (short) trk->rte_waypt_ct;
+  auto num_trail_points = (short) trk->rte_waypt_ct;
   short max_trail_size = MAX_TRAIL_POINTS;
   if (num_trail_points > max_trail_size) {
     num_trail_points = max_trail_size;
@@ -2022,7 +2022,7 @@ lowranceusr_route_hdr(const route_head* rte)
   gbfputs(name, file_out);
 
   /* num legs */
-  short num_legs = (short) rte->rte_waypt_ct;
+  auto num_legs = (short) rte->rte_waypt_ct;
   gbfputint16(num_legs, file_out);
   char route_reversed=0;
   gbfwrite(&route_reversed, 1, 1, file_out);
@@ -2040,7 +2040,7 @@ lowranceusr4_route_hdr(const route_head* rte)
            route_uid, qPrintable(rte->rte_name), rte->rte_waypt_ct);
   }
 
-  lowranceusr4_fsdata* fs = (lowranceusr4_fsdata*) fs_chain_find(rte->fs, FS_LOWRANCEUSR4);
+  auto* fs = (lowranceusr4_fsdata*) fs_chain_find(rte->fs, FS_LOWRANCEUSR4);
 
   /* UID unit number */
   if (opt_serialnum_i > 0) {
@@ -2071,7 +2071,7 @@ lowranceusr4_route_leg_disp(const Waypoint* wpt)
   for (int i = 0; i < waypt_table_ct; i++) {
     const Waypoint* cmp = waypt_table[i];
     if (cmp->shortname == wpt->shortname) {
-      lowranceusr4_fsdata* fs = (lowranceusr4_fsdata*) fs_chain_find(cmp->fs, FS_LOWRANCEUSR4);
+      auto* fs = (lowranceusr4_fsdata*) fs_chain_find(cmp->fs, FS_LOWRANCEUSR4);
 
       if (opt_serialnum_i > 0) {
         gbfputint32(opt_serialnum_i, file_out);  // use option serial number if specified

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -413,7 +413,7 @@ static
 lowranceusr4_fsdata*
 lowranceusr4_alloc_fsdata()
 {
-  auto* fsdata = (lowranceusr4_fsdata*) xcalloc(sizeof(*fsdata), 1);
+  auto* fsdata = (lowranceusr4_fsdata*) xcalloc(1, sizeof(lowranceusr4_fsdata));
   fsdata->fs.type = FS_LOWRANCEUSR4;
   fsdata->fs.copy = (fs_copy) lowranceusr4_copy_fsdata;
   fsdata->fs.destroy = lowranceusr4_free_fsdata;

--- a/mkshort.cc
+++ b/mkshort.cc
@@ -125,7 +125,7 @@ void
 add_to_hashlist(mkshort_handle_imp* h, char* name)
 {
   int hash = hash_string(name);
-  uniq_shortname* s = (uniq_shortname*) xcalloc(1, sizeof(uniq_shortname));
+  auto* s = (uniq_shortname*) xcalloc(1, sizeof(uniq_shortname));
 
   s->orig_shortname = xstrdup(name);
   h->namelist[hash].append(s);
@@ -159,7 +159,7 @@ mkshort_add_to_list(mkshort_handle_imp* h, char* name)
 void
 mkshort_del_handle(short_handle* h)
 {
-  mkshort_handle_imp* hdr = (mkshort_handle_imp*) *h;
+  auto* hdr = (mkshort_handle_imp*) *h;
 
   if (!h || !hdr) {
     return;
@@ -253,7 +253,7 @@ replace_constants(char* s)
 void
 setshort_length(short_handle h, int l)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
   if (l == 0) {
     hdl->target_len = default_target_len;
   } else {
@@ -268,7 +268,7 @@ setshort_length(short_handle h, int l)
 void
 setshort_whitespace_ok(short_handle h, int l)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
   hdl->whitespaceok = l;
 }
 
@@ -280,7 +280,7 @@ setshort_whitespace_ok(short_handle h, int l)
 void
 setshort_repeating_whitespace_ok(short_handle h, int l)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
   hdl->repeating_whitespaceok = l;
 }
 
@@ -291,7 +291,7 @@ setshort_repeating_whitespace_ok(short_handle h, int l)
 void
 setshort_defname(short_handle h, const char* s)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
   if (s == nullptr) {
     fatal("setshort_defname called without a valid name.");
   }
@@ -309,7 +309,7 @@ setshort_defname(short_handle h, const char* s)
 void
 setshort_badchars(short_handle h, const char* s)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
 
   if ((hdl->badchars != nullptr)) {
     xfree(hdl->badchars);
@@ -324,7 +324,7 @@ setshort_badchars(short_handle h, const char* s)
 void
 setshort_goodchars(short_handle h, const char* s)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
 
   if (hdl->goodchars != nullptr) {
     xfree(hdl->goodchars);
@@ -342,7 +342,7 @@ setshort_goodchars(short_handle h, const char* s)
 void
 setshort_mustupper(short_handle h, int i)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
   hdl->mustupper = i;
 }
 
@@ -354,7 +354,7 @@ setshort_mustupper(short_handle h, int i)
 void
 setshort_mustuniq(short_handle h, int i)
 {
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
   hdl->must_uniq = i;
 }
 
@@ -365,7 +365,7 @@ mkshort(short_handle h, const char* istring, bool is_utf8)
   char* tstring;
   char* cp;
   int i, l, replaced;
-  mkshort_handle_imp* hdl = (mkshort_handle_imp*) h;
+  auto* hdl = (mkshort_handle_imp*) h;
 
   if (is_utf8) {
     ostring = cet_utf8_strdup(istring);  /* clean UTF-8 string */

--- a/mmo.cc
+++ b/mmo.cc
@@ -250,7 +250,7 @@ mmo_printbuf(const char* buf, int count, const char* comment)
 static mmo_data_t*
 mmo_register_object(const int objid, const void* ptr, const gpsdata_type type)
 {
-  auto* data = (mmo_data_t*) xcalloc(1, sizeof(*data));
+  auto* data = (mmo_data_t*) xcalloc(1, sizeof(mmo_data_t));
   data->data = const_cast<void*>(ptr);
   data->visible = 1;
   data->locked = 0;

--- a/mmo.cc
+++ b/mmo.cc
@@ -250,7 +250,7 @@ mmo_printbuf(const char* buf, int count, const char* comment)
 static mmo_data_t*
 mmo_register_object(const int objid, const void* ptr, const gpsdata_type type)
 {
-  mmo_data_t* data = (mmo_data_t*) xcalloc(1, sizeof(*data));
+  auto* data = (mmo_data_t*) xcalloc(1, sizeof(*data));
   data->data = const_cast<void*>(ptr);
   data->visible = 1;
   data->locked = 0;
@@ -334,7 +334,7 @@ mmo_end_of_route(mmo_data_t* data)
 #ifdef MMO_DBG
   const char* sobj = "CObjRoute";
 #endif
-  route_head* rte = (route_head*) data->data;
+  auto* rte = (route_head*) data->data;
   char buf[7];
 
   if (mmo_version >= 0x12) {
@@ -906,7 +906,7 @@ mmo_read_object()
 static void
 mmo_finalize_rtept_cb(const Waypoint* wptref)
 {
-  Waypoint* wpt = const_cast<Waypoint*>(wptref);
+  auto* wpt = const_cast<Waypoint*>(wptref);
 
   if ((wpt->shortname[0] == 1) && (wpt->latitude == 0) && (wpt->longitude == 0)) {
     mmo_data_t* data;

--- a/naviguide.cc
+++ b/naviguide.cc
@@ -111,9 +111,9 @@ ng_convert_datum(Waypoint* wpt)
 {
   double lat, lon;
 
-  double east = (double) WPNC.wp_data.East;
-  double north = (double) WPNC.wp_data.North;
-  double alt = (double) WPNC.wp_data.Alt;
+  auto east = (double) WPNC.wp_data.East;
+  auto north = (double) WPNC.wp_data.North;
+  auto alt = (double) WPNC.wp_data.Alt;
 
   GPS_Math_ICS_EN_To_WGS84(east, north, &lat, &lon);
   wpt->latitude = lat;

--- a/navilink.cc
+++ b/navilink.cc
@@ -243,7 +243,7 @@ dump_packet(char* prefix, unsigned char* packet, unsigned length)
 static void
 write_packet(unsigned type, const void* payload, unsigned length)
 {
-  unsigned char* packet = (unsigned char*) xmalloc(length + 9);
+  auto* packet = (unsigned char*) xmalloc(length + 9);
 
   packet[0] = 0xa0;
   packet[1] = 0xa2;
@@ -302,7 +302,7 @@ read_packet(unsigned type, void* payload,
     fatal(MYNAME ": Protocol error: Packet too short\n");
   }
 
-  unsigned char* data = (unsigned char*) xmalloc(size);
+  auto* data = (unsigned char*) xmalloc(size);
 
   if (gbser_read_wait(serial_handle, data, size, SERIAL_TIMEOUT) != size) {
     fatal(MYNAME ": Read error reading %d byte payload\n", size);
@@ -492,7 +492,7 @@ serial_read_waypoints()
 
     write_packet(PID_QRY_WAYPOINTS, payload, sizeof(payload));
 
-    unsigned char*  waypoints = (unsigned char*) xmalloc(count * 32);
+    auto*  waypoints = (unsigned char*) xmalloc(count * 32);
 
     read_packet(PID_DATA, waypoints, count * 32, count * 32, false);
 
@@ -562,7 +562,7 @@ serial_read_track()
 
     write_packet(PID_READ_TRACKPOINTS, payload, sizeof(payload));
 
-    unsigned char*  trackpoints = (unsigned char*) xmalloc(count * 32);
+    auto*  trackpoints = (unsigned char*) xmalloc(count * 32);
 
     read_packet(PID_DATA, trackpoints, count * 32, count * 32, false);
     write_packet(PID_ACK, nullptr, 0);
@@ -721,7 +721,7 @@ serial_write_route_end(const route_head* route)
   }
 
   unsigned src = (route_id_ptr + MAX_SUBROUTE_LENGTH) / MAX_SUBROUTE_LENGTH;
-  unsigned char* data = (unsigned char*) xmalloc(32 + src * 32);
+  auto* data = (unsigned char*) xmalloc(32 + src * 32);
 
   le_write16(data + 0, 0x2000);
   data[2] = 0;

--- a/netstumbler.cc
+++ b/netstumbler.cc
@@ -307,7 +307,7 @@ fix_netstumbler_dupes(const WaypointList* waypt_list)
   int ct = waypt_list->count(), serial = 0;
   unsigned long last_crc;
 
-  auto* htable = (htable_t*) xmalloc(ct * sizeof *htable);
+  auto* htable = (htable_t*) xmalloc(ct * sizeof(htable_t));
   htable_t* bh = htable;
 
   int i = 0;

--- a/netstumbler.cc
+++ b/netstumbler.cc
@@ -307,7 +307,7 @@ fix_netstumbler_dupes(const WaypointList* waypt_list)
   int ct = waypt_list->count(), serial = 0;
   unsigned long last_crc;
 
-  htable_t* htable = (htable_t*) xmalloc(ct * sizeof *htable);
+  auto* htable = (htable_t*) xmalloc(ct * sizeof *htable);
   htable_t* bh = htable;
 
   int i = 0;

--- a/osm.cc
+++ b/osm.cc
@@ -763,7 +763,7 @@ static void
 osm_release_ids(const Waypoint* wpt)
 {
   if (wpt && wpt->extra_data) {
-    Waypoint* tmp = const_cast<Waypoint*>(wpt);
+    auto* tmp = const_cast<Waypoint*>(wpt);
     xfree(tmp->extra_data);
     tmp->extra_data = nullptr;
   }

--- a/ozi.cc
+++ b/ozi.cc
@@ -188,7 +188,7 @@ static
 ozi_fsdata*
 ozi_alloc_fsdata()
 {
-  ozi_fsdata* fsdata = (ozi_fsdata*) xcalloc(sizeof(*fsdata), 1);
+  auto* fsdata = (ozi_fsdata*) xcalloc(sizeof(*fsdata), 1);
   fsdata->fs.type = FS_OZI;
   fsdata->fs.copy = (fs_copy) ozi_copy_fsdata;
   fsdata->fs.destroy = ozi_free_fsdata;
@@ -878,7 +878,7 @@ ozi_waypt_pr(const Waypoint* wpt)
   int faked_fsdata = 0;
   int icon = 0;
 
-  ozi_fsdata* fs = (ozi_fsdata*) fs_chain_find(wpt->fs, FS_OZI);
+  auto* fs = (ozi_fsdata*) fs_chain_find(wpt->fs, FS_OZI);
 
   if (!fs) {
     fs = ozi_alloc_fsdata();

--- a/ozi.cc
+++ b/ozi.cc
@@ -188,7 +188,7 @@ static
 ozi_fsdata*
 ozi_alloc_fsdata()
 {
-  auto* fsdata = (ozi_fsdata*) xcalloc(sizeof(*fsdata), 1);
+  auto* fsdata = (ozi_fsdata*) xcalloc(1, sizeof(ozi_fsdata));
   fsdata->fs.type = FS_OZI;
   fsdata->fs.copy = (fs_copy) ozi_copy_fsdata;
   fsdata->fs.destroy = ozi_free_fsdata;

--- a/radius.cc
+++ b/radius.cc
@@ -44,8 +44,8 @@ int RadiusFilter::dist_comp(const void* a, const void* b)
 {
   const Waypoint* x1 = *(Waypoint**)a;
   const Waypoint* x2 = *(Waypoint**)b;
-  extra_data* x1e = (extra_data*) x1->extra_data;
-  extra_data* x2e = (extra_data*) x2->extra_data;
+  auto* x1e = (extra_data*) x1->extra_data;
+  auto* x2e = (extra_data*) x2->extra_data;
 
   if (x1e->distance > x2e->distance) {
     return 1;
@@ -77,7 +77,7 @@ void RadiusFilter::process()
       continue;
     }
 
-    extra_data* ed = (extra_data*) xcalloc(1, sizeof(*ed));
+    auto* ed = (extra_data*) xcalloc(1, sizeof(*ed));
     ed->distance = dist;
     waypointp->extra_data = ed;
   }

--- a/radius.cc
+++ b/radius.cc
@@ -77,7 +77,7 @@ void RadiusFilter::process()
       continue;
     }
 
-    auto* ed = (extra_data*) xcalloc(1, sizeof(*ed));
+    auto* ed = (extra_data*) xcalloc(1, sizeof(extra_data));
     ed->distance = dist;
     waypointp->extra_data = ed;
   }

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -279,7 +279,7 @@ same_points(const Waypoint* A, const Waypoint* B)
 static void
 register_waypt(const Waypoint* ref, const char)
 {
-  Waypoint* wpt = const_cast<Waypoint*>(ref);
+  auto* wpt = const_cast<Waypoint*>(ref);
 
   for (int i = 0; i < waypt_table_ct; i++) {
     Waypoint* cmp = waypt_table[i];

--- a/reverse_route.cc
+++ b/reverse_route.cc
@@ -36,7 +36,7 @@ void ReverseRouteFilter::reverse_route_wpt(const Waypoint* waypointp)
 {
 
   /* Cast away const-ness */
-  Waypoint* wpp = const_cast<Waypoint*>(waypointp);
+  auto* wpp = const_cast<Waypoint*>(waypointp);
 
   int curr_new_trkseg = waypointp->wpt_flags.new_trkseg;
   wpp->wpt_flags.new_trkseg = prev_new_trkseg;

--- a/saroute.cc
+++ b/saroute.cc
@@ -66,7 +66,7 @@ QVector<arglist_t> saroute_args = {
 static unsigned char*
 ReadRecord(gbfile* f, gbsize_t size)
 {
-  unsigned char* result = (unsigned char*) xmalloc(size);
+  auto* result = (unsigned char*) xmalloc(size);
 
   (void)gbfread(result, size, 1, f);
   return result;

--- a/sbn.cc
+++ b/sbn.cc
@@ -86,7 +86,7 @@ read_packet(int* type, void* payload, size_t max_len)
   size_t data_size = size + 4;
 
   /* data_size can be up to about 64k */
-  unsigned char* data = (unsigned char*) xmalloc(data_size);
+  auto* data = (unsigned char*) xmalloc(data_size);
 
   if (gbfread(data, data_size, 1, file_handle) != 1) {
     fatal(MYNAME ": Format error: could not read %d bytes.\n",

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -1115,7 +1115,7 @@ skytraq_read_tracks()
     }
   }
 
-  uint8_t* buffer = (uint8_t*) xmalloc(SECTOR_SIZE*read_at_once+sizeof(SECTOR_READ_END)+6);
+  auto* buffer = (uint8_t*) xmalloc(SECTOR_SIZE*read_at_once+sizeof(SECTOR_READ_END)+6);
   // m.ad/090930: removed code that tried reducing read_at_once if necessary since doesn't work with xmalloc
 
   if (opt_dump_file) {
@@ -1391,7 +1391,7 @@ file_read()
   int opt_last_sector_val = atoi(opt_last_sector);
 
   state_init(&st);
-  uint8_t* buffer = (uint8_t*) xmalloc(SECTOR_SIZE);
+  auto* buffer = (uint8_t*) xmalloc(SECTOR_SIZE);
 
   if (opt_first_sector_val > 0) {
     db(4, MYNAME ": Seeking to first-sector index %i\n", opt_first_sector_val*SECTOR_SIZE);

--- a/src/core/usasciicodec.cc
+++ b/src/core/usasciicodec.cc
@@ -60,7 +60,7 @@ QString UsAsciiCodec::convertToUnicode(const char* chars, int len, ConverterStat
 {
   QString result(len, Qt::Uninitialized);
   QChar* uc = result.data();
-  const unsigned char* c = (const unsigned char*)chars;
+  const auto* c = (const unsigned char*)chars;
   int invalid = 0;
 
   for (int i = 0; i < len; i++) {
@@ -82,7 +82,7 @@ QString UsAsciiCodec::convertToUnicode(const char* chars, int len, ConverterStat
 QByteArray UsAsciiCodec::convertFromUnicode(const QChar* uc, int len, ConverterState* state) const
 {
   QByteArray result(len, Qt::Uninitialized);
-  unsigned char* c = (unsigned char*)result.data();
+  auto* c = (unsigned char*)result.data();
   const char replacement = (state && state->flags & ConvertInvalidToNull) ? 0 : '?';
   int invalid = 0;
 

--- a/swapdata.cc
+++ b/swapdata.cc
@@ -29,7 +29,7 @@
 
 void SwapDataFilter::swapdata_cb(const Waypoint* ref)
 {
-  Waypoint* wpt = const_cast<Waypoint*>(ref);
+  auto* wpt = const_cast<Waypoint*>(ref);
 
   double x = wpt->latitude;
   wpt->latitude = wpt->longitude;

--- a/tomtom.cc
+++ b/tomtom.cc
@@ -365,7 +365,7 @@ static struct blockheader*
 compute_blocks(struct hdr* start, int count,
                double minlon, double maxlon, double minlat, double maxlat)
 {
-  auto* newblock = (struct blockheader*)xcalloc(sizeof(*newblock), 1);
+  auto* newblock = (struct blockheader*)xcalloc(1, sizeof(struct blockheader));
   newblock->start = start;
   newblock->count = count;
   newblock->minlon = minlon;

--- a/tomtom.cc
+++ b/tomtom.cc
@@ -260,8 +260,8 @@ static
 int
 compare_lat(const void* a, const void* b)
 {
-  const struct hdr* wa = (const struct hdr*) a;
-  const struct hdr* wb = (const struct hdr*) b;
+  const auto* wa = (const struct hdr*) a;
+  const auto* wb = (const struct hdr*) b;
 
   double difference = wa->wpt->latitude - wb->wpt->latitude;
   if (difference < 0) {
@@ -280,8 +280,8 @@ static
 int
 compare_lon(const void* a, const void* b)
 {
-  const struct hdr* wa = (const struct hdr*)a;
-  const struct hdr* wb = (const struct hdr*)b;
+  const auto* wa = (const struct hdr*)a;
+  const auto* wb = (const struct hdr*)b;
 
   double difference = wa->wpt->longitude - wb->wpt->longitude;
   if (difference < 0) {
@@ -365,7 +365,7 @@ static struct blockheader*
 compute_blocks(struct hdr* start, int count,
                double minlon, double maxlon, double minlat, double maxlat)
 {
-  struct blockheader* newblock = (struct blockheader*)xcalloc(sizeof(*newblock), 1);
+  auto* newblock = (struct blockheader*)xcalloc(sizeof(*newblock), 1);
   newblock->start = start;
   newblock->count = count;
   newblock->minlon = minlon;

--- a/tpg.cc
+++ b/tpg.cc
@@ -222,7 +222,7 @@ tpg_waypt_pr(const Waypoint* wpt)
   lon *= -1.0;
 
   /* convert meters back to feets */
-  short int elev = (short int) METERS_TO_FEET(wpt->altitude);
+  auto elev = (short int) METERS_TO_FEET(wpt->altitude);
 
   /* 1 bytes stringsize for shortname */
   char c = shortname.length();

--- a/tpo.cc
+++ b/tpo.cc
@@ -373,7 +373,7 @@ static void tpo_read_2_x()
 //
 static int tpo_read_int()
 {
-  unsigned char val = (unsigned char) gbfgetc(tpo_file_in);
+  auto val = (unsigned char) gbfgetc(tpo_file_in);
 
   switch (val) {
 
@@ -671,7 +671,7 @@ static void tpo_process_tracks()
     // proper place for the next track.
 
     // Read the track bytes into a buffer
-    unsigned char* buf = (unsigned char*) xmalloc(track_byte_count);
+    auto* buf = (unsigned char*) xmalloc(track_byte_count);
     gbfread(buf, 1, track_byte_count, tpo_file_in);
 
     int latscale = 0;

--- a/util.cc
+++ b/util.cc
@@ -538,28 +538,28 @@ is_fatal(const int condition, const char* fmt, ...)
 signed int
 be_read32(const void* ptr)
 {
-  const unsigned char* i = (const unsigned char*) ptr;
+  const auto* i = (const unsigned char*) ptr;
   return i[0] << 24 | i[1] << 16  | i[2] << 8 | i[3];
 }
 
 signed int
 be_read16(const void* ptr)
 {
-  const unsigned char* i = (const unsigned char*) ptr;
+  const auto* i = (const unsigned char*) ptr;
   return i[0] << 8 | i[1];
 }
 
 unsigned int
 be_readu16(const void* ptr)
 {
-  const unsigned char* i = (const unsigned char*) ptr;
+  const auto* i = (const unsigned char*) ptr;
   return i[0] << 8 | i[1];
 }
 
 void
 be_write16(void* ptr, const unsigned value)
 {
-  unsigned char* p = (unsigned char*) ptr;
+  auto* p = (unsigned char*) ptr;
   p[0] = value >> 8;
   p[1] = value;
 }
@@ -567,7 +567,7 @@ be_write16(void* ptr, const unsigned value)
 void
 be_write32(void* ptr, const unsigned value)
 {
-  unsigned char* p = (unsigned char*) ptr;
+  auto* p = (unsigned char*) ptr;
 
   p[0] = value >> 24;
   p[1] = value >> 16;
@@ -578,28 +578,28 @@ be_write32(void* ptr, const unsigned value)
 signed int
 le_read16(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) ptr;
+  const auto* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8);
 }
 
 unsigned int
 le_readu16(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) ptr;
+  const auto* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8);
 }
 
 signed int
 le_read32(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) ptr;
+  const auto* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
 }
 
 unsigned int
 le_readu32(const void* ptr)
 {
-  const unsigned char* p = (const unsigned char*) ptr;
+  const auto* p = (const unsigned char*) ptr;
   return p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
 }
 
@@ -626,7 +626,7 @@ le_read64(void* dest, const void* src)
 void
 le_write16(void* ptr, const unsigned value)
 {
-  unsigned char* p = (unsigned char*) ptr;
+  auto* p = (unsigned char*) ptr;
   p[0] = value;
   p[1] = value >> 8;
 }
@@ -634,7 +634,7 @@ le_write16(void* ptr, const unsigned value)
 void
 le_write32(void* ptr, const unsigned value)
 {
-  unsigned char* p = (unsigned char*) ptr;
+  auto* p = (unsigned char*) ptr;
   p[0] = value;
   p[1] = value >> 8;
   p[2] = value >> 16;
@@ -967,14 +967,14 @@ be_write_double(void* ptr, double value)
 /* Magellan and PCX formats use this DDMM.mm format */
 double ddmm2degrees(double pcx_val)
 {
-  signed int deg = (signed int)(pcx_val / 100.0);
+  auto deg = (signed int)(pcx_val / 100.0);
   double minutes = (((pcx_val / 100.0) - deg) * 100.0) / 60.0;
   return (double) deg + minutes;
 }
 
 double degrees2ddmm(double deg_val)
 {
-  signed int deg = (signed int) deg_val;
+  auto deg = (signed int) deg_val;
   return (deg * 100.0) + ((deg_val - deg) * 60.0);
 }
 
@@ -1691,7 +1691,7 @@ const QString get_filename(const QString& fname)
  */
 void gb_setbit(void* buf, const uint32_t nr)
 {
-  unsigned char* bytes = (unsigned char*) buf;
+  auto* bytes = (unsigned char*) buf;
   bytes[nr / 8] |= (1 << (nr % 8));
 }
 
@@ -1700,7 +1700,7 @@ void gb_setbit(void* buf, const uint32_t nr)
  */
 char gb_getbit(const void* buf, const uint32_t nr)
 {
-  const unsigned char* bytes = (const unsigned char*) buf;
+  const auto* bytes = (const unsigned char*) buf;
   return (bytes[nr / 8] & (1 << (nr % 8)));
 
 }

--- a/vitosmt.cc
+++ b/vitosmt.cc
@@ -38,7 +38,7 @@ const size_t vitosmt_datasize = 64;
 static unsigned char*
 ReadRecord(gbfile* f, gbsize_t size)
 {
-  unsigned char* result = (unsigned char*) xmalloc(size);
+  auto* result = (unsigned char*) xmalloc(size);
 
   gbfread(result, size, 1, f);
   return result;
@@ -214,7 +214,7 @@ vitosmt_waypt_pr(const Waypoint* waypointp)
   double  seconds  =0;
 
   ++count;
-  unsigned char*  workbuffer = (unsigned char*) xcalloc(vitosmt_datasize,1);
+  auto*  workbuffer = (unsigned char*) xcalloc(vitosmt_datasize,1);
 
   WriteDouble(&workbuffer[position], RAD(waypointp->latitude));
   position += sizeof(double);
@@ -288,7 +288,7 @@ vitosmt_waypt_pr(const Waypoint* waypointp)
 static void
 vitosmt_write()
 {
-  unsigned char* workbuffer = (unsigned char*) xcalloc(vitosmt_headersize,1);
+  auto* workbuffer = (unsigned char*) xcalloc(vitosmt_headersize,1);
 
   count = 0;
 

--- a/wbt-200.cc
+++ b/wbt-200.cc
@@ -208,7 +208,7 @@ static void buf_extend(struct buf_head* h, size_t amt)
 {
   size_t sz = amt + sizeof(struct buf_chunk);
 
-  struct buf_chunk* c = (struct buf_chunk*) xmalloc(sz);
+  auto* c = (struct buf_chunk*) xmalloc(sz);
   c->next = nullptr;
   c->size = amt;
   c->used = 0;
@@ -224,7 +224,7 @@ static void buf_extend(struct buf_head* h, size_t amt)
 
 static void buf_update_checksum(struct buf_head* h, const void* data, size_t len)
 {
-  unsigned char* cp = (unsigned char*) data;
+  auto* cp = (unsigned char*) data;
 
   db(4, "Updating checksum with %p, %lu, before: %02x ",
      data, (unsigned long) len, h->checksum);
@@ -809,7 +809,7 @@ static int wbt201_data_chunk(struct read_state* st, const void* buf)
 
   double lat = (double)((int32_t) le_read32(bp +  6)) / 10000000;
   double lon = (double)((int32_t) le_read32(bp + 10)) / 10000000;
-  double alt = (double)((int16_t) le_read16(bp + 14));
+  auto alt = (double)((int16_t) le_read16(bp + 14));
 
   time_t rtim = decode_date(tim);
 

--- a/xmltag.cc
+++ b/xmltag.cc
@@ -63,7 +63,7 @@ copy_xml_tag(xml_tag** copy, xml_tag* src, xml_tag* parent)
 static void
 fs_xml_destroy(void* fs)
 {
-  fs_xml* xml = (fs_xml*)fs;
+  auto* xml = (fs_xml*)fs;
   if (xml) {
     free_xml_tag(xml->tag);
   }
@@ -73,7 +73,7 @@ fs_xml_destroy(void* fs)
 static void
 fs_xml_copy(void** copy, void* source)
 {
-  fs_xml* src = (fs_xml*)source;
+  auto* src = (fs_xml*)source;
   if (!source) {
     *copy = nullptr;
     return;


### PR DESCRIPTION
only on:
Message: use auto when initializing with a cast to avoid duplicating the type name

not on:
Message: use auto when initializing with new to avoid duplicating the type name
Message: use auto when initializing with a template cast to avoid duplicating the

Before running clang-tidy gbfile.h was changed to replace the macro definition of
gbfopen_le, gbfgetuint32, gbfgetuint16, gbfputuint16, gbfputuin32 with inline
function definitions.  Without this change the application of modernize-use-auto
made it difficult to recognize the type of the result. Note this change has merit
of it's own,
see https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-macros

This was run with clang-tidy from llvm version 8.  It generated several
compilation errors that had to be fixed by hand.