### PR TITLE
backward compatible changes for Qt6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
           - $HOME/Cache
         timeout: 600
     - os: linux
-      dist: bionic
+      dist: focal
       compiler: gcc
       env:
         - BUILD_TYPE="coverage"

--- a/mmo.cc
+++ b/mmo.cc
@@ -929,7 +929,7 @@ mmo_finalize_rtept_cb(const Waypoint* wptref)
 {
   auto* wpt = const_cast<Waypoint*>(wptref);
 
-  if ((wpt->shortname[0] == 1) && (wpt->latitude == 0) && (wpt->longitude == 0)) {
+  if ((wpt->shortname[0] == '\01') && (wpt->latitude == 0) && (wpt->longitude == 0)) {
     mmo_data_t* data;
     Waypoint* wpt2;
 

--- a/tools/travis_script_linux_coverage
+++ b/tools/travis_script_linux_coverage
@@ -17,8 +17,7 @@ make -j 3 coverage
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 if [ -v CODACY_PROJECT_TOKEN ] ; then
   # upload coverate report to codacy.
-  wget -nv -c https://github.com/codacy/codacy-coverage-reporter/releases/download/11.4.1/codacy-coverage-reporter-assembly-11.4.1.jar
-  java -jar codacy-coverage-reporter-assembly-11.4.1.jar report -l cpp -f -r gpsbabel_coverage.xml
+  bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l CPP -r gpsbabel_coverage.xml
 else
   echo "Skipping codacy coverage upload as CODACY_PROJECT_TOKEN is not set."
 fi

--- a/tools/travis_script_linux_coverage
+++ b/tools/travis_script_linux_coverage
@@ -17,8 +17,8 @@ make -j 3 coverage
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 if [ -v CODACY_PROJECT_TOKEN ] ; then
   # upload coverate report to codacy.
-  wget -nv -c https://github.com/codacy/codacy-coverage-reporter/releases/download/6.2.0/codacy-coverage-reporter-assembly-6.2.0.jar
-  java -jar codacy-coverage-reporter-assembly-6.2.0.jar report -l cpp -f -r gpsbabel_coverage.xml
+  wget -nv -c https://github.com/codacy/codacy-coverage-reporter/releases/download/11.4.1/codacy-coverage-reporter-assembly-11.4.1.jar
+  java -jar codacy-coverage-reporter-assembly-11.4.1.jar report -l cpp -f -r gpsbabel_coverage.xml
 else
   echo "Skipping codacy coverage upload as CODACY_PROJECT_TOKEN is not set."
 fi


### PR DESCRIPTION
- Avoid implicit conversion of int to QChar, in Qt6 the constructor QChar(int code) is explicit by default.
- use focal for coverage generation
- use binary codacy coverage reporter.  the java version was failing on travis with "java.io.IOException: Error writing to server"


