### PR TITLE
sprintf/snprintf replacements

### DIFF
--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -362,11 +362,11 @@ GarminFitFormat::fit_parse_data(const fit_message_def& def, int time_offset)
   uint8_t cadence = 0xff;
   uint16_t power = 0xffff;
   int8_t temperature = 0x7f;
-  int32_t startlat = 0x7fffffff;
-  int32_t startlon = 0x7fffffff;
+  //int32_t startlat = 0x7fffffff;
+  //int32_t startlon = 0x7fffffff;
   int32_t endlat = 0x7fffffff;
   int32_t endlon = 0x7fffffff;
-  uint32_t starttime = 0; // ??? default ?
+  //uint32_t starttime = 0; // ??? default ?
   uint8_t event = 0xff;
   uint8_t eventtype = 0xff;
 
@@ -500,19 +500,19 @@ GarminFitFormat::fit_parse_data(const fit_message_def& def, int time_offset)
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: starttime=%d\n", MYNAME, val);
           }
-          starttime = val;
+          //starttime = val;
           break;
         case kFieldStartLatitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: startlat=%d\n", MYNAME, val);
           }
-          startlat = val;
+          //startlat = val;
           break;
         case kFieldStartLongitude:
           if (global_opts.debug_level >= 7) {
             debug_print(7,"%s: parsing fit data: startlon=%d\n", MYNAME, val);
           }
-          startlon = val;
+          //startlon = val;
           break;
         case kFieldEndLatitude:
           if (global_opts.debug_level >= 7) {
@@ -587,9 +587,7 @@ GarminFitFormat::fit_parse_data(const fit_message_def& def, int time_offset)
     auto* lappt = new Waypoint;
     lappt->latitude = GPS_Math_Semi_To_Deg(endlat);
     lappt->longitude = GPS_Math_Semi_To_Deg(endlon);
-    char cbuf[10];
-    snprintf(cbuf, sizeof(cbuf), "LAP%03d", ++lap_ct);
-    lappt->shortname = cbuf;
+    lappt->shortname = QString("LAP%1").arg(++lap_ct, 3, 10, QLatin1Char('0'));
     waypt_add(lappt);
   }
   break;

--- a/garmin_fs.cc
+++ b/garmin_fs.cc
@@ -285,12 +285,7 @@ garmin_fs_convert_category(const char* category_name, uint16_t* category)
   } else if (global_opts.inifile != nullptr) {
     // Do we have a gpsbabel.ini that maps category names to category #'s?
     for (i = 0; i < 16; i++) {
-      char key[3];
-
-      // use assertion to silence gcc 7.3 warning
-      // warning: ‘%d’ directive output may be truncated writing between 1 and 11 bytes into a region of size 3 [-Wformat-truncation=]
-      assert((i>=0) && (i<16));
-      snprintf(key, sizeof(key), "%d", i + 1);
+      QString key = QString::number(i + 1);
       QString c = inifile_readstr(global_opts.inifile, GMSD_SECTION_CATEGORIES, key);
       if (c.compare(category_name, Qt::CaseInsensitive) == 0) {
         cat = (1 << i);

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -408,8 +408,7 @@ print_categories(uint16_t categories)
     if ((categories & 1) != 0) {
       QString c;
       if (global_opts.inifile != nullptr) {
-        char key[3];
-        snprintf(key, sizeof(key), "%d", i + 1);
+        QString key = QString::number(i + 1);
         c = inifile_readstr(global_opts.inifile, GMSD_SECTION_CATEGORIES, key);
       }
 

--- a/netstumbler.cc
+++ b/netstumbler.cc
@@ -90,7 +90,7 @@ data_read()
   char* ibuf;
   char ssid[2 + 32 + 2 + 1];			/* "( " + SSID + " )" + null */
   char mac[2 + 17 + 2 + 1];			/* "( " + MAC + " )" + null */
-  char desc[sizeof ssid - 1 + 15 + 1];	/* room for channel/speed */
+  QString desc;
   double lat = 0, lon = 0;
   int line_no = 0;
   int stealth_num = 0, whitespace_num = 0;
@@ -240,10 +240,10 @@ data_read()
     }
 
     if (snmac) {
-      snprintf(desc, sizeof desc, "%s/%d Mbps/Ch %d", ssid, speed, channel);
+      desc = QString("%1/%2 Mbps/Ch %3").arg(ssid).arg(speed).arg(channel);
       wpt_tmp->shortname = (mac);
     } else {
-      snprintf(desc, sizeof desc, "%d Mbps/Ch %d/%s", speed, channel, mac);
+      desc = QString("%1 Mbps/Ch %2/%3").arg(speed).arg(channel).arg(mac);
       wpt_tmp->shortname = (ssid);
     }
 

--- a/stmwpp.cc
+++ b/stmwpp.cc
@@ -20,10 +20,6 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-
-
-#if CSVFMTS_ENABLED
-
 #include <cstdio>                  // for sscanf, snprintf
 #include <cstdlib>                 // for atof, atoi
 #include <cstring>                 // for memset
@@ -40,6 +36,8 @@
 #include "gbfile.h"                // for gbfprintf, gbfclose, gbfgetstr, gbfopen, gbfile, gbfputs
 #include "src/core/datetime.h"     // for DateTime
 
+
+#if CSVFMTS_ENABLED
 
 static gbfile* fin, *fout;
 static route_head* track, *route;

--- a/stmwpp.cc
+++ b/stmwpp.cc
@@ -21,15 +21,25 @@
 */
 
 
-#include "defs.h"
 
 #if CSVFMTS_ENABLED
 
-#include "csv_util.h"
-#include "cet_util.h"
-#include <cctype>
-#include <cstdio>
-#include <cstdlib>
+#include <cstdio>                  // for sscanf, snprintf
+#include <cstdlib>                 // for atof, atoi
+#include <cstring>                 // for memset
+#include <ctime>                   // for tm
+
+#include <QtCore/QDateTime>        // for QDateTime
+#include <QtCore/QString>          // for QString
+#include <QtCore/QTime>            // for QTime
+#include <QtCore/QVector>          // for QVector
+
+#include "defs.h"
+#include "cet_util.h"              // for cet_convert_init
+#include "csv_util.h"              // for csv_lineparse
+#include "gbfile.h"                // for gbfprintf, gbfclose, gbfgetstr, gbfopen, gbfile, gbfputs
+#include "src/core/datetime.h"     // for DateTime
+
 
 static gbfile* fin, *fout;
 static route_head* track, *route;
@@ -229,19 +239,9 @@ stmwpp_write_double(const double val)
 static void
 stmwpp_waypt_cb(const Waypoint* wpt)
 {
-  char cdate[16], ctime[16];
-
   if (track_index != track_num) {
     return;
   }
-
-  const time_t tt = wpt->GetCreationTime().toTime_t();
-  struct tm tm = *gmtime(&tt);
-  tm.tm_year += 1900;
-  tm.tm_mon++;
-
-  snprintf(cdate, sizeof(cdate), "%02d/%02d/%04d", tm.tm_mon, tm.tm_mday, tm.tm_year);
-  snprintf(ctime, sizeof(ctime), "%02d:%02d:%02d", tm.tm_hour, tm.tm_min, tm.tm_sec);
 
   QString sn;
   switch (what) {
@@ -262,7 +262,8 @@ stmwpp_waypt_cb(const Waypoint* wpt)
   }
   stmwpp_write_double(wpt->latitude);
   stmwpp_write_double(wpt->longitude);
-  gbfprintf(fout, "%s,%s", cdate, ctime);
+  QString datetime = wpt->GetCreationTime().toUTC().toString("MM/dd/yyyy,HH:mm:ss");
+  gbfputs(datetime, fout);
   switch (what) {
   case STM_WAYPT:
   case STM_RTEPT:


### PR DESCRIPTION
These changes fix a number of gcc 9 warnings.  In these cases the s[n]printf functionality is replaced by QString methods.