### PR TITLE
clean up cppcheck errors, warnings

### DIFF
--- a/alan.cc
+++ b/alan.cc
@@ -24,8 +24,18 @@
 
  */
 
+#include <cctype>                  // for isprint
+#include <cstdio>                  // for snprintf, sprintf, SEEK_SET, size_t
+#include <cstdint>                 // for int16_t, int32_t, uint8_t, uint32_t, uint16_t, int8_t
+#include <cstring>                 // for memset, strlen, strncpy, memcpy, strncmp
+#include <ctime>                   // for gmtime, time, time_t
+
+#include <QtCore/QString>          // for QString
+#include <QtCore/QVector>          // for QVector
+
 #include "defs.h"
-#include <cstdio>
+#include "gbfile.h"                // for gbfwrite, gbfile, gbfread, gbfclose, gbfopen, gbfseek
+#include "src/core/datetime.h"     // for DateTime
 
 #define MYNAME "alan"
 
@@ -195,9 +205,16 @@ static QVector<arglist_t> trl_args = {
 // FIXME: Why is this code doing its own byte order conversion?
 static unsigned int byte_order()
 {
-  unsigned long test = BYTEORDER_TEST;
+  // avoid cppcheck error: The address of local variable 'test' is accessed at non-zero index.
+  // avoid undefined behavior accessing inactive union member.
+  // avoid  "strict aliasing" warnings.
+  // see https://en.cppreference.com/w/cpp/language/reinterpret_cast#Notes
+  uint32_t test = BYTEORDER_TEST;
+  unsigned char ptr[4];
+  
+  static_assert(sizeof ptr == sizeof test, "byte order test construction failure.");
+  memcpy(&ptr[0], &test, sizeof test);
 
-  auto* ptr = (unsigned char*)(&test);
   unsigned int order = (ptr[0] << 12) | (ptr[1] << 8) | (ptr[2] << 4) | ptr[3];
 
   return order;

--- a/energympro.cc
+++ b/energympro.cc
@@ -43,15 +43,15 @@
 //           local helper functions
 //*******************************************************************************
 void
-EnergymproFormat::read_point(route_head* gpsbabel_route,gpsbabel::DateTime& gpsDateTime) const
+EnergymproFormat::read_point(route_head* gpsbabel_route, gpsbabel::DateTime& gpsDateTime) const
 {
   tw_point point{};
-  gbfread(&point,sizeof(tw_point),1,file_in);
+  gbfread(&point, sizeof(tw_point), 1, file_in);
   if (global_opts.debug_level > 1) {
-    printf("Point: lat:%8u long:%8u alt:%8d ",point.Latitude,point.Longitude,point.Altitude);
-    printf("speed:%6u dist:%5u time:%5d Status:%1u", point.Speed,point.IntervalDist,point.lntervalTime,point.Status);
-    printf("HR:(%3d,%1d)", point.HR_Heartrate,point.HR_Status);
-    printf("Speed:(%8d,%1d)", point.Speed_Speed,point.Speed_Status);
+    printf("Point: lat:%8u long:%8u alt:%8d ", point.Latitude, point.Longitude, point.Altitude);
+    printf("speed:%6u dist:%5u time:%5u Status:%1u", point.Speed, point.IntervalDist, point.lntervalTime, point.Status);
+    printf("HR:(%3d,%1d)", point.HR_Heartrate, point.HR_Status);
+    printf("Speed:(%8u,%1d)", point.Speed_Speed, point.Speed_Status);
     printf("Cad:(%3d,%1d)", point.Cadence_Cadence, point.Cadence_Status);
     printf("Power (Cad:%6d Pow:%6d,%2d)Temp:%3d\n", point.Power_Cadence, point.Power_Power, point.Power_Status, point.Temp);
 
@@ -95,15 +95,15 @@ void
 EnergymproFormat::read_lap() const
 {
   tw_lap lap{};
-  gbfread(&lap,sizeof(tw_lap),1,file_in);
+  gbfread(&lap, sizeof(tw_lap), 1, file_in);
   if (global_opts.debug_level > 1) {
-    printf("LAP: splitTime:%6ds TotalTime:%6ds LapNumber:%5d ",lap.splitTime/10,lap.TotalTime/10,lap.Number);
-    printf("dist:%08dm Cal:%5d Speed:(%6d,%6d) ", lap.lDistance,lap.Calorie,lap.MaxSpeed,lap.AvgSpeed);
-    printf("HR:(%3d,%3d)", lap.MaxHeartrate,lap.AvgHeartrate);
-    printf("Alt:(%6d,%6d) ", lap.MinAlti,lap.MaxAlti);
-    printf("Cad:(%3d,%3d) ", lap.AvgCad,lap.MaxCad);
-    printf("Power:(%3d,%3d)w ", lap.AvgPower,lap.MaxPower);
-    printf("Pt:(%6d,%6d)\n", lap.StartRecPt,lap.FinishRecPt);
+    printf("LAP: splitTime:%6us TotalTime:%6us LapNumber:%5d ", lap.splitTime/10, lap.TotalTime/10, lap.Number);
+    printf("dist:%08um Cal:%5u Speed:(%6u,%6u) ", lap.lDistance, lap.Calorie, lap.MaxSpeed, lap.AvgSpeed);
+    printf("HR:(%3d,%3d)", lap.MaxHeartrate, lap.AvgHeartrate);
+    printf("Alt:(%6d,%6d) ", lap.MinAlti, lap.MaxAlti);
+    printf("Cad:(%3d,%3d) ", lap.AvgCad, lap.MaxCad);
+    printf("Power:(%3d,%3d)w ", lap.AvgPower, lap.MaxPower);
+    printf("Pt:(%6d,%6d)\n", lap.StartRecPt, lap.FinishRecPt);
   }
 }
 
@@ -123,7 +123,7 @@ EnergymproFormat::rd_init(const QString& fname)
   file_in = gbfopen(nullptr, "wb", MYNAME);
   gbsize_t size = gbfcopyfrom(file_in, fileorg_in, 0x7FFFFFFF);
   if (global_opts.debug_level > 1) {
-    printf(MYNAME "  filesize=%d\n",size);
+    printf(MYNAME "  filesize=%u\n", size);
   }
   gbfclose(fileorg_in);
   if (opt_timezone) {
@@ -178,21 +178,21 @@ EnergymproFormat::track_read()
   workout.AvgHeart = gbfgetc(file_in);
 
   if (global_opts.debug_level > 1) {
-    printf("%04d-%02d-%02d ", workout.dateStart.Year+2000,workout.dateStart.Month, workout.dateStart.Day);
-    printf("%02d:%02d:%02d ", workout.timeStart.Hour,workout.timeStart.Minute, workout.timeStart.Second);
-    printf("Total(RecPt:%6d Time:%6ds Dist:%9dm) LapNumber:%5d \n",workout.TotalRecPt,workout.TotalTime/10, workout.TotalDist, workout.LapNumber);
+    printf("%04d-%02d-%02d ", workout.dateStart.Year+2000, workout.dateStart.Month, workout.dateStart.Day);
+    printf("%02d:%02d:%02d ", workout.timeStart.Hour, workout.timeStart.Minute, workout.timeStart.Second);
+    printf("Total(RecPt:%6d Time:%6us Dist:%9um) LapNumber:%5d \n", workout.TotalRecPt, workout.TotalTime/10, workout.TotalDist, workout.LapNumber);
   }
 
   /*
    * GPS year: 2000+; struct tm year: 1900+
    */
-  QDate gpsDate = QDate(workout.dateStart.Year+2000,workout.dateStart.Month,workout.dateStart.Day);
-  QTime gpsTime = QTime(workout.timeStart.Hour,workout.timeStart.Minute,workout.timeStart.Second);
+  QDate gpsDate = QDate(workout.dateStart.Year+2000, workout.dateStart.Month, workout.dateStart.Day);
+  QTime gpsTime = QTime(workout.timeStart.Hour, workout.timeStart.Minute, workout.timeStart.Second);
   gpsbabel::DateTime gpsDateTime;
   if (timezn != nullptr) {
-    gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate,gpsTime,*timezn).toUTC());
+    gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate, gpsTime, *timezn).toUTC());
   } else {
-    gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate,gpsTime,Qt::LocalTime).toUTC());
+    gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate, gpsTime, Qt::LocalTime).toUTC());
   }
 
   auto* gpsbabel_route = new route_head;
@@ -201,7 +201,7 @@ EnergymproFormat::track_read()
   gbfseek(file_in, 0L, SEEK_SET);
 
   for (int point=0; point<workout.TotalRecPt; point++) {
-    read_point(gpsbabel_route,gpsDateTime);
+    read_point(gpsbabel_route, gpsDateTime);
   }
 
   gbfseek(file_in, sizeof(tw_point)*(workout.TotalRecPt), SEEK_SET);

--- a/garmin.cc
+++ b/garmin.cc
@@ -969,7 +969,7 @@ waypoint_prepare()
     } else {
       if (global_opts.smart_names &&
           wpt->gc_data->diff && wpt->gc_data->terr) {
-        snprintf(obuf, sizeof(obuf), "%s%d/%d %s",
+        snprintf(obuf, sizeof(obuf), "%s%u/%u %s",
                  get_gc_info(wpt),
                  wpt->gc_data->diff, wpt->gc_data->terr,
                  CSTRc(src));

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -268,10 +268,10 @@ GlobalsatSportFormat::rd_init(const QString& fname)
   if (opt_dump_file) {
     dumpfile = gbfopen(opt_dump_file, "wb", MYNAME);
     if (!dumpfile) {
-      printf(MYNAME " rd_init() creating dumpfile %s FAILED continue anyway\n",opt_dump_file);
+      printf(MYNAME " rd_init() creating dumpfile %s FAILED continue anyway\n", opt_dump_file);
     } else {
       if (global_opts.debug_level > 1) {
-        printf(MYNAME " rd_init() creating dumpfile %s for writing binary copy of serial stream\n",opt_dump_file);
+        printf(MYNAME " rd_init() creating dumpfile %s for writing binary copy of serial stream\n", opt_dump_file);
       }
     }
   }
@@ -389,16 +389,16 @@ GlobalsatSportFormat::track_read()
       header.DataType = hdr[28];
 
       if (showlist || global_opts.debug_level > 1) {
-        printf("Track[%02i]: %02d-%02d-%02d ", i,header.dateStart.Year,header.dateStart.Month, header.dateStart.Day);
-        printf("%02d:%02d:%02d ", header.timeStart.Hour,header.timeStart.Minute, header.timeStart.Second);
+        printf("Track[%02i]: %02d-%02d-%02d ", i, header.dateStart.Year, header.dateStart.Month, header.dateStart.Day);
+        printf("%02d:%02d:%02d ", header.timeStart.Hour, header.timeStart.Minute, header.timeStart.Second);
         int time_s=header.TotalTime / 10;
         int time_h=time_s/(60*60);
         time_s-=time_h*(60*60);
         int time_m=time_s/60;
         time_s-=time_m*60;
-        printf("Points:%6d Time:%02d:%02d:%02d Dist:%9dm LapCnts:%5d ",	header.TotalPoint, time_h,time_m,time_s, header.TotalDistance, header.LapCnts);
-        printf("Index/StartPt:%d ", header.gh_ptrec.Index);
-        printf("LapIndex/EndPt:%d ", header.gh_laprec.LapIndex);
+        printf("Points:%6u Time:%02d:%02d:%02d Dist:%9um LapCnts:%5d ", header.TotalPoint, time_h, time_m, time_s, header.TotalDistance, header.LapCnts);
+        printf("Index/StartPt:%u ", header.gh_ptrec.Index);
+        printf("LapIndex/EndPt:%u ", header.gh_laprec.LapIndex);
         printf("DataType:0x%x\n", header.DataType);
       }
 
@@ -427,7 +427,9 @@ GlobalsatSportFormat::track_read()
         uint8_t trackDeviceCommand;
         int track_length;
         uint8_t* track_payload = globalsat_read_package(&track_length, &trackDeviceCommand);
-        is_fatal(((track_length == 0) || (track_payload == nullptr)), "track length is 0 bytes or payload nonexistent");
+        if ((track_length == 0) || (track_payload == nullptr)) {
+          fatal(MYNAME ": track length is 0 bytes or payload nonexistent.\n");
+        }
         //      printf("Got track package!!! Train data\n");
 
         uint8_t* dbtrain = track_payload;
@@ -464,11 +466,11 @@ GlobalsatSportFormat::track_read()
         db_train.Sport5 = dbtrain[57];
 
         if (global_opts.debug_level > 1) {
-          printf("\nTrainData:%02d-%02d-%02d ", db_train.dateStart.Year,db_train.dateStart.Month, db_train.dateStart.Day);
+          printf("\nTrainData:%02d-%02d-%02d ", db_train.dateStart.Year, db_train.dateStart.Month, db_train.dateStart.Day);
           printf("%02d:%02d:%02d ", db_train.timeStart.Hour, db_train.timeStart.Minute, db_train.timeStart.Second);
-          printf("Total(points:%6d time:%6ds dist:%9dm) LapCnts:%5d ", db_train.TotalPoint,db_train.TotalTime / 10,db_train.TotalDistance, db_train.LapCnts);
-          printf("Index/StartPt:%d ", db_train.gh_ptrec.Index);
-          printf("LapIndex/EndPt:%d ", db_train.gh_laprec.LapIndex);
+          printf("Total(points:%6u time:%6us dist:%9um) LapCnts:%5d ", db_train.TotalPoint, db_train.TotalTime / 10, db_train.TotalDistance, db_train.LapCnts);
+          printf("Index/StartPt:%u ", db_train.gh_ptrec.Index);
+          printf("LapIndex/EndPt:%u ", db_train.gh_laprec.LapIndex);
           printf("MultiSport:0x%x ", db_train.MultiSport);
         }
         int total_laps = db_train.LapCnts;
@@ -482,7 +484,9 @@ GlobalsatSportFormat::track_read()
         while (total_laps_left > 0) {
           globalsat_send_simple(CommandGetNextTrackSection);
           track_payload = globalsat_read_package(&track_length, &trackDeviceCommand);
-          is_fatal(((track_length == 0) || (track_payload == nullptr)), "track length is 0 bytes or payload nonexistent");
+          if ((track_length == 0) || (track_payload == nullptr)) {
+            fatal(MYNAME ": track length is 0 bytes or payload nonexistent.\n");
+          }
           //	printf("Got track package!!! Laps data\n");
 
           uint8_t* hdr = track_payload;
@@ -505,9 +509,9 @@ GlobalsatSportFormat::track_read()
           if (global_opts.debug_level > 1) {
             printf("Lap Trainheader: %02d-%02d-%02d ", header.dateStart.Year, header.dateStart.Month, header.dateStart.Day);
             printf("%02d:%02d:%02d ", header.timeStart.Hour, header.timeStart.Minute, header.timeStart.Second);
-            printf("Total(points:%6d time:%6ds dist:%9dm) LapCnts:%5d ", header.TotalPoint,header.TotalTime / 10, header.TotalDistance, header.LapCnts);
-            printf("Index/StartPt:%d ", header.gh_ptrec.Index);
-            printf("LapIndex/EndPt:%d ", header.gh_laprec.LapIndex);
+            printf("Total(points:%6u time:%6us dist:%9um) LapCnts:%5d ", header.TotalPoint, header.TotalTime / 10, header.TotalDistance, header.LapCnts);
+            printf("Index/StartPt:%u ", header.gh_ptrec.Index);
+            printf("LapIndex/EndPt:%u ", header.gh_laprec.LapIndex);
             printf("DataType:0x%x\n", header.DataType);
           }
 
@@ -516,12 +520,12 @@ GlobalsatSportFormat::track_read()
            * GPS month: 1-12, struct tm month: 0-11
            */
 
-          QDate gpsDate = QDate(header.dateStart.Year+2000,header.dateStart.Month,header.dateStart.Day);
-          QTime gpsTime = QTime(header.timeStart.Hour,header.timeStart.Minute,header.timeStart.Second);
+          QDate gpsDate = QDate(header.dateStart.Year+2000, header.dateStart.Month, header.dateStart.Day);
+          QTime gpsTime = QTime(header.timeStart.Hour, header.timeStart.Minute, header.timeStart.Second);
           if (timezn != nullptr) {
-            gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate,gpsTime,*timezn).toUTC());
+            gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate, gpsTime, *timezn).toUTC());
           } else {
-            gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate,gpsTime,Qt::LocalTime).toUTC());
+            gpsDateTime = gpsbabel::DateTime(QDateTime(gpsDate, gpsTime, Qt::LocalTime).toUTC());
           }
 
           int laps_in_package = header.gh_laprec.LapIndex - header.gh_ptrec.Index + 1;
@@ -549,13 +553,13 @@ GlobalsatSportFormat::track_read()
             db_lap.EndPt = be_read32(dblap+37);
 
             if (global_opts.debug_level > 1) {
-              printf("     lap[%d] AccruedTime:%ds TotalTime:%ds TotalDist:%dm", lap, db_lap.AccruedTime, db_lap.TotalTime / 10, db_lap.TotalDistance);
-              printf(" Calory:%d MaxSpeed:%d Hearth max:%d avg:%d ", db_lap.Calory, db_lap.MaxSpeed, db_lap.MaxHeart, db_lap.AvgHeart);
+              printf("     lap[%d] AccruedTime:%us TotalTime:%us TotalDist:%um", lap, db_lap.AccruedTime, db_lap.TotalTime / 10, db_lap.TotalDistance);
+              printf(" Calory:%d MaxSpeed:%u Hearth max:%d avg:%d ", db_lap.Calory, db_lap.MaxSpeed, db_lap.MaxHeart, db_lap.AvgHeart);
               printf(" Alt min:%d max:%d", db_lap.MinAlti, db_lap.MaxAlti);
               printf(" Cadns avg:%d best:%d", db_lap.AvgCadns, db_lap.BestCadns);
               printf(" Power avg:%d Max:%d", db_lap.AvgPower, db_lap.MaxPower);
               printf(" MultisportIndex:%d", db_lap.MultiSportIndex);
-              printf(" StartPt:%d EndPt:%d\n", db_lap.StartPt, db_lap.EndPt);
+              printf(" StartPt:%u EndPt:%u\n", db_lap.StartPt, db_lap.EndPt);
             }
           }
           free(track_payload);
@@ -595,9 +599,9 @@ GlobalsatSportFormat::track_read()
             if (global_opts.debug_level > 1) {
               printf("Lap Trainheader: %02d-%02d-%02d ", header.dateStart.Year, header.dateStart.Month, header.dateStart.Day);
               printf("%02d:%02d:%02d ", header.timeStart.Hour, header.timeStart.Minute, header.timeStart.Second);
-              printf("Total(points:%6d time:%6ds dist:%9dm) LapCnts:%5d ", header.TotalPoint, header.TotalTime / 10, header.TotalDistance, header.LapCnts);
-              printf("StartPt:%d ", header.gh_ptrec.StartPt);
-              printf("EndPt:%d ", header.gh_laprec.EndPt);
+              printf("Total(points:%6u time:%6us dist:%9um) LapCnts:%5d ", header.TotalPoint, header.TotalTime / 10, header.TotalDistance, header.LapCnts);
+              printf("StartPt:%u ", header.gh_ptrec.StartPt);
+              printf("EndPt:%u ", header.gh_laprec.EndPt);
               printf("DataType:0x%x\n", header.DataType);
             }
 
@@ -625,10 +629,10 @@ GlobalsatSportFormat::track_read()
               //   qDebug() << "DateTime2:" << gpsDateTime.toString();
               // }
               if (global_opts.debug_level > 1) {
-                printf("     recpoint[%2d] Lat:%f Long:%f Alt:%dm", recpoint,(double)((int32_t) point.Latitude) / 1000000.0,(double)((int32_t) point.Longitude) / 1000000.0, point.Altitude);
-                printf(" Speed:%f HR:%d",(double) point.Speed / 100, point.HeartRate);
-                printf(" Time:%d Cadence:%d", point.IntervalTime, point.Cadence);
-                printf(" PwrCadense:%d Power:%d\n", point.PwrCadence,point.Power);
+                printf("     recpoint[%2d] Lat:%f Long:%f Alt:%dm", recpoint, (double)((int32_t) point.Latitude) / 1000000.0, (double)((int32_t) point.Longitude) / 1000000.0, point.Altitude);
+                printf(" Speed:%f HR:%d", (double) point.Speed / 100, point.HeartRate);
+                printf(" Time:%u Cadence:%d", point.IntervalTime, point.Cadence);
+                printf(" PwrCadense:%d Power:%d\n", point.PwrCadence, point.Power);
               }
 
               auto* wpt = new Waypoint(); // waypt_new();

--- a/gopal.cc
+++ b/gopal.cc
@@ -316,11 +316,11 @@ gopal_read()
           ((speed>maxspeed)||(speed<minspeed)))
        ) {
       if (global_opts.debug_level > 1) {
-        fprintf(stderr,"Problem in or around line %5lu: \"%s\" %lf km/h\n",line,buff,speed);
+        fprintf(stderr,"Problem in or around line %5ld: \"%s\" %lf km/h\n",line,buff,speed);
       }
     } else {
       if (global_opts.debug_level > 1) {
-        fprintf(stderr,"valid                line %5lu: \"%s\" %lf km/h\n",line,buff,speed);
+        fprintf(stderr,"valid                line %5ld: \"%s\" %lf km/h\n",line,buff,speed);
       }
       lastwpt=wpt;
       lat_old=wpt->latitude;

--- a/jeeps/gpscom.cc
+++ b/jeeps/gpscom.cc
@@ -1235,7 +1235,7 @@ int32 GPS_Command_Send_Track_As_Course(const char* port, GPS_PTrack* trk, int32 
     if (trk[i]->ishdr) {
       /* Index of new track, must match the track index in associated course */
       memset(ctk[n_ctk]->trk_ident, 0, sizeof(ctk[n_ctk]->trk_ident));
-      sprintf(ctk[n_ctk]->trk_ident, "%d", crs[new_crs]->track_index);
+      sprintf(ctk[n_ctk]->trk_ident, "%u", crs[new_crs]->track_index);
       new_crs++;
     }
     n_ctk++;

--- a/jeeps/gpsdevice.cc
+++ b/jeeps/gpsdevice.cc
@@ -83,6 +83,8 @@ bool GPS_Get_Ack(gpsdevh* fd, GPS_PPacket* tra, GPS_PPacket* rec)
 void GPS_Make_Packet(GPS_PPacket* packet, US type, UC* data, uint32 n)
 {
   packet->type = type;
-  memcpy(packet->data, data, n);
+  if (n > 0) {
+    memcpy(packet->data, data, n);
+  }
   packet->n = n;
 }

--- a/navilink.cc
+++ b/navilink.cc
@@ -249,7 +249,9 @@ write_packet(unsigned type, const void* payload, unsigned length)
   packet[1] = 0xa2;
   le_write16(packet + 2, length + 1);
   packet[4] = type;
-  memcpy(packet + 5, payload, length);
+  if (length > 0) {
+    memcpy(packet + 5, payload, length);
+  }
   le_write16(packet + length + 5, navilink_checksum_packet(packet + 4, length + 1));
   packet[length + 7] = 0xb0;
   packet[length + 8] = 0xb3;

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -184,7 +184,7 @@ raymarine_read()
     QString str, name, lat, lon;
 
     /* built section identifier */
-    snprintf(sect, sizeof(sect), "Wp%d", ix);
+    snprintf(sect, sizeof(sect), "Wp%u", ix);
 
     /* try to read our most expected values */
     name = inifile_readstr(fin, sect, "Name");

--- a/shape.h
+++ b/shape.h
@@ -105,6 +105,6 @@ private:
       nullptr, ARGTYPE_STRING, "0", nullptr, nullptr
     },
   };
-#endif /* SHAPELIB_ENABLED */
 };
+#endif /* SHAPELIB_ENABLED */
 #endif // SHAPE_H_INCLUDED_

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -23,10 +23,16 @@
 
 */
 
-#include <QtCore/QXmlStreamAttributes>
+#include <QtCore/QLatin1String>         // for QLatin1String
+#include <QtCore/QString>               // for QString
+#include <QtCore/QStringRef>            // for QStringRef
+#include <QtCore/QVector>               // for QVector
+#include <QtCore/QXmlStreamAttribute>   // for QXmlStreamAttribute
+#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QtCore/Qt>                    // for CaseInsensitive
 
 #include "defs.h"
-#include "xmlgeneric.h"
+#include "xmlgeneric.h"                 // for cb_start, cb_end, xg_callback, xg_string, xg_cb_type, xml_deinit, xml_init, xml_read, xg_tag_mapping
 
 static Waypoint* wpt_tmp;
 static int item_count;
@@ -65,12 +71,12 @@ xg_tag_mapping tef_xml_map[] = {
  * tef_start: check for comment "TourExchangeFormat"
  */
 
-void
+static void
 tef_start(xg_string, const QXmlStreamAttributes* attrv)
 {
   bool valid = false;
 
-  foreach(QXmlStreamAttribute attr, *attrv) {
+  for (const auto& attr : *attrv) {
     if (attr.name().compare(QLatin1String("Comment"), Qt::CaseInsensitive) == 0) {
       if (attr.value().compare(QLatin1String("TourExchangeFormat"), Qt::CaseInsensitive) == 0) {
         valid = true;
@@ -93,7 +99,7 @@ static void
 tef_header(xg_string, const QXmlStreamAttributes* attrv)
 {
   route = new route_head;
-  foreach(QXmlStreamAttribute attr, *attrv) {
+  for (const auto& attr : *attrv) {
     if (attr.name().compare(QLatin1String("Name"), Qt::CaseInsensitive) == 0) {
       route->rte_name = attr.value().toString().trimmed();
     } else if (attr.name().compare(QLatin1String("Software"), Qt::CaseInsensitive) == 0) {
@@ -113,9 +119,11 @@ tef_list_start(xg_string, const QXmlStreamAttributes* attrv)
 
 #if OMG
 
-TODO: this whole horrible mess is not covered at all in the test suite,
-so just stub it all out until someone cares. (TEF is rarely used from 
-what we can tell.)
+/*
+ * TODO: this whole horrible mess is not covered at all in the test suite,
+ * so just stub it all out until someone cares. (TEF is rarely used from 
+ * what we can tell.)
+ */
 
 
 /* in "TourExchangeFormat" the following can happen:
@@ -242,7 +250,7 @@ tef_item_start(xg_string, const QXmlStreamAttributes* attrv)
     wpt_tmp->wpt_flags.fmt_use ++;
   }
 
-  foreach(QXmlStreamAttribute attr, *attrv) {
+  for (const auto& attr : *attrv) {
     QString attrstr = attr.value().toString();
 
     if (attr.name().compare(QLatin1String("SegDescription"), Qt::CaseInsensitive) == 0) {

--- a/tpo.cc
+++ b/tpo.cc
@@ -643,7 +643,7 @@ static void tpo_process_tracks()
     //  (what are correct values for KML or other outputs??)
     track_temp->line_width = styles[track_style].wide;
 
-    if (DEBUG) printf("Track Name: %s, ?Type?: %d, Style Name: %s, Width: %d, Dashed: %d, Color: #%s\n",
+    if (DEBUG) printf("Track Name: %s, ?Type?: %u, Style Name: %s, Width: %d, Dashed: %d, Color: #%s\n",
                         qPrintable(track_name), line_type, 
                         qPrintable(styles[track_style].name),
                         styles[track_style].wide,


### PR DESCRIPTION
For cppcheck it is problematic to use is_fatal() to check for someptr == nullptr.  cppcheck won't figure out that code following the is_fatal check can assume that someptr != nullptr.  Alternatively if the code is written as
```
if (someptr == nullptr) {
  fatal("")
}
```
then cppcheck will know the following code can assume someptr != nullptr.