### PR TITLE
Destructor of class Waypoint should be virtual

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -539,7 +539,7 @@ public:
 
 public:
   Waypoint();
-  ~Waypoint();
+  virtual ~Waypoint();
   Waypoint(const Waypoint& other);
   Waypoint& operator=(const Waypoint& other);
 


### PR DESCRIPTION
In nmea.cc, waypoints are allocated as NmeaWaypoint, which
is a subclass of Waypoint. Later on those waypoints are
deleted through a pointer to the base class in WaypointList::flush().

Found by gcc 9.2.1 with address sanitizer on Fedora 31.

(./gpsbabel -i nmea -f ./reference/track/nmea -o gpx -F /tmp/gpsbabel.69273/nmea.gpx)
=================================================================
==70649==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x610000000340 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   192 bytes;
  size of the deallocated type: 184 bytes.
    #0 0x7f210e8a70b5 in operator delete(void*, unsigned long) (/lib64/libasan.so.5+0x1110b5)
    #1 0x6edd68 in WaypointList::flush() /home/gpsbabel/gpsbabel.git/waypt.cc:742
    #2 0x6e4ea3 in route_head::~route_head() /home/gpsbabel/gpsbabel.git/route.cc:391
    #3 0x6e5929 in RouteList::flush() /home/gpsbabel/gpsbabel.git/route.cc:473
    #4 0x6e29e8 in route_flush_all_tracks() /home/gpsbabel/gpsbabel.git/route.cc:180
    #5 0x6e29fe in route_deinit() /home/gpsbabel/gpsbabel.git/route.cc:187
    #6 0x74648f in main /home/gpsbabel/gpsbabel.git/main.cc:669
    #7 0x7f210dd3c1a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)
    #8 0x4104bd in _start (/home/gpsbabel/gpsbabel.git/gpsbabel+0x4104bd)

0x610000000340 is located 0 bytes inside of 192-byte region [0x610000000340,0x610000000400)
allocated by thread T0 here:
    #0 0x7f210e8a59d7 in operator new(unsigned long) (/lib64/libasan.so.5+0x10f9d7)
    #1 0x484492 in gpgga_parse /home/gpsbabel/gpsbabel.git/nmea.cc:514
    #2 0x489418 in nmea_parse_one_line /home/gpsbabel/gpsbabel.git/nmea.cc:996
    #3 0x489bd3 in nmea_read /home/gpsbabel/gpsbabel.git/nmea.cc:1092
    #4 0x41e409 in LegacyFormat::read() (/home/gpsbabel/gpsbabel.git/gpsbabel+0x41e409)
    #5 0x742667 in run /home/gpsbabel/gpsbabel.git/main.cc:301
    #6 0x74647f in main /home/gpsbabel/gpsbabel.git/main.cc:666
    #7 0x7f210dd3c1a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)

SUMMARY: AddressSanitizer: new-delete-type-mismatch (/lib64/libasan.so.5+0x1110b5) in operator delete(void*, unsigned long)