### PR TITLE
Fallthrough corrections

### DIFF
--- a/dmtlog.cc
+++ b/dmtlog.cc
@@ -586,7 +586,8 @@ inflate_buff(const char* buff, const size_t size, char** out_buff)
 
     switch (res) {
     case Z_NEED_DICT:
-      res = Z_DATA_ERROR;     /* and fall through */
+      res = Z_DATA_ERROR;
+      /* fallthrough */
     case Z_DATA_ERROR:
     case Z_MEM_ERROR:
       (void)inflateEnd(&strm);

--- a/g7towin.cc
+++ b/g7towin.cc
@@ -188,7 +188,7 @@ parse_line(char* buff, int index, const char* delimiter, Waypoint* wpt)
       if (strcmp(cin, "1.0e25") == 0) {
         break;
       }
-      /* !!! NO BREAK !!! */
+      /* fallthrough */
     case WPT_cD_OFS + 1:
     case WPT_cB_OFS + 6:
       WAYPT_SET(wpt, temperature, atof(cin));

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -785,7 +785,7 @@ process_data_item(struct read_state* pst, const item_frame* pitem, int len)
 
   case 0xc:	/* POI item (same structure as full) */
     poi = 1;
-    /* fall through: */
+    /* fallthrough */
 
   case 0x2:	/* Multi HZ item */
     if (len < MULTI_HZ_ITEM_LEN) {
@@ -822,7 +822,7 @@ process_data_item(struct read_state* pst, const item_frame* pitem, int len)
 
   case 0x6:	/* POI item (same structure as full) */
     poi = 1;
-    /* fall through: */
+    /* fallthrough */
 
   case 0x4:	/* full item */
     if (len < FULL_ITEM_LEN) {

--- a/util.cc
+++ b/util.cc
@@ -483,6 +483,7 @@ str_match(const char* str, const char* match)
         return 0;  /* incomplete escape sequence */
       }
     /* pass-through next character */
+    /* fallthrough */
 
     default:
       if (*m != *s) {

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -1524,6 +1524,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
       garmin_fs_t* gmsd = garmin_fs_t::find(wpt);
       buff = QString::asprintf(fmp.printfc.constData(), CSTR(garmin_fs_t::get_facility(gmsd, "")));
     }
+    break;
     case XT_EMAIL: {
       garmin_fs_t* gmsd = garmin_fs_t::find(wpt);
       buff = QString::asprintf(fmp.printfc.constData(), CSTR(garmin_fs_t::get_email(gmsd, "")));


### PR DESCRIPTION
Fix an actual bug that resulted in a fallthrough warning!

Silence other fallthrough warnings with comments recognized by gcc.

The real fix is the to add the attribute [[fallthrough]];
which was added in c++17.
gcc accepts this, but until c++17 there wasn't
a requirement to ignore unrecognized attributes, so we can
imagine a pre c++17 compiler might choke on it.