### PR TITLE
convert unicsv to Format class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ set(HEADERS
   shapelib/shapefil.h
   strptime.h
   subrip.h
+  unicsv.h
   units.h
   vecs.h
   xcsv.h

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -148,6 +148,7 @@ HEADERS =  \
 	shapelib/shapefil.h \
 	strptime.h \
 	subrip.h \
+	unicsv.h \
 	units.h \
 	vecs.h \
 	xcsv.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -511,12 +511,12 @@ filter_vecs.o: filter_vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
   format.h energympro.h garmin_fit.h geojson.h src/core/file.h ggv_bin.h \
   globalsat_sport.h gpx.h src/core/xmlstreamwriter.h src/core/xmltag.h \
   kml.h xmlgeneric.h legacyformat.h lowranceusr.h mynav.h nmea.h \
-  qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h subrip.h xcsv.h \
-  garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
-  jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
-  jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
-  jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h src/core/textstream.h \
-  yahoo.h
+  qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h subrip.h \
+  unicsv.h src/core/textstream.h xcsv.h garmin_fs.h jeeps/gps.h \
+  jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+  jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+  jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+  jeeps/gpsrqst.h yahoo.h
 formspec.o: formspec.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
   src/core/optional.h
@@ -537,8 +537,8 @@ garmin.o: garmin.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   energympro.h garmin_fit.h geojson.h src/core/file.h ggv_bin.h \
   globalsat_sport.h gpx.h src/core/xmlstreamwriter.h src/core/xmltag.h \
   kml.h xmlgeneric.h legacyformat.h lowranceusr.h mynav.h nmea.h \
-  qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h subrip.h xcsv.h \
-  src/core/textstream.h yahoo.h
+  qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h subrip.h \
+  unicsv.h src/core/textstream.h xcsv.h yahoo.h
 garmin_device_xml.o: garmin_device_xml.cc defs.h config.h zlib/zlib.h \
   zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
   src/core/datetime.h src/core/optional.h garmin_device_xml.h \
@@ -546,7 +546,7 @@ garmin_device_xml.o: garmin_device_xml.cc defs.h config.h zlib/zlib.h \
 garmin_fit.o: garmin_fit.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
   src/core/optional.h garmin_fit.h format.h jeeps/gpsmath.h \
-  jeeps/gpsport.h
+  jeeps/gpsport.h src/core/logging.h
 garmin_fs.o: garmin_fs.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
   src/core/optional.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
@@ -824,12 +824,12 @@ magproto.o: magproto.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
   energympro.h garmin_fit.h geojson.h src/core/file.h ggv_bin.h \
   globalsat_sport.h gpx.h src/core/xmlstreamwriter.h src/core/xmltag.h \
   kml.h xmlgeneric.h legacyformat.h lowranceusr.h mynav.h nmea.h \
-  qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h subrip.h xcsv.h \
-  garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
-  jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
-  jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
-  jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h src/core/textstream.h \
-  yahoo.h
+  qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h subrip.h \
+  unicsv.h src/core/textstream.h xcsv.h garmin_fs.h jeeps/gps.h \
+  jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+  jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+  jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+  jeeps/gpsrqst.h yahoo.h
 main.o: main.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
   cet_util.h csv_util.h filter.h filter_vecs.h arcdist.h bend.h \
@@ -840,11 +840,11 @@ main.o: main.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   garmin_fit.h geojson.h ggv_bin.h globalsat_sport.h gpx.h \
   src/core/xmlstreamwriter.h src/core/xmltag.h kml.h xmlgeneric.h \
   legacyformat.h lowranceusr.h mynav.h nmea.h qstarz_bl_1000.h random.h \
-  shape.h shapelib/shapefil.h subrip.h xcsv.h garmin_fs.h jeeps/gps.h \
-  jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-  jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-  jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-  jeeps/gpsrqst.h src/core/textstream.h yahoo.h
+  shape.h shapelib/shapefil.h subrip.h unicsv.h src/core/textstream.h \
+  xcsv.h garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+  jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+  jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+  jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h yahoo.h
 mapasia.o: mapasia.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
 mapbar_track.o: mapbar_track.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
@@ -1037,11 +1037,12 @@ transform.o: transform.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
   src/core/optional.h transform.h filter.h
 unicsv.o: unicsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
-  csv_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+  unicsv.h format.h src/core/textstream.h src/core/file.h csv_util.h \
+  garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h \
-  src/core/logging.h src/core/textstream.h src/core/file.h
+  src/core/logging.h
 units.o: units.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
   units.h
@@ -1063,11 +1064,11 @@ vecs.o: vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   ggv_bin.h globalsat_sport.h gpx.h src/core/xmlstreamwriter.h \
   src/core/xmltag.h kml.h xmlgeneric.h legacyformat.h lowranceusr.h \
   mynav.h nmea.h qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h \
-  subrip.h xcsv.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
-  jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
-  jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
-  jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
-  src/core/textstream.h yahoo.h gbversion.h src/core/logging.h
+  subrip.h unicsv.h src/core/textstream.h xcsv.h garmin_fs.h jeeps/gps.h \
+  jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+  jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+  jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+  jeeps/gpsrqst.h yahoo.h gbversion.h src/core/logging.h
 vidaone.o: vidaone.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
 vitosmt.o: vitosmt.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \

--- a/unicsv.h
+++ b/unicsv.h
@@ -1,0 +1,256 @@
+/*
+    Universal CSV - support for csv files, divining field order from the header.
+
+    Copyright (C) 2006-2013 Robert Lipe, robertlipe+source@gpsbabel.org
+    copyright (C) 2007,2008 Olaf Klein, o.b.klein@gpsbabel.org
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+#ifndef UNICSV_H_INCLUDED_
+#define UNICSV_H_INCLUDED_
+
+#include <cstdint>
+#include <ctime>                  // for gmtime
+
+#include <QtCore/QDateTime>       // for QDateTime
+#include <QtCore/QString>         // for QString, operator!=, operator==
+#include <QtCore/QVector>         // for QVector
+
+#include "defs.h"
+#include "format.h"               // for Format
+#include "src/core/textstream.h"  // for TextStream
+
+
+class UnicsvFormat : public Format
+{
+public:
+  QVector<arglist_t>* get_args() override
+  {
+    return &unicsv_args;
+  }
+
+  ff_type get_type() const override
+  {
+    return ff_type_file;
+  }
+
+  QVector<ff_cap> get_cap() const override
+  {
+    return FF_CAP_RW_ALL;
+  }
+
+  QString get_encode() const override
+  {
+    return CET_CHARSET_UTF8;
+  }
+
+  int get_fixed_encode() const override
+  {
+    return 0;
+  }
+
+  void rd_init(const QString& fname) override;
+  void read() override;
+  void rd_deinit() override;
+  void wr_init(const QString& fname) override;
+  void write() override;
+  void wr_deinit() override;
+
+private:
+  /* Types */
+
+  /* GPSBabel internal and calculated fields */
+
+  enum field_e {
+    fld_shortname = 0,
+    fld_latitude,
+    fld_longitude,
+    fld_description,
+    fld_notes,
+    fld_url,
+    fld_altitude,
+    fld_utm_zone,
+    fld_utm_zone_char,
+    fld_utm_northing,
+    fld_utm_easting,
+    fld_utm,
+    fld_bng,
+    fld_bng_zone,
+    fld_bng_northing,
+    fld_bng_easting,
+    fld_swiss,
+    fld_swiss_northing,
+    fld_swiss_easting,
+    fld_hdop,
+    fld_pdop,
+    fld_vdop,
+    fld_sat,
+    fld_fix,
+    fld_utc_date,
+    fld_utc_time,
+    fld_course,
+    fld_speed,
+    fld_temperature,
+    fld_temperature_f,
+    fld_heartrate,
+    fld_cadence,
+    fld_power,
+    fld_proximity,
+    fld_depth,
+    fld_symbol,
+    fld_date,
+    fld_time,
+    fld_datetime,
+    fld_iso_time,
+    fld_year,
+    fld_month,
+    fld_day,
+    fld_hour,
+    fld_min,
+    fld_sec,
+    fld_ns,
+    fld_ew,
+
+    fld_garmin_city,
+    fld_garmin_postal_code,
+    fld_garmin_state,
+    fld_garmin_country,
+    fld_garmin_addr,
+    fld_garmin_phone_nr,
+    fld_garmin_phone_nr2,
+    fld_garmin_fax_nr,
+    fld_garmin_email,
+    fld_garmin_facility,
+    fld_gc_id,
+    fld_gc_type,
+    fld_gc_container,
+    fld_gc_terr,
+    fld_gc_diff,
+    fld_gc_is_archived,
+    fld_gc_is_available,
+    fld_gc_exported,
+    fld_gc_last_found,
+    fld_gc_placer,
+    fld_gc_placer_id,
+    fld_gc_hint,
+    fld_terminator
+  };
+
+  struct field_t {
+    const char* name;
+    field_e type;
+    uint32_t options;
+  };
+
+  /* Constants */
+
+  /* "UNICSV_FIELD_SEP" and "UNICSV_LINE_SEP" are only used by the writer */
+
+  static constexpr const char* kUnicsvFieldSep = ",";
+  static constexpr const char* kUnicsvLineSep = "\r\n";
+  static constexpr const char* kUnicsvQuoteChar = "\"";
+
+  static constexpr uint32_t kStrLeft = 1;
+  static constexpr uint32_t kStrRight = 2;
+  static constexpr uint32_t kStrAny = 4;
+  static constexpr uint32_t kStrEqual = 8;
+  static constexpr uint32_t kStrCase = 16;
+
+  static constexpr double kUnicsvUnknown = 1e25;
+
+  /* Member Functions */
+
+  long long int unicsv_parse_gc_code(const QString& str) const;
+  static time_t unicsv_parse_date(const char* str, int* consumed);
+  time_t unicsv_parse_time(const char* str, int* usec, time_t* date) const;
+  time_t unicsv_parse_time(const QString& str, int* msec, time_t* date) const;
+  static status_type unicsv_parse_status(const QString& str);
+  QDateTime unicsv_adjust_time(time_t time, const time_t* date) const;
+  static bool unicsv_compare_fields(const QString& s, const field_t* f);
+  void unicsv_fondle_header(QString header);
+  void unicsv_parse_one_line(const QString& ibuf);
+  void unicsv_fatal_outside(const Waypoint* wpt) const;
+  void unicsv_print_str(const QString& s) const;
+  void unicsv_print_data_time(const QDateTime& idt) const;
+  void unicsv_waypt_enum_cb(const Waypoint* wpt);
+  void unicsv_waypt_disp_cb(const Waypoint* wpt);
+  static void unicsv_check_modes(bool test);
+
+  /* Data Members */
+
+  static const field_t fields_def[];
+
+  QVector<field_e> unicsv_fields_tab;
+  double unicsv_altscale{};
+  double unicsv_depthscale{};
+  double unicsv_proximityscale{};
+  const char* unicsv_fieldsep{nullptr};
+  gpsbabel::TextStream* fin{nullptr};
+  gpsbabel::TextStream* fout{nullptr};
+  gpsdata_type unicsv_data_type{unknown_gpsdata};
+  route_head* unicsv_track{nullptr};
+  route_head* unicsv_route{nullptr};
+  char unicsv_outp_flags[(fld_terminator + 8) / 8] {};
+  grid_type unicsv_grid_idx{grid_unknown};
+  int unicsv_datum_idx{};
+  char* opt_datum{nullptr};
+  char* opt_grid{nullptr};
+  char* opt_utc{nullptr};
+  char* opt_filename{nullptr};
+  char* opt_format{nullptr};
+  char* opt_prec{nullptr};
+  char* opt_fields{nullptr};
+  char* opt_codec{nullptr};
+  int unicsv_waypt_ct{};
+  char unicsv_detect{};
+  int llprec{};
+
+  QVector<arglist_t> unicsv_args = {
+    {
+      "datum", &opt_datum, "GPS datum (def. WGS 84)",
+      "WGS 84", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
+    },
+    {
+      "grid",  &opt_grid,  "Write position using this grid.",
+      nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
+    },
+    {
+      "utc",   &opt_utc,   "Write timestamps with offset x to UTC time",
+      nullptr, ARGTYPE_INT, "-23", "+23", nullptr
+    },
+    {
+      "format", &opt_format,   "Write name(s) of format(s) from input session(s)",
+      nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
+    },
+    {
+      "filename", &opt_filename,   "Write filename(s) from input session(s)",
+      nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
+    },
+    {
+      "prec", &opt_prec,   "Precision of numerical coordinates (no grid set)",
+      "6", ARGTYPE_INT | ARGTYPE_HIDDEN, "0", "15", nullptr
+    },
+    {
+      "fields",  &opt_fields,  "Name and order of input fields, separated by '+'",
+      nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
+    },
+    {
+      "codec", &opt_codec, "codec to use for reading and writing strings (default UTF-8)",
+      "UTF-8", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
+    },
+  };
+
+};
+#endif // UNICSV_H_INCLUDED_

--- a/vecs.h
+++ b/vecs.h
@@ -44,6 +44,7 @@
 #include "random.h"
 #include "shape.h"
 #include "subrip.h"
+#include "unicsv.h"
 #include "xcsv.h"
 #include "yahoo.h"
 
@@ -111,7 +112,6 @@ extern ff_vecs_t nmn4_vecs;
 extern ff_vecs_t compegps_vecs;
 #endif // CSVFMTS_ENABLED
 // extern ff_vecs_t yahoo_vecs;
-extern ff_vecs_t unicsv_vecs;
 extern ff_vecs_t gtm_vecs;
 extern ff_vecs_t gpssim_vecs;
 #if CSVFMTS_ENABLED
@@ -338,7 +338,7 @@ private:
   LegacyFormat compegps_fmt {compegps_vecs};
 #endif // CSVFMTS_ENABLED
   YahooFormat yahoo_fmt;
-  LegacyFormat unicsv_fmt {unicsv_vecs};
+  UnicsvFormat unicsv_fmt;
   LegacyFormat gtm_fmt {gtm_vecs};
   LegacyFormat gpssim_fmt {gpssim_vecs};
 #if CSVFMTS_ENABLED


### PR DESCRIPTION
Two bugs are fixed as well:
1. { "datum",  fld_date, STR_ANY } is removed from the fields_def.
Note that the type is fld_date.  I don't think this was ever used.
We do have the datum option to set the datum from the command line.
2. unicsv_fondle_header changed the fields_def type to fld_iso_time
if it was fld_time or fld_date and the value contained "iso".
However, fields_def isn't used outside unicsv_fondle_header, so
this had no effect.