### PR TITLE
Fail configuration if libusb-1.0 is not found

### DIFF
--- a/configure
+++ b/configure
@@ -6328,7 +6328,7 @@ as_fn_error $? "libusb-1.0 not found (--without-libusb to disable)
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 
-			OSJEEPS=jeeps/gpslibusb.o
+		OSJEEPS=jeeps/gpslibusb.o
 
 fi
  ;;

--- a/configure
+++ b/configure
@@ -728,6 +728,7 @@ enable_csv
 enable_most
 enable_filters
 with_zlib
+with_libusb
 with_doc
 '
       ac_precious_vars='build_alias
@@ -1377,6 +1378,7 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-zlib=(included)|system|no
 
+  --without-libusb        disable support for libusb
   --with-doc=DIR          Path where the documentation will be stored.
 
 Some influential environment variables:
@@ -6261,17 +6263,21 @@ fi
   *) :
 
 	GBSER=gbser_posix.o
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libusb-1.0" >&5
-$as_echo_n "checking for libusb-1.0... " >&6; }
+
+# Check whether --with-libusb was given.
+if test "${with_libusb+set}" = set; then :
+  withval=$with_libusb;
+else
+  with_libusb=yes
+fi
+
 	if test "$with_libusb" = "no"; then :
 
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: check not done" >&5
-$as_echo "check not done" >&6; }
 		OSJEEPS=jeeps/gpsusbstub.o
 
 else
 
-
+    # Die if libusb-1.0 not found. This prevents link failures later.
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libusb_init in -lusb-1.0" >&5
 $as_echo_n "checking for libusb_init in -lusb-1.0... " >&6; }
 if ${ac_cv_lib_usb_1_0_libusb_init+:} false; then :
@@ -6315,9 +6321,14 @@ _ACEOF
 
   LIBS="-lusb-1.0 $LIBS"
 
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "libusb-1.0 not found (--without-libusb to disable)
+See \`config.log' for more details" "$LINENO" 5; }
 fi
 
-		OSJEEPS=jeeps/gpslibusb.o
+			OSJEEPS=jeeps/gpslibusb.o
 
 fi
  ;;

--- a/configure.ac
+++ b/configure.ac
@@ -229,14 +229,17 @@ AS_CASE(["$target"], [*-*-cygwin* | *-*-mingw32*], [
 	QT_SYSINC_OPT="-iframework"
 ], [
 	GBSER=gbser_posix.o
-	AC_MSG_CHECKING(for libusb-1.0)
+	AC_ARG_WITH([libusb],
+		[AS_HELP_STRING([--without-libusb], [disable support for libusb])],
+		[],
+		[with_libusb=yes])
 	AS_IF([test "$with_libusb" = "no"], [
-		AC_MSG_RESULT(check not done)
 		OSJEEPS=jeeps/gpsusbstub.o
 	], [
-
-		AC_CHECK_LIB([usb-1.0], [libusb_init])
-		OSJEEPS=jeeps/gpslibusb.o
+    # Die if libusb-1.0 not found. This prevents link failures later.
+		AC_CHECK_LIB([usb-1.0], [libusb_init], [],
+			[AC_MSG_FAILURE(libusb-1.0 not found (--without-libusb to disable))])
+			OSJEEPS=jeeps/gpslibusb.o
 	])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -239,7 +239,7 @@ AS_CASE(["$target"], [*-*-cygwin* | *-*-mingw32*], [
     # Die if libusb-1.0 not found. This prevents link failures later.
 		AC_CHECK_LIB([usb-1.0], [libusb_init], [],
 			[AC_MSG_FAILURE(libusb-1.0 not found (--without-libusb to disable))])
-			OSJEEPS=jeeps/gpslibusb.o
+		OSJEEPS=jeeps/gpslibusb.o
 	])
 ])
 


### PR DESCRIPTION
The configuration flow configuration will now fail if libusb-1.0 isn't found and libusb usage hasn't been disabled with configure option --without-libusb.  This prevents subsequent link failures where the cause is not readily apparent.  This is not relevant for macos builds as libusb is included in gpsbabel on that platform.

With the qmake flow libusb-1.0 is assumed to be available, and compilation will fail if the libusb-1.0 headers are not found.  This behavior is unchanged.

This resolves #563 .