### PR TITLE
catch windows installer up with renamed vc redistributable installer.

### DIFF
--- a/gui/setup.iss
+++ b/gui/setup.iss
@@ -47,9 +47,9 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: gmapbase.html; 			DestDir: "{app}"; Flags: ignoreversion
 Source: qt.conf;       			DestDir: "{app}"; Flags: ignoreversion
 
-Source: "..\{#gui_build_dir_name}\release\*"; Excludes: "app.res,vcredist_*.exe,*.cpp,*.h,*.o,*.obj"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\{#gui_build_dir_name}\release\vcredist_x86.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
-Source: "..\{#gui_build_dir_name}\release\vcredist_x64.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: "..\{#gui_build_dir_name}\release\*"; Excludes: "app.res,vc_redist.*.exe,*.cpp,*.h,*.o,*.obj"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\{#gui_build_dir_name}\release\vc_redist.x86.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: "..\{#gui_build_dir_name}\release\vc_redist.x64.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
 Source: "..\..\{#gpsbabel_build_dir_name}\release\gpsbabel.exe";   	DestDir: "{app}"; Flags: ignoreversion
 ; Source: release\help\*;           	DestDir: "{app}\help"; Flags: ignoreversion recursesubdirs createallsubdirs
 
@@ -76,8 +76,8 @@ Name: "{group}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"
 Name: "{commondesktop}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\vcredist_x86.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
-Filename: "{app}\vcredist_x64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.x86.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.x64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
 Filename: "{app}\gpsbabelfe.exe"; Description: "{cm:LaunchProgram,GPSBabelFE}"; Flags: nowait postinstall skipifsilent
 
 [Registry]

--- a/gui/setup.iss.in
+++ b/gui/setup.iss.in
@@ -47,9 +47,9 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: gmapbase.html; 			DestDir: "{app}"; Flags: ignoreversion
 Source: qt.conf;       			DestDir: "{app}"; Flags: ignoreversion
 
-Source: "..\{#gui_build_dir_name}\release\*"; Excludes: "app.res,vcredist_*.exe,*.cpp,*.h,*.o,*.obj"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\{#gui_build_dir_name}\release\vcredist_x86.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
-Source: "..\{#gui_build_dir_name}\release\vcredist_x64.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: "..\{#gui_build_dir_name}\release\*"; Excludes: "app.res,vc_redist.*.exe,*.cpp,*.h,*.o,*.obj"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\{#gui_build_dir_name}\release\vc_redist.x86.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: "..\{#gui_build_dir_name}\release\vc_redist.x64.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
 Source: "..\..\{#gpsbabel_build_dir_name}\release\gpsbabel.exe";   	DestDir: "{app}"; Flags: ignoreversion
 ; Source: release\help\*;           	DestDir: "{app}\help"; Flags: ignoreversion recursesubdirs createallsubdirs
 
@@ -76,8 +76,8 @@ Name: "{group}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"
 Name: "{commondesktop}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\vcredist_x86.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
-Filename: "{app}\vcredist_x64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.x86.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.x64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
 Filename: "{app}\gpsbabelfe.exe"; Description: "{cm:LaunchProgram,GPSBabelFE}"; Flags: nowait postinstall skipifsilent
 
 [Registry]

--- a/gui/setup.iss.qmake.in
+++ b/gui/setup.iss.qmake.in
@@ -47,9 +47,9 @@ Name: \"desktopicon\"; Description: \"{cm:CreateDesktopIcon}\"; GroupDescription
 Source: gmapbase.html; 			DestDir: \"{app}\"; Flags: ignoreversion
 Source: qt.conf;       			DestDir: \"{app}\"; Flags: ignoreversion
 
-Source: \"..\\{#gui_build_dir_name}\\release\\*\"; Excludes: \"app.res,vcredist_*.exe,*.cpp,*.h,*.o,*.obj\"; DestDir: \"{app}\"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: \"..\\{#gui_build_dir_name}\\release\\vcredist_x86.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
-Source: \"..\\{#gui_build_dir_name}\\release\\vcredist_x64.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: \"..\\{#gui_build_dir_name}\\release\\*\"; Excludes: \"app.res,vc_redist.*.exe,*.cpp,*.h,*.o,*.obj\"; DestDir: \"{app}\"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: \"..\\{#gui_build_dir_name}\\release\\vc_redist.x86.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: \"..\\{#gui_build_dir_name}\\release\\vc_redist.x64.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
 Source: \"..\\..\\{#gpsbabel_build_dir_name}\\release\\gpsbabel.exe\";   	DestDir: \"{app}\"; Flags: ignoreversion
 ; Source: release\\help\\*;           	DestDir: \"{app}\\help\"; Flags: ignoreversion recursesubdirs createallsubdirs
 
@@ -76,8 +76,8 @@ Name: \"{group}\\GPSBabel\"; Filename: \"{app}\\gpsbabelfe.exe\"
 Name: \"{commondesktop}\\GPSBabel\"; Filename: \"{app}\\gpsbabelfe.exe\"; Tasks: desktopicon
 
 [Run]
-Filename: \"{app}\\vcredist_x86.exe\"; Parameters: \"/quiet\"; Flags: skipifdoesntexist
-Filename: \"{app}\\vcredist_x64.exe\"; Parameters: \"/quiet\"; Flags: skipifdoesntexist
+Filename: \"{app}\\vc_redist.x86.exe\"; Parameters: \"/quiet\"; Flags: skipifdoesntexist
+Filename: \"{app}\\vc_redist.x64.exe\"; Parameters: \"/quiet\"; Flags: skipifdoesntexist
 Filename: \"{app}\\gpsbabelfe.exe\"; Description: \"{cm:LaunchProgram,GPSBabelFE}\"; Flags: nowait postinstall skipifsilent
 
 [Registry]


### PR DESCRIPTION
Some time ago the vc redistributables got renamed from vcredist_x86.exe and vcredist_x64.exe to vc_redist.x86.exe and vc_redist.x64.exe.  Our inno setup installer tries to run vcredist_x86.exe or vcredist_x64.exe, and delete it after it runs.  Unfortunately because the vc installer included in GPSBabelFE-1.6.0-Setup.exe and GPSBabelFE-1.7.0-Setup.exe had the name vc_redist.x86.exe it was not run on installation and then deleted as intended.  In the case that the user has never installed the vc redistributable (which apparently isn't too likely) they will see errors like "MSVCP140.dll  was not found" and "VCRUNTIME140.dll was not found" when they try to run GPSBabelFE.exe or gpsbabel.exe.  One such user problem was reported recently https://sourceforge.net/p/gpsbabel/mailman/message/37151619/

This restores the intended function of our installer to run the microsoft vc resdistributable installer when gpsbabel is installed and delete the microsoft installer afterwards.  It's not clear when this was broken, but it was broken in 1.6.0 and 1.7.0.