### PR TITLE
relocate no output format display routine.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -617,6 +617,7 @@ void waypt_add_to_bounds(bounds* bounds, const Waypoint* waypointp);
 void waypt_compute_bounds(bounds* bounds);
 Waypoint* find_waypt_by_name(const QString& name);
 void waypt_flush_all();
+void waypt_deinit();
 void waypt_append(WaypointList* src);
 void waypt_backup(WaypointList** head_bak);
 void waypt_restore(WaypointList* head_bak);

--- a/defs.h
+++ b/defs.h
@@ -608,7 +608,6 @@ void waypt_init();
 void waypt_add(Waypoint* wpt);
 void waypt_del(Waypoint* wpt);
 unsigned int waypt_count();
-void waypt_disp(const Waypoint* wpt);
 void waypt_status_disp(int total_ct, int myct);
 //void waypt_disp_all(waypt_cb); /* template */
 //void waypt_disp_session(const session_t* se, waypt_cb cb); /* template */

--- a/main.cc
+++ b/main.cc
@@ -20,7 +20,6 @@
 #include <clocale>                  // for setlocale, LC_NUMERIC, LC_TIME
 #include <csignal>                  // for signal, SIGINT, SIG_ERR
 #include <cstdio>                   // for printf, fgetc, stdin
-#include <cstdlib>                  // for exit
 #include <cstring>                  // for strcmp
 
 #include <QtCore/QByteArray>        // for QByteArray
@@ -707,12 +706,12 @@ main(int argc, char* argv[])
 
   rc = run(prog_name);
 
-  waypt_flush_all();
   route_deinit();
+  waypt_deinit();
   session_exit();
-  Vecs::Instance().exit_vecs();
   FilterVecs::Instance().exit_filter_vecs();
+  Vecs::Instance().exit_vecs();
   inifile_done(global_opts.inifile);
 
-  exit(rc);
+  return rc;
 }

--- a/main.cc
+++ b/main.cc
@@ -198,6 +198,43 @@ signal_handler(int sig)
   tracking_status.request_terminate = 1;
 }
 
+class FallbackOutput
+{
+public:
+  FallbackOutput() : mkshort_handle(mkshort_new_handle()) {}
+  // delete copy and move constructors and assignment operators.
+  // The defaults are not appropriate, and we haven't implemented proper ones.
+  FallbackOutput(const FallbackOutput&) = delete;
+  FallbackOutput& operator=(const FallbackOutput&) = delete;
+  FallbackOutput(FallbackOutput&&) = delete;
+  FallbackOutput& operator=(FallbackOutput&&) = delete;
+  ~FallbackOutput() {mkshort_del_handle(&mkshort_handle);}
+
+  void waypt_disp(const Waypoint* wpt)
+  {
+    if (wpt->GetCreationTime().isValid()) {
+      printf("%s ", qPrintable(wpt->creation_time.toString()));
+    }
+    printposn(wpt->latitude,1);
+    printposn(wpt->longitude,0);
+    if (!wpt->description.isEmpty()) {
+      printf("%s/%s",
+             global_opts.synthesize_shortnames ?
+             qPrintable(mkshort(mkshort_handle, wpt->description)) :
+             qPrintable(wpt->shortname),
+             qPrintable(wpt->description));
+    }
+  
+    if (wpt->altitude != unknown_alt) {
+      printf(" %f", wpt->altitude);
+    }
+    printf("\n");
+  }
+
+private:
+  short_handle mkshort_handle;
+};
+
 static int
 run(const char* prog_name)
 {
@@ -210,6 +247,8 @@ run(const char* prog_name)
   int opt_version = 0;
   bool did_something = false;
   QStack<QargStackElement> qargs_stack;
+  FallbackOutput fbOutput;
+
 
   // Use QCoreApplication::arguments() to process the command line.
   QStringList qargs = QCoreApplication::arguments();
@@ -518,7 +557,10 @@ run(const char* prog_name)
   }
   if (ovecs == nullptr) {
     cet_convert_init(CET_CHARSET_ASCII, 1);
-    waypt_disp_all(waypt_disp);
+    auto waypt_disp_lambda = [&fbOutput](const Waypoint* wpt)->void {
+      fbOutput.waypt_disp(wpt);
+    };
+    waypt_disp_all(waypt_disp_lambda);
   }
 
   /*
@@ -567,7 +609,7 @@ run(const char* prog_name)
 //          ovecs->wr_position_deinit();
         } else {
           /* Just print to screen */
-          waypt_disp(wpt);
+          fbOutput.waypt_disp(wpt);
         }
         delete wpt;
       }

--- a/waypt.cc
+++ b/waypt.cc
@@ -22,10 +22,8 @@
 #include <cassert>              // for assert
 #include <cmath>                // for fabs
 #include <cstdio>               // for printf, fflush, fprintf, stdout
-#include <ctime>                // for time_t
 #include <algorithm>            // for stable_sort
 
-#include <QtCore/QByteArray>    // for QByteArray
 #include <QtCore/QChar>         // for QChar
 #include <QtCore/QDateTime>     // for QDateTime
 #include <QtCore/QList>         // for QList
@@ -166,6 +164,13 @@ void
 waypt_flush_all()
 {
   global_waypoint_list->flush();
+}
+
+void
+waypt_deinit()
+{
+  waypt_flush_all();
+  delete global_waypoint_list;
 }
 
 void

--- a/waypt.cc
+++ b/waypt.cc
@@ -42,7 +42,6 @@
 
 WaypointList* global_waypoint_list;
 
-static short_handle mkshort_handle;
 geocache_data Waypoint::empty_gc_data;
 static global_trait traits;
 
@@ -54,7 +53,6 @@ const global_trait* get_traits()
 void
 waypt_init()
 {
-  mkshort_handle = mkshort_new_handle();
   global_waypoint_list = new WaypointList;
 }
 
@@ -90,29 +88,6 @@ unsigned int
 waypt_count()
 {
   return global_waypoint_list->count();
-}
-
-// TODO: should this, and mkshort_handle, be part of main, which is the only user?
-void
-waypt_disp(const Waypoint* wpt)
-{
-  if (wpt->GetCreationTime().isValid()) {
-    printf("%s ", qPrintable(wpt->creation_time.toString()));
-  }
-  printposn(wpt->latitude,1);
-  printposn(wpt->longitude,0);
-  if (!wpt->description.isEmpty()) {
-    printf("%s/%s",
-           global_opts.synthesize_shortnames ?
-           qPrintable(mkshort(mkshort_handle, wpt->description)) :
-           qPrintable(wpt->shortname),
-           qPrintable(wpt->description));
-  }
-
-  if (wpt->altitude != unknown_alt) {
-    printf(" %f", wpt->altitude);
-  }
-  printf("\n");
 }
 
 void
@@ -190,9 +165,6 @@ find_waypt_by_name(const QString& name)
 void
 waypt_flush_all()
 {
-  if (mkshort_handle) {
-    mkshort_del_handle(&mkshort_handle);
-  }
   global_waypoint_list->flush();
 }
 


### PR DESCRIPTION
waypt_disp() is used by main when no output format is specified.
This moves that routine from waypt.cc to main.cc.