### PR TITLE
support doc creation in qmake.

### DIFF
--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -331,15 +331,16 @@ QMAKE_EXTRA_TARGETS += index.html
 
 #
 # The .fo and PDF versions depend on additional tools.
-# 'fop' must be obtained from http://xmlgraphics.apache.org/fop/
+# 'fop' must be obtained from your distribution or http://xmlgraphics.apache.org/fop/
 #   0.92beta seems to work OK, BUT.
 #   * If you have a package called 'docbook-xml-website' it's reported
 #     to prevent the build from working.   Remove it. (Suse)
 #   * Sun Java seems to be required.   GCJ 1.4.2 doesn't work.   You can
 #     force Sun Java to be used by creating ~/.foprc with 'rpm_mode=' (Fedora)
 #     Get it from http://www.java.com
-# The Hyphenation package must be installed from
-#   http://offo.sourceforge.net/hyphenation/index.html - be sure to get the
+# The Hyphenation package must be installed.  Perhaps your distribution has
+#   a package, e.g. Ubuntu libfop-java, or you can go to the project site at
+#   http://offo.sourceforge.net/ - be sure to get the
 #   version that corresponds to the version of FOP that you used above.
 # The docbook XSL must be 1.71.1 or higher.
 #   * Remember to update /etc/xml/catalogs if you manually update this.

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -16,6 +16,7 @@ if(equals(QT_MAJOR_VERSION, $$MIN_QT_VERSION_MAJOR):equals(QT_MINOR_VERSION, $$M
 QT -= gui
 
 TARGET = gpsbabel
+VERSION = 1.7.0
 
 CONFIG += console
 CONFIG -= app_bundle
@@ -305,12 +306,68 @@ linux{
 cppcheck.commands = cppcheck --enable=all --force --config-exclude=zlib --config-exclude=shapelib $(INCPATH) $$ALL_FMTS $$FILTERS $$SUPPORT $$JEEPS
 QMAKE_EXTRA_TARGETS += cppcheck
 
-gpsbabel.pdf.depends = FORCE
+!defined(WEB, var) {
+  WEB = ../babelweb
+}
+!defined(DOCVERSION, var) {
+  DOCVERSION=$${VERSION}
+}
+
+index.html.depends = gpsbabel FORCE
+index.html.commands += web=\$\${WEB:-$${WEB}} &&
+index.html.commands += docversion=\$\${DOCVERSION:-$${DOCVERSION}} &&
+index.html.commands += mkdir -p \$\${web}/htmldoc-\$\${docversion} &&
+index.html.commands += perl xmldoc/makedoc &&
+index.html.commands += xmlwf xmldoc/readme.xml &&  #check for well-formedness
+index.html.commands += xmllint --noout --valid xmldoc/readme.xml &&    #validate
+index.html.commands += xsltproc \
+  --stringparam base.dir "\$\${web}/htmldoc-\$\${docversion}/" \
+  --stringparam root.filename "index" \
+  xmldoc/babelmain.xsl \
+  xmldoc/readme.xml &&
+index.html.commands += tools/fixdoc \$\${web}/htmldoc-\$\${docversion} "GPSBabel \$\${docversion}:" &&
+index.html.commands += tools/mkcapabilities \$\${web} \$\${web}/htmldoc-\$\${docversion}
+QMAKE_EXTRA_TARGETS += index.html
+
+#
+# The .fo and PDF versions depend on additional tools.
+# 'fop' must be obtained from http://xmlgraphics.apache.org/fop/
+#   0.92beta seems to work OK, BUT.
+#   * If you have a package called 'docbook-xml-website' it's reported
+#     to prevent the build from working.   Remove it. (Suse)
+#   * Sun Java seems to be required.   GCJ 1.4.2 doesn't work.   You can
+#     force Sun Java to be used by creating ~/.foprc with 'rpm_mode=' (Fedora)
+#     Get it from http://www.java.com
+# The Hyphenation package must be installed from
+#   http://offo.sourceforge.net/hyphenation/index.html - be sure to get the
+#   version that corresponds to the version of FOP that you used above.
+# The docbook XSL must be 1.71.1 or higher.
+#   * Remember to update /etc/xml/catalogs if you manually update this.
+#
+
+gpsbabel.html.depends = gpsbabel FORCE
+gpsbabel.html.commands += perl xmldoc/makedoc &&
+gpsbabel.html.commands += xsltproc \
+   --output gpsbabel.html \
+   --stringparam toc.section.depth "1" \
+   --stringparam html.cleanup "1" \
+   --stringparam make.clean.html "1" \
+   --stringparam html.valid.html "1" \
+   --stringparam html.stylesheet \
+   "https://www.gpsbabel.org/style3.css" \
+   http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl \
+ xmldoc/readme.xml
+QMAKE_EXTRA_TARGETS += gpsbabel.html
+
+gpsbabel.pdf.depends = gpsbabel FORCE
+gpsbabel.pdf.commands += web=\$\${WEB:-$${WEB}} &&
+gpsbabel.pdf.commands += docversion=\$\${DOCVERSION:-$${DOCVERSION}} &&
 gpsbabel.pdf.commands += perl xmldoc/makedoc && 
 gpsbabel.pdf.commands += xmlwf xmldoc/readme.xml && #check for well-formedness
 gpsbabel.pdf.commands += xmllint --noout --valid xmldoc/readme.xml &&   #validate
 gpsbabel.pdf.commands += xsltproc -o gpsbabel.fo xmldoc/babelpdf.xsl xmldoc/readme.xml &&
-gpsbabel.pdf.commands += HOME=. fop -q -fo gpsbabel.fo -pdf gpsbabel.pdf
-#gpsbabel.pdf.commands += cp gpsbabel.pdf $(WEB)/htmldoc-$(DOCVERSION)/gpsbabel-$(DOCVERSION).pdf
+gpsbabel.pdf.commands += HOME=. fop -q -fo gpsbabel.fo -pdf gpsbabel.pdf &&
+gpsbabel.pdf.commands += mkdir -p \$\${web}/htmldoc-\$\${docversion} &&
+gpsbabel.pdf.commands += cp gpsbabel.pdf \$\${web}/htmldoc-\$\${docversion}/gpsbabel-\$\${docversion}.pdf
 QMAKE_EXTRA_TARGETS += gpsbabel.pdf
 

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -330,7 +330,9 @@ index.html.commands += tools/mkcapabilities \$\${web} \$\${web}/htmldoc-\$\${doc
 QMAKE_EXTRA_TARGETS += index.html
 
 #
-# The .fo and PDF versions depend on additional tools.
+# The gpsbabel.pdf target depends on additional tools.
+# On macOS you can 'brew install fop' to get fop and the hyphenation package.
+# On Debian/Ubuntu you can 'apt-get install fop' to get fop and the hyphenation package.
 # 'fop' must be obtained from your distribution or http://xmlgraphics.apache.org/fop/
 #   0.92beta seems to work OK, BUT.
 #   * If you have a package called 'docbook-xml-website' it's reported
@@ -338,10 +340,11 @@ QMAKE_EXTRA_TARGETS += index.html
 #   * Sun Java seems to be required.   GCJ 1.4.2 doesn't work.   You can
 #     force Sun Java to be used by creating ~/.foprc with 'rpm_mode=' (Fedora)
 #     Get it from http://www.java.com
-# The Hyphenation package must be installed.  Perhaps your distribution has
-#   a package, e.g. Ubuntu libfop-java, or you can go to the project site at
-#   http://offo.sourceforge.net/ - be sure to get the
+# The Hyphenation package must be obtained from your distribution or
+#   the project site at http://offo.sourceforge.net/ - be sure to get the
 #   version that corresponds to the version of FOP that you used above.
+#
+#
 # The docbook XSL must be 1.71.1 or higher.
 #   * Remember to update /etc/xml/catalogs if you manually update this.
 #

--- a/Makefile.in
+++ b/Makefile.in
@@ -158,7 +158,7 @@ gpsbabel$(EXEEXT): configure Makefile $(OBJS) @USB_DEPS@ @GPSBABEL_DEBUG@
 gpsbabel-debug: $(OBJS) @USB_DEPS@
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(OBJS) @LIBS@ $(QT_LIBS) @USB_LIBS@ $(OUTPUT_SWITCH)$@
 
-Makefile gbversion.h: Makefile.in config.status xmldoc/makedoc.in \
+Makefile gbversion.h: Makefile.in config.status \
 	  gbversion.h.in gui/setup.iss.in
 	CONFIG_FILES=$@ CONFIG_HEADERS= $(SHELL) ./config.status
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -233,7 +233,7 @@ dep:
 	echo '	$$(srcdir)/mkstyle.sh > internal_styles.cc || (rm -f internal_styles.cc ; exit 1)'  >> /tmp/dep
 	echo Edit Makefile.in and bring in /tmp/dep
 
-$(WEB)/htmldoc-$(DOCVERSION)/index.html: FORCE
+$(WEB)/htmldoc-$(DOCVERSION)/index.html: gpsbabel FORCE
 	mkdir -p $(WEB)/htmldoc-$(DOCVERSION)
 	perl xmldoc/makedoc
 	xmlwf xmldoc/readme.xml		#check for well-formedness
@@ -244,7 +244,7 @@ $(WEB)/htmldoc-$(DOCVERSION)/index.html: FORCE
 	 xmldoc/babelmain.xsl \
 	 xmldoc/readme.xml
 	tools/fixdoc $(WEB)/htmldoc-$(DOCVERSION) "GPSBabel $(DOCVERSION):"
-	tools/mkcapabilities
+	tools/mkcapabilities $(WEB) $(WEB)/htmldoc-$(DOCVERSION)
 
 #
 # The .fo and PDF versions depend on additional tools.
@@ -261,7 +261,7 @@ $(WEB)/htmldoc-$(DOCVERSION)/index.html: FORCE
 # The docbook XSL must be 1.71.1 or higher.
 #   * Remember to update /etc/xml/catalogs if you manually update this.
 #
-gpsbabel.fo:  FORCE
+gpsbabel.fo: gpsbabel FORCE
 	perl xmldoc/makedoc
 	xmlwf xmldoc/readme.xml		#check for well-formedness
 	xmllint --noout --valid xmldoc/readme.xml    	#validate
@@ -269,11 +269,12 @@ gpsbabel.fo:  FORCE
 
 gpsbabel.pdf: gpsbabel.fo
 	HOME=. fop -q -fo gpsbabel.fo -pdf gpsbabel.pdf
+	mkdir -p $(WEB)/htmldoc-$(DOCVERSION)
 	cp gpsbabel.pdf $(WEB)/htmldoc-$(DOCVERSION)/gpsbabel-$(DOCVERSION).pdf
 
 
-gpsbabel.html: FORCE # gpsbabel
-	# perl xmldoc/makedoc
+gpsbabel.html: gpsbabel FORCE
+	perl xmldoc/makedoc
 	xsltproc \
 	  --output $@ \
 	  --stringparam toc.section.depth "1" \

--- a/configure
+++ b/configure
@@ -6549,9 +6549,7 @@ as_dir=zlib/contrib/minizip; as_fn_mkdir_p
 as_dir=testo.d; as_fn_mkdir_p
 as_dir=mac/libusb; as_fn_mkdir_p
 
-ac_config_files="$ac_config_files Makefile gbversion.h gui/setup.iss xmldoc/makedoc"
-
-ac_config_files="$ac_config_files tools/mkcapabilities"
+ac_config_files="$ac_config_files Makefile gbversion.h gui/setup.iss"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -7249,8 +7247,6 @@ do
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "gbversion.h") CONFIG_FILES="$CONFIG_FILES gbversion.h" ;;
     "gui/setup.iss") CONFIG_FILES="$CONFIG_FILES gui/setup.iss" ;;
-    "xmldoc/makedoc") CONFIG_FILES="$CONFIG_FILES xmldoc/makedoc" ;;
-    "tools/mkcapabilities") CONFIG_FILES="$CONFIG_FILES tools/mkcapabilities" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac
@@ -7801,11 +7797,6 @@ $as_echo "$as_me: $ac_file is unchanged" >&6;}
 
   esac
 
-
-  case $ac_file$ac_mode in
-    "tools/mkcapabilities":F) chmod +x tools/mkcapabilities ;;
-
-  esac
 done # for ac_tag
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -369,6 +369,5 @@ AS_MKDIR_P([zlib/contrib/minizip])
 AS_MKDIR_P([testo.d])
 AS_MKDIR_P([mac/libusb])
 
-AC_CONFIG_FILES([Makefile gbversion.h gui/setup.iss xmldoc/makedoc])
-AC_CONFIG_FILES([tools/mkcapabilities], [chmod +x tools/mkcapabilities])
+AC_CONFIG_FILES([Makefile gbversion.h gui/setup.iss])
 AC_OUTPUT

--- a/tools/mkcapabilities
+++ b/tools/mkcapabilities
@@ -1,6 +1,8 @@
+#!/bin/sh
 #
-# mkcapabilities.in is used to create mkcapabilities.  
-#
+capabilitiesdir=$1
+htmldocdir=$2
+
 ./gpsbabel -^2 | sed 's/\&/\&amp;/' | awk  -F'\t' '
 function getcap(type, cap, sname, lname) {
 	if (type == "internal") return
@@ -19,12 +21,12 @@ function getcap(type, cap, sname, lname) {
 }
 
 getcap($1, $2, $3, $5)
-' > @DOCDIR@capabilities.inc > @DOCDIR@capabilities.inc
+' > ${capabilitiesdir}/capabilities.inc
 
 FMTS=`./gpsbabel -^2 | grep -v '^internal' | sed 's/\&/\&amp;/' | awk  -F'\t' '{print $3}'`
 for f in $FMTS
 do
-	[ ! -f @DOCDIR@/htmldoc-@DOCVERSION@/fmt_${f}.html ] && echo Missing doc for $f
+	[ ! -f ${htmldocdir}/fmt_${f}.html ] && echo Missing doc for $f
 done
 
 exit 0

--- a/xmldoc/.gitignore
+++ b/xmldoc/.gitignore
@@ -1,2 +1,1 @@
 /autogen/
-/makedoc

--- a/xmldoc/makedoc
+++ b/xmldoc/makedoc
@@ -31,14 +31,14 @@ sub expandrw {
 sub expandoptions {
    my $opts = shift;
    my $res = "  <para role=\"fmtcapshdr\">\n    This format can...\n    <itemizedlist>\n";
-   
+
    $res .= expandrw( substr($opts,0,1), substr($opts,1,1), 'waypoints' );
    $res .= expandrw( substr($opts,2,1), substr($opts,3,1), 'tracks' );
    $res .= expandrw( substr($opts,4,1), substr($opts,5,1), 'routes' );
- 
+
    $res .= "    </itemizedlist></para>\n";
 
-   $res;  
+   $res;
 }
 
 sub expandsuboptions {
@@ -51,11 +51,11 @@ sub expandsuboptions {
 
   # Comma separate the human-readable variation.
   $olist =~ s/> </>, </g;
- 
+
   $res .= "<para>This format has the following options: ";
   $res .= $olist;
   $res .= ".</para>";
- 
+
   $res;
 }
 
@@ -89,7 +89,6 @@ sub includef {
 
 
 
-@dir=`mkdir -p @DOCDIR@`;
 $dir = $0;
 $dir =~ s:/.*$::;
 


### PR DESCRIPTION
pass parameters to tools/mkcapabilites instead of
using text replacement in configure.

text replacement in xmldoc/makedoc was unnecessary, directory
creation is handled in the recipee.

there is some foolishness in GPSBabel.pro to allow overriding of
WEB and DOCVERSION on the command line of make.  If those values
are known when running qmake it could be slightly simpler.