### PR TITLE
use rounding when interpolating time in arcdist filter.

### DIFF
--- a/arcdist.cc
+++ b/arcdist.cc
@@ -19,15 +19,22 @@
 
  */
 
+#include <cmath>                // for round
+#include <cstdio>               // for printf, sscanf
+#include <cstdlib>              // for strtod
+#include <cstring>              // for strchr, strlen, strncmp, strspn
+
+#include <QtCore/QByteArray>    // for QByteArray
+#include <QtCore/QString>       // for QString
+#include <QtCore/QtGlobal>      // for foreach, qPrintable, qint64
 
 #include "defs.h"
 #include "arcdist.h"
-#include "grtcirc.h"
+#include "gbfile.h"             // for gbfclose, gbfgetstr, gbfopen, gbfile
+#include "grtcirc.h"            // for RAD, gcdist, linedistprj, radtomi
+#include "src/core/datetime.h"  // for DateTime
+#include "src/core/logging.h"   // for Fatal
 
-#include <cmath>
-#include <cstdio>
-#include <cstdlib> // strtod
-#include <src/core/logging.h>
 
 #if FILTERS_ENABLED
 #define MYNAME "Arc filter"
@@ -36,14 +43,15 @@
 
 void ArcDistanceFilter::arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2)
 {
-  static Waypoint* arcpt1 = nullptr;
-  double prjlat, prjlon, frac;
+  static const Waypoint* arcpt1 = nullptr;
+  double prjlat;
+  double prjlon;
+  double frac;
 
   if (arcpt2 && arcpt2->latitude != BADVAL && arcpt2->longitude != BADVAL &&
       (ptsopt || (arcpt1 &&
                   (arcpt1->latitude != BADVAL && arcpt1->longitude != BADVAL)))) {
     foreach (Waypoint* waypointp, *global_waypoint_list) {
-      double dist;
       extra_data* ed;
       if (waypointp->extra_data) {
         ed = (extra_data*) waypointp->extra_data;
@@ -52,12 +60,13 @@ void ArcDistanceFilter::arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2)
         ed->distance = BADVAL;
       }
       if (ed->distance == BADVAL || projectopt || ed->distance >= pos_dist) {
+        double dist;
         if (ptsopt) {
           dist = gcdist(RAD(arcpt2->latitude),
                         RAD(arcpt2->longitude),
                         RAD(waypointp->latitude),
                         RAD(waypointp->longitude));
-          prjlat =  arcpt2->latitude;
+          prjlat = arcpt2->latitude;
           prjlon = arcpt2->longitude;
           frac = 1.0;
         } else {
@@ -87,14 +96,14 @@ void ArcDistanceFilter::arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2)
             ed->prjlongitude = prjlon;
             ed->frac = frac;
             ed->arcpt1 = arcpt1;
-            ed->arcpt2 = const_cast<Waypoint*>(arcpt2);
+            ed->arcpt2 = arcpt2;
           }
         }
         waypointp->extra_data = ed;
       }
     }
   }
-  arcpt1 = const_cast<Waypoint*>(arcpt2);
+  arcpt1 = arcpt2;
 }
 
 void ArcDistanceFilter::arcdist_arc_disp_hdr_cb(const route_head*)
@@ -184,12 +193,12 @@ void ArcDistanceFilter::process()
             wp->SetCreationTime(ed->arcpt2->GetCreationTime());
           } else {
             // Apply the multiplier to the difference between the times
-            // of the two points.   Add that to the first for the
+            // of the two points.  Add that to the first for the
             // interpolated time.
-            int scaled_time = ed->frac *
-                              ed->arcpt1->GetCreationTime().msecsTo(ed->arcpt2->GetCreationTime());
-            QDateTime new_time(ed->arcpt1->GetCreationTime().addMSecs(scaled_time));
-            wp->SetCreationTime(new_time);
+            qint64 span =
+              ed->arcpt1->GetCreationTime().msecsTo(ed->arcpt2->GetCreationTime());
+            qint64 offset = std::round(ed->frac * span);
+            wp->SetCreationTime(ed->arcpt1->GetCreationTime().addMSecs(offset));
           }
         }
         if (global_opts.debug_level >= 1) {

--- a/arcdist.h
+++ b/arcdist.h
@@ -51,9 +51,11 @@ private:
 
   struct extra_data {
     double distance;
-    double prjlatitude, prjlongitude;
+    double prjlatitude;
+    double prjlongitude;
     double frac;
-    Waypoint* arcpt1, * arcpt2;
+    const Waypoint* arcpt1;
+    const Waypoint* arcpt2;
   };
 
   QVector<arglist_t> args = {

--- a/reference/arc-project3.gpx
+++ b/reference/arc-project3.gpx
@@ -23,7 +23,7 @@
     <sym>valley</sym>
   </wpt>
   <wpt lat="28.359197123" lon="-16.501778011">
-    <time>2011-09-26T00:00:13.731Z</time>
+    <time>2011-09-26T00:00:13.732Z</time>
     <name>wpt1</name>
     <cmt>wpt1</cmt>
     <desc>wpt1</desc>


### PR DESCRIPTION
It is hoped that this fixes #493.

eliminate unnecessary casting away of const.
reduce variable scope.