### PR TITLE
manually install Qt 5.12.10 for Appveyor msvc 2017 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,13 +41,13 @@ init:
       }
   - ps: |
       if ($env:qt -eq "5.12\msvc2017") {
-          $env:path = "C:\Qt\5.12.9\msvc2017\bin"; $env:path
+          $env:path = "C:\Qt\5.12.9\msvc2017\bin;$env:path"
       }
       elseif ($env:qt -eq "5.12\msvc2017_64") {
-          $env:path = "C:\Qt\5.12.9\msvc2017_64\bin"; $env:path
+          $env:path = "C:\Qt\5.12.9\msvc2017_64\bin;$env:path"
       }
       else {
-          $env:path = "C:\Qt\$env:qt\bin"; $env:PATH
+          $env:path = "C:\Qt\$env:qt\bin;$env:PATH"
       }
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,30 +26,31 @@ environment:
   #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 init:
-  - set PATH=C:\Qt\%qt%\bin;%PATH%
+  - ps: |
+      if ($env:qt -eq "5.12\msvc2017") {
+          Invoke-Expression ((New-Object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
+          Install-QtComponent -Version '5.12.9' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
+          Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
+          ConfigureQtVersion 'C:\Qt' '5.12.9'
+      }
+      if ($env:qt -eq "5.12\msvc2017_64") {
+          Invoke-Expression ((New-Object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
+          Install-QtComponent -Version '5.12.9' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
+          Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
+          ConfigureQtVersion 'C:\Qt' '5.12.9'
+      }
+  - ps: |
+      if ($env:qt -eq "5.12\msvc2017") {
+          $env:path = "C:\Qt\5.12.9\msvc2017\bin"; $env:path
+      }
+      elseif ($env:qt -eq "5.12\msvc2017_64") {
+          $env:path = "C:\Qt\5.12.9\msvc2017_64\bin"; $env:path
+      }
+      else {
+          $env:path = "C:\Qt\$env:qt\bin"; $env:PATH
+      }
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch%
-
-install:
-  - ps: |
-      if ($env:qt -eq "5.12\msvc2017")
-      {
-        iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
-        Install-QtComponent -Version '5.12.9' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
-        Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
-        ConfigureQtVersion 'C:\Qt' '5.12.9'
-      }
-      if ($env:qt -eq "5.12\msvc2017_64")
-      {
-        iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
-        Install-QtComponent -Version '5.12.9' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
-        Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
-        ConfigureQtVersion 'C:\Qt' '5.12.9'
-      }
-
-before_build:
-  - if "%QT%"=="5.12\msvc2017" call "C:\Qt\5.12.9\msvc2017\bin\qtenv2.bat"
-  - if "%QT%"=="5.12\msvc2017_64" call "C:\Qt\5.12.9\msvc2017_64\bin\qtenv2.bat"
   - cd /D %APPVEYOR_BUILD_FOLDER%
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,17 +29,17 @@ init:
   - ps: |
       if ($env:qt -eq "5.12\msvc2017") {
           Invoke-Expression ((New-Object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
-          Install-QtComponent -Version '5.12.9' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
-          Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
-          ConfigureQtVersion 'C:\Qt' '5.12.9'
-          $env:Path = "C:\Qt\5.12.9\msvc2017\bin;$env:Path"
+          Install-QtComponent -Version '5.12.10' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
+          Install-QtComponent -Version '5.12.10' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
+          ConfigureQtVersion 'C:\Qt' '5.12.10'
+          $env:Path = "C:\Qt\5.12.10\msvc2017\bin;$env:Path"
       }
       elseif ($env:qt -eq "5.12\msvc2017_64") {
           Invoke-Expression ((New-Object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
-          Install-QtComponent -Version '5.12.9' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
-          Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
-          ConfigureQtVersion 'C:\Qt' '5.12.9'
-          $env:Path = "C:\Qt\5.12.9\msvc2017_64\bin;$env:Path"
+          Install-QtComponent -Version '5.12.10' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
+          Install-QtComponent -Version '5.12.10' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
+          ConfigureQtVersion 'C:\Qt' '5.12.10'
+          $env:Path = "C:\Qt\5.12.10\msvc2017_64\bin;$env:Path"
       }
       else {
           $env:Path = "C:\Qt\$env:qt\bin;$env:Path"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,26 +32,20 @@ init:
           Install-QtComponent -Version '5.12.9' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
           Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
           ConfigureQtVersion 'C:\Qt' '5.12.9'
+          $env:Path = "C:\Qt\5.12.9\msvc2017\bin;$env:Path"
       }
-      if ($env:qt -eq "5.12\msvc2017_64") {
+      elseif ($env:qt -eq "5.12\msvc2017_64") {
           Invoke-Expression ((New-Object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
           Install-QtComponent -Version '5.12.9' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
           Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
           ConfigureQtVersion 'C:\Qt' '5.12.9'
-      }
-  - ps: |
-      if ($env:qt -eq "5.12\msvc2017") {
-          $env:path = "C:\Qt\5.12.9\msvc2017\bin;$env:path"
-      }
-      elseif ($env:qt -eq "5.12\msvc2017_64") {
-          $env:path = "C:\Qt\5.12.9\msvc2017_64\bin;$env:path"
+          $env:Path = "C:\Qt\5.12.9\msvc2017_64\bin;$env:Path"
       }
       else {
-          $env:path = "C:\Qt\$env:qt\bin;$env:PATH"
+          $env:Path = "C:\Qt\$env:qt\bin;$env:Path"
       }
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch%
-  - cd /D %APPVEYOR_BUILD_FOLDER%
 
 build_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,6 @@ install:
         Install-QtComponent -Version '5.12.9' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
         Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
         ConfigureQtVersion 'C:\Qt' '5.12.9'
-        C:\Qt\5.12.9\msvc2017\bin\qtenv2.bat
       }
       if ($env:qt -eq "5.12\msvc2017_64")
       {
@@ -46,8 +45,11 @@ install:
         Install-QtComponent -Version '5.12.9' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
         Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
         ConfigureQtVersion 'C:\Qt' '5.12.9'
-        C:\Qt\5.12.9\msvc2017_64\bin\qtenv2.bat
       }
+
+before_build:
+  - if "%QT%"=="5.12\msvc2017" call "C:\Qt\5.12.9\msvc2017\bin\qtenv2.bat"
+  - if "%QT%"=="5.12\msvc2017_64" call "C:\Qt\5.12.9\msvc2017_64\bin\qtenv2.bat"
 
 build_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,7 @@ install:
 before_build:
   - if "%QT%"=="5.12\msvc2017" call "C:\Qt\5.12.9\msvc2017\bin\qtenv2.bat"
   - if "%QT%"=="5.12\msvc2017_64" call "C:\Qt\5.12.9\msvc2017_64\bin\qtenv2.bat"
+  - cd /D %APPVEYOR_BUILD_FOLDER%
 
 build_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ install:
         Install-QtComponent -Version '5.12.9' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
         Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
         ConfigureQtVersion 'C:\Qt' '5.12.9'
+        C:\Qt\5.12.9\msvc2017\bin\qtenv2.bat
       }
       if ($env:qt -eq "5.12\msvc2017_64")
       {
@@ -45,6 +46,7 @@ install:
         Install-QtComponent -Version '5.12.9' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
         Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
         ConfigureQtVersion 'C:\Qt' '5.12.9'
+        C:\Qt\5.12.9\msvc2017_64\bin\qtenv2.bat
       }
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,23 @@ init:
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch%
 
+install:
+  - ps: |
+      if ($env:qt -eq "5.12\msvc2017")
+      {
+        iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
+        Install-QtComponent -Version '5.12.9' -Name 'win32_msvc2017' -ExcludeDocs -ExcludeExamples
+        Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win32_msvc2017' -ExcludeDocs -ExcludeExamples
+        ConfigureQtVersion 'C:\Qt' '5.12.9'
+      }
+      if ($env:qt -eq "5.12\msvc2017_64")
+      {
+        iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/build-images/master/scripts/Windows/install_qt_module.ps1'))
+        Install-QtComponent -Version '5.12.9' -Name 'win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
+        Install-QtComponent -Version '5.12.9' -Name 'qtwebengine.win64_msvc2017_64' -ExcludeDocs -ExcludeExamples
+        ConfigureQtVersion 'C:\Qt' '5.12.9'
+      }
+
 build_script:
   - ps: |
       # be aware that vcvarsall will reset platform amd64 to X64!


### PR DESCRIPTION
Appveyor has not updated Qt 5.12 in the MSVC 2017 build environment for some time.  A ticket https://github.com/appveyor/ci/issues/3306 from February 2020 says these environments will be updated, but it hasn't happened yet.

This uses Appveyor install scripts to install the Qt version of our choice as suggested in the above ticket.