### PR TITLE
migrate advanced travis build to focal.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       compiler: gcc
       env:
         - BUILD_TYPE="docker"
-        - DOCKER_IMG="eoan"
+        - DOCKER_IMG="focal"
         - DOCKER_SCRIPT="./tools/build_extra_tests"
     - os: linux
       dist: xenial

--- a/tools/Dockerfile_focal
+++ b/tools/Dockerfile_focal
@@ -1,6 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:eoan
+FROM ubuntu:focal
 
 LABEL maintainer="https://github.com/tsteven4"
 

--- a/util.cc
+++ b/util.cc
@@ -1774,7 +1774,7 @@ void list_timezones()
   };
   std::sort(zoneids.begin(), zoneids.end(), alpha);
   Warning() << "Available timezones are:";
-  for (const auto& id : zoneids) {
+  for (const auto& id : qAsConst(zoneids)) {
     Warning() << id;
   }
 }


### PR DESCRIPTION
and fix a new clazy warning.  This warning shows up on focal
with clazy 1.6, but not on eoan with clazy 1.5.