### PR TITLE
Allow gpsbabel to build `--without-libusb`

### DIFF
--- a/jeeps/gpsusbstub.cc
+++ b/jeeps/gpsusbstub.cc
@@ -34,7 +34,7 @@ typedef struct gpsdevh gpsdevh;
 int
 gusb_init(const char* portname, gpsdevh** dh)
 {
-  Fatal() << no_usb;
+  fatal(no_usb);
   return 0;
 }
 


### PR DESCRIPTION
Build fails when configured `--without-libusb`:
```
jeeps/gpsusbstub.cc:39:3: error: ‘Fatal’ was not declared in this scope
   Fatal() << no_usb;
   ^~~~~
jeeps/gpsusbstub.cc:39:3: note: suggested alternative: ‘fatal’
   Fatal() << no_usb;
   ^~~~~
   fatal
```