### PR TITLE
fix error detection for osx script, allow macOS sed for mkstyle.

### DIFF
--- a/mkstyle.sh
+++ b/mkstyle.sh
@@ -16,6 +16,12 @@ if gsed v /dev/null 1>/dev/null 2>&1; then
 elif sed v /dev/null 1>/dev/null 2>&1; then
   # sed is gnu sed
   SED=sed
+elif [ "$(uname -s)" = "Darwin" ]; then
+  # BSD sed is usually fine, but if a style file is encoded in ISO-8859 then it
+  # can echo a warning "sed: RE error: illegal byte sequence" to stderr and the
+  # output can be corrupted, while return exit status 0.  Since we no longer use
+  # this encoding for style files allow Darwin's sed.
+  SED=/usr/bin/sed
 elif [ "$(uname -s)" = "FreeBSD" ]; then
   # BSD sed is fine
   SED=/usr/bin/sed

--- a/tools/travis_script_osx
+++ b/tools/travis_script_osx
@@ -14,11 +14,14 @@ VERSIONID=${VERSIONID:-$(date -ju -f %Y-%m-%dT%H:%M:%S%z $(git show -s --format=
 "$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"/ci_tokens
 
 # build and test the CLI
-$QMAKE GPSBabel.pro && make -j 2 && make check
+$QMAKE GPSBabel.pro
+make -j 3
+make check
 
 # build the GUI
 pushd gui
-$QMAKE app.pro && make -j 2
+$QMAKE app.pro
+make -j 3
 make package
 popd
 
@@ -28,5 +31,4 @@ find /Volumes/GPSBabelFE -ls
 hdiutil detach /Volumes/GPSBabelFE
 
 mv gui/GPSBabelFE.dmg gui/GPSBabel-${VERSIONID}.dmg
-
 


### PR DESCRIPTION
Fix issue with 'set -e' and shell exit in command lists that caused make failures to go undetected.

Allow macOS sed to be used by mkstyle.sh.  It was originally excluded due to issues with ISO-8859 encoded style files.  We no longer use this encoding for style files.