### PR TITLE
Double quote to prevent globbing and word splitting of PNAME

### DIFF
--- a/test_encoding_latin1
+++ b/test_encoding_latin1
@@ -21,7 +21,7 @@ filenamebase=test_encoding_file¢
   echo "testing input file name with gpsbabel::File"
   rm -f ${TMPDIR}/test_encoding_file*
   cp ${REFERENCE}/bounds-test.gpx ${TMPDIR}/${filenamebase}.gpx
-  ${PNAME} -i gpx -f ${TMPDIR}/${filenamebase}.gpx -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -i gpx -f ${TMPDIR}/${filenamebase}.gpx -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -29,7 +29,7 @@ filenamebase=test_encoding_file¢
 # test output file name mangling with gpsbabel::File
   echo "testing output file name with gpsbabel::File"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -i gpx -f ${REFERENCE}/bounds-test.gpx -o kml -F ${TMPDIR}/${filenamebase}.kml
+  "${PNAME}" -i gpx -f ${REFERENCE}/bounds-test.gpx -o kml -F ${TMPDIR}/${filenamebase}.kml
   count=$(ls -1 -l ${TMPDIR}/${filenamebase}.kml 2>/dev/null | wc -l)
   if [ $count -lt 1 ]; then
     echo "ERROR: The output file name was mangled."
@@ -40,7 +40,7 @@ filenamebase=test_encoding_file¢
   echo "testing input file name with gbfile stdapi"
   rm -f ${TMPDIR}/test_encoding_file*
   cp ${REFERENCE}/unicsv_subsec.csv ${TMPDIR}/${filenamebase}.csv
-  ${PNAME} -i unicsv -f ${TMPDIR}/${filenamebase}.csv -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -i unicsv -f ${TMPDIR}/${filenamebase}.csv -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -48,7 +48,7 @@ filenamebase=test_encoding_file¢
 # test output file name mangling with gbfile stdapi
   echo "testing output file name with gbfile stdapi"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -i gpx -f ${REFERENCE}/bounds-test.gpx -o unicsv -F ${TMPDIR}/${filenamebase}.csv
+  "${PNAME}" -i gpx -f ${REFERENCE}/bounds-test.gpx -o unicsv -F ${TMPDIR}/${filenamebase}.csv
   count=$(ls -1 -l ${TMPDIR}/${filenamebase}.csv 2>/dev/null | wc -l)
   if [ $count -lt 1 ]; then
     echo "ERROR: The output file name was mangled."
@@ -59,7 +59,7 @@ filenamebase=test_encoding_file¢
   echo "testing input file name with gbfile gzapi"
   rm -f ${TMPDIR}/test_encoding_file*
   cp ${REFERENCE}/sample.gtm.gz ${TMPDIR}/${filenamebase}.gtm.gz
-  ${PNAME} -i gtm -f ${TMPDIR}/${filenamebase}.gtm.gz -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -i gtm -f ${TMPDIR}/${filenamebase}.gtm.gz -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -67,7 +67,7 @@ filenamebase=test_encoding_file¢
 # test output file name mangling with gbfile gzapi
   echo "testing output file name with gbfile gzapi"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -i gpx -f ${REFERENCE}/bounds-test.gpx -o gtm -F ${TMPDIR}/${filenamebase}.gtm.gz
+  "${PNAME}" -i gpx -f ${REFERENCE}/bounds-test.gpx -o gtm -F ${TMPDIR}/${filenamebase}.gtm.gz
   count=$(ls -1 -l ${TMPDIR}/${filenamebase}.gtm.gz 2>/dev/null | wc -l)
   if [ $count -lt 1 ]; then
     echo "ERROR: The output file name was mangled."
@@ -81,7 +81,7 @@ filenamebase=test_encoding_file¢
   do
     cp ${REFERENCE}/gis.osm_railways_free_1.${ext} ${TMPDIR}/${filenamebase}.${ext}
   done
-  ${PNAME} -r -i shape -f ${TMPDIR}/${filenamebase}.shp -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -r -i shape -f ${TMPDIR}/${filenamebase}.shp -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -89,7 +89,7 @@ filenamebase=test_encoding_file¢
 # test output file name mangling with shape files
   echo "testing output file name with shape files"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -r -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
+  "${PNAME}" -r -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
   for ext in cpg dbf shp shx
   do
     count=$(ls -1 -l ${TMPDIR}/${filenamebase}.${ext} 2>/dev/null | wc -l)
@@ -99,7 +99,7 @@ filenamebase=test_encoding_file¢
     fi
   done
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -w -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
+  "${PNAME}" -w -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
   for ext in cpg dbf shp shx
   do
     count=$(ls -1 -l ${TMPDIR}/${filenamebase}.${ext} 2>/dev/null | wc -l)

--- a/test_encoding_utf8
+++ b/test_encoding_utf8
@@ -21,7 +21,7 @@ filenamebase=test_encoding_fileαβγ
   echo "testing input file name with gpsbabel::File"
   rm -f ${TMPDIR}/test_encoding_file*
   cp ${REFERENCE}/bounds-test.gpx ${TMPDIR}/${filenamebase}.gpx
-  ${PNAME} -i gpx -f ${TMPDIR}/${filenamebase}.gpx -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -i gpx -f ${TMPDIR}/${filenamebase}.gpx -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -29,7 +29,7 @@ filenamebase=test_encoding_fileαβγ
 # test output file name mangling with gpsbabel::File
   echo "testing output file name with gpsbabel::File"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -i gpx -f ${REFERENCE}/bounds-test.gpx -o kml -F ${TMPDIR}/${filenamebase}.kml
+  "${PNAME}" -i gpx -f ${REFERENCE}/bounds-test.gpx -o kml -F ${TMPDIR}/${filenamebase}.kml
   count=$(ls -1 -l ${TMPDIR}/${filenamebase}.kml 2>/dev/null | wc -l)
   if [ $count -lt 1 ]; then
     echo "ERROR: The output file name was mangled."
@@ -40,7 +40,7 @@ filenamebase=test_encoding_fileαβγ
   echo "testing input file name with gbfile stdapi"
   rm -f ${TMPDIR}/test_encoding_file*
   cp ${REFERENCE}/unicsv_subsec.csv ${TMPDIR}/${filenamebase}.csv
-  ${PNAME} -i unicsv -f ${TMPDIR}/${filenamebase}.csv -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -i unicsv -f ${TMPDIR}/${filenamebase}.csv -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -48,7 +48,7 @@ filenamebase=test_encoding_fileαβγ
 # test output file name mangling with gbfile stdapi
   echo "testing output file name with gbfile stdapi"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -i gpx -f ${REFERENCE}/bounds-test.gpx -o unicsv -F ${TMPDIR}/${filenamebase}.csv
+  "${PNAME}" -i gpx -f ${REFERENCE}/bounds-test.gpx -o unicsv -F ${TMPDIR}/${filenamebase}.csv
   count=$(ls -1 -l ${TMPDIR}/${filenamebase}.csv 2>/dev/null | wc -l)
   if [ $count -lt 1 ]; then
     echo "ERROR: The output file name was mangled."
@@ -59,7 +59,7 @@ filenamebase=test_encoding_fileαβγ
   echo "testing input file name with gbfile gzapi"
   rm -f ${TMPDIR}/test_encoding_file*
   cp ${REFERENCE}/sample.gtm.gz ${TMPDIR}/${filenamebase}.gtm.gz
-  ${PNAME} -i gtm -f ${TMPDIR}/${filenamebase}.gtm.gz -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -i gtm -f ${TMPDIR}/${filenamebase}.gtm.gz -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -67,7 +67,7 @@ filenamebase=test_encoding_fileαβγ
 # test output file name mangling with gbfile gzapi
   echo "testing output file name with gbfile gzapi"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -i gpx -f ${REFERENCE}/bounds-test.gpx -o gtm -F ${TMPDIR}/${filenamebase}.gtm.gz
+  "${PNAME}" -i gpx -f ${REFERENCE}/bounds-test.gpx -o gtm -F ${TMPDIR}/${filenamebase}.gtm.gz
   count=$(ls -1 -l ${TMPDIR}/${filenamebase}.gtm.gz 2>/dev/null | wc -l)
   if [ $count -lt 1 ]; then
     echo "ERROR: The output file name was mangled."
@@ -81,7 +81,7 @@ filenamebase=test_encoding_fileαβγ
   do
     cp ${REFERENCE}/gis.osm_railways_free_1.${ext} ${TMPDIR}/${filenamebase}.${ext}
   done
-  ${PNAME} -r -i shape -f ${TMPDIR}/${filenamebase}.shp -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
+  "${PNAME}" -r -i shape -f ${TMPDIR}/${filenamebase}.shp -o kml -F ${TMPDIR}/test_encoding_fileo.kml || {
     echo "ERROR: The input file name was mangled."
     errorcount=`expr $errorcount + 1`
   }
@@ -89,7 +89,7 @@ filenamebase=test_encoding_fileαβγ
 # test output file name mangling with shape files
   echo "testing output file name with shape files"
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -r -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
+  "${PNAME}" -r -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
   for ext in cpg dbf shp shx
   do
     count=$(ls -1 -l ${TMPDIR}/${filenamebase}.${ext} 2>/dev/null | wc -l)
@@ -99,7 +99,7 @@ filenamebase=test_encoding_fileαβγ
     fi
   done
   rm -f ${TMPDIR}/test_encoding_file*
-  ${PNAME} -w -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
+  "${PNAME}" -w -i gpx -f ${REFERENCE}/bounds-test.gpx -o shape -F ${TMPDIR}/${filenamebase}.shp
   for ext in cpg dbf shp shx
   do
     count=$(ls -1 -l ${TMPDIR}/${filenamebase}.${ext} 2>/dev/null | wc -l)

--- a/testo
+++ b/testo
@@ -84,7 +84,7 @@ sort_and_compare()
 
 gpsbabel()
 {
-	${PNAME} "$@" || {
+	"${PNAME}" "$@" || {
 		echo "$PNAME returned error $?"
 		echo "($PNAME $@)"
 		errorcount=`expr $errorcount + 1`

--- a/testo.d/track-discard.test
+++ b/testo.d/track-discard.test
@@ -6,7 +6,7 @@ rm -f ${TMPDIR}/discard*
 
 # gpx file with points with missing timestamps (has 4 trkpts, 2 duplicate times, 1 missing time, expect merge to output 2 valid trkpts)
 # expecting this to fail during a standard -x track,merge so call directly rather than via gpsbabel function
-${PNAME} -t -i gpx -f ${REFERENCE}/track/trackfilter_discard.gpx -x track,merge -o csv -F - 2> ${TMPDIR}/discard.err && {
+"${PNAME}" -t -i gpx -f ${REFERENCE}/track/trackfilter_discard.gpx -x track,merge -o csv -F - 2> ${TMPDIR}/discard.err && {
          echo "$PNAME succeeded! (it shouldn't have with this input...)"
 }
 # check error message is what we expected

--- a/testo.d/validate.test
+++ b/testo.d/validate.test
@@ -2,7 +2,7 @@ gpsbabel -i gpx -f ${REFERENCE}/basecamp.gpx -x validate,debug > /dev/null 2> ${
 compare ${REFERENCE}/validate_debug.log ${TMPDIR}/validate_debug.log
 
 # expecting this to fail so call directly rather than via gpsbabel function
-${PNAME} -i gpx -f ${REFERENCE}/empty.gpx -x validate,checkempty > /dev/null 2> ${TMPDIR}/validate_empty.log && {
+"${PNAME}" -i gpx -f ${REFERENCE}/empty.gpx -x validate,checkempty > /dev/null 2> ${TMPDIR}/validate_empty.log && {
   echo "${PNAME} succeeded! (it shouldn't have with this input...)"
 }
 compare ${REFERENCE}/validate_empty.log ${TMPDIR}/validate_empty.log

--- a/testo.d/xol.test
+++ b/testo.d/xol.test
@@ -12,7 +12,7 @@ compare ${REFERENCE}/xol-sample.gpx ${TMPDIR}/xol-sample.gpx
 # check xmlgeneric can detect no input file
 # we expect this to fail
 rm -f ${TMPDIR}/xol-sample_si.gpx
-${PNAME} -i xol -f ${REFERENCE}/doesnotexist -o gpx -F ${TMPDIR}/xol-sample_si.gpx 2> ${TMPDIR}/nonexistent.err && {
+"${PNAME}" -i xol -f ${REFERENCE}/doesnotexist -o gpx -F ${TMPDIR}/xol-sample_si.gpx 2> ${TMPDIR}/nonexistent.err && {
          echo "${PNAME} succeeded! (it shouldn't have with this input...)"
 }
 # check error message is what we expected


### PR DESCRIPTION
This allows testing on windows with the installed version of
gpsbabel.exe, which is likely in C:\Program Files (x86)\GPSBabel.