### PR TITLE
Change qmake target to lowercase gpsbabel on BSD

### DIFF
--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -15,7 +15,7 @@ if(equals(QT_MAJOR_VERSION, $$MIN_QT_VERSION_MAJOR):equals(QT_MINOR_VERSION, $$M
 
 QT -= gui
 
-linux: {
+linux|bsd: {
   TARGET = gpsbabel
 } else {
   TARGET = GPSBabel


### PR DESCRIPTION
The BSDs all package lowercase "gpsbabel", so switch the qmake
TARGET to lowercase as well. See also:

https://github.com/freebsd/freebsd-ports/blob/master/astro/gpsbabel/pkg-plist
https://github.com/openbsd/ports/blob/master/geo/gpsbabel/pkg/PLIST-main
http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/pkgsrc/geography/gpsbabel/PLIST