### PR TITLE
fix lupdate warning.

### DIFF
--- a/gui/preferences.cc
+++ b/gui/preferences.cc
@@ -23,7 +23,7 @@
 class FormatListEntry : public QListWidgetItem
 {
 public:
-  FormatListEntry(Format& fmt) /*: fmt_(fmt)*/
+  FormatListEntry(Format& fmt) /* : fmt_(fmt) */
   {
     setText(fmt.getDescription());
     bool enabled = !fmt.isHidden();


### PR DESCRIPTION
With Qt 5.12.9 the lupdate command in package_app could print a warning:
gui/preferences.cc:28: Discarding unconsumed meta data