### PR TITLE
fix Qt 5.15.0 Wdeprecated-declarations warnings for

### DIFF
--- a/gui/map.cc
+++ b/gui/map.cc
@@ -117,11 +117,11 @@ Map::~Map()
 #ifdef DEBUG_JS_GENERATION
   if (dbgout_) {
     delete dbgout_;
-    dbgout_ = NULL;
+    dbgout_ = nullptr;
   }
   if (dbgdata_) {
     delete dbgdata_;
-    dbgdata_ = NULL;
+    dbgdata_ = nullptr;
   }
 #endif
 }

--- a/gui/map.h
+++ b/gui/map.h
@@ -28,7 +28,7 @@
 #include <QWebView>
 #endif
 #include <QPlainTextEdit>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QTextStream>
 #include "gpx.h"
@@ -113,7 +113,7 @@ private:
   const Gpx& gpx_;
   bool mapPresent_;
   bool busyCursor_;
-  QTime stopWatch_;
+  QElapsedTimer stopWatch_;
   QPlainTextEdit* textEdit_;
 
   void evaluateJS(const QString& s, bool update = true);


### PR DESCRIPTION
QTime::start()
QTime::elapsed()