### PR TITLE
backward compatible changes for Qt6.

### DIFF
--- a/gui/aboutdlg.cc
+++ b/gui/aboutdlg.cc
@@ -21,8 +21,13 @@
 //
 
 #include "aboutdlg.h"
-#include "appname.h"
-#include "upgrade.h"
+#include <QtCore/QRegularExpression>  // for QRegularExpression
+#include <QtGui/QTextCursor>          // for QTextCursor
+#include <QtGui/QTextDocument>        // for QTextDocument
+#include <QtWidgets/QTextEdit>        // for QTextEdit
+#include "appname.h"                  // for appName
+#include "upgrade.h"                  // for UpgradeCheck
+
 
 AboutDlg::AboutDlg(QWidget* parent, const QString& ver1,
                    const QString& ver2, const QString& installationId): QDialog(parent)
@@ -31,13 +36,13 @@ AboutDlg::AboutDlg(QWidget* parent, const QString& ver1,
   QTextDocument* doc = ui_.textEdit->document();
   ui_.textEdit->setReadOnly(true);
   QString tt = doc->toHtml();
-  tt.replace(QRegExp("\\$appname\\$"),  QString(appName));
-  tt.replace(QRegExp("\\$babelversion\\$"),  ver1);
-  tt.replace(QRegExp("\\$babelfeversion\\$"),  ver2);
-  tt.replace(QRegExp("\\$installationId\\$"),  installationId);
+  tt.replace(QRegularExpression(R"(\$appname\$)"), QString(appName));
+  tt.replace(QRegularExpression(R"(\$babelversion\$)"), ver1);
+  tt.replace(QRegularExpression(R"(\$babelfeversion\$)"), ver2);
+  tt.replace(QRegularExpression(R"(\$installationId\$)"), installationId);
 
   // Not localized as it should never be seen.
-  tt.replace(QRegExp("\\$upgradetestmode\\$"),
+  tt.replace(QRegularExpression(R"(\$upgradetestmode\$)"),
              UpgradeCheck::isTestMode() ? "**Upgrade test mode**" : "");
 
   doc->setHtml(tt);

--- a/gui/aboutdlg.cc
+++ b/gui/aboutdlg.cc
@@ -21,7 +21,6 @@
 //
 
 #include "aboutdlg.h"
-#include <QtCore/QRegularExpression>  // for QRegularExpression
 #include <QtGui/QTextCursor>          // for QTextCursor
 #include <QtGui/QTextDocument>        // for QTextDocument
 #include <QtWidgets/QTextEdit>        // for QTextEdit
@@ -36,13 +35,13 @@ AboutDlg::AboutDlg(QWidget* parent, const QString& ver1,
   QTextDocument* doc = ui_.textEdit->document();
   ui_.textEdit->setReadOnly(true);
   QString tt = doc->toHtml();
-  tt.replace(QRegularExpression(R"(\$appname\$)"), QString(appName));
-  tt.replace(QRegularExpression(R"(\$babelversion\$)"), ver1);
-  tt.replace(QRegularExpression(R"(\$babelfeversion\$)"), ver2);
-  tt.replace(QRegularExpression(R"(\$installationId\$)"), installationId);
+  tt.replace("$appname$", appName);
+  tt.replace("$babelversion$", ver1);
+  tt.replace("$babelfeversion$", ver2);
+  tt.replace("$installationId$", installationId);
 
   // Not localized as it should never be seen.
-  tt.replace(QRegularExpression(R"(\$upgradetestmode\$)"),
+  tt.replace("$upgradetestmode$",
              UpgradeCheck::isTestMode() ? "**Upgrade test mode**" : "");
 
   doc->setHtml(tt);

--- a/gui/aboutdlg.h
+++ b/gui/aboutdlg.h
@@ -23,9 +23,10 @@
 #ifndef ABOUTDLG_H
 #define ABOUTDLG_H
 
-#include <QDialog>
-
-#include "ui_aboutui.h"
+#include <QtCore/QString>     // for QString
+#include <QtWidgets/QDialog>  // for QDialog
+#include <QtWidgets/QWidget>  // for QWidget
+#include "ui_aboutui.h"       // for Ui_AboutDlg
 
 class AboutDlg: public QDialog
 {

--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -21,24 +21,24 @@
 //
 //------------------------------------------------------------------------
 
-#include <QtCore/QByteArray>        // for QByteArray
-#include <QtCore/QChar>             // for operator==, QChar
-#include <QtCore/QCharRef>          // for QCharRef
-#include <QtCore/QCoreApplication>  // for QCoreApplication
-#ifdef GENERATE_CORE_STRINGS
-#include <QtCore/QDebug>
-#endif
-#include <QtCore/QObject>           // for QObject
-#include <QtCore/QProcess>          // for QProcess
-#include <QtCore/QRegExp>           // for QRegExp
-#include <QtCore/QString>           // for QString, operator+
-#include <QtCore/QTextStream>       // for QTextStream
-#include <QtCore/QVariant>          // for QVariant
-#include <QtWidgets/QApplication>   // for QApplication
-#include <QtWidgets/QMessageBox>    // for QMessageBox
-
 #include "formatload.h"
-#include "appname.h"                // for appName
+#include <QtCore/QByteArray>               // for QByteArray
+#include <QtCore/QChar>                    // for operator==, QChar
+#include <QtCore/QCharRef>                 // for QCharRef
+#include <QtCore/QCoreApplication>         // for QCoreApplication
+#ifdef GENERATE_CORE_STRINGS
+#include <QtCore/QDebug>                   // for QDebug, operator<<
+#endif
+#include <QtCore/QObject>                  // for QObject
+#include <QtCore/QProcess>                 // for QProcess
+#include <QtCore/QRegularExpression>       // for QRegularExpression
+#include <QtCore/QRegularExpressionMatch>  // for QRegularExpressionMatch
+#include <QtCore/QString>                  // for QString, operator+
+#include <QtCore/QTextStream>              // for QTextStream
+#include <QtCore/QVariant>                 // for QVariant
+#include <QtWidgets/QApplication>          // for QApplication
+#include <QtWidgets/QMessageBox>           // for QMessageBox
+#include "appname.h"                       // for appName
 
 
 //------------------------------------------------------------------------
@@ -53,8 +53,8 @@ static QString xlt(const QString& f)
 //------------------------------------------------------------------------
 bool FormatLoad::skipToValidLine()
 {
-  QRegExp regex("^(file|serial)");
-  while (currentLine_ <lines_.size() && regex.indexIn(lines_[currentLine_]) != 0) {
+  QRegularExpression regex("^file|serial");
+  while ((currentLine_ < lines_.size()) && !regex.match(lines_[currentLine_]).hasMatch()) {
     currentLine_++;
   }
   return (currentLine_<lines_.size());
@@ -67,13 +67,11 @@ bool FormatLoad::processFormat(Format& format)
   if (hfields.size() < 5) {
     return false;
   }
-  QString htmlPage = lines_[currentLine_++];
-  htmlPage.replace(QRegExp("^[\\s]*"), "");
-  htmlPage.replace(QRegExp("[\\s]$"), "");
+  QString htmlPage = lines_[currentLine_++].trimmed();
 
-  QRegExp regex("^option");
+  QRegularExpression regex("^option");
   QList <FormatOption> optionList;
-  while (currentLine_ <lines_.size() && regex.indexIn(lines_[currentLine_]) == 0) {
+  while ((currentLine_ < lines_.size()) && regex.match(lines_[currentLine_]).hasMatch()) {
     QStringList ofields = lines_[currentLine_].split("\t");
     if (ofields.size() < 9) {
       return false;
@@ -131,7 +129,7 @@ bool FormatLoad::processFormat(Format& format)
 #ifndef GENERATE_CORE_STRINGS
   if (htmlPage.length() > 0 && Format::getHtmlBase().length() == 0) {
     QString base = htmlPage;
-    base.replace(QRegExp("/[^/]+$"), "/");
+    base.replace(QRegularExpression("/[^/]+$"), "/");
     Format::setHtmlBase(base);
   }
 #endif
@@ -162,7 +160,7 @@ bool FormatLoad::getFormats(QList<Format>& formatList)
   while (!tstream.atEnd()) {
     QString l = tstream.readLine();
     k++;
-    if (!QRegExp("^[\\s]*$").exactMatch(l)) {
+    if (!l.trimmed().isEmpty()) {
       lines_ << l;
       lineList<<k;
     }

--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -69,9 +69,8 @@ bool FormatLoad::processFormat(Format& format)
   }
   QString htmlPage = lines_[currentLine_++].trimmed();
 
-  QRegularExpression regex("^option");
   QList <FormatOption> optionList;
-  while ((currentLine_ < lines_.size()) && regex.match(lines_[currentLine_]).hasMatch()) {
+  while ((currentLine_ < lines_.size()) && lines_[currentLine_].startsWith("option")) {
     QStringList ofields = lines_[currentLine_].split("\t");
     if (ofields.size() < 9) {
       return false;

--- a/gui/help.cc
+++ b/gui/help.cc
@@ -20,22 +20,22 @@
 //  USA.
 //
 //------------------------------------------------------------------------
-#include <QUrl>
-#include <QDesktopServices>
-
 #include "help.h"
-#include "format.h"
+
+#include <QtCore/QRegularExpression>  // for QRegularExpression
+#include <QtCore/QString>             // for QString
+#include <QtCore/QUrl>                // for QUrl
+#include <QtGui/QDesktopServices>     // for QDesktopServices
+
+#include "format.h"                   // for Format
 
 //------------------------------------------------------------------------
 void ShowHelp(const QString& urlIn)
 
 {
   QString url = urlIn;
-  if (!url.contains(QRegExp("^http://"))) {
+  if (!url.contains(QRegularExpression(R"(^https?://)"))) {
     url = Format::getHtmlBase() + url;
   }
   QDesktopServices::openUrl(QUrl(url));
 }
-
-
-

--- a/gui/help.h
+++ b/gui/help.h
@@ -22,7 +22,7 @@
 
 #ifndef HELP_H
 #define HELP_H
-#include <QString>
+#include <QtCore/QString>  // for QString
 
 extern void ShowHelp(const QString& name);
 

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -30,7 +30,6 @@
 #include <QtCore/QLocale>              // for QLocale
 #include <QtCore/QMimeData>            // for QMimeData
 #include <QtCore/QProcess>             // for QProcess, QProcess::NotRunning
-#include <QtCore/QRegExp>              // for QRegExp
 #include <QtCore/QSettings>            // for QSettings
 #include <QtCore/QString>              // for QString
 #include <QtCore/QStringList>          // for QStringList
@@ -100,8 +99,6 @@ QString MainWindow::findBabelVersion()
   isBeta_ = str.contains("-beta");
   str.replace("Version",  "");
   str.replace("GPSBabel",  "");
-  str.replace(QRegExp("^[\\s]*"),  "");
-  str.replace(QRegExp("[\\s]+$"),  "");
   str = str.simplified();
   return str;
 }
@@ -510,8 +507,8 @@ void MainWindow::outputFileNameEdited()
 QString MainWindow::filterForFormat(int idx)
 {
   QString str = formatList_[idx].getDescription();
-  str.replace(QRegExp("\\("), "[");
-  str.replace(QRegExp("\\)"), "]");
+  str.replace('(', '[');
+  str.replace(')', ']');
   QStringList extensions = formatList_[idx].getExtensions();
 
   // If we don't have any meaningful extensions available for this format,

--- a/gui/serial_unix.cc
+++ b/gui/serial_unix.cc
@@ -21,8 +21,16 @@
 #include "mainwindow.h"
 
 #ifdef HAVE_UDEV
-#include <libudev.h>
-#include <QDebug>
+#include <libudev.h>            // for udev_device_get_property_value, udev_device_get_devnode, udev_device_new_from_syspath, udev_device_unref, udev_enumerate_add_match_subsystem, udev_enumerate_get_list_entry, udev_enumerate_new, udev_enumerate_scan_devices, udev_enumerate_unref, udev_list_ent...
+
+#include <QtCore/QDebug>        // for QDebug
+#include <QtCore/QSet>          // for QSet
+#include <QtCore/QString>       // for QString, operator==
+#include <QtCore/QStringList>   // for QStringList
+#include <QtWidgets/QComboBox>  // for QComboBox
+
+#include "mainwindow.h"         // for MainWindow
+
 
 static QStringList dynamicDevices()
 {
@@ -71,8 +79,8 @@ static QStringList dynamicDevices()
   udev_enumerate_unref(enumerate);
   udev_unref(udev);
 
-  QStringList list = devices.toList();
-  qSort(list);
+  QStringList list = devices.values();
+  list.sort();
   return list;
 }
 #else

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -19,26 +19,28 @@
 
  */
 
-
-#include "babeldata.h"
-#include "format.h"
 #include "upgrade.h"
-#include "../gbversion.h"
-
-#include <cstdio>
-
-#include <QtCore/QDebug>
-#include <QtCore/QLocale>
-#include <QtCore/QSysInfo>
-#include <QtCore/QUrl>
-#include <QtCore/QVariant>
-#include <QtCore/QVersionNumber>
-#include <QtGui/QDesktopServices>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
-#include <QtNetwork/QNetworkRequest>
-#include <QtWidgets/QMessageBox>
-#include <QtXml/QDomDocument>
+#include <QtCore/qglobal.h>                 // for qDebug
+#include <QtCore/QByteArray>                // for QByteArray
+#include <QtCore/QDebug>                    // for QDebug
+#include <QtCore/QLocale>                   // for QLocale
+#include <QtCore/QSysInfo>                  // for QSysInfo
+#include <QtCore/QUrl>                      // for QUrl
+#include <QtCore/QVariant>                  // for QVariant
+#include <QtCore/QVersionNumber>            // for QVersionNumber, operator<, operator==
+#include <QtCore/Qt>                        // for ISODate, RichText
+#include <QtGui/QDesktopServices>           // for QDesktopServices
+#include <QtNetwork/QNetworkAccessManager>  // for QNetworkAccessManager
+#include <QtNetwork/QNetworkReply>          // for QNetworkReply, QNetworkReply::NoError
+#include <QtNetwork/QNetworkRequest>        // for QNetworkRequest, QNetworkRequest::ContentTypeHeader, QNetworkRequest::HttpReasonPhraseAttribute, QNetworkRequest::HttpStatusCodeAttribute, QNetworkRequest::NoLessSafeRedirectPolicy, QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::Redi...
+#include <QtWidgets/QMessageBox>            // for QMessageBox, QMessageBox::Yes, operator|, QMessageBox::No
+#include <QtXml/QDomDocument>               // for QDomDocument
+#include <QtXml/QDomElement>                // for QDomElement
+#include <QtXml/QDomNode>                   // for QDomNode
+#include <QtXml/QDomNodeList>               // for QDomNodeList
+#include "../gbversion.h"                   // for VERSION
+#include "babeldata.h"                      // for BabelData
+#include "format.h"                         // for Format
 
 
 #if 0
@@ -117,7 +119,7 @@ UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
   // In Qt 5.6 and later, it can reissue with a redirect. With this in
   // place, we don't see the 301 redirect, but the server has to issue
   // one for the thousands of older clients out there.
-  request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
   request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
   request.setRawHeader("Accept-Encoding","identity");
 

--- a/gui/upgrade.h
+++ b/gui/upgrade.h
@@ -19,13 +19,17 @@
 
  */
 
-#include "babeldata.h"
-#include "format.h"
-#include <QDateTime>
-#include <QUrl>
+#include <QtCore/QDateTime>                 // for QDateTime
+#include <QtCore/QList>                     // for QList
+#include <QtCore/QObject>                   // for QObject
+#include <QtCore/QString>                   // for QString
+#include <QtCore/QUrl>                      // for QUrl
+#include <QtNetwork/QNetworkAccessManager>  // for QNetworkAccessManager
+#include <QtNetwork/QNetworkReply>          // for QNetworkReply
+#include <QtWidgets/QWidget>                // for QWidget
+#include "babeldata.h"                      // for BabelData
+#include "format.h"                         // for Format
 
-class QNetworkAccessManager;
-class QNetworkReply;
 
 class UpgradeCheck : public QObject
 {


### PR DESCRIPTION
This is mostly QRegExp -> QRegularExpression.
Some QRegExp usage was was replaced by QString::trimmed.
There is also a QNetworkRequest redirect attribute change that is backward
compatible to Qt5.9.