### PR TITLE
update linux/macos CI Qt 5.12.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: cpp
 
-matrix:
+jobs:
   include:
     - os: linux
       dist: bionic
-      sudo: required
       services: docker
       compiler: gcc
       env:
@@ -12,7 +11,6 @@ matrix:
         - DOCKER_IMG="qtio"
     - os: linux
       dist: bionic
-      sudo: required
       services: docker
       compiler: clang
       env:
@@ -20,7 +18,6 @@ matrix:
         - DOCKER_IMG="qtio"
     - os: linux
       dist: bionic
-      sudo: required
       services: docker
       compiler: gcc
       env:
@@ -28,7 +25,6 @@ matrix:
         - DOCKER_IMG=""
     - os: linux
       dist: bionic
-      sudo: required
       services: docker
       compiler: gcc
       env:
@@ -37,7 +33,6 @@ matrix:
         - DOCKER_SCRIPT="./tools/build_extra_tests"
     - os: linux
       dist: xenial
-      sudo: required
       compiler: gcc
       env:
         - BUILD_TYPE="local"
@@ -75,7 +70,6 @@ matrix:
         timeout: 600
     - os: linux
       dist: bionic
-      sudo: required
       compiler: gcc
       env:
         - BUILD_TYPE="coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
           - $HOME/Cache
         timeout: 600
     - os: osx
+      osx_image: xcode10.3
       compiler: clang
       env: QT_VERSION="5.12.8"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ jobs:
           - $HOME/Cache
         timeout: 600
     - os: osx
-      osx_image: xcode10.3
       compiler: clang
       env: QT_VERSION="5.12.8"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
           - $HOME/Cache
         timeout: 600
     - os: osx
-      osx_image: xcode11.3
+      osx_image: xcode10.3
       compiler: clang
       env: QT_VERSION="5.12.8"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
           - $HOME/Cache
         timeout: 600
     - os: osx
-      osx_image: xcode10.3
+      osx_image: xcode11.3
       compiler: clang
       env: QT_VERSION="5.12.8"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
         timeout: 600
     - os: osx
       compiler: clang
-      env: QT_VERSION="5.12.7"
+      env: QT_VERSION="5.12.8"
       cache:
         directories:
           - $HOME/Cache
@@ -100,7 +100,7 @@ script:
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   # only deploy pushes to master or prs that target master.  the prs will go to transfr.sh, the pushes go to github.
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ] &&  [ "${QT_VERSION}" = "5.12.7" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash ./tools/uploadtool/upload.sh  gui/GPSBabel-*.dmg; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ] &&  [ "${QT_VERSION}" = "5.12.8" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash ./tools/uploadtool/upload.sh  gui/GPSBabel-*.dmg; fi
 
 branches:
   except:

--- a/tools/Dockerfile_qtio
+++ b/tools/Dockerfile_qtio
@@ -1,6 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:bionic as qt_install
+FROM ubuntu:bionic as qt_install_prep
 WORKDIR /app
 
 # update environment.
@@ -25,14 +25,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
  && rm -rf /var/lib/apt/lists/*
 
+FROM qt_install_prep as qt_install
 # basic build and test tools
-COPY ./qtci/install-qt-online ./qtci/extract-qt-installer ./qtci/qt-install.qs /app/
-RUN QT_CI_DOWNLOADER="wget -nv -c" PATH=/app:${PATH} ./install-qt-online "qt.qt5.5127.gcc_64,qt.qt5.5127.qtwebengine" /opt
-RUN echo "export PATH=/opt/Qt/5.12.7/gcc_64/bin:$PATH" > /opt/qt-5.12.7.env
+ARG INSTALLER
+ARG QT_CI_PACKAGES
+ARG QT_VERSION
+COPY ./extract-qt-installer ./qt-install.qs ./$INSTALLER /app/
+RUN ./extract-qt-installer $INSTALLER /opt/Qt \
+ && rm ./extract-qt-installer ./qt-install.qs ./$INSTALLER \
+ && echo "export PATH=/opt/Qt/$QT_VERSION/gcc_64/bin:$PATH" > /opt/qt-$QT_VERSION.env
 
 FROM ubuntu:bionic
 LABEL maintainer="https://github.com/tsteven4"
 WORKDIR /app
+ARG QT_VERSION
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -89,8 +95,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 # Qt
-COPY --from=qt_install /opt/qt-5.12.7.env /opt/qtio.env
-COPY --from=qt_install /opt/Qt/5.12.7 /opt/Qt/5.12.7
+COPY --from=qt_install /opt/qt-$QT_VERSION.env /opt/qtio.env
+COPY --from=qt_install /opt/Qt/$QT_VERSION /opt/Qt/$QT_VERSION
 COPY --from=qt_install /opt/Qt/Licenses /opt/Qt/Licenses
 
 # pkgs needed to generate coverage report:

--- a/tools/make_docker_image
+++ b/tools/make_docker_image
@@ -3,10 +3,15 @@
 
 versuffix=${1:+_$1} # tag name must be lower case
 tag=$(date -u +%Y%m%dT%H%M%SZ)
-docker build --pull --file Dockerfile${versuffix} --tag gpsbabel_build_environment${versuffix}:latest .
-docker tag gpsbabel_build_environment${versuffix}:latest gpsbabel_build_environment${versuffix}:$tag
-docker tag gpsbabel_build_environment${versuffix}:latest tsteven4/gpsbabel_build_environment${versuffix}:latest 
-docker tag gpsbabel_build_environment${versuffix}:latest tsteven4/gpsbabel_build_environment${versuffix}:$tag
+TMPDIR=$(mktemp -d)
+
+cp Dockerfile${versuffix} $TMPDIR
+
+docker build --pull --file Dockerfile${versuffix} \
+             --tag tsteven4/gpsbabel_build_environment${versuffix}:latest \
+             --tag tsteven4/gpsbabel_build_environment${versuffix}:$tag \
+             $TMPDIR
+/bin/rm -fr $TMPDIR
 docker push tsteven4/gpsbabel_build_environment${versuffix}:$tag
 docker push tsteven4/gpsbabel_build_environment${versuffix}:latest
 docker image ls

--- a/tools/make_docker_qtio_image
+++ b/tools/make_docker_qtio_image
@@ -1,0 +1,44 @@
+#!/bin/bash -ex
+# you must be logged into docker for the push to succeed.
+
+#versuffix=${1:+_$1} # tag name must be lower case
+versuffix=_qtio
+tag=$(date -u +%Y%m%dT%H%M%SZ)
+
+QT_VERSION=5.12.8
+QT_VERSION_SHORT=${QT_VERSION//./}
+QT_CI_PACKAGES="qt.qt5.${QT_VERSION_SHORT}.gcc_64,qt.qt5.${QT_VERSION_SHORT}.qtwebengine"
+DOWNLOAD_URL=$(./qtci/find_qt_installer ${QT_VERSION})
+INSTALLER=$(basename $DOWNLOAD_URL)
+
+TMPDIR=$(mktemp -d)
+
+cp Dockerfile${versuffix} $TMPDIR
+cp Dockerfile${versuffix} $TMPDIR
+cp ./qtci/extract-qt-installer ./qtci/qt-install.qs $TMPDIR
+
+pushd $TMPDIR
+wget -nv -c -N ${DOWNLOAD_URL}
+
+docker build --pull --file Dockerfile${versuffix} \
+             --target qt_install_prep \
+             .
+docker build --pull --file Dockerfile${versuffix} \
+             --network none \
+             --build-arg INSTALLER=${INSTALLER} \
+             --build-arg QT_CI_PACKAGES=${QT_CI_PACKAGES} \
+             --build-arg QT_VERSION=${QT_VERSION} \
+             --target qt_install \
+             .
+docker build --pull --file Dockerfile${versuffix} \
+             --build-arg INSTALLER=${INSTALLER} \
+             --build-arg QT_CI_PACKAGES=${QT_CI_PACKAGES} \
+             --build-arg QT_VERSION=${QT_VERSION} \
+             --tag tsteven4/gpsbabel_build_environment${versuffix}:latest \
+             --tag tsteven4/gpsbabel_build_environment${versuffix}:$tag \
+             .
+popd
+/bin/rm -fr $TMPDIR
+docker push tsteven4/gpsbabel_build_environment${versuffix}:$tag
+docker push tsteven4/gpsbabel_build_environment${versuffix}:latest
+docker image ls

--- a/tools/make_docker_qtio_image
+++ b/tools/make_docker_qtio_image
@@ -10,34 +10,29 @@ QT_VERSION_SHORT=${QT_VERSION//./}
 QT_CI_PACKAGES="qt.qt5.${QT_VERSION_SHORT}.gcc_64,qt.qt5.${QT_VERSION_SHORT}.qtwebengine"
 DOWNLOAD_URL=$(./qtci/find_qt_installer ${QT_VERSION})
 INSTALLER=$(basename $DOWNLOAD_URL)
-
 TMPDIR=$(mktemp -d)
 
 cp Dockerfile${versuffix} $TMPDIR
-cp Dockerfile${versuffix} $TMPDIR
 cp ./qtci/extract-qt-installer ./qtci/qt-install.qs $TMPDIR
-
-pushd $TMPDIR
-wget -nv -c -N ${DOWNLOAD_URL}
+wget -nv -c -N -P $TMPDIR ${DOWNLOAD_URL}
 
 docker build --pull --file Dockerfile${versuffix} \
              --target qt_install_prep \
-             .
+             $TMPDIR
 docker build --pull --file Dockerfile${versuffix} \
              --network none \
              --build-arg INSTALLER=${INSTALLER} \
              --build-arg QT_CI_PACKAGES=${QT_CI_PACKAGES} \
              --build-arg QT_VERSION=${QT_VERSION} \
              --target qt_install \
-             .
+             $TMPDIR
 docker build --pull --file Dockerfile${versuffix} \
              --build-arg INSTALLER=${INSTALLER} \
              --build-arg QT_CI_PACKAGES=${QT_CI_PACKAGES} \
              --build-arg QT_VERSION=${QT_VERSION} \
              --tag tsteven4/gpsbabel_build_environment${versuffix}:latest \
              --tag tsteven4/gpsbabel_build_environment${versuffix}:$tag \
-             .
-popd
+             $TMPDIR
 /bin/rm -fr $TMPDIR
 docker push tsteven4/gpsbabel_build_environment${versuffix}:$tag
 docker push tsteven4/gpsbabel_build_environment${versuffix}:latest

--- a/tools/qtci/extract-qt-installer
+++ b/tools/qtci/extract-qt-installer
@@ -84,17 +84,25 @@ fi
 
 unset DISPLAY
 
+# platform minimal doesn't work on macos 10.14, 10.15.  It did work on 10.13.
+# https://bugreports.qt.io/browse/QTIFW-1471
+PLATFORM="--platform minimal"
+if [ "$(uname)" = "Darwin" ]; then
+  vn=$(sw_vers -productVersion | cut -d. -f2,2)
+  if [ $vn -ge 14 ]; then
+     unset PLATFORM
+  fi
+fi
+
 if [ -n "$DISABLE_PROGRESS_REPORT" ]
 then
-	QT_QPA_PLATFORM=minimal $INSTALLER --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT" 
+	$INSTALLER $PLATFORM --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT" 
 else
-	ARGS="-v"
-
 	if [ -n "$VERBOSE" ]
 	then
-		QT_QPA_PLATFORM=minimal $INSTALLER $ARGS --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT"
+		$INSTALLER --verbose $PLATFORM --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT"
 	else
-		QT_QPA_PLATFORM=minimal $INSTALLER $ARGS --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT" | grep "\(QTCI\|operation\)"
+		$INSTALLER --verbose $PLATFORM --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT" | grep "\(QTCI\|operation\)"
 	fi
 fi
 

--- a/tools/qtci/find_qt_installer
+++ b/tools/qtci/find_qt_installer
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+# Reference:
+#   https://github.com/musescore/MuseScore/blob/master/build/travis/job_macos/install.sh
+
+QT_VERSION=${1:-5.12.0}
+
+QT_MAJOR_VERSION=$(echo ${QT_VERSION} | cut -d "." -f 1)
+QT_MINOR_VERSION=$(echo ${QT_VERSION} | cut -d "." -f 2)
+if [ "$(uname)" = "Darwin" ]; then
+  if { [ "${QT_MAJOR_VERSION}" -eq 5 ] && [ "${QT_MINOR_VERSION}" -ge 9 ]; } || [ "${QT_MAJOR_VERSION}" -ge 6 ]; then
+    # this was good from 5.9.0 through at least 5.12.0
+    DOWNLOAD_URL=https://download.qt.io/archive/qt/${QT_MAJOR_VERSION}.${QT_MINOR_VERSION}/${QT_VERSION}/qt-opensource-mac-x64-${QT_VERSION}.dmg
+  else
+    # this was good from 5.2.1 through 5.8.0
+    DOWNLOAD_URL=https://download.qt.io/archive/qt/${QT_MAJOR_VERSION}.${QT_MINOR_VERSION}/${QT_VERSION}/qt-opensource-mac-x64-clang-${QT_VERSION}.dmg
+  fi
+elif [ "$(uname)" = "Linux" ]; then
+  # this was good from 5.2.1 through at least 5.12.0
+  DOWNLOAD_URL=https://download.qt.io/archive/qt/${QT_MAJOR_VERSION}.${QT_MINOR_VERSION}/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run
+else
+  echo "Unsupported system." >&2
+  exit 1
+fi
+echo $DOWNLOAD_URL

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -51,7 +51,7 @@ else
   mkdir -p ${CACHEDIR}
   pushd ${CACHEDIR}
   # install-qt creates the install at $PWD/Qt.
-  VERBOSE=1 QT_CI_PACKAGES=qt.qt5.${QT_VERSION_SHORT}.clang_64,qt.qt5.${QT_VERSION_SHORT}.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=${TRAVIS_BUILD_DIR}/tools/qtci:${PATH} install-qt ${QT_VERSION}
+  QT_CI_PACKAGES=qt.qt5.${QT_VERSION_SHORT}.clang_64,qt.qt5.${QT_VERSION_SHORT}.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=${TRAVIS_BUILD_DIR}/tools/qtci:${PATH} install-qt ${QT_VERSION}
   popd
   validate
   rm ${CACHEDIR}/qt-opensource*.dmg

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -51,7 +51,7 @@ else
   mkdir -p ${CACHEDIR}
   pushd ${CACHEDIR}
   # install-qt creates the install at $PWD/Qt.
-  QT_CI_PACKAGES=qt.qt5.${QT_VERSION_SHORT}.clang_64,qt.qt5.${QT_VERSION_SHORT}.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=${TRAVIS_BUILD_DIR}/tools/qtci:${PATH} install-qt ${QT_VERSION}
+  VERBOSE=1 QT_CI_PACKAGES=qt.qt5.${QT_VERSION_SHORT}.clang_64,qt.qt5.${QT_VERSION_SHORT}.qtwebengine QT_CI_DOWNLOADER="wget -nv -c" PATH=${TRAVIS_BUILD_DIR}/tools/qtci:${PATH} install-qt ${QT_VERSION}
   popd
   validate
   rm ${CACHEDIR}/qt-opensource*.dmg


### PR DESCRIPTION
Move from Qt 5.12.7 to Qt 5.12.8 on docker qtio builds.
Move macos Qt 5.12 build from 5.12.7 to 5.12.8.  Also move this build from macos10.13-xcode9.4.1 to macos10.14-xcode10.3.

update docker build scripts to build in a clean directory.
update travis yaml syntax.