### PR TITLE
warning fixes

### DIFF
--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -815,7 +815,6 @@ data_read()
 ff_vecs_t globalsat_sport_vecs = {
   ff_type_serial,			// type
   {
-    // cap
     ff_cap_none,			// waypoints
     ff_cap_read,			// tracks
     ff_cap_none,			// routes
@@ -827,7 +826,7 @@ ff_vecs_t globalsat_sport_vecs = {
   data_read,					// read
   nullptr,						// write
   nullptr,						// exit
-  &globalsat_args,			// args
+  &globalsat_args,		// args
   CET_CHARSET_ASCII,	// encode
   0,									// fixed_encode
   NULL_POS_OPS,				// position_ops

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -529,9 +529,13 @@ track_read()
       if (!showlist) {
         route_head* trk = route_head_alloc();
 
-        QString str;
-        str.asprintf("%02d-%02d-%02d_%02d:%02d:%02d", header.dateStart.Year, header.dateStart.Month, header.dateStart.Day, header.timeStart.Hour, header.timeStart.Minute, header.timeStart.Second);
-        trk->rte_name = str;
+        trk->rte_name = QString::asprintf("%02d-%02d-%02d_%02d:%02d:%02d",
+                                          header.dateStart.Year,
+                                          header.dateStart.Month,
+                                          header.dateStart.Day,
+                                          header.timeStart.Hour,
+                                          header.timeStart.Minute,
+                                          header.timeStart.Second);
         trk->rte_desc = QString("GH625XT GPS tracklog data");
 
         track_add_head(trk);
@@ -547,7 +551,7 @@ track_read()
         uint8_t trackDeviceCommand;
         int track_length;
         uint8_t* track_payload = globalsat_read_package(&track_length, &trackDeviceCommand);
-        is_fatal(((track_length == 0) || (track_payload == nullptr)) , "track length is 0 bytes or payload nonexistent");
+        is_fatal(((track_length == 0) || (track_payload == nullptr)), "track length is 0 bytes or payload nonexistent");
         //      printf("Got track package!!! Train data\n");
 
         uint8_t* dbtrain = track_payload;
@@ -810,7 +814,8 @@ data_read()
 // This used the serial communication to the watch
 ff_vecs_t globalsat_sport_vecs = {
   ff_type_serial,			// type
-  {										// cap
+  {
+    // cap
     ff_cap_none,			// waypoints
     ff_cap_read,			// tracks
     ff_cap_none,			// routes

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -530,7 +530,7 @@ track_read()
         route_head* trk = route_head_alloc();
 
         QString str;
-        str.sprintf("%02d-%02d-%02d_%02d:%02d:%02d", header.dateStart.Year, header.dateStart.Month, header.dateStart.Day, header.timeStart.Hour, header.timeStart.Minute, header.timeStart.Second);
+        str.asprintf("%02d-%02d-%02d_%02d:%02d:%02d", header.dateStart.Year, header.dateStart.Month, header.dateStart.Day, header.timeStart.Hour, header.timeStart.Minute, header.timeStart.Second);
         trk->rte_name = str;
         trk->rte_desc = QString("GH625XT GPS tracklog data");
 

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -162,7 +162,7 @@ GMapDialog::GMapDialog(QWidget* parent, const QString& gpxFileName, QPlainTextEd
     wptItem_->appendRow(it);
     it->setCheckable(true);
     it->setCheckState(Qt::Checked);
-    it->setData(qVariantFromValue((void*)&wpt));
+    it->setData(QVariant::fromValue((void*)&wpt));
     appendWaypointInfo(it, wpt);
     wptList_ << it;
   }
@@ -177,7 +177,7 @@ GMapDialog::GMapDialog(QWidget* parent, const QString& gpxFileName, QPlainTextEd
     trkItem_->appendRow(it);
     it->setCheckable(true);
     it->setCheckState(Qt::Checked);
-    it->setData(qVariantFromValue((void*)&trk));
+    it->setData(QVariant::fromValue((void*)&trk));
     appendTrackInfo(it, trk);
     trkList_ << it;
   }
@@ -192,7 +192,7 @@ GMapDialog::GMapDialog(QWidget* parent, const QString& gpxFileName, QPlainTextEd
     rteItem_->appendRow(it);
     it->setCheckable(true);
     it->setCheckState(Qt::Checked);
-    it->setData(qVariantFromValue((void*)&rte));
+    it->setData(QVariant::fromValue((void*)&rte));
     appendRouteInfo(it, rte);
     rteList_ << it;
   }

--- a/mapsource.cc
+++ b/mapsource.cc
@@ -1405,7 +1405,7 @@ mps_routedatapoint_w_wrapper(const Waypoint* rte)
  * MRCB
  */
 static void
-mps_routetrlr_w(gbfile* mps_file, int mps_ver, const route_head* rte)
+mps_routetrlr_w(gbfile* mps_file, int mps_ver, const route_head* /* rte */)
 {
   char		hdr[2];
   int			value = 0;

--- a/waypt.cc
+++ b/waypt.cc
@@ -633,7 +633,7 @@ WaypointList::waypt_add(Waypoint* wpt)
       wpt->shortname = wpt->notes;
     } else {
       QString n;
-      n.sprintf("%03d", waypt_count());
+      n.asprintf("%03d", waypt_count());
       wpt->shortname = QString("WPT%1").arg(n);
     }
   }

--- a/waypt.cc
+++ b/waypt.cc
@@ -632,9 +632,7 @@ WaypointList::waypt_add(Waypoint* wpt)
     } else if (!wpt->notes.isNull()) {
       wpt->shortname = wpt->notes;
     } else {
-      QString n;
-      n.asprintf("%03d", waypt_count());
-      wpt->shortname = QString("WPT%1").arg(n);
+      wpt->shortname = QString::asprintf("WPT%03d", waypt_count());
     }
   }
 


### PR DESCRIPTION
Replace deprecated Qt code.  They generated compile warnings with Qt 5.14.1.

Fix warning C4100: 'rte': unreferenced formal parameter that annoyed MSVC.