### PR TITLE
Fix access to QByteArray/QString outside the valid range.

### DIFF
--- a/ggv_bin.cc
+++ b/ggv_bin.cc
@@ -84,7 +84,7 @@ GgvBinFormat::ggv_bin_read_text16(QDataStream& stream, QByteArray& buf, const ch
 {
   quint16 len = ggv_bin_read16(stream, descr);
   ggv_bin_read_bytes(stream, buf, len, descr);
-  buf[len] = 0;
+  buf.append('\0');
   if (global_opts.debug_level > 1) {
     qDebug() << "ovl: text =" << QString::fromLatin1(buf.constData()).simplified();
   }
@@ -102,7 +102,7 @@ GgvBinFormat::ggv_bin_read_text32(QDataStream& stream, QByteArray& buf, const ch
     fatal(MYNAME ": Read error, max len exceeded (%s)\n", descr ? descr : "");
   }
   ggv_bin_read_bytes(stream, buf, len, descr);
-  buf[len] = 0;
+  buf.append('\0');
   if (global_opts.debug_level > 1) {
     qDebug() << "ovl: text =" << QString::fromLatin1(buf.constData()).simplified();
   }
@@ -490,7 +490,7 @@ GgvBinFormat::read()
 
   QByteArray buf;
   ggv_bin_read_bytes(stream, buf, 0x17, "magic");
-  buf[23] = 0;
+  buf.append('\0');
   if (global_opts.debug_level > 1) {
     qDebug() << "ovl: header =" << buf.constData();
   }

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -983,8 +983,6 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
   double utme, utmn;
   char utmzc;
 
-  buff[0] = '\0';
-
   if (oldlon < 900) {
     pathdist += radtomiles(gcdist(RAD(oldlat),RAD(oldlon),
                                   RAD(wpt->latitude),RAD(wpt->longitude)));


### PR DESCRIPTION
With Qt 5.15, and likely 5.14, the following warnings were generated during
testo:
Using QByteRef with an index pointing outside the valid range of a QByteArray. The corresponding behavior is deprecated, and will be changed in a future version of Qt.
Using QCharRef with an index pointing outside the valid range of a QString. The corresponding behavior is deprecated, and will be changed in a future version of Qt.
Note this requires Qt to be compiled for debug.

These warnings can be debugged by running testo with
"export QT_FATAL_WARNINGS=1" to generate core dumps.

I suspect the appending of null terminators in ggv_bin is unnecessary,
i.e. I believe QByteArray::resize() in ggv_bin_read_bytes will take
care of this.  Never the less I slavishly kept adding them just to make
certain.