### PR TITLE
add address sanitizer, undefined behavior sanitizer, clazy to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,15 @@ matrix:
         - BUILD_TYPE="docker"
         - DOCKER_IMG=""
     - os: linux
+      dist: bionic
+      sudo: required
+      services: docker
+      compiler: gcc
+      env:
+        - BUILD_TYPE="docker"
+        - DOCKER_IMG="eoan"
+        - DOCKER_SCRIPT="./tools/build_extra_tests"
+    - os: linux
       dist: xenial
       sudo: required
       compiler: gcc
@@ -89,7 +98,7 @@ install:
 
 script:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "coverage" ]; then ./tools/travis_script_linux_coverage; fi
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "docker" ]; then ./tools/travis_script_linux_docker ${DOCKER_IMG}; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "docker" ]; then ./tools/travis_script_linux_docker ${DOCKER_IMG} ${DOCKER_SCRIPT}; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "local" ]; then echo $PATH; ./build_and_test; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./tools/travis_script_osx; fi
 

--- a/mmo.cc
+++ b/mmo.cc
@@ -706,7 +706,7 @@ mmo_read_CObjTrack(mmo_data_t* data)
       // XXX ARB was u8 = gbfgetc(fin); but actually a string
       // Don't construct a QString we aren't going to use.
       // avoid clazy-unused-non-trivial-variable
-#if 1
+#ifdef MMO_DBG
       QString text =
 #else
       (void)

--- a/mmo.cc
+++ b/mmo.cc
@@ -704,7 +704,14 @@ mmo_read_CObjTrack(mmo_data_t* data)
 
     if (mmo_version >= 0x16) {
       // XXX ARB was u8 = gbfgetc(fin); but actually a string
-      QString text = mmo_readstr();
+      // Don't construct a QString we aren't going to use.
+      // avoid clazy-unused-non-trivial-variable
+#if 1
+      QString text =
+#else
+      (void)
+#endif
+        mmo_readstr();
       DBG((sobj, "text = \"%s\"\n", qPrintable(text)));
       uint16_t u16 = gbfgetuint16(fin);
       DBG((sobj, "unknown value = 0x%04X (since 0x16)\n", u16));
@@ -739,12 +746,26 @@ mmo_read_CObjText(mmo_data_t*)
   (void) lat;
   (void) lon;
 
-  QString text = mmo_readstr();
+  // Don't construct a QString we aren't going to use.
+  // avoid clazy-unused-non-trivial-variable
+#ifdef MMO_DBG
+  QString text =
+#else
+  (void)
+#endif
+    mmo_readstr();
   DBG((sobj, "text = \"%s\"\n", qPrintable(text)));
 
   mmo_fillbuf(buf, 28, 1);
 
-  QString font = mmo_readstr();
+  // Don't construct a QString we aren't going to use.
+  // avoid clazy-unused-non-trivial-variable
+#ifdef MMO_DBG
+  QString font =
+#else
+  (void)
+#endif
+    mmo_readstr();
   DBG((sobj, "font = \"%s\"\n", qPrintable(font)));
 
   mmo_fillbuf(buf, 25, 1);
@@ -980,7 +1001,7 @@ mmo_rd_deinit()
 
   legacy_codec = nullptr;
   utf16le_codec = nullptr;
-  
+
   gbfclose(fin);
 }
 
@@ -1415,7 +1436,7 @@ mmo_wr_deinit()
 
   legacy_codec = nullptr;
   utf16le_codec = nullptr;
-  
+
   gbfclose(fout);
 }
 

--- a/tools/Dockerfile_eoan
+++ b/tools/Dockerfile_eoan
@@ -1,0 +1,74 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:eoan
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    gperf \
+    git \
+    valgrind \
+    expat \
+    libxml2-utils \
+    bear \
+    clazy \
+ && rm -rf /var/lib/apt/lists/*
+
+# alternative compiler
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs needed to build document
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fop \
+    xsltproc \
+    docbook-xml \
+    docbook-xsl \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-dev \
+    libusb-1.0-0-dev \
+    pkg-config \
+    libudev-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    libqt5webkit5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs needed to generate coverage report:
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcovr \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+

--- a/tools/build_extra_tests
+++ b/tools/build_extra_tests
@@ -1,0 +1,47 @@
+#!/bin/bash -ex
+#
+# this script is triggered by SCM changes and is run on the build server.
+# output is conditionally mailed to gpsbabel-code.
+#
+
+# echo some system info to log
+uname -a
+if [ -e /etc/system-release ]; then
+	cat /etc/system-release
+fi
+if [ -e /etc/os-release ]; then
+	cat /etc/os-release
+fi
+git --no-pager log -n 1
+# the timestamps from a svn co are unpredicatble.
+# this can cause problems if targets are checked into svn.
+# some of our targets are part of the svn repository to allow a
+# minimal set of build tools to be used.
+# touch these targets to make sure they aren't considered out of date.
+touch xcsv_tokens.gperf
+touch internal_styles.cc
+
+# build and test keeping output within the pwd.
+export GBTEMP=$(mktemp -d -p $(pwd) GBTEMPXXXX)
+
+#note that debug will also enable assertions.
+qmake "CONFIG+=debug sanitizer sanitize_address"
+make clean
+make -j 3
+make check
+
+qmake "CONFIG+=debug sanitizer sanitize_undefined"
+make clean
+make -j 3
+make check
+
+export CLAZY_CHECKS=level0,level1,no-non-pod-global-static
+qmake -spec linux-clang "CONFIG+=debug" "QMAKE_CXX=clazy"
+make clean
+make -j 3 2>&1 | tee clazy.log
+if grep -- '-Wclazy' clazy.log; then
+  exit 1
+else
+  exit 0
+fi
+

--- a/tools/travis_script_linux_docker
+++ b/tools/travis_script_linux_docker
@@ -10,6 +10,7 @@
 
 ver=${1}
 versuffix=${ver:+_$1}
+script=${2:-./build_and_test}
 docker run \
 --rm \
 --mount type=bind,source="$(pwd)",target=/app \
@@ -19,5 +20,6 @@ docker run \
 --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
 --mount type=bind,source=/etc/group,target=/etc/group,readonly \
 --user "$(id -u):$(id -g)" \
+--cap-add SYS_PTRACE \
 tsteven4/gpsbabel_build_environment${versuffix} \
-bash -c "if [ -n ${ver} ]; then if [ -e /opt/${ver}.env ]; then . /opt/${ver}.env; fi; fi; ./build_and_test"
+bash -c "if [ -n ${ver} ]; then if [ -e /opt/${ver}.env ]; then . /opt/${ver}.env; fi; fi; ${script}"


### PR DESCRIPTION
All these run on a Docker image of Ubuntu Eoan Ermin, 19.10.  We will need to migrate them to Focal Fossa 20.04 LTS when it is available (scheduled release April 2020).  These images are close to the bleeding edge.

The sanitizers are run via gcc, currently on Eoan this is version 9.2.1.  This version did expose recent issues, #491, #494, commit 5366625ad308898dc620d37ce2eb7cd9bfa4bf14.

clazy on Eoan is version 1.5.  It often catches errors like
c++11 range-loop might detach Qt container (QByteArray) [-Wclazy-range-loop]
which can be fixed by making the container const or using qAsConst() in the for clause.