### PR TITLE
CLI renamed to gpsbabel on all builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,8 +262,8 @@ add_definitions(-DFILTERS_ENABLED)
 add_definitions(-DSHAPELIB_ENABLED)
 add_definitions(-DCSVFMTS_ENABLED)
 
-add_executable(GPSBabel ${SOURCES} ${HEADERS})
-target_link_libraries(GPSBabel ${Qt5Core_LIBRARIES} ${LIBS})
+add_executable(gpsbabel ${SOURCES} ${HEADERS})
+target_link_libraries(gpsbabel ${Qt5Core_LIBRARIES} ${LIBS})
 
 message("Sources are:")
 message("${SOURCES}")
@@ -277,5 +277,5 @@ message("${LIBS}")
 
 if(UNIX)
   # the tests only work if the pwd is top level source dir due to the file name getting embedded in the file nonexistent.err.
-  add_custom_target(check cd ${CMAKE_SOURCE_DIR}\; PNAME=${CMAKE_BINARY_DIR}/GPSBabel ./testo DEPENDS GPSBabel)
+  add_custom_target(check cd ${CMAKE_SOURCE_DIR}\; PNAME=${CMAKE_BINARY_DIR}/gpsbabel ./testo DEPENDS gpsbabel)
 endif()

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -279,7 +279,6 @@ QMAKE_EXTRA_TARGETS += clang-tidy
 linux{
   coverage.commands = make clean;
   coverage.commands += rm -f gpsbabel_coverage.xml;
-  coverage.commands += ln -sf GPSBabel gpsbabel;
   coverage.commands += $(MAKE) CFLAGS=\"$(CFLAGS) -fprofile-arcs -ftest-coverage\" CXXFLAGS=\"$(CXXFLAGS) -fprofile-arcs -ftest-coverage\" LFLAGS=\"$(LFLAGS) --coverage\" &&
   coverage.commands += ./testo &&
   coverage.commands += gcov -r -o . $(SOURCES) &&

--- a/gui/package_app
+++ b/gui/package_app
@@ -112,7 +112,7 @@ if [ "${machine}" = "Linux" ]; then
   cp gmapbase.html "${APPDIR}"
   cp COPYING.txt "${APPDIR}"
 else # Mac
-  cp ../GPSBabel "${APPDIR}/Contents/MacOS/gpsbabel"
+  cp ../gpsbabel "${APPDIR}/Contents/MacOS/gpsbabel"
   cp gmapbase.html "${APPDIR}/Contents/MacOS"
   cp COPYING.txt "${APPDIR}/Contents/MacOS"
   rm -f GPSBabelFE.dmg


### PR DESCRIPTION
This chases some lose ends from
23379e741bf98603a5737e6f36422b753fc4bbdb