### PR TITLE
fix windows issues with kml.h including windows.h

### DIFF
--- a/kml.cc
+++ b/kml.cc
@@ -20,10 +20,6 @@
 
  */
 
-#ifdef __WIN32__
-# include <windows.h>
-#endif
-
 #include <cctype>                       // for tolower, toupper
 #include <cmath>                        // for fabs
 #include <cstdio>                       // for sscanf, printf

--- a/kml.h
+++ b/kml.h
@@ -22,10 +22,6 @@
 #ifndef KML_H_INCLUDED_
 #define KML_H_INCLUDED_
 
-#ifdef __WIN32__
-# include <windows.h>
-#endif
-
 #include <tuple>                        // for tuple, make_tuple, tie
 
 #include <QtCore/QList>                 // for QList


### PR DESCRIPTION
windows.h defines macros for max and min, which lead to compiler
warnings:
random.h(125): warning C4003: not enough arguments for function-like macro invocation 'max' (compiling source file

kml hasn't needed windows.h since ea82fa6d6