### PR TITLE
let clang-tidy provide default member initializers

### DIFF
--- a/arcdist.h
+++ b/arcdist.h
@@ -40,7 +40,7 @@ public:
   void process() override;
 
 private:
-  double pos_dist;
+  double pos_dist{};
   char* distopt = nullptr;
   char* arcfileopt = nullptr;
   char* rteopt = nullptr;

--- a/bend.h
+++ b/bend.h
@@ -45,8 +45,8 @@ private:
   char* distopt = nullptr;
   char* minangleopt = nullptr;
 
-  double maxDist;
-  double minAngle;
+  double maxDist{};
+  double minAngle{};
 
   RouteList* routes_orig = nullptr;
 

--- a/discard.h
+++ b/discard.h
@@ -58,13 +58,13 @@ private:
   char* iconopt = nullptr;
   QRegExp icon_regex;
 
-  double hdopf;
-  double vdopf;
-  int satpf;
-  int eleminpf;
-  int elemaxpf;
+  double hdopf{};
+  double vdopf{};
+  int satpf{};
+  int eleminpf{};
+  int elemaxpf{};
   gpsdata_type what;
-  route_head* head;
+  route_head* head{};
 
   QVector<arglist_t> args = {
     {

--- a/filter_vecs.h
+++ b/filter_vecs.h
@@ -66,7 +66,7 @@ private:
 
 private:
   struct fl_vecs_t {
-    Filter* vec;
+    Filter* vec{};
     QString name;
     QString desc;
   };

--- a/filter_vecs.h
+++ b/filter_vecs.h
@@ -66,7 +66,7 @@ private:
 
 private:
   struct fl_vecs_t {
-    Filter* vec{};
+    Filter* vec;
     QString name;
     QString desc;
   };

--- a/gpx.h
+++ b/gpx.h
@@ -229,15 +229,15 @@ private:
   void gpx_waypt_bound_calc(const Waypoint* waypointp);
   void gpx_write_bounds();
 
-  QXmlStreamReader* reader;
-  xml_tag* cur_tag;
+  QXmlStreamReader* reader{};
+  xml_tag* cur_tag{};
   QString cdatastr;
   char* opt_logpoint = nullptr;
   char* opt_humminbirdext = nullptr;
   char* opt_garminext = nullptr;
   char* opt_elevation_precision = nullptr;
   int logpoint_ct = 0;
-  int elevation_precision;
+  int elevation_precision{};
 
   // to check if two numbers are equivalent use normalized values.
   const QVersionNumber gpx_1_0 = QVersionNumber(1,0).normalized();
@@ -249,14 +249,14 @@ private:
 
   QString current_tag;
 
-  Waypoint* wpt_tmp;
-  UrlLink* link_;
-  UrlLink* rh_link_;
-  bool cache_descr_is_html;
-  gpsbabel::File* iqfile;
-  gpsbabel::File* oqfile;
-  gpsbabel::XmlStreamWriter* writer;
-  short_handle mkshort_handle;
+  Waypoint* wpt_tmp{};
+  UrlLink* link_{};
+  UrlLink* rh_link_{};
+  bool cache_descr_is_html{};
+  gpsbabel::File* iqfile{};
+  gpsbabel::File* oqfile{};
+  gpsbabel::XmlStreamWriter* writer{};
+  short_handle mkshort_handle{};
   QString link_url;
   QString link_text;
   QString link_type;
@@ -265,14 +265,14 @@ private:
   char* snlen = nullptr;
   char* suppresswhite = nullptr;
   char* urlbase = nullptr;
-  route_head* trk_head;
-  route_head* rte_head;
-  const route_head* current_trk_head;		// Output.
+  route_head* trk_head{};
+  route_head* rte_head{};
+  const route_head* current_trk_head{};		// Output.
   /* used for bounds calculation on output */
-  bounds all_bounds;
-  int next_trkpt_is_new_seg;
+  bounds all_bounds{};
+  int next_trkpt_is_new_seg{};
 
-  FormatSpecificDataList* fs_ptr;
+  FormatSpecificDataList* fs_ptr{};
 
   /*
    * The file-level information.

--- a/height.h
+++ b/height.h
@@ -46,7 +46,7 @@ public:
 private:
   char* addopt        = nullptr;
   char* wgs84tomslopt = nullptr;
-  double addf;
+  double addf{};
   // include static constexpr data member definitions with intializers for grid as private members.
   #include "heightgrid.h"
 

--- a/lowranceusr.h
+++ b/lowranceusr.h
@@ -452,37 +452,37 @@ private:
 
   /* Data Members */
 
-  gbfile*        file_in;
-  gbfile*        file_out;
-  short_handle   mkshort_handle;
+  gbfile*        file_in{};
+  gbfile*        file_out{};
+  short_handle   mkshort_handle{};
 
-  route_head*    trk_head;
-  route_head*    rte_head;
+  route_head*    trk_head{};
+  route_head*    rte_head{};
 
-  int            waypt_uid;
-  int            route_uid;
-  int            trail_uid;
+  int            waypt_uid{};
+  int            route_uid{};
+  int            trail_uid{};
 
-  char*          opt_ignoreicons;
-  char*          opt_writeasicons;
-  char*          opt_seg_break;
-  char*          opt_wversion;
-  char*          opt_title;
-  char*          opt_content_descr;
-  char*          opt_serialnum;
-  int            opt_serialnum_i;
+  char*          opt_ignoreicons{};
+  char*          opt_writeasicons{};
+  char*          opt_seg_break{};
+  char*          opt_wversion{};
+  char*          opt_title{};
+  char*          opt_content_descr{};
+  char*          opt_serialnum{};
+  int            opt_serialnum_i{};
 
   QList<const Waypoint*>* waypt_table{nullptr};
 
-  unsigned short waypt_out_count;
-  int            trail_count, lowrance_route_count;
-  int            trail_point_count;
+  unsigned short waypt_out_count{};
+  int            trail_count{}, lowrance_route_count{};
+  int            trail_point_count{};
   char           continuous = 1;
-  short          num_section_points;
-  char*          merge;
-  int            reading_version;
-  int            rstream_version;
-  int            writing_version;
+  short          num_section_points{};
+  char*          merge{};
+  int            reading_version{};
+  int            rstream_version{};
+  int            writing_version{};
   QTextCodec*    utf16le_codec{nullptr};
 
   template <typename T>

--- a/nmea.h
+++ b/nmea.h
@@ -126,47 +126,47 @@ private:
 
   /* Data Members */
 
-  gbfile* file_in, *file_out;
-  route_head* trk_head;
-  short_handle mkshort_handle;
+  gbfile* file_in{}, *file_out{};
+  route_head* trk_head{};
+  short_handle mkshort_handle{};
   preferred_posn_type posn_type;
-  struct tm tm;
-  Waypoint* curr_waypt;
-  Waypoint* last_waypt;
-  void* gbser_handle;
+  struct tm tm{};
+  Waypoint* curr_waypt{};
+  Waypoint* last_waypt{};
+  void* gbser_handle{};
   QString posn_fname;
   QList<Waypoint*> pcmpt_head;
 
-  int without_date;	/* number of created trackpoints without a valid date */
-  struct tm opt_tm;	/* converted "date" parameter */
+  int without_date{};	/* number of created trackpoints without a valid date */
+  struct tm opt_tm{};	/* converted "date" parameter */
 
-  char* opt_gprmc;
-  char* opt_gpgga;
-  char* opt_gpvtg;
-  char* opt_gpgsa;
-  char* snlenopt;
-  char* optdate;
-  char* getposnarg;
-  char* opt_sleep;
-  char* opt_baud;
-  char* opt_append;
-  char* opt_gisteq;
-  char* opt_ignorefix;
+  char* opt_gprmc{};
+  char* opt_gpgga{};
+  char* opt_gpvtg{};
+  char* opt_gpgsa{};
+  char* snlenopt{};
+  char* optdate{};
+  char* getposnarg{};
+  char* opt_sleep{};
+  char* opt_baud{};
+  char* opt_append{};
+  char* opt_gisteq{};
+  char* opt_ignorefix{};
 
-  long sleepus;
-  int getposn;
-  int append_output;
-  bool amod_waypoint;
+  long sleepus{};
+  int getposn{};
+  int append_output{};
+  bool amod_waypoint{};
 
-  time_t last_time;
-  double last_read_time;   /* Last timestamp of GGA or PRMC */
-  int datum;
-  int had_checksum;
+  time_t last_time{};
+  double last_read_time{};   /* Last timestamp of GGA or PRMC */
+  int datum{};
+  int had_checksum{};
 
   Waypoint* nmea_rd_posn(posn_status*);
   void nmea_rd_posn_init(const QString& fname);
 
-  int wpt_not_added_yet;
+  int wpt_not_added_yet{};
 
   QVector<arglist_t> nmea_args = {
     {"snlen", &snlenopt, "Max length of waypoint name to write", "6", ARGTYPE_INT, "1", "64", nullptr },

--- a/nukedata.h
+++ b/nukedata.h
@@ -40,9 +40,9 @@ public:
   void process() override;
 
 private:
-  char* nukewpts;
-  char* nuketrks;
-  char* nukertes;
+  char* nukewpts{};
+  char* nuketrks{};
+  char* nukertes{};
 
   QVector<arglist_t> args = {
     {

--- a/position.h
+++ b/position.h
@@ -42,12 +42,12 @@ public:
 private:
   route_head* cur_rte = nullptr;
 
-  double pos_dist;
-  double max_diff_time;
+  double pos_dist{};
+  double max_diff_time{};
   char* distopt = nullptr;
   char* timeopt = nullptr;
   char* purge_duplicates = nullptr;
-  bool check_time;
+  bool check_time{};
 
   QVector<arglist_t> args = {
     {

--- a/qstarz_bl_1000.h
+++ b/qstarz_bl_1000.h
@@ -43,13 +43,13 @@ struct qstarz_bl_1000_fsdata : FormatSpecificData {
     return new qstarz_bl_1000_fsdata(*this);
   }
 
-  char rcr; // record reason. possible values are listed in switch-case in .cc file
-  float accelerationX; // horizonal acceleration value measured in acceleration due to gravity or g
-  float accelerationY; // vertical acceleration value measured in acceleration due to gravity or g
-  float accelerationZ; // depth acceleration value measured in acceleration due to gravity or g
-  quint16 maxSNR;
-  qint8 satTotal; // satellite count (view)
-  quint8 batteryPercent;
+  char rcr{}; // record reason. possible values are listed in switch-case in .cc file
+  float accelerationX{}; // horizonal acceleration value measured in acceleration due to gravity or g
+  float accelerationY{}; // vertical acceleration value measured in acceleration due to gravity or g
+  float accelerationZ{}; // depth acceleration value measured in acceleration due to gravity or g
+  quint16 maxSNR{};
+  qint8 satTotal{}; // satellite count (view)
+  quint8 batteryPercent{};
 };
 
 class QstarzBL1000Format : public Format

--- a/radius.h
+++ b/radius.h
@@ -41,7 +41,7 @@ public:
   void deinit() override;
 
 private:
-  double pos_dist;
+  double pos_dist{};
   char* distopt = nullptr;
   char* latopt = nullptr;
   char* lonopt = nullptr;
@@ -49,9 +49,9 @@ private:
   char* nosort = nullptr;
   char* maxctarg = nullptr;
   char* routename = nullptr;
-  int maxct;
+  int maxct{};
 
-  Waypoint* home_pos;
+  Waypoint* home_pos{};
 
   struct extra_data {
     double distance;

--- a/reverse_route.h
+++ b/reverse_route.h
@@ -39,7 +39,7 @@ public:
   void process() override;
 
 private:
-  int prev_new_trkseg;
+  int prev_new_trkseg{};
   QVector<arglist_t> args = {
   };
 

--- a/shape.h
+++ b/shape.h
@@ -79,18 +79,18 @@ private:
   void poly_point(const Waypoint* wpt);
   void poly_deinit(const route_head* rte);
 
-  SHPHandle ihandle;
-  DBFHandle ihandledb;
-  SHPHandle ohandle;
-  DBFHandle ohandledb;
+  SHPHandle ihandle{};
+  DBFHandle ihandledb{};
+  SHPHandle ohandle{};
+  DBFHandle ohandledb{};
 
-  int poly_count;
-  double* polybufx;
-  double* polybufy;
-  double* polybufz;
+  int poly_count{};
+  double* polybufx{};
+  double* polybufy{};
+  double* polybufz{};
   QString ifname;
   QString ofname;
-  int nameFieldIdx;	// the field index of the field with fieldName "name" in the output DBF.
+  int nameFieldIdx{};	// the field index of the field with fieldName "name" in the output DBF.
 
   char* opt_name = nullptr;
   char* opt_url = nullptr;

--- a/smplrout.h
+++ b/smplrout.h
@@ -87,7 +87,7 @@ private:
   char* xteopt = nullptr;
   char* lenopt = nullptr;
   char* relopt = nullptr;
-  void (*waypt_del_fnp)(route_head* rte, Waypoint* wpt);
+  void (*waypt_del_fnp)(route_head* rte, Waypoint* wpt){};
 
   QVector<arglist_t> args = {
     {

--- a/sort.h
+++ b/sort.h
@@ -60,9 +60,9 @@ private:
   SortModeRteHd rte_sort_mode = SortModeRteHd::none;	/* How are we sorting these? */
   SortModeRteHd trk_sort_mode = SortModeRteHd::none;	/* How are we sorting these? */
 
-  char* opt_sm_gcid, *opt_sm_shortname, *opt_sm_description, *opt_sm_time;
-  char* opt_sm_rtenum, *opt_sm_rtename, *opt_sm_rtedesc;
-  char* opt_sm_trknum, *opt_sm_trkname, *opt_sm_trkdesc;
+  char* opt_sm_gcid{}, *opt_sm_shortname{}, *opt_sm_description{}, *opt_sm_time{};
+  char* opt_sm_rtenum{}, *opt_sm_rtename{}, *opt_sm_rtedesc{};
+  char* opt_sm_trknum{}, *opt_sm_trkname{}, *opt_sm_trkdesc{};
 
   QVector<arglist_t> args = {
     {

--- a/trackfilter.h
+++ b/trackfilter.h
@@ -175,7 +175,7 @@ private:
   QList<route_head*> track_list;
   int opt_interval = 0;
   int opt_distance = 0;
-  bool need_time;		/* initialized within trackfilter_init */
+  bool need_time{};		/* initialized within trackfilter_init */
 
   int trackfilter_opt_count();
   qint64 trackfilter_parse_time_opt(const char* arg);

--- a/transform.h
+++ b/transform.h
@@ -41,14 +41,14 @@ public:
   void process() override;
 
 private:
-  char current_target;
-  route_head* current_trk;
-  route_head* current_rte;
+  char current_target{};
+  route_head* current_trk{};
+  route_head* current_rte{};
 
-  char* opt_routes, *opt_tracks, *opt_waypts, *opt_delete, *rpt_name_digits, *opt_rpt_name;
+  char* opt_routes{}, *opt_tracks{}, *opt_waypts{}, *opt_delete{}, *rpt_name_digits{}, *opt_rpt_name{};
   QString current_namepart;
 
-  int name_digits, use_src_name;
+  int name_digits{}, use_src_name{};
 
   const QString RPT = "RPT";
 

--- a/validate.h
+++ b/validate.h
@@ -40,14 +40,14 @@ public:
   void process() override;
 
 private:
-  char* opt_debug;
-  bool debug;
-  char* opt_checkempty;
-  bool checkempty;
-  unsigned int point_ct;
-  unsigned int head_ct;
-  unsigned int segment_ct_start;
-  const char* segment_type;
+  char* opt_debug{};
+  bool debug{};
+  char* opt_checkempty{};
+  bool checkempty{};
+  unsigned int point_ct{};
+  unsigned int head_ct{};
+  unsigned int segment_ct_start{};
+  const char* segment_type{};
   QVector<arglist_t> args = {
     {
       "checkempty", &opt_checkempty, "Check for empty input",

--- a/yahoo.h
+++ b/yahoo.h
@@ -67,8 +67,8 @@ public:
   void rd_deinit() override;
 
 private:
-  Waypoint* wpt_tmp;
-  char* as;
+  Waypoint* wpt_tmp{};
+  char* as{};
 
   QVector<arglist_t> yahoo_args = {
     {


### PR DESCRIPTION
This is the check cppcoreguidelines-pro-type-member-init, but
it was only applied to the class declarations for our filters,
formats and vectors.
This is currently irrelevant as all these are constructed globally,
but if one constructs dynamic instances errors can be seen in gpx, kml, nmea
and lowranceusr formats.