### PR TITLE
introduce xasprintf that accepts a QScopedPointer&

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -19,38 +19,39 @@
 #ifndef DEFS_H_INCLUDED_
 #define DEFS_H_INCLUDED_
 
-#include <algorithm>            // for sort, stable_sort
-#include <cmath>                // for M_PI
-#include <cstdarg>              // for va_list
-#include <cstddef>              // for NULL, nullptr_t, size_t
-#include <cstdint>              // for int32_t, uint32_t
-#include <cstdio>               // for NULL, fprintf, FILE, stdout
-#include <ctime>                // for time_t
-#include <utility>              // for move
+#include <algorithm>              // for sort, stable_sort
+#include <cmath>                  // for M_PI
+#include <cstdarg>                // for va_list
+#include <cstddef>                // for NULL, nullptr_t, size_t
+#include <cstdint>                // for int32_t, uint32_t
+#include <cstdio>                 // for NULL, fprintf, FILE, stdout
+#include <ctime>                  // for time_t
+#include <utility>                // for move
 
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
 #if HAVE_LIBZ
-#include <zlib.h>               // doesn't really belong here, but is missing elsewhere.
+#include <zlib.h>                 // doesn't really belong here, but is missing elsewhere.
 #elif !ZLIB_INHIBITED
-#include "zlib.h"               // doesn't really belong here, but is missing elsewhere.
+#include "zlib.h"                 // doesn't really belong here, but is missing elsewhere.
 #endif
 
-#include <QtCore/QList>         // for QList, QList<>::const_reverse_iterator, QList<>::reverse_iterator
-#include <QtCore/QString>       // for QString
-#include <QtCore/QStringRef>    // for QStringRef
-#include <QtCore/QTextCodec>    // for QTextCodec
-#include <QtCore/QVector>       // for QVector
-#include <QtCore/Qt>            // for CaseInsensitive
-#include <QtCore/QtGlobal>      // for foreach
+#include <QtCore/QList>           // for QList, QList<>::const_reverse_iterator, QList<>::reverse_iterator
+#include <QtCore/QScopedPointer>  // for QScopedPointer
+#include <QtCore/QString>         // for QString
+#include <QtCore/QStringRef>      // for QStringRef
+#include <QtCore/QTextCodec>      // for QTextCodec
+#include <QtCore/QVector>         // for QVector
+#include <QtCore/Qt>              // for CaseInsensitive
+#include <QtCore/QtGlobal>        // for foreach
 
-#include "formspec.h"           // for FormatSpecificData
-#include "inifile.h"            // for inifile_t
-#include "gbfile.h"             // doesn't really belong here, but is missing elsewhere.
-#include "session.h"            // for session_t
-#include "src/core/datetime.h"  // for DateTime
-#include "src/core/optional.h"  // for optional
+#include "formspec.h"             // for FormatSpecificData
+#include "inifile.h"              // for inifile_t
+#include "gbfile.h"               // doesn't really belong here, but is missing elsewhere.
+#include "session.h"              // for session_t
+#include "src/core/datetime.h"    // for DateTime
+#include "src/core/optional.h"    // for optional
 
 
 #define CSTR(qstr) ((qstr).toUtf8().constData())
@@ -1108,6 +1109,7 @@ void rtrim(char* s);
 char* lrtrim(char* buff);
 int xasprintf(char** strp, const char* fmt, ...) PRINTFLIKE(2, 3);
 int xasprintf(QString* strp, const char* fmt, ...) PRINTFLIKE(2, 3);
+int xasprintf(QScopedPointer<char, QScopedPointerPodDeleter>& strp, const char* fmt, ...) PRINTFLIKE(2, 3);
 int xvasprintf(char** strp, const char* fmt, va_list ap);
 char* strupper(char* src);
 char* strlower(char* src);

--- a/util.cc
+++ b/util.cc
@@ -19,36 +19,39 @@
 
  */
 
-#include <cctype>                      // for isspace, isalpha, ispunct, tolower, toupper
-#include <cerrno>                      // for errno
-#include <cmath>                       // for fabs, floor
-#include <cstdarg>                     // for va_list, va_end, va_start, va_copy
-#include <cstdio>                      // for size_t, vsnprintf, FILE, fopen, printf, sprintf, stderr, stdin, stdout
-#include <cstdint>                     // for uint32_t
-#include <cstdlib>                     // for abs, getenv, calloc, free, malloc, realloc
-#include <cstring>                     // for strlen, strcat, strstr, memcpy, strcmp, strcpy, strdup, strchr, strerror
-#include <ctime>                       // for mktime, localtime
+#include <algorithm>                    // for sort
+#include <cctype>                       // for isspace, isalpha, ispunct, tolower, toupper
+#include <cerrno>                       // for errno
+#include <cmath>                        // for fabs, floor
+#include <cstdarg>                      // for va_list, va_end, va_start, va_copy
+#include <cstdio>                       // for size_t, vsnprintf, FILE, fopen, printf, sprintf, stderr, stdin, stdout
+#include <cstdint>                      // for uint32_t
+#include <cstdlib>                      // for abs, getenv, calloc, free, malloc, realloc
+#include <cstring>                      // for strlen, strcat, strstr, memcpy, strcmp, strcpy, strdup, strchr, strerror
+#include <ctime>                        // for mktime, localtime
 
-#include <QtCore/QByteArray>           // for QByteArray
-#include <QtCore/QChar>                // for QChar, operator<=, operator>=
-#include <QtCore/QCharRef>             // for QCharRef
-#include <QtCore/QDateTime>            // for QDateTime
-#include <QtCore/QFileInfo>            // for QFileInfo
-#include <QtCore/QList>                // for QList
-#include <QtCore/QString>              // for QString
-#include <QtCore/QStringRef>           // for QStringRef
-#include <QtCore/QTextCodec>           // for QTextCodec
-#include <QtCore/QTextStream>          // for operator<<, QTextStream, qSetFieldWidth, endl, QTextStream::AlignLeft
-#include <QtCore/QXmlStreamAttribute>  // for QXmlStreamAttribute
-#include <QtCore/Qt>                   // for CaseInsensitive
-#include <QtCore/QTimeZone>            // for QTimeZone
-#include <QtCore/QtGlobal>             // for qAsConst, QAddConst<>::Type, qPrintable
+#include <QtCore/QByteArray>            // for QByteArray
+#include <QtCore/QChar>                 // for QChar, operator<=, operator>=
+#include <QtCore/QCharRef>              // for QCharRef
+#include <QtCore/QDateTime>             // for QDateTime
+#include <QtCore/QFileInfo>             // for QFileInfo
+#include <QtCore/QList>                 // for QList
+#include <QtCore/QScopedPointer>        // for QScopedPointer
+#include <QtCore/QString>               // for QString
+#include <QtCore/QStringRef>            // for QStringRef
+#include <QtCore/QTextCodec>            // for QTextCodec
+#include <QtCore/QTextStream>           // for operator<<, QTextStream, qSetFieldWidth, endl, QTextStream::AlignLeft
+#include <QtCore/QXmlStreamAttribute>   // for QXmlStreamAttribute
+#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QtCore/Qt>                    // for CaseInsensitive
+#include <QtCore/QTimeZone>             // for QTimeZone
+#include <QtCore/QtGlobal>              // for qAsConst, QAddConst<>::Type, qPrintable
 
 #include "defs.h"
-#include "cet.h"                       // for cet_utf8_to_ucs4
-#include "src/core/datetime.h"         // for DateTime
-#include "src/core/logging.h"          // for Warning
-#include "src/core/xmltag.h"           // for xml_tag, xml_attribute, xml_findfirst, xml_findnext
+#include "cet.h"                        // for cet_utf8_to_ucs4
+#include "src/core/datetime.h"          // for DateTime
+#include "src/core/logging.h"           // for Warning
+#include "src/core/xmltag.h"            // for xml_tag, xml_attribute, xml_findfirst, xml_findnext
 
 // First test Apple's clever macro that's really a runtime test so
 // that our universal binaries work right.
@@ -249,6 +252,20 @@ xasprintf(QString* strp, const char* fmt, ...)
   int res = xvasprintf(&cstrp, fmt, args);
   *strp = cstrp;
   xfree(cstrp);
+  va_end(args);
+
+  return res;
+}
+
+int
+xasprintf(QScopedPointer<char, QScopedPointerPodDeleter>& strp, const char* fmt, ...)
+{
+  va_list args;
+
+  va_start(args, fmt);
+  char* cstrp;
+  int res = xvasprintf(&cstrp, fmt, args);
+  strp.reset(cstrp);
   va_end(args);
 
   return res;


### PR DESCRIPTION
and use it to fix gcc 9 warnings in magproto, as well as other
possible string truncations/overflows.

This is a minimal risk stop gap measure.  It requires much less effort than conversion of all the legacy character strings, and avoids the back and forth between QStrings and character strings that sometimes occurs.  The use of a smart pointer to wrap the dynamically allocated string from xasprintf minimizes the risk of memory leaks.

QScopedPointerPodDeleter uses free as opposed to our xfree (which uses free).  For a purer implementation we could write our own deleter or get rid of our own memory allocation/deallocation routines, but this slight mismatch seems acceptable to me.

This could all be implemented with std::unique_ptr instead of QScopedPointer, but we have already introduced QScopedPointer to our code base while std::unique_ptr has not been used yet.

The passing of a smart pointer by non const reference to a function that will reset it is suggested by
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r33-take-a-unique_ptrwidget-parameter-to-express-that-a-function-reseats-thewidget