### PR TITLE
use standard bionic image for travis coverage build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,25 +74,20 @@ matrix:
           - $HOME/Cache
         timeout: 600
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       compiler: gcc
       env:
         - BUILD_TYPE="coverage"
-        - QT_VERSION="5.9.9"
       addons:
         apt:
           packages:
-            - libusb-1.0-0-dev
             - gcovr
             - lcov
-            - libxkbcommon-x11-0 # for qt onliner installer 3.2.1
-      cache:
-        directories:
-          - $HOME/Cache
+            - libusb-1.0-0-dev
+            - qt5-default
 
 install:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "coverage" ]; then ./tools/travis_install_linux_coverage ${QT_VERSION} && source ${HOME}/Cache/qt-${QT_VERSION}.env; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${BUILD_TYPE}" = "local" ]; then ./tools/travis_install_linux_local ${QT_VERSION} && source ${HOME}/Cache/qt-${QT_VERSION}.env; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./tools/travis_install_osx ${QT_VERSION} && source ${HOME}/Cache/qt-${QT_VERSION}.env; fi
 


### PR DESCRIPTION
For the coverage job this avoids a dependency on the Qt installer.