### PR TITLE
A few build changes for Open/FreeBSD

### DIFF
--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -171,7 +171,7 @@ load(configure)
 
 CONFIG(release, debug|release): DEFINES *= NDEBUG
 
-macx|linux|openbsd {
+macx|linux|openbsd|freebsd {
   qtCompileTest(unistd) {
     # this is used by zlib
     DEFINES += HAVE_UNISTD_H
@@ -206,6 +206,10 @@ win32-msvc* {
 
 linux|openbsd {
   LIBS += "-lusb-1.0"
+}
+
+freebsd {
+  LIBS += "-lusb"
 }
 
 macx {
@@ -251,7 +255,7 @@ openbsd {
   check.commands = DIFF=gdiff
 }
 
-macx|linux|openbsd{
+macx|linux|openbsd|freebsd {
   check.commands += PNAME=./$(TARGET) ./testo
   check.depends = $(TARGET)
   QMAKE_EXTRA_TARGETS += check

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -247,8 +247,12 @@ DEFINES += CSVFMTS_ENABLED
 QMAKE_CFLAGS_WARN_ON -= -W
 QMAKE_CXXFLAGS_WARN_ON -= -W
 
+openbsd {
+  check.commands = DIFF=gdiff
+}
+
 macx|linux|openbsd{
-  check.commands = PNAME=./$(TARGET) ./testo
+  check.commands += PNAME=./$(TARGET) ./testo
   check.depends = $(TARGET)
   QMAKE_EXTRA_TARGETS += check
 }

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -15,7 +15,7 @@ if(equals(QT_MAJOR_VERSION, $$MIN_QT_VERSION_MAJOR):equals(QT_MINOR_VERSION, $$M
 
 QT -= gui
 
-linux: {
+linux|bsd: {
   TARGET = gpsbabel
 } else {
   TARGET = GPSBabel

--- a/jeeps/gpslibusb.cc
+++ b/jeeps/gpslibusb.cc
@@ -31,6 +31,8 @@
 #  if __APPLE__
 // We use our own libusb.
 #    include "mac/libusb/libusb.h"
+#  elif defined(__FreeBSD__)
+#    include <libusb.h>
 #  else
 #    include <libusb-1.0/libusb.h>
 #  endif


### PR DESCRIPTION
This was tested on Linux, OpenBSD and  FreeBSD 12.1. See individual commits for more details.

NetBSD is kind of special, they doesn't seem to define QMAKE_PLATFORM in their Qt5 package (although the mkspecs for NetBSD on other platforms do so). So it's somewhat hard to make that work with qmake. I did try at least.
