### PR TITLE
improve kml reader speed 5.1x.

### DIFF
--- a/gtrnctr.cc
+++ b/gtrnctr.cc
@@ -170,8 +170,7 @@ gtc_tags_to_ignore[] = {
 static void
 gtc_rd_init(const QString& fname)
 {
-  xml_init(fname, gtc_map, nullptr);
-  xml_ignore_tags(gtc_tags_to_ignore);
+  xml_init(fname, gtc_map, nullptr, gtc_tags_to_ignore);
 }
 
 static void

--- a/kml.cc
+++ b/kml.cc
@@ -312,6 +312,10 @@ xg_tag_mapping kml_map[] = {
 
 static
 const char* kml_tags_to_ignore[] = {
+  "styleUrl",
+  "snippet",
+  "LookAt",
+  "tilt",
   "kml",
   "Document",
   "Folder",

--- a/kml.cc
+++ b/kml.cc
@@ -555,9 +555,7 @@ static
 void
 kml_rd_init(const QString& fname)
 {
-  xml_init(fname, kml_map, nullptr);
-  xml_ignore_tags(kml_tags_to_ignore);
-  xml_skip_tags(kml_tags_to_skip);
+  xml_init(fname, kml_map, nullptr, kml_tags_to_ignore, kml_tags_to_skip);
 }
 
 static

--- a/kml.cc
+++ b/kml.cc
@@ -312,14 +312,19 @@ xg_tag_mapping kml_map[] = {
 
 static
 const char* kml_tags_to_ignore[] = {
-  "styleUrl",
-  "snippet",
-  "LookAt",
-  "tilt",
   "kml",
   "Document",
   "Folder",
-  nullptr,
+  nullptr
+};
+
+static
+const char* kml_tags_to_skip[] = {
+  "Camera",
+  "LookAt",
+  "styleUrl",
+  "snippet",
+  nullptr
 };
 
 // The TimeSpan/begin and TimeSpan/end DateTimes:
@@ -552,6 +557,7 @@ kml_rd_init(const QString& fname)
 {
   xml_init(fname, kml_map, nullptr);
   xml_ignore_tags(kml_tags_to_ignore);
+  xml_skip_tags(kml_tags_to_skip);
 }
 
 static

--- a/xmlgeneric.cc
+++ b/xmlgeneric.cc
@@ -122,7 +122,7 @@ xml_run_parser(QXmlStreamReader& reader)
     switch (reader.tokenType()) {
     case QXmlStreamReader::StartDocument:
       if (!reader.documentEncoding().isEmpty()) {
-        codec = QTextCodec::codecForName(CSTR(reader.documentEncoding().toString()));
+        codec = QTextCodec::codecForName(reader.documentEncoding().toUtf8());
       }
       if (codec == nullptr) {
         // According to http://www.opentag.com/xfaq_enc.htm#enc_default , we
@@ -202,11 +202,11 @@ void xml_read()
 
   xml_run_parser(reader);
   if (reader.hasError())  {
-    fatal(MYNAME ":Read error: %s (%s, line %ld, col %ld)\n",
+    fatal(MYNAME ":Read error: %s (%s, line %lld, col %lld)\n",
           qPrintable(reader.errorString()),
           qPrintable(file.fileName()),
-          (long) reader.lineNumber(),
-          (long) reader.columnNumber());
+          reader.lineNumber(),
+          reader.columnNumber());
   }
 }
 
@@ -241,11 +241,11 @@ void xml_readstring(const char* str)
 
   xml_run_parser(reader);
   if (reader.hasError())  {
-    fatal(MYNAME ":Read error: %s (%s, line %ld, col %ld)\n",
+    fatal(MYNAME ":Read error: %s (%s, line %lld, col %lld)\n",
           qPrintable(reader.errorString()),
           "unknown",
-          (long) reader.lineNumber(),
-          (long) reader.columnNumber());
+          reader.lineNumber(),
+          reader.columnNumber());
   }
 }
 

--- a/xmlgeneric.cc
+++ b/xmlgeneric.cc
@@ -59,8 +59,10 @@ static QTextCodec* codec = utf8_codec;  // Qt has no vanilla ASCII encoding =(
 xg_callback*
 xml_tbl_lookup(const QString& tag, xg_cb_type cb_type)
 {
-  for (xg_tag_mapping* tm = xg_tag_tbl; tm->tag_cb != nullptr; tm++) {
-    if (str_match(CSTR(tag), tm->tag_name) && (cb_type == tm->cb_type)) {
+  const QByteArray key = tag.toUtf8();
+  const char* keyptr = key.constData();
+  for (xg_tag_mapping* tm = xg_tag_tbl; tm->tag_cb != nullptr; ++tm) {
+    if ((cb_type == tm->cb_type) && str_match(keyptr, tm->tag_name)) {
       return tm->tag_cb;
     }
   }
@@ -122,7 +124,7 @@ xml_run_parser(QXmlStreamReader& reader)
         goto readnext;
       }
 
-      current_tag.append("/");
+      current_tag.append(QLatin1Char('/'));
       current_tag.append(reader.qualifiedName());
 
       cb = xml_tbl_lookup(current_tag, cb_start);
@@ -191,7 +193,7 @@ void xml_read()
 
 void xml_ignore_tags(const char** taglist)
 {
-  for (; taglist && *taglist; taglist++) {
+  for (; taglist && *taglist; ++taglist) {
     xg_ignore_taglist.insert(QString::fromUtf8(*taglist));
   }
 }

--- a/xmlgeneric.h
+++ b/xmlgeneric.h
@@ -47,10 +47,10 @@ struct xg_tag_mapping {
 };
 
 extern const char* xhtml_entities;
-void xml_ignore_tags(const char** taglist);
-void xml_skip_tags(const char** taglist);
 
-void xml_init(const QString& fname, xg_tag_mapping* tbl,const char* encoding);
+void xml_init(const QString& fname, xg_tag_mapping* tbl,const char* encoding,
+              const char** ignorelist = nullptr,
+              const char** skiplist = nullptr);
 void xml_read();
 void xml_readstring(const char* str);
 void xml_readprefixstring(const char* str);

--- a/xmlgeneric.h
+++ b/xmlgeneric.h
@@ -22,7 +22,8 @@
 #ifndef XMLGENERIC_H_INCLUDED_
 #define XMLGENERIC_H_INCLUDED_
 
-#include <QtCore/QString>
+#include <QtCore/QString>               // for QString
+#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
 
 // Maybe the XmlGeneric string callback really shouldn't have a type
 // of its own; this was a crutch during the move from char* to QString.
@@ -37,7 +38,6 @@ enum xg_cb_type {
   cb_end,
 };
 
-class QXmlStreamAttributes;
 using xg_callback = void (xg_string, const QXmlStreamAttributes*);
 
 struct xg_tag_mapping {
@@ -48,6 +48,7 @@ struct xg_tag_mapping {
 
 extern const char* xhtml_entities;
 void xml_ignore_tags(const char** taglist);
+void xml_skip_tags(const char** taglist);
 
 void xml_init(const QString& fname, xg_tag_mapping* tbl,const char* encoding);
 void xml_read();


### PR DESCRIPTION
This also improves the reader speed of all other format using
xmlgeneric.

kml reader speed measured with
gpsbabel -i kml -f lowrance-v4.kml -o lowranceusr -F /dev/null

our entire test suite (testo) takes about 23% less time to execute.

Thanks to callgrind again.

This PR also adds a skip option that can be used to skip an element and all it's
children.  This saves looking up all the callbacks for any children.  It can be used just like  xml_ignore_tags() and is named xml_skip_tags().

For the record I did try to do the tag lookup with QRegExp and QRegularExpression.  Both were slower that str_match.  Presumably this is explained because they use 16 bit characters while str_match uses 8 bit characters.