### PR TITLE
support third party library configuration in qmake

### DIFF
--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -10,7 +10,7 @@ count(MIN_QT_VERSION_PATCH, 0): MIN_QT_VERSION_PATCH = 0
 lessThan(QT_MAJOR_VERSION, $$MIN_QT_VERSION_MAJOR) | \
 if(equals(QT_MAJOR_VERSION, $$MIN_QT_VERSION_MAJOR):lessThan(QT_MINOR_VERSION, $$MIN_QT_VERSION_MINOR)) | \
 if(equals(QT_MAJOR_VERSION, $$MIN_QT_VERSION_MAJOR):equals(QT_MINOR_VERSION, $$MIN_QT_VERSION_MINOR):lessThan(QT_PATCH_VERSION, $$MIN_QT_VERSION_PATCH)) {
-  error("$$QMAKE_QMAKE uses Qt version $$QT_VERSION but version $${MIN_QT_VERSION_MAJOR}.$${MIN_QT_VERSION_MINOR}.$${MIN_QT_VERSION_PATCH} or newer is required.")  
+  error("$$QMAKE_QMAKE uses Qt version $$QT_VERSION but version $${MIN_QT_VERSION_MAJOR}.$${MIN_QT_VERSION_MINOR}.$${MIN_QT_VERSION_PATCH} or newer is required.")
 }
 
 QT -= gui
@@ -20,6 +20,7 @@ TARGET = gpsbabel
 CONFIG += console
 CONFIG -= app_bundle
 CONFIG += c++14
+CONFIG += link_pkgconfig
 
 TEMPLATE = app
 
@@ -61,13 +62,6 @@ FILTERS=position.cc radius.cc duplicate.cc arcdist.cc polygon.cc smplrout.cc \
 FILTER_HEADERS = $$FILTERS
 FILTER_HEADERS ~= s/\.cc/.h/g
 
-SHAPE=shapelib/shpopen.c shapelib/dbfopen.c shapelib/safileio.c
-
-ZLIB=zlib/adler32.c zlib/compress.c zlib/crc32.c zlib/deflate.c zlib/inffast.c \
-        zlib/inflate.c zlib/infback.c zlib/inftrees.c zlib/trees.c \
-        zlib/uncompr.c zlib/gzlib.c zlib/gzclose.c zlib/gzread.c \
-        zlib/gzwrite.c zlib/zutil.c
-
 JEEPS += jeeps/gpsapp.cc jeeps/gpscom.cc \
          jeeps/gpsmath.cc jeeps/gpsmem.cc  \
          jeeps/gpsprot.cc jeeps/gpsread.cc \
@@ -84,7 +78,7 @@ SUPPORT = route.cc waypt.cc filter_vecs.cc util.cc vecs.cc mkshort.cc \
           gbfile.cc parse.cc session.cc main.cc globals.cc \
           src/core/textstream.cc \
           src/core/usasciicodec.cc \
-          src/core/xmlstreamwriter.cc 
+          src/core/xmlstreamwriter.cc
 
 HEADERS =  \
 	an1sym.h \
@@ -147,7 +141,6 @@ HEADERS =  \
 	random.h \
 	session.h \
 	shape.h \
-	shapelib/shapefil.h \
 	strptime.h \
 	subrip.h \
 	unicsv.h \
@@ -156,17 +149,6 @@ HEADERS =  \
 	xcsv.h \
 	xmlgeneric.h \
 	yahoo.h \
-	zlib/crc32.h \
-	zlib/deflate.h \
-	zlib/gzguts.h \
-	zlib/inffast.h \
-	zlib/inffixed.h \
-	zlib/inflate.h \
-	zlib/inftrees.h \
-	zlib/trees.h \
-	zlib/zconf.h \
-	zlib/zlib.h \
-	zlib/zutil.h \
 	src/core/datetime.h \
 	src/core/file.h \
 	src/core/logging.h \
@@ -177,8 +159,6 @@ HEADERS =  \
 	src/core/xmltag.h
 
 HEADERS += $$FILTER_HEADERS
-
-INCLUDEPATH += zlib
 
 load(configure)
 
@@ -193,23 +173,21 @@ macx|linux|openbsd {
     # this is used by zlib
     DEFINES += HAVE_STDARG_H
   }
-  DEFINES += HAVE_LIBUSB_1_0
   SOURCES += gbser_posix.cc
   HEADERS += gbser_posix.h
-  JEEPS += jeeps/gpslibusb.cc
   INCLUDEPATH += jeeps
 }
 
 win32 {
   DEFINES += __WIN32__ _CONSOLE
-  DEFINES -= UNICODE ZLIB_INHIBITED
+  DEFINES -= UNICODE
   CONFIG(debug, debug|release) {
     DEFINES += _DEBUG
   }
   SOURCES += gbser_win.cc
   HEADERS += gbser_win.h
   JEEPS += jeeps/gpsusbwin.cc
-  LIBS += "-lsetupapi" 
+  LIBS += "-lsetupapi"
   RC_FILE = win32/gpsbabel.rc
 }
 
@@ -218,39 +196,15 @@ win32-msvc* {
   QMAKE_CXXFLAGS += /MP -wd4100
 }
 
-linux|openbsd {
-  LIBS += "-lusb-1.0"
-}
+include(shapelib.pri)
+include(zlib.pri)
+include(libusb.pri)
 
-macx {
-  LIBS += -lobjc -framework IOKit -framework CoreFoundation
-  INCLUDEPATH += mac/libusb \
-                 mac/libusb/Xcode
-  SOURCES += mac/libusb/core.c \
-             mac/libusb/descriptor.c \
-             mac/libusb/hotplug.c \
-             mac/libusb/io.c \
-             mac/libusb/strerror.c \
-             mac/libusb/sync.c \
-             mac/libusb/os/darwin_usb.c \
-             mac/libusb/os/poll_posix.c \
-             mac/libusb/os/threads_posix.c
-  HEADERS += mac/libusb/hotplug.h \
-             mac/libusb/libusb.h \
-             mac/libusb/libusbi.h \
-             mac/libusb/version.h \
-             mac/libusb/version_nano.h \
-             mac/libusb/os/darwin_usb.h \
-             mac/libusb/os/poll_posix.h \
-             mac/libusb/os/threads_posix.h
-}
-
-SOURCES += $$ALL_FMTS $$FILTERS $$SUPPORT $$SHAPE $$ZLIB $$JEEPS
+SOURCES += $$ALL_FMTS $$FILTERS $$SUPPORT $$JEEPS
 
 # We don't care about stripping things out of the build.  Full monty, baby.
 DEFINES += MAXIMAL_ENABLED
 DEFINES += FILTERS_ENABLED
-DEFINES += SHAPELIB_ENABLED
 DEFINES += CSVFMTS_ENABLED
 
 # Creator insists on adding -W to -Wall which results in a completely
@@ -278,7 +232,7 @@ macx|linux|openbsd{
 # example usage:
 # make clang-tidy RUN_CLANG_TIDY_FLAGS="-header-filter=.*\\\.h -checks=-*,modernize-use-nullptr -fix"
 # It seems to be better to use run-clang-tidy with the compilation database as opposed to
-# running clang-tidy directly and listing the 
+# running clang-tidy directly and listing the
 # compilation options on the clang-tidy line after --.
 # An example is modernize-use-override which inserts repeadted overrides when run directly,
 # but works as expected when run with run-clang-tidy.
@@ -306,7 +260,7 @@ cppcheck.commands = cppcheck --enable=all --force --config-exclude=zlib --config
 QMAKE_EXTRA_TARGETS += cppcheck
 
 gpsbabel.pdf.depends = FORCE
-gpsbabel.pdf.commands += perl xmldoc/makedoc && 
+gpsbabel.pdf.commands += perl xmldoc/makedoc &&
 gpsbabel.pdf.commands += xmlwf xmldoc/readme.xml && #check for well-formedness
 gpsbabel.pdf.commands += xmllint --noout --valid xmldoc/readme.xml &&   #validate
 gpsbabel.pdf.commands += xsltproc -o gpsbabel.fo xmldoc/babelpdf.xsl xmldoc/readme.xml &&

--- a/defs.h
+++ b/defs.h
@@ -31,16 +31,10 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#ifdef ZLIB_H_SYSTEM_INCLUDE
-#  include <zlib.h>                   // doesn't really belong here, but is missing elsewhere.
-#elif ZLIB_H_LOCAL_INCLUDE
-#  include "zlib/zlib.h"              // doesn't really belong here, but is missing elsewhere.
-#else
-#  if HAVE_LIBZ
-#    include <zlib.h>                 // doesn't really belong here, but is missing elsewhere.
-#  elif !ZLIB_INHIBITED
-#    include "zlib.h"                 // doesn't really belong here, but is missing elsewhere.
-#  endif
+#if HAVE_LIBZ
+#include <zlib.h>                 // doesn't really belong here, but is missing elsewhere.
+#elif !ZLIB_INHIBITED
+#include "zlib.h"                 // doesn't really belong here, but is missing elsewhere.
 #endif
 
 #include <QtCore/QDebug>          // for QDebug

--- a/defs.h
+++ b/defs.h
@@ -31,10 +31,16 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#if HAVE_LIBZ
-#include <zlib.h>                 // doesn't really belong here, but is missing elsewhere.
-#elif !ZLIB_INHIBITED
-#include "zlib.h"                 // doesn't really belong here, but is missing elsewhere.
+#ifdef ZLIB_H_SYSTEM_INCLUDE
+#  include <zlib.h>                   // doesn't really belong here, but is missing elsewhere.
+#elif ZLIB_H_LOCAL_INCLUDE
+#  include "zlib/zlib.h"              // doesn't really belong here, but is missing elsewhere.
+#else
+#  if HAVE_LIBZ
+#    include <zlib.h>                 // doesn't really belong here, but is missing elsewhere.
+#  elif !ZLIB_INHIBITED
+#    include "zlib.h"                 // doesn't really belong here, but is missing elsewhere.
+#  endif
 #endif
 
 #include <QtCore/QDebug>          // for QDebug

--- a/jeeps/gpslibusb.cc
+++ b/jeeps/gpslibusb.cc
@@ -28,12 +28,15 @@
 #include "config.h"
 #endif
 #if HAVE_LIBUSB_1_0
+#ifdef LIBUSB_H_INCLUDE
+#  include LIBUSB_H_INCLUDE
+#else
 #  if __APPLE__
-// We use our own libusb.
 #    include "mac/libusb/libusb.h"
 #  else
 #    include <libusb-1.0/libusb.h>
 #  endif
+#endif
 #include "../defs.h"
 #include "garminusb.h"
 #include "gpsdevice.h"

--- a/jeeps/gpslibusb.cc
+++ b/jeeps/gpslibusb.cc
@@ -29,9 +29,15 @@
 #endif
 #if HAVE_LIBUSB_1_0
 #ifdef LIBUSB_H_INCLUDE
+// Warning: LIBUSB_H_INCLUDE necessarily includes bracket or double quote
+//          characters.
+//          qmake -tp vc doesn't properly quote these characters, and the
+//          produced project file is invalid.  However, we don't use libusb
+//          at all on windows, so this isn't an issue in this application.
 #  include LIBUSB_H_INCLUDE
-#else
+#else  // TODO: delete this clause when configure is removed and CMakeLists updated.
 #  if __APPLE__
+// We use our own libusb.
 #    include "mac/libusb/libusb.h"
 #  else
 #    include <libusb-1.0/libusb.h>

--- a/jeeps/gpsusbstub.cc
+++ b/jeeps/gpsusbstub.cc
@@ -25,7 +25,6 @@
 #endif
 
 #include "../defs.h"
-#include "src/core/logging.h"
 
 #if !HAVE_LIBUSB_1_0
 
@@ -34,7 +33,7 @@ typedef struct gpsdevh gpsdevh;
 int
 gusb_init(const char* portname, gpsdevh** dh)
 {
-  fatal(FatalMsg() << no_usb);
+  fatal(no_usb);
   return 0;
 }
 

--- a/jeeps/gpsusbstub.cc
+++ b/jeeps/gpsusbstub.cc
@@ -34,7 +34,7 @@ typedef struct gpsdevh gpsdevh;
 int
 gusb_init(const char* portname, gpsdevh** dh)
 {
-  Fatal() << no_usb;
+  fatal(FatalMsg() << no_usb);
   return 0;
 }
 

--- a/libusb.pri
+++ b/libusb.pri
@@ -1,0 +1,64 @@
+macx|linux|openbsd {
+  !defined(WITH_LIBUSB, var) {
+    macx: WITH_LIBUSB = included
+    linux|openbsd: WITH_LIBUSB = system
+  }
+  equals(WITH_LIBUSB, no) {
+    JEEPS += jeeps/gpsusbstub.cc
+  } else {
+    DEFINES += HAVE_LIBUSB_1_0
+    JEEPS += jeeps/gpslibusb.cc
+    equals(WITH_LIBUSB, pkgconfig) {
+      message("Using libusb-1.0 found by pkg-config")
+      PKGCONFIG += libusb-1.0
+      DEFINES += LIBUSB_H_INCLUDE=$$shell_quote(<libusb.h>)
+    } else {
+      linux|openbsd {
+        equals(WITH_LIBUSB, system) {
+          LIBS += "-lusb-1.0"
+          DEFINES += LIBUSB_H_INCLUDE=$$shell_quote(<libusb-1.0/libusb.h>)
+        } else:equals(WITH_LIBUSB, custom) {
+          message("libusb-1.0 is enabled but but must be manually configured")
+          message("  e.g. qmake WITH_LIBUSB=custom LIBS+=... INCLUDEPATH+=...")
+          DEFINES += LIBUSB_H_INCLUDE=$$shell_quote(<libusb.h>)
+        } else {
+          error("WITH_LIBUSB=no|pkgconfig|system*|custom");
+        }
+      }
+
+      macx {
+        equals(WITH_LIBUSB, included) {
+          # TODO: It would be better to create an archive and link to it
+          #       to separate library build requirements from gpsbabel requirements.
+          DEFINES += LIBUSB_H_INCLUDE=$$shell_quote(\"mac/libusb/libusb.h\")
+          LIBS += -lobjc -framework IOKit -framework CoreFoundation
+          INCLUDEPATH += mac/libusb \
+                         mac/libusb/Xcode
+          SOURCES += mac/libusb/core.c \
+                     mac/libusb/descriptor.c \
+                     mac/libusb/hotplug.c \
+                     mac/libusb/io.c \
+                     mac/libusb/strerror.c \
+                     mac/libusb/sync.c \
+                     mac/libusb/os/darwin_usb.c \
+                     mac/libusb/os/poll_posix.c \
+                     mac/libusb/os/threads_posix.c
+          HEADERS += mac/libusb/hotplug.h \
+                     mac/libusb/libusb.h \
+                     mac/libusb/libusbi.h \
+                     mac/libusb/version.h \
+                     mac/libusb/version_nano.h \
+                     mac/libusb/os/darwin_usb.h \
+                     mac/libusb/os/poll_posix.h \
+                     mac/libusb/os/threads_posix.h
+        } else:equals(WITH_LIBUSB, custom) {
+          message("libusb-1.0 is enabled but but must be manually configured")
+          message("  e.g. qmake WITH_LIBUSB=custom LIBS+=... INCLUDEPATH+=...")
+          DEFINES += LIBUSB_H_INCLUDE=$$shell_quote(<libusb.h>)
+        } else {
+          error("WITH_LIBUSB=no|pkgconfig|included*|custom");
+        }
+      }
+    }
+  }
+}

--- a/libusb.pri
+++ b/libusb.pri
@@ -4,6 +4,7 @@ macx|linux|openbsd {
     linux|openbsd: WITH_LIBUSB = system
   }
   equals(WITH_LIBUSB, no) {
+    message("libusb-1.0 disabled")
     JEEPS += jeeps/gpsusbstub.cc
   } else {
     DEFINES += HAVE_LIBUSB_1_0

--- a/shape.cc
+++ b/shape.cc
@@ -32,7 +32,13 @@
 
 #include "defs.h"
 #include "shape.h"
-#include "shapelib/shapefil.h"
+#ifdef SHAPEFILE_H_SYSTEM_INCLUDE
+#  include <shapefil.h>
+#elif SHAPEFILE_H_LOCAL_INCLUDE
+#  include "shapelib/shapefil.h"
+#else
+#  include "shapelib/shapefil.h"
+#endif
 
 
 #if SHAPELIB_ENABLED

--- a/shape.cc
+++ b/shape.cc
@@ -32,16 +32,14 @@
 
 #include "defs.h"
 #include "shape.h"
-#ifdef SHAPEFIL_H_SYSTEM_INCLUDE
+#if SHAPELIB_ENABLED
+#if HAVE_LIBSHAPE
 #  include <shapefil.h>
-#elif SHAPEFIL_H_LOCAL_INCLUDE
-#  include "shapelib/shapefil.h"
 #else
 #  include "shapelib/shapefil.h"
 #endif
 
 
-#if SHAPELIB_ENABLED
 #define MYNAME "shape"
 
 /************************************************************************/

--- a/shape.cc
+++ b/shape.cc
@@ -32,9 +32,9 @@
 
 #include "defs.h"
 #include "shape.h"
-#ifdef SHAPEFILE_H_SYSTEM_INCLUDE
+#ifdef SHAPEFIL_H_SYSTEM_INCLUDE
 #  include <shapefil.h>
-#elif SHAPEFILE_H_LOCAL_INCLUDE
+#elif SHAPEFIL_H_LOCAL_INCLUDE
 #  include "shapelib/shapefil.h"
 #else
 #  include "shapelib/shapefil.h"

--- a/shape.h
+++ b/shape.h
@@ -27,9 +27,9 @@
 
 #include "defs.h"               // for arglist_t, ARGTYPE_STRING, Waypoint, route_head, CET_CHARSET_ASCII, FF_CAP_RW_ALL, ff_cap, ff_type, ff_type_file
 #include "format.h"             // for Format
-#ifdef SHAPEFILE_H_SYSTEM_INCLUDE
+#ifdef SHAPEFIL_H_SYSTEM_INCLUDE
 #  include <shapefil.h>
-#elif SHAPEFILE_H_LOCAL_INCLUDE
+#elif SHAPEFIL_H_LOCAL_INCLUDE
 #  include "shapelib/shapefil.h"
 #else
 #  include "shapelib/shapefil.h"  // for DBFHandle, SHPAPI_CALL, SHPHandle

--- a/shape.h
+++ b/shape.h
@@ -27,16 +27,14 @@
 
 #include "defs.h"               // for arglist_t, ARGTYPE_STRING, Waypoint, route_head, CET_CHARSET_ASCII, FF_CAP_RW_ALL, ff_cap, ff_type, ff_type_file
 #include "format.h"             // for Format
-#ifdef SHAPEFIL_H_SYSTEM_INCLUDE
+#if SHAPELIB_ENABLED
+#if HAVE_LIBSHAPE
 #  include <shapefil.h>
-#elif SHAPEFIL_H_LOCAL_INCLUDE
-#  include "shapelib/shapefil.h"
 #else
 #  include "shapelib/shapefil.h"  // for DBFHandle, SHPAPI_CALL, SHPHandle
 #endif
 
 
-#if SHAPELIB_ENABLED
 class ShapeFormat : public Format
 {
 public:

--- a/shape.h
+++ b/shape.h
@@ -27,7 +27,13 @@
 
 #include "defs.h"               // for arglist_t, ARGTYPE_STRING, Waypoint, route_head, CET_CHARSET_ASCII, FF_CAP_RW_ALL, ff_cap, ff_type, ff_type_file
 #include "format.h"             // for Format
-#include "shapelib/shapefil.h"  // for DBFHandle, SHPAPI_CALL, SHPHandle
+#ifdef SHAPEFILE_H_SYSTEM_INCLUDE
+#  include <shapefil.h>
+#elif SHAPEFILE_H_LOCAL_INCLUDE
+#  include "shapelib/shapefil.h"
+#else
+#  include "shapelib/shapefil.h"  // for DBFHandle, SHPAPI_CALL, SHPHandle
+#endif
 
 
 #if SHAPELIB_ENABLED

--- a/shapelib.pri
+++ b/shapelib.pri
@@ -1,0 +1,27 @@
+!defined(WITH_SHAPELIB, var):WITH_SHAPELIB = included
+equals(WITH_SHAPELIB, no) {
+  message("shapelib disabled")
+} else {
+  DEFINES += SHAPELIB_ENABLED
+  equals(WITH_SHAPELIB, pkgconfig) {
+    message("Using shapelib found by pkg-config")
+    PKGCONFIG += shapelib
+    # This gets trashed on windows with qmake -tp vc:
+    #DEFINES += SHAPEFIL_H_INCLUDE=$$shell_quote(<shapefil.h>)
+    DEFINES += SHAPEFIL_H_SYSTEM_INCLUDE
+  } else:equals(WITH_SHAPELIB, included) {
+    # TODO: It would be better to create an archive and link to it
+    #       to separate library build requirements from gpsbabel requirements.
+    SOURCES += shapelib/shpopen.c shapelib/dbfopen.c shapelib/safileio.c
+    #DEFINES += SHAPEFIL_H_INCLUDE=$$shell_quote(\"shapelib/shapefil.h\")
+    DEFINES += SHAPEFIL_H_LOCAL_INCLUDE
+    HEADERS += shapelib/shapefil.h
+  } else:equals(WITH_SHAPELIB, custom) {
+    message("shapelib is enabled but but must be manually configured")
+    message("  e.g. qmake WITH_SHAPELIB=custom LIBS+=... INCLUDEPATH+=...")
+    #DEFINES += SHAPEFIL_H_INCLUDE=$$shell_quote(<shapefil.h>)
+    DEFINES += SHAPEFIL_H_SYSTEM_INCLUDE
+  } else {
+    error("WITH_SHAPELIB=no|pkgconfig|included*|custom");
+  }
+}

--- a/shapelib.pri
+++ b/shapelib.pri
@@ -6,21 +6,16 @@ equals(WITH_SHAPELIB, no) {
   equals(WITH_SHAPELIB, pkgconfig) {
     message("Using shapelib found by pkg-config")
     PKGCONFIG += shapelib
-    # This gets trashed on windows with qmake -tp vc:
-    #DEFINES += SHAPEFIL_H_INCLUDE=$$shell_quote(<shapefil.h>)
-    DEFINES += SHAPEFIL_H_SYSTEM_INCLUDE
+    DEFINES += HAVE_LIBSHAPE
   } else:equals(WITH_SHAPELIB, included) {
     # TODO: It would be better to create an archive and link to it
     #       to separate library build requirements from gpsbabel requirements.
     SOURCES += shapelib/shpopen.c shapelib/dbfopen.c shapelib/safileio.c
-    #DEFINES += SHAPEFIL_H_INCLUDE=$$shell_quote(\"shapelib/shapefil.h\")
-    DEFINES += SHAPEFIL_H_LOCAL_INCLUDE
     HEADERS += shapelib/shapefil.h
   } else:equals(WITH_SHAPELIB, custom) {
     message("shapelib is enabled but but must be manually configured")
     message("  e.g. qmake WITH_SHAPELIB=custom LIBS+=... INCLUDEPATH+=...")
-    #DEFINES += SHAPEFIL_H_INCLUDE=$$shell_quote(<shapefil.h>)
-    DEFINES += SHAPEFIL_H_SYSTEM_INCLUDE
+    DEFINES += HAVE_LIBSHAPE
   } else {
     error("WITH_SHAPELIB=no|pkgconfig|included*|custom");
   }

--- a/zlib.pri
+++ b/zlib.pri
@@ -1,0 +1,52 @@
+!defined(WITH_ZLIB, var):WITH_ZLIB = included
+equals(WITH_ZLIB, no) {
+  message("zlib disabled")
+  DEFINES += ZLIB_INHIBITED
+} else {
+  equals(WITH_ZLIB, pkgconfig) {
+    message("Using zlib found by pkg-config")
+    PKGCONFIG += $$shell_quote(zlib > 1.2.8)
+    # This gets trashed on windows with qmake -tp vc:
+    #DEFINES += ZLIB_H_INCLUDE=$$shell_quote(<zlib.h>)
+    DEFINES += ZLIB_H_SYSTEM_INCLUDE
+  } else:equals(WITH_ZLIB, included) {
+    # TODO: It would be better to create an archive and link to it
+    #       to separate library build requirements from gpsbabel requirements.
+    SOURCES += zlib/adler32.c \
+               zlib/compress.c \
+               zlib/crc32.c \
+               zlib/deflate.c \
+               zlib/inffast.c \
+               zlib/inflate.c \
+               zlib/infback.c \
+               zlib/inftrees.c \
+               zlib/trees.c \
+               zlib/uncompr.c \
+               zlib/gzlib.c \
+               zlib/gzclose.c \
+               zlib/gzread.c \
+               zlib/gzwrite.c \
+               zlib/zutil.c
+    #DEFINES += ZLIB_H_INCLUDE=$$shell_quote(\"zlib/zlib.h\")
+    DEFINES += ZLIB_H_LOCAL_INCLUDE
+    INCLUDEPATH += zlib
+    HEADERS += zlib/crc32.h \
+               zlib/deflate.h \
+               zlib/gzguts.h \
+               zlib/inffast.h \
+               zlib/inffixed.h \
+               zlib/inflate.h \
+               zlib/inftrees.h \
+               zlib/trees.h \
+               zlib/zconf.h \
+               zlib/zlib.h \
+               zlib/zutil.h
+  } else:equals(WITH_ZLIB, custom) {
+    message("zlib is enabled but but must be manually configured")
+    message("  e.g. qmake WITH_ZLIB=custom LIBS+=... INCLUDEPATH+=...")
+    #DEFINES += ZLIB_H_INCLUDE=$$shell_quote(<zlib.h>)
+    DEFINES += ZLIB_H_SYSTEM_INCLUDE
+  } else {
+    error("WITH_ZLIB=no|pkgconfig|included*|custom");
+  }
+}

--- a/zlib.pri
+++ b/zlib.pri
@@ -6,9 +6,7 @@ equals(WITH_ZLIB, no) {
   equals(WITH_ZLIB, pkgconfig) {
     message("Using zlib found by pkg-config")
     PKGCONFIG += $$shell_quote(zlib > 1.2.8)
-    # This gets trashed on windows with qmake -tp vc:
-    #DEFINES += ZLIB_H_INCLUDE=$$shell_quote(<zlib.h>)
-    DEFINES += ZLIB_H_SYSTEM_INCLUDE
+    DEFINES += HAVE_LIBZ
   } else:equals(WITH_ZLIB, included) {
     # TODO: It would be better to create an archive and link to it
     #       to separate library build requirements from gpsbabel requirements.
@@ -27,8 +25,6 @@ equals(WITH_ZLIB, no) {
                zlib/gzread.c \
                zlib/gzwrite.c \
                zlib/zutil.c
-    #DEFINES += ZLIB_H_INCLUDE=$$shell_quote(\"zlib/zlib.h\")
-    DEFINES += ZLIB_H_LOCAL_INCLUDE
     INCLUDEPATH += zlib
     HEADERS += zlib/crc32.h \
                zlib/deflate.h \
@@ -44,8 +40,7 @@ equals(WITH_ZLIB, no) {
   } else:equals(WITH_ZLIB, custom) {
     message("zlib is enabled but but must be manually configured")
     message("  e.g. qmake WITH_ZLIB=custom LIBS+=... INCLUDEPATH+=...")
-    #DEFINES += ZLIB_H_INCLUDE=$$shell_quote(<zlib.h>)
-    DEFINES += ZLIB_H_SYSTEM_INCLUDE
+    DEFINES += HAVE_LIBZ
   } else {
     error("WITH_ZLIB=no|pkgconfig|included*|custom");
   }


### PR DESCRIPTION
The use of system libraries by distributions is common.  This is partially supported in the configure flow, but distributions usually require patches to achieve the linking they desire.

This PR gets us a step closer to deprecation/removal of the autotools base flow.