### PR TITLE
Fix NMEA parsing creating Null Island waypoints

### DIFF
--- a/nmea.cc
+++ b/nmea.cc
@@ -402,11 +402,13 @@ NmeaFormat::gpgga_parse(char* ibuf)
   double hms = 0;
   if (fields.size() > 1) hms = fields[1].toDouble();
   double latdeg = 0;
-  if (fields.size() > 2) latdeg = fields[2].toDouble();
+  bool lat_ok = false;
+  if (fields.size() > 2) latdeg = fields[2].toDouble(&lat_ok);
   QChar latdir = 'N';
   if (fields.size() > 3) latdir = fields[3][0];
   double lngdeg = 0;
-  if (fields.size() > 4) lngdeg = fields[4].toDouble();
+  bool lng_ok = false;
+  if (fields.size() > 4) lngdeg = fields[4].toDouble(&lng_ok);
   QChar lngdir = 'W';
   if (fields.size() > 5) lngdir = fields[5][0];
   int fix = fix_unknown;
@@ -431,7 +433,7 @@ NmeaFormat::gpgga_parse(char* ibuf)
    * that is more comfortable than nothing at all...
    */
   CHECK_BOOL(opt_ignorefix);
-  if ((fix <= 0) && (read_mode != rm_serial || (latdeg == 0.0 && lngdeg == 0.0)) && (!opt_ignorefix)) {
+  if ((fix <= 0) && (read_mode != rm_serial || !lat_ok || !lng_ok) && (!opt_ignorefix)) {
     return;
   }
 

--- a/nmea.cc
+++ b/nmea.cc
@@ -426,11 +426,12 @@ NmeaFormat::gpgga_parse(char* ibuf)
 
   /*
    * In serial mode, allow the fix with an invalid position through
+   * (unless if the position lat/lng is absent or completely bogus)
    * as serial units will often spit a remembered position up and
    * that is more comfortable than nothing at all...
    */
   CHECK_BOOL(opt_ignorefix);
-  if ((fix <= 0) && (read_mode != rm_serial) && (!opt_ignorefix)) {
+  if ((fix <= 0) && (read_mode != rm_serial || (latdeg == 0.0 && lngdeg == 0.0)) && (!opt_ignorefix)) {
     return;
   }
 

--- a/nmea.cc
+++ b/nmea.cc
@@ -402,13 +402,11 @@ NmeaFormat::gpgga_parse(char* ibuf)
   double hms = 0;
   if (fields.size() > 1) hms = fields[1].toDouble();
   double latdeg = 0;
-  bool lat_ok = false;
-  if (fields.size() > 2) latdeg = fields[2].toDouble(&lat_ok);
+  if (fields.size() > 2) latdeg = fields[2].toDouble();
   QChar latdir = 'N';
   if (fields.size() > 3) latdir = fields[3][0];
   double lngdeg = 0;
-  bool lng_ok = false;
-  if (fields.size() > 4) lngdeg = fields[4].toDouble(&lng_ok);
+  if (fields.size() > 4) lngdeg = fields[4].toDouble();
   QChar lngdir = 'W';
   if (fields.size() > 5) lngdir = fields[5][0];
   int fix = fix_unknown;
@@ -433,7 +431,7 @@ NmeaFormat::gpgga_parse(char* ibuf)
    * that is more comfortable than nothing at all...
    */
   CHECK_BOOL(opt_ignorefix);
-  if ((fix <= 0) && (read_mode != rm_serial || !lat_ok || !lng_ok) && (!opt_ignorefix)) {
+  if ((fix <= 0) && (read_mode != rm_serial || (latdeg == 0.0 && lngdeg == 0.0)) && (!opt_ignorefix)) {
     return;
   }
 


### PR DESCRIPTION
Fix parsing of NMEA [GPGGA](https://www.gpsinformation.org/dale/nmea.htm#GGA) sentences: ones with 0 "fix quality" (i.e. "invalid") are allowed in serial (i.e. live GPS) mode because (according to the comment) some GPS devices will report previously-read data in the absence of a current good fix. Adjust this allowance to require an actual coordinate value; at least one popular USB GPS device will issue GPGGA such as `$GPGGA,010222.00,,,,,0,00,99.99,,,,,,*65` if it loses a good fix, and the empty lat/lng coordinates (`,,,,,`) are parsed as 0N 0W (a.k.a. "Null Island").

[`QString::toDouble()`](https://doc.qt.io/qt-5/qstring.html#toDouble)'s optional `bool *ok` argument won't report a problem with an empty input so we simply check for 0 lat/lng.