### PR TITLE
clang tidy readability fixes

### DIFF
--- a/bend.cc
+++ b/bend.cc
@@ -52,7 +52,7 @@ void BendFilter::init()
 }
 
 Waypoint* BendFilter::create_wpt_dest(const Waypoint* wpt_orig, double lat_orig,
-                                      double long_orig, double lat_orig_adj, double long_orig_adj)
+                                      double long_orig, double lat_orig_adj, double long_orig_adj) const
 {
   double distance = gcdist(lat_orig, long_orig,
                            lat_orig_adj, long_orig_adj);
@@ -77,7 +77,7 @@ Waypoint* BendFilter::create_wpt_dest(const Waypoint* wpt_orig, double lat_orig,
 
 int BendFilter::is_small_angle(double lat_orig, double long_orig, double lat_orig_prev,
                                double long_orig_prev, double lat_orig_next,
-                               double long_orig_next)
+                               double long_orig_next) const
 {
   double heading_prev = heading_true_degrees(lat_orig, long_orig,
                         lat_orig_prev, long_orig_prev);

--- a/bend.h
+++ b/bend.h
@@ -62,10 +62,10 @@ private:
   };
 
   Waypoint* create_wpt_dest(const Waypoint* wpt_orig, double lat_orig,
-                            double long_orig, double lat_orig_adj, double long_orig_adj);
+                            double long_orig, double lat_orig_adj, double long_orig_adj) const;
   int is_small_angle(double lat_orig, double long_orig, double lat_orig_prev,
                      double long_orig_prev, double lat_orig_next,
-                     double long_orig_next);
+                     double long_orig_next) const;
   void process_route(const route_head* route_orig, route_head* route_dest);
   void process_route_orig(const route_head* route_orig);
 

--- a/defs.h
+++ b/defs.h
@@ -536,7 +536,6 @@ public:
 
   bool HasUrlLink() const;
   const UrlLink& GetUrlLink() const;
-  [[deprecated]] const QList<UrlLink> GetUrlLinks() const;
   void AddUrlLink(const UrlLink& l);
   QString CreationTimeXML() const;
   gpsbabel::DateTime GetCreationTime() const;
@@ -1118,7 +1117,7 @@ char* convert_human_date_format(const char* human_datef);	/* "MM,YYYY,DD" -> "%m
 char* convert_human_time_format(const char* human_timef);	/* "HH+mm+ss"   -> "%H+%M+%S" */
 char* pretty_deg_format(double lat, double lon, char fmt, const char* sep, int html);    /* decimal ->  dd.dddd or dd mm.mmm or dd mm ss */
 
-const QString get_filename(const QString& fname);			/* extract the filename portion */
+QString get_filename(const QString& fname);			/* extract the filename portion */
 
 /*
  * Character encoding transformations.

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -145,7 +145,7 @@ Dg100Format::dg100_log(const char* fmt, ...)
 
 /* TODO: check whether negative lat/lon (West/South) are handled correctly */
 float
-Dg100Format::bin2deg(int val) const
+Dg100Format::bin2deg(int val)
 {
   /* Assume that val prints in decimal digits as [-]dddmmffff
    * ddd:  degrees

--- a/dg-100.h
+++ b/dg-100.h
@@ -121,7 +121,7 @@ protected:
   static QDateTime bintime2utc(int date, int time);
   static void dg100_debug(const char* hdr, int include_nl, size_t sz, unsigned char* buf);
   static void dg100_log(const char* fmt, ...);
-  float bin2deg(int val) const;
+  static float bin2deg(int val);
   void process_gpsfile(uint8_t* data, route_head** track) const;
   static uint16_t dg100_checksum(const uint8_t* buf, int count);
   size_t dg100_send(uint8_t cmd, const void* payload, size_t param_len) const;

--- a/duplicate.cc
+++ b/duplicate.cc
@@ -165,7 +165,7 @@ void DuplicateFilter::process()
   qsort(htable, ct, sizeof(*htable), compare);
 
   for (i=0; i<ct; i++) {
-    auto waypointp = htable[i].wpt;
+    auto* waypointp = htable[i].wpt;
 
     memset(&dupe, '\0', sizeof(dupe));
 

--- a/duplicate.h
+++ b/duplicate.h
@@ -70,7 +70,7 @@ private:
     Waypoint* wpt;
   };
 
-  btree_node* addnode(btree_node* tree, btree_node* newnode, btree_node** oldnode);
+  static btree_node* addnode(btree_node* tree, btree_node* newnode, btree_node** oldnode);
   void free_tree(btree_node* tree);
 
   struct wpt_ptr {

--- a/energympro.cc
+++ b/energympro.cc
@@ -89,7 +89,7 @@ EnergymproFormat::read_point(route_head* gpsbabel_route, gpsbabel::DateTime& gps
   // convert to millisecs
   gpsDateTime = gpsDateTime.addMSecs(point.IntervalTime*100);
 
-  auto waypt = new Waypoint;
+  auto* waypt = new Waypoint;
   waypt->latitude = (point.Latitude / 1000000.0);
   waypt->longitude = (point.Longitude / 1000000.0);
   waypt->altitude = point.Altitude;

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -1184,7 +1184,7 @@ GarminFitFormat::fit_collect_waypt(const Waypoint* waypointp)
 
   // Try to find a better course point type than "generic", based on the
   // course point name
-  for (auto& cptm: kCoursePointTypeMapping) {
+  for (const auto& cptm: kCoursePointTypeMapping) {
     if (crpt.shortname.contains(cptm.first, Qt::CaseInsensitive)) {
       crpt.course_point_type = cptm.second;
       break;

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -778,7 +778,7 @@ compare_strings(const QString& s1, const QString& s2)
 static writer_data_t*
 wdata_alloc()
 {
-  auto res = new writer_data_t;
+  auto* res = new writer_data_t;
   waypt_init_bounds(&res->bds);
 
   return res;

--- a/garmin_tables.cc
+++ b/garmin_tables.cc
@@ -421,7 +421,7 @@ gt_switch_display_mode_value(const unsigned char display_mode, const int protoid
   }
 }
 
-const QString
+QString
 gt_find_desc_from_icon_number(const int icon, garmin_formats_e garmin_format)
 {
   if ((garmin_format == GDB) && (icon >= 500) && (icon <= 563)) {

--- a/garmin_tables.h
+++ b/garmin_tables.h
@@ -38,7 +38,7 @@ struct icon_mapping_t {
 
 enum garmin_formats_e {MAPSOURCE, PCX, GARMIN_SERIAL, GDB};
 
-const QString gt_find_desc_from_icon_number(int icon, garmin_formats_e garmin_format);
+QString gt_find_desc_from_icon_number(int icon, garmin_formats_e garmin_format);
 int gt_find_icon_number_from_desc(const QString& desc, garmin_formats_e garmin_format);
 
 extern const icon_mapping_t garmin_icon_table[];

--- a/geojson.cc
+++ b/geojson.cc
@@ -33,13 +33,15 @@
 
 
 void
-GeoJsonFormat::rd_init(const QString& fname) {
-	ifd = new gpsbabel::File(fname);
-	ifd->open(QIODevice::ReadOnly | QIODevice::Text);
+GeoJsonFormat::rd_init(const QString& fname)
+{
+  ifd = new gpsbabel::File(fname);
+  ifd->open(QIODevice::ReadOnly | QIODevice::Text);
 }
 
 void
-GeoJsonFormat::wr_init(const QString& fname) {
+GeoJsonFormat::wr_init(const QString& fname)
+{
   feature_collection = new QJsonArray;
   ofd = new gpsbabel::File(fname);
   ofd->open(QIODevice::WriteOnly);
@@ -82,19 +84,21 @@ GeoJsonFormat::geojson_waypt_pr(const Waypoint* waypoint) const
   if (!properties.empty()) {
     feature[PROPERTIES] = properties;
   }
-  
+
   feature_collection->append(feature);
 }
 
 void
-GeoJsonFormat::rd_deinit() {
+GeoJsonFormat::rd_deinit()
+{
   ifd->close();
   delete ifd;
   ifd = nullptr;
 }
 
 void
-GeoJsonFormat::wr_deinit() {
+GeoJsonFormat::wr_deinit()
+{
   QJsonObject object;
   object[TYPE] = FEATURE_COLLECTION;
   object[FEATURES]  = *feature_collection;
@@ -110,146 +114,120 @@ GeoJsonFormat::wr_deinit() {
   feature_collection = nullptr;
 }
 
-Waypoint* 
+Waypoint*
 GeoJsonFormat::waypoint_from_coordinates(const QJsonArray& coordinates)
 {
-	auto waypoint = new Waypoint();
-	waypoint->latitude = coordinates.at(1).toDouble();
-	waypoint->longitude = coordinates.at(0).toDouble();
-	if (coordinates.size() > 2)
-	{
-		waypoint->altitude = coordinates.at(3).toDouble();
-	}
-	return waypoint;
-}
-
-void 
-GeoJsonFormat::routes_from_polygon_coordinates(const QJsonArray& polygon)
-{
-	for (auto && lineStringIterator : polygon)
-	{
-		QJsonArray coordinates = (lineStringIterator).toArray();
-		auto* route = new route_head;
-		route_add_head(route);
-		for (auto && coordinate : coordinates)
-		{
-			auto waypoint = waypoint_from_coordinates(coordinate.toArray());
-			route_add_wpt(route, waypoint);
-		}
-	}
+  auto* waypoint = new Waypoint();
+  waypoint->latitude = coordinates.at(1).toDouble();
+  waypoint->longitude = coordinates.at(0).toDouble();
+  if (coordinates.size() > 2) {
+    waypoint->altitude = coordinates.at(3).toDouble();
+  }
+  return waypoint;
 }
 
 void
-GeoJsonFormat::read() {
-	QString file_content = ifd->readAll();
-	QJsonParseError error{};
-	QJsonDocument document = QJsonDocument::fromJson(file_content.toUtf8(), &error);
+GeoJsonFormat::routes_from_polygon_coordinates(const QJsonArray& polygon)
+{
+  for (auto&& lineStringIterator : polygon) {
+    QJsonArray coordinates = (lineStringIterator).toArray();
+    auto* route = new route_head;
+    route_add_head(route);
+    for (auto&& coordinate : coordinates) {
+      auto* waypoint = waypoint_from_coordinates(coordinate.toArray());
+      route_add_wpt(route, waypoint);
+    }
+  }
+}
+
+void
+GeoJsonFormat::read()
+{
+  QString file_content = ifd->readAll();
+  QJsonParseError error{};
+  QJsonDocument document = QJsonDocument::fromJson(file_content.toUtf8(), &error);
   if (error.error != QJsonParseError::NoError) {
     fatal(FatalMsg().nospace() << MYNAME << ": GeoJSON parse error in " << ifd->fileName() << ": " << error.errorString());
   }
-	QJsonObject rootObject = document.object();
+  QJsonObject rootObject = document.object();
 
-	if (rootObject[TYPE] != FEATURE_COLLECTION)
-	{
-		return;
-	}
-	QJsonArray features = rootObject.value(FEATURES).toArray();
-	for (auto && iterator : features)
-	{
-		QJsonObject feature = iterator.toObject();
-		QJsonObject properties = (feature.value(PROPERTIES)).toObject();
-		QString name;
-		QString description;
-		if (!properties.empty())
-		{
-			if (properties.contains(NAME))
-			{
-				name = properties[NAME].toString();
-			}
-			if (properties.contains(DESCRIPTION))
-			{
-				description = properties[DESCRIPTION].toString();
-			}
-		}
-		
-		QJsonObject geometry = feature.value(GEOMETRY).toObject();
-		auto geometry_type = geometry[TYPE];
-		if (geometry_type == POINT)
-		{
-			QJsonArray coordinates = geometry.value(COORDINATES).toArray();
-			auto waypoint = waypoint_from_coordinates(coordinates);
-			waypoint->shortname = name;
-			waypoint->description = description;
-			if (properties.contains(URL))
-			{
-				QString url = properties[URL].toString();
-				if (properties.contains(URLNAME))
-				{
-					QString url_text = properties[URLNAME].toString();
-					waypoint->AddUrlLink(UrlLink(url, url_text));
-				}
-				else
-				{
-					waypoint->AddUrlLink(UrlLink(url));
-				}
-			}
-			waypt_add(waypoint);
-		}
-		else if (geometry_type == MULTIPOINT)
-		{
-			QJsonArray coordinates = geometry.value(COORDINATES).toArray();
-			for (auto && coordinate : coordinates)
-			{
-				auto waypoint = waypoint_from_coordinates(coordinate.toArray());
-				waypt_add(waypoint);
-			}
-		}
-		else if (geometry_type == LINESTRING)
-		{
-			QJsonArray coordinates = geometry.value(COORDINATES).toArray();
-			auto* route = new route_head;
-			route->rte_name = name;
-			route_add_head(route);
-			for (auto && coordinate : coordinates)
-			{
-				auto waypoint = waypoint_from_coordinates(coordinate.toArray());
-				route_add_wpt(route, waypoint);
-			}
-		}
-		else if (geometry_type == POLYGON)
-		{
-			QJsonArray polygon = geometry.value(COORDINATES).toArray();
-			routes_from_polygon_coordinates(polygon);
-		}
-		else if (geometry_type == MULTIPOLYGON)
-		{
-			QJsonArray polygons = geometry.value(COORDINATES).toArray();
-			for (auto && polygons_iterator : polygons)
-			{
-				QJsonArray polygon = polygons_iterator.toArray();
-				routes_from_polygon_coordinates(polygon);
-			}
-		}
-		else if (geometry_type == MULTILINESTRING)
-		{
-			QJsonArray line_strings = geometry.value(COORDINATES).toArray();
-			for (auto && line_string : line_strings)
-			{
-				QJsonArray coordinates = line_string.toArray();
-				auto* route = new route_head;
-				track_add_head(route);
-				for (auto && coordinate : coordinates)
-				{
-					auto waypoint = waypoint_from_coordinates(coordinate.toArray());
-					route_add_wpt(route, waypoint);
-				}
-			}
-		}
-	}
+  if (rootObject[TYPE] != FEATURE_COLLECTION) {
+    return;
+  }
+  QJsonArray features = rootObject.value(FEATURES).toArray();
+  for (auto&& iterator : features) {
+    QJsonObject feature = iterator.toObject();
+    QJsonObject properties = (feature.value(PROPERTIES)).toObject();
+    QString name;
+    QString description;
+    if (!properties.empty()) {
+      if (properties.contains(NAME)) {
+        name = properties[NAME].toString();
+      }
+      if (properties.contains(DESCRIPTION)) {
+        description = properties[DESCRIPTION].toString();
+      }
+    }
+
+    QJsonObject geometry = feature.value(GEOMETRY).toObject();
+    auto geometry_type = geometry[TYPE];
+    if (geometry_type == POINT) {
+      QJsonArray coordinates = geometry.value(COORDINATES).toArray();
+      auto* waypoint = waypoint_from_coordinates(coordinates);
+      waypoint->shortname = name;
+      waypoint->description = description;
+      if (properties.contains(URL)) {
+        QString url = properties[URL].toString();
+        if (properties.contains(URLNAME)) {
+          QString url_text = properties[URLNAME].toString();
+          waypoint->AddUrlLink(UrlLink(url, url_text));
+        } else {
+          waypoint->AddUrlLink(UrlLink(url));
+        }
+      }
+      waypt_add(waypoint);
+    } else if (geometry_type == MULTIPOINT) {
+      QJsonArray coordinates = geometry.value(COORDINATES).toArray();
+      for (auto&& coordinate : coordinates) {
+        auto* waypoint = waypoint_from_coordinates(coordinate.toArray());
+        waypt_add(waypoint);
+      }
+    } else if (geometry_type == LINESTRING) {
+      QJsonArray coordinates = geometry.value(COORDINATES).toArray();
+      auto* route = new route_head;
+      route->rte_name = name;
+      route_add_head(route);
+      for (auto&& coordinate : coordinates) {
+        auto* waypoint = waypoint_from_coordinates(coordinate.toArray());
+        route_add_wpt(route, waypoint);
+      }
+    } else if (geometry_type == POLYGON) {
+      QJsonArray polygon = geometry.value(COORDINATES).toArray();
+      routes_from_polygon_coordinates(polygon);
+    } else if (geometry_type == MULTIPOLYGON) {
+      QJsonArray polygons = geometry.value(COORDINATES).toArray();
+      for (auto&& polygons_iterator : polygons) {
+        QJsonArray polygon = polygons_iterator.toArray();
+        routes_from_polygon_coordinates(polygon);
+      }
+    } else if (geometry_type == MULTILINESTRING) {
+      QJsonArray line_strings = geometry.value(COORDINATES).toArray();
+      for (auto&& line_string : line_strings) {
+        QJsonArray coordinates = line_string.toArray();
+        auto* route = new route_head;
+        track_add_head(route);
+        for (auto&& coordinate : coordinates) {
+          auto* waypoint = waypoint_from_coordinates(coordinate.toArray());
+          route_add_wpt(route, waypoint);
+        }
+      }
+    }
+  }
 }
 
 
-void GeoJsonFormat::geojson_track_hdr(const route_head* track) {
+void GeoJsonFormat::geojson_track_hdr(const route_head* track)
+{
   track_object = new QJsonObject();
 
   (*track_object)[TYPE] = FEATURE;
@@ -274,7 +252,8 @@ void GeoJsonFormat::geojson_track_disp(const Waypoint* trackpoint) const
   (*track_coords).append(coords);
 }
 
-void GeoJsonFormat::geojson_track_tlr(const route_head* /*unused*/) {
+void GeoJsonFormat::geojson_track_tlr(const route_head* /*unused*/)
+{
   QJsonObject geometry;
   geometry[TYPE] = LINESTRING;
   geometry[COORDINATES] = *track_coords;
@@ -287,7 +266,8 @@ void GeoJsonFormat::geojson_track_tlr(const route_head* /*unused*/) {
 }
 
 void
-GeoJsonFormat::write() {
+GeoJsonFormat::write()
+{
   auto geojson_waypt_pr_lambda = [this](const Waypoint* waypointp)->void {
     geojson_waypt_pr(waypointp);
   };

--- a/geojson.h
+++ b/geojson.h
@@ -71,7 +71,7 @@ private:
 
   void geojson_waypt_pr(const Waypoint* waypoint) const;
   static Waypoint* waypoint_from_coordinates(const QJsonArray& coordinates);
-  void routes_from_polygon_coordinates(const QJsonArray& polygon);
+  static void routes_from_polygon_coordinates(const QJsonArray& polygon);
   void geojson_track_hdr(const route_head* track);
   void geojson_track_disp(const Waypoint* trackpoint) const;
   void geojson_track_tlr(const route_head* unused);

--- a/gpx.cc
+++ b/gpx.cc
@@ -71,12 +71,12 @@ GpxFormat::gpx_add_to_global(QStringList& ge, const QString& s)
 // Temporarily mock the old GPX writer's hardcoded fixed length for float/double
 // types.  This can be removed once we have time/interest in regenerating all our
 // zillion reference files.
-inline QString GpxFormat::toString(double d) const
+inline QString GpxFormat::toString(double d)
 {
   return QString::number(d, 'f', 9);
 }
 
-inline QString GpxFormat::toString(float f) const
+inline QString GpxFormat::toString(float f)
 {
   return QString::number(f, 'f', 6);
 }

--- a/gpx.h
+++ b/gpx.h
@@ -188,8 +188,8 @@ private:
 
 
   static void gpx_add_to_global(QStringList& ge, const QString& s);
-  inline QString toString(double d) const;
-  inline QString toString(float f) const;
+  static inline QString toString(double d);
+  static inline QString toString(float f);
   void gpx_reset_short_handle();
   void gpx_write_gdata(const QStringList& ge, const QString& tag) const;
   tag_mapping get_tag(const QString& t) const;

--- a/height.h
+++ b/height.h
@@ -61,7 +61,7 @@ private:
     },
   };
 
-  double bilinear(double x1, double y1, double x2, double y2, double x, double y, double z11, double z12, double z21, double z22);
+  static double bilinear(double x1, double y1, double x2, double y2, double x, double y, double z11, double z12, double z21, double z22);
   double wgs84_separation(double lat, double lon);
   void correct_height(const Waypoint* wpt);
 

--- a/igo8.cc
+++ b/igo8.cc
@@ -128,17 +128,17 @@ static QVector<arglist_t> igo8_options = {
 // Sanity check
 static void igo8_check_type_sizes()
 {
-  if constexpr (sizeof(igo8_point) != 12) {
+  if constexpr(sizeof(igo8_point) != 12) {
     fatal(MYNAME ": igo8_point is %ld bytes instead of the required 12.\n",
           (long) sizeof(igo8_point));
   }
 
-  if constexpr (sizeof(igo8_information_block) != 12) {
+  if constexpr(sizeof(igo8_information_block) != 12) {
     fatal(MYNAME ": igo8_information_block is %ld bytes instead of the required 12.\n",
           (long) sizeof(igo8_information_block));
   }
 
-  if constexpr (sizeof(igo8_id_block) != 20) {
+  if constexpr(sizeof(igo8_id_block) != 20) {
     fatal(MYNAME ": igo8_id_block is %ld bytes instead of the required 20.\n",
           (long) sizeof(igo8_id_block));
   }
@@ -275,7 +275,7 @@ static void write_header()
 {
   char header[IGO8_HEADER_SIZE] = {};
   igo8_id_block tmp_id_block;
-  auto id_block = (p_igo8_id_block)header;
+  auto* id_block = (p_igo8_id_block)header;
   uint32_t current_position = 0;
   const char* title = "Title";
   const char* description = "Description";

--- a/inifile.cc
+++ b/inifile.cc
@@ -148,7 +148,7 @@ inifile_load_file(QTextStream* stream, inifile_t* inifile, const char* myname)
   }
 }
 
-static const QString
+static QString
 inifile_find_value(const inifile_t* inifile, const QString& sec_name, const QString& key)
 {
   if (inifile == nullptr) {

--- a/jeeps/gpslibusb.cc
+++ b/jeeps/gpslibusb.cc
@@ -123,7 +123,7 @@ char** os_get_garmin_mountpoints()
 static int
 gusb_libusb_send(const garmin_usb_packet* opkt, size_t sz)
 {
-  auto buf = const_cast<unsigned char*>(&opkt->dbuf[0]);
+  auto* buf = const_cast<unsigned char*>(&opkt->dbuf[0]);
   int transferred;
 
   int ret = libusb_bulk_transfer(udev, gusb_bulk_out_ep, buf, sz,
@@ -400,7 +400,7 @@ garmin_usb_start(struct libusb_device* dev,
       const struct libusb_interface_descriptor* altsetting = &interface->altsetting[j];
       /*
        * FIXME: Since we never use libusb_set_interface_alt_setting()
-       * shouldn't we only look at the default interface descriptor, i.e. 
+       * shouldn't we only look at the default interface descriptor, i.e.
        * the one that has a bAlternateSetting of 0 and/or the one
        * that has index 0?
        * From the USB spec:
@@ -543,7 +543,7 @@ int
 gusb_init(const char* portname, gpsdevh** dh)
 {
   int req_unit_number = 0;
-  auto lud = (libusb_unit_data*) xcalloc(sizeof(libusb_unit_data), 1);
+  auto* lud = (libusb_unit_data*) xcalloc(sizeof(libusb_unit_data), 1);
 
   *dh = (gpsdevh*) lud;
 

--- a/kml.cc
+++ b/kml.cc
@@ -670,7 +670,7 @@ void KmlFormat::kml_output_header(const route_head* header, const computed_trkda
   }
 }
 
-int KmlFormat::kml_altitude_known(const Waypoint* waypoint) const
+int KmlFormat::kml_altitude_known(const Waypoint* waypoint)
 {
   if (waypoint->altitude == unknown_alt) {
     return 0;

--- a/kml.h
+++ b/kml.h
@@ -134,7 +134,7 @@ private:
   static void kml_td(gpsbabel::XmlStreamWriter& hwriter, const QString& data);
   void kml_output_trkdescription(const route_head* header, const computed_trkdata* td) const;
   void kml_output_header(const route_head* header, const computed_trkdata* td) const;
-  int kml_altitude_known(const Waypoint* waypoint) const;
+  static int kml_altitude_known(const Waypoint* waypoint);
   void kml_write_coordinates(const Waypoint* waypointp) const;
   void kml_output_lookat(const Waypoint* waypointp) const;
   void kml_output_positioning(bool tessellate) const;

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -150,7 +150,7 @@ LowranceusrFormat::register_waypt(const Waypoint* wpt) const
 /* end borrowed from raymarine.c */
 
 const Waypoint*
-LowranceusrFormat::lowranceusr4_find_waypt(uint uid_unit, int uid_seq_low, int uid_seq_high) const
+LowranceusrFormat::lowranceusr4_find_waypt(uint uid_unit, int uid_seq_low, int uid_seq_high)
 {
   // Iterate with waypt_disp_all?
   for (const Waypoint* waypointp : qAsConst(*global_waypoint_list)) {
@@ -171,7 +171,7 @@ LowranceusrFormat::lowranceusr4_find_waypt(uint uid_unit, int uid_seq_low, int u
 }
 
 const Waypoint*
-LowranceusrFormat::lowranceusr4_find_global_waypt(uint id1, uint id2, uint id3, uint id4) const
+LowranceusrFormat::lowranceusr4_find_global_waypt(uint id1, uint id2, uint id3, uint id4)
 {
   // Iterate with waypt_disp_all?
   for (const Waypoint* waypointp : qAsConst(*global_waypoint_list)) {

--- a/lowranceusr.h
+++ b/lowranceusr.h
@@ -397,8 +397,8 @@ private:
 
   static char same_points(const Waypoint*, const Waypoint*);
   void register_waypt(const Waypoint*) const;
-  const Waypoint* lowranceusr4_find_waypt(uint, int, int) const;
-  const Waypoint* lowranceusr4_find_global_waypt(uint, uint, uint, uint) const;
+  static const Waypoint* lowranceusr4_find_waypt(uint, int, int);
+  static const Waypoint* lowranceusr4_find_global_waypt(uint, uint, uint, uint);
   QString lowranceusr4_readstr(gbfile*, int) const;
   void lowranceusr4_writestr(const QString&, gbfile*, int) const;
   static gpsbabel::DateTime lowranceusr4_get_timestamp(unsigned int, unsigned int);

--- a/mkshort.cc
+++ b/mkshort.cc
@@ -98,7 +98,7 @@ unsigned int hash_string(const char* key)
 short_handle
 mkshort_new_handle()
 {
-  auto h = new mkshort_handle_imp;
+  auto* h = new mkshort_handle_imp;
 
   h->badchars = xstrdup(DEFAULT_BADCHARS);
   h->defname = xstrdup("WPT");
@@ -165,7 +165,7 @@ mkshort_del_handle(short_handle* h)
     return;
   }
 
-  for (auto &i : hdr->namelist) {
+  for (auto& i : hdr->namelist) {
     while (!i.isEmpty()) {
 #if 0
       if (global_opts.verbose_status >= 2 && s->conflictctr) {
@@ -173,7 +173,7 @@ mkshort_del_handle(short_handle* h)
                 s->conflictctr, s->orig_shortname);
       }
 #endif
-      auto s = i.takeFirst();
+      auto* s = i.takeFirst();
       xfree(s->orig_shortname);
       xfree(s);
     }

--- a/mmo.cc
+++ b/mmo.cc
@@ -994,7 +994,7 @@ mmo_rd_deinit()
 
   icons.clear();
 
-  for (auto value : qAsConst(objects)) {
+  for (auto* value : qAsConst(objects)) {
     mmo_free_object(value);
   }
   objects.clear();
@@ -1429,7 +1429,7 @@ mmo_wr_deinit()
   mmobjects.clear();
   category_names.clear();
 
-  for (auto value : qAsConst(objects)) {
+  for (auto* value : qAsConst(objects)) {
     mmo_free_object(value);
   }
   objects.clear();

--- a/mtk_logger.cc
+++ b/mtk_logger.cc
@@ -303,7 +303,7 @@ static void dbg(int l, const char* msg, ...)
 //
 // It returns a temporary C string - it's totally kludged in to replace
 // TEMP_DATA_BIN being string constants.
-static const QString GetTempName(bool backup)
+static QString GetTempName(bool backup)
 {
   const char kData[]= "data.bin";
   const char kDataBackup[]= "data_old.bin";

--- a/osm.cc
+++ b/osm.cc
@@ -415,7 +415,7 @@ OsmFormat::osm_strip_html(const char* str)
 }
 
 QString
-OsmFormat::osm_strip_html(const QString& str) const
+OsmFormat::osm_strip_html(const QString& str)
 {
   char* r = osm_strip_html(CSTR(str));
   QString rv(r);

--- a/osm.h
+++ b/osm.h
@@ -97,7 +97,7 @@ private:
   char osm_feature_ikey(const QString& key) const;
   QString osm_feature_symbol(int ikey, const char* value) const;
   static char* osm_strip_html(const char* str);
-  QString osm_strip_html(const QString& str) const;
+  static QString osm_strip_html(const QString& str);
   void osm_node_end(xg_string /* unused */, const QXmlStreamAttributes* /* unused */);
   void osm_node(xg_string /* unused */, const QXmlStreamAttributes* attrv);
   void osm_node_tag(xg_string /* unused */, const QXmlStreamAttributes* attrv);

--- a/polygon.h
+++ b/polygon.h
@@ -58,7 +58,7 @@ private:
     },
   };
 
-  void polytest(double lat1, double lon1,
+  static void polytest(double lat1, double lon1,
                 double lat2, double lon2,
                 double wlat, double wlon,
                 unsigned short* state, int first, int last);

--- a/position.cc
+++ b/position.cc
@@ -46,7 +46,7 @@ void PositionFilter::position_runqueue(WaypointList* waypt_list, int qtype)
 {
   QList<WptRecord> qlist;
 
-  for (const auto waypointp : qAsConst(*waypt_list)) {
+  for (auto* const waypointp : qAsConst(*waypt_list)) {
     qlist.append(WptRecord(waypointp));
   }
   int nelems = qlist.size();

--- a/position.h
+++ b/position.h
@@ -74,7 +74,7 @@ private:
     explicit WptRecord(Waypoint* w) : wpt(w) {}
   };
 
-  double gc_distance(double lat1, double lon1, double lat2, double lon2);
+  static double gc_distance(double lat1, double lon1, double lat2, double lon2);
   void position_runqueue(WaypointList* waypt_list, int qtype);
   void position_process_any_route(const route_head* rh, int type);
   void position_process_rte(const route_head* rh);

--- a/radius.h
+++ b/radius.h
@@ -88,7 +88,7 @@ private:
     },
   };
 
-  double gc_distance(double lat1, double lon1, double lat2, double lon2);
+  static double gc_distance(double lat1, double lon1, double lat2, double lon2);
 
 };
 #endif // FILTERS_ENABLED

--- a/random.cc
+++ b/random.cc
@@ -105,7 +105,7 @@ RandomFormat::rd_deinit()
 Waypoint*
 RandomFormat::random_generate_wpt(int i, const QDateTime& time, const Waypoint* prev)
 {
-  auto wpt = new Waypoint;
+  auto* wpt = new Waypoint;
   garmin_fs_t* gmsd = garmin_fs_alloc(-1);
   wpt->fs.FsChainAdd(gmsd);
 

--- a/reverse_route.cc
+++ b/reverse_route.cc
@@ -46,7 +46,7 @@ void ReverseRouteFilter::reverse_route_wpt(const Waypoint* waypointp)
 void ReverseRouteFilter::reverse_route_head(const route_head* rte_hd)
 {
   /* Cast away const-ness */
-  auto rh = const_cast<route_head*>(rte_hd);
+  auto* rh = const_cast<route_head*>(rte_hd);
   std::reverse(rh->waypoint_list.begin(), rh->waypoint_list.end());
   prev_new_trkseg = 1;
 }

--- a/smplrout.h
+++ b/smplrout.h
@@ -126,7 +126,7 @@ private:
     const Waypoint* wpt{nullptr};
   };
 
-  void free_xte(struct xte* xte_rec);
+  static void free_xte(struct xte* xte_rec);
 
   struct xte_intermed* tmpprev = nullptr;
   int xte_count = 0;

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -268,7 +268,7 @@ void TrackFilter::trackfilter_pack_init_rte_name(route_head* track, const gpsbab
     if (track->rte_waypt_ct == 0) {
       dt = default_time;
     } else {
-      auto wpt = track->waypoint_list.front();
+      auto* wpt = track->waypoint_list.front();
       dt = wpt->GetCreationTime();
     }
     time_t t = dt.toTime_t();
@@ -294,7 +294,7 @@ void TrackFilter::trackfilter_title()
   if (strlen(opt_title) == 0) {
     fatal(MYNAME "-title: Missing your title!\n");
   }
-  for (auto track : qAsConst(track_list)) {
+  for (auto* track : qAsConst(track_list)) {
     trackfilter_pack_init_rte_name(track, QDateTime::fromMSecsSinceEpoch(0, Qt::UTC));
   }
 }
@@ -376,7 +376,7 @@ void TrackFilter::trackfilter_merge()
 
     Waypoint* prev = nullptr;
 
-    for (auto wpt : buff) {
+    for (auto* wpt : buff) {
       if ((prev == nullptr) || (prev->GetCreationTime() != wpt->GetCreationTime())) {
         track_add_wpt(master, wpt);
         prev = wpt;
@@ -571,7 +571,7 @@ void TrackFilter::trackfilter_move()
     return;
   }
 
-  for (auto track : qAsConst(track_list)) {
+  for (auto* track : qAsConst(track_list)) {
     foreach (Waypoint* wpt, track->waypoint_list) {
       wpt->creation_time = wpt->creation_time.addSecs(delta);
     }
@@ -593,7 +593,7 @@ void TrackFilter::trackfilter_synth()
 
   fix_type fix = trackfilter_parse_fix(&nsats);
 
-  for (auto track : qAsConst(track_list)) {
+  for (auto* track : qAsConst(track_list)) {
     bool first = true;
     foreach (Waypoint* wpt, track->waypoint_list) {
       if (opt_fix) {
@@ -742,7 +742,7 @@ void TrackFilter::trackfilter_seg2trk()
 {
   if (!track_list.isEmpty()) {
     QList<route_head*> new_track_list;
-    for (auto src : qAsConst(track_list)) {
+    for (auto* src : qAsConst(track_list)) {
       new_track_list.append(src);
       route_head* dest = nullptr;
       route_head* insert_point = src;
@@ -863,7 +863,7 @@ void TrackFilter::trackfilter_faketime()
   assert(opt_faketime != nullptr);
   faketime_t faketime = trackfilter_faketime_check(opt_faketime);
 
-  for (auto track : qAsConst(track_list)) {
+  for (auto* track : qAsConst(track_list)) {
     foreach (Waypoint* wpt, track->waypoint_list) {
 
       if (!wpt->creation_time.isValid() || faketime.force) {
@@ -907,7 +907,7 @@ void TrackFilter::trackfilter_segment_head(const route_head* rte)
   const double ktoo_close = 0.000005;
 
   for (auto it = rte->waypoint_list.cbegin(); it != rte->waypoint_list.cend(); ++it) {
-    auto wpt = *it;
+    auto* wpt = *it;
     if (index > 0) {
       double cur_dist = gcdist(RAD(prev_wpt->latitude),
                                RAD(prev_wpt->longitude),
@@ -920,7 +920,7 @@ void TrackFilter::trackfilter_segment_head(const route_head* rte)
 
       if (cur_dist < ktoo_close) {
         if (wpt != rte->waypoint_list.back()) {
-          auto next_wpt = *std::next(it);
+          auto* next_wpt = *std::next(it);
           if (trackfilter_points_are_same(prev_wpt, wpt) &&
               trackfilter_points_are_same(wpt, next_wpt)) {
             track_del_wpt(const_cast<route_head*>(rte), wpt);

--- a/trackfilter.h
+++ b/trackfilter.h
@@ -178,7 +178,7 @@ private:
   bool need_time{};		/* initialized within trackfilter_init */
 
   int trackfilter_opt_count();
-  qint64 trackfilter_parse_time_opt(const char* arg);
+  static qint64 trackfilter_parse_time_opt(const char* arg);
   static bool trackfilter_init_sort_cb(const route_head* ha, const route_head* hb);
   static bool trackfilter_merge_sort_cb(const Waypoint* wa, const Waypoint* wb);
   fix_type trackfilter_parse_fix(int* nsats);
@@ -202,7 +202,7 @@ private:
 
   void trackfilter_synth();
 
-  QDateTime trackfilter_range_check(const char* timestr);
+  static QDateTime trackfilter_range_check(const char* timestr);
   void trackfilter_range();
 
   void trackfilter_seg2trk();
@@ -215,9 +215,9 @@ private:
     bool   force{false};
   };
 
-  faketime_t trackfilter_faketime_check(const char* timestr);
+  static faketime_t trackfilter_faketime_check(const char* timestr);
   void trackfilter_faketime();             /* returns number of track points left after filtering */
-  bool trackfilter_points_are_same(const Waypoint* wpta, const Waypoint* wptb);
+  static bool trackfilter_points_are_same(const Waypoint* wpta, const Waypoint* wptb);
 
   void trackfilter_segment_head(const route_head* rte);
 

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -170,7 +170,7 @@ const UnicsvFormat::field_t UnicsvFormat::fields_def[] = {
 // Parse GC-Code / geo cache reference code into int64 (GC-ID)
 // (see also https://api.groundspeak.com/documentation#referencecodes)
 long long
-UnicsvFormat::unicsv_parse_gc_code(const QString& str) const
+UnicsvFormat::unicsv_parse_gc_code(const QString& str)
 {
   if (! str.startsWith("GC")) {
     return 0;
@@ -283,7 +283,7 @@ UnicsvFormat::unicsv_parse_date(const char* str, int* consumed)
 }
 
 time_t
-UnicsvFormat::unicsv_parse_time(const char* str, int* usec, time_t* date) const
+UnicsvFormat::unicsv_parse_time(const char* str, int* usec, time_t* date)
 {
   int hour, min, sec;
   int consumed = 0;

--- a/unicsv.h
+++ b/unicsv.h
@@ -172,9 +172,9 @@ private:
 
   /* Member Functions */
 
-  long long int unicsv_parse_gc_code(const QString& str) const;
+  static long long int unicsv_parse_gc_code(const QString& str);
   static time_t unicsv_parse_date(const char* str, int* consumed);
-  time_t unicsv_parse_time(const char* str, int* usec, time_t* date) const;
+  static time_t unicsv_parse_time(const char* str, int* usec, time_t* date);
   time_t unicsv_parse_time(const QString& str, int* msec, time_t* date) const;
   static status_type unicsv_parse_status(const QString& str);
   QDateTime unicsv_adjust_time(time_t time, const time_t* date) const;

--- a/util.cc
+++ b/util.cc
@@ -1679,9 +1679,9 @@ QString xml_attribute(const QXmlStreamAttributes& attributes, const QString& att
   return QString();
 }
 
-const QString get_filename(const QString& fname)
+QString get_filename(const QString& fname)
 {
-  return  QFileInfo(fname).fileName();
+  return QFileInfo(fname).fileName();
 }
 
 /* bit manipulation functions */

--- a/util.cc
+++ b/util.cc
@@ -211,11 +211,12 @@ ufopen(const QString& fname, const char* mode)
 /*
  * OS-abstracting wrapper for getting Unicode environment variables.
  */
-QString ugetenv(const char* env_var) {
+QString ugetenv(const char* env_var)
+{
 #ifdef __WIN32__
   // Use QString to convert 8-bit env_var argument to wchar_t* for _wgetenv().
   return QString::fromWCharArray(
-      _wgetenv((const wchar_t*) QString(env_var).utf16()));
+           _wgetenv((const wchar_t*) QString(env_var).utf16()));
 #else
   // Everyone else uses UTF-8 or some other locale-specific 8-bit encoding.
   return QString::fromLocal8Bit(std::getenv(env_var));
@@ -500,8 +501,8 @@ str_match(const char* str, const char* match)
       if (*m == '\0') {
         return 0;  /* incomplete escape sequence */
       }
-    /* pass-through next character */
-    [[fallthrough]];
+      /* pass-through next character */
+      [[fallthrough]];
 
     default:
       if (*m != *s) {
@@ -632,7 +633,7 @@ le_read64(void* dest, const void* src)
   char* cdest = (char*) dest;
   const char* csrc = (const char*) src;
 
-  if constexpr (i_am_little_endian) {
+  if constexpr(i_am_little_endian) {
     memcpy(dest, src, 8);
   } else {
     int i;
@@ -1740,7 +1741,7 @@ list_codecs()
   const auto mibs = QTextCodec::availableMibs();
   int maxlen = 0;
   for (auto mib : mibs) {
-    auto codec = QTextCodec::codecForMib(mib);
+    auto* codec = QTextCodec::codecForMib(mib);
     if (codec->name().size() > maxlen) {
       maxlen = codec->name().size();
     }
@@ -1748,7 +1749,7 @@ list_codecs()
   info << "Available Codecs:" << endl;
   info << qSetFieldWidth(8) << "MIBenum" << qSetFieldWidth(maxlen+1) << "Name" << qSetFieldWidth(0) << "Aliases" << endl;
   for (auto mib : mibs) {
-    auto codec = QTextCodec::codecForMib(mib);
+    auto* codec = QTextCodec::codecForMib(mib);
     info << qSetFieldWidth(8) << mib << qSetFieldWidth(maxlen+1) << codec->name() << qSetFieldWidth(0);
     bool first = true;
     const auto aliases = codec->aliases();

--- a/vecs.cc
+++ b/vecs.cc
@@ -269,7 +269,7 @@ Format* Vecs::find_vec(const QString& vecname)
      * format that utilized an internal style file, then we need to let
      * xcsv know the internal style file is no longer in play.
      */
-     xcsv_fmt.xcsv_setup_internal_style(nullptr);
+    xcsv_fmt.xcsv_setup_internal_style(nullptr);
 #endif // CSVFMTS_ENABLED
     vec.vec->set_name(vec.name);	/* needed for session information */
     return vec.vec;
@@ -533,7 +533,7 @@ void Vecs::disp_v1(ff_type t)
 
 void Vecs::disp_v2(const vecinfo_t& v)
 {
-  for (auto& i : v.cap) {
+  for (const auto& i : v.cap) {
     putchar((i & ff_cap_read) ? 'r' : '-');
     putchar((i & ff_cap_write) ? 'w' : '-');
   }

--- a/waypt.cc
+++ b/waypt.cc
@@ -597,11 +597,11 @@ WaypointList::waypt_add(Waypoint* wpt)
 
   if ((wpt->latitude < -90) || (wpt->latitude > 90.0))
     fatal(FatalMsg() << wpt->session->name
-            << "Invalid latitude" << lat_orig << "in waypoint"
-            << wpt->shortname);
+          << "Invalid latitude" << lat_orig << "in waypoint"
+          << wpt->shortname);
   if ((wpt->longitude < -180) || (wpt->longitude > 180.0))
     fatal(FatalMsg() << "Invalid longitude" << lon_orig << "in waypoint"
-            << wpt->shortname);
+          << wpt->shortname);
 
   /*
    * Some input may not have one or more of these types so we
@@ -642,10 +642,10 @@ WaypointList::add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, const QStri
 {
   append(wpt);
 
-   if (synth && wpt->shortname.isEmpty()) {
-     wpt->shortname = QString("%1%2").arg(namepart).arg(waypt_ct, number_digits, 10, QChar('0'));
-     wpt->wpt_flags.shortname_is_synthetic = 1;
-   }
+  if (synth && wpt->shortname.isEmpty()) {
+    wpt->shortname = QString("%1%2").arg(namepart).arg(waypt_ct, number_digits, 10, QChar('0'));
+    wpt->wpt_flags.shortname_is_synthetic = 1;
+  }
 }
 
 void
@@ -662,7 +662,7 @@ WaypointList::del_rte_waypt(Waypoint* wpt)
   const int idx = indexOf(wpt);
   assert(idx >= 0);
   if (wpt->wpt_flags.new_trkseg && ((idx+1) < size())) {
-    auto wpt_next = at(idx+1);
+    auto* wpt_next = at(idx+1);
     wpt_next->wpt_flags.new_trkseg = 1;
   }
   wpt->wpt_flags.new_trkseg = 0;
@@ -709,7 +709,7 @@ WaypointList::copy(WaypointList** dst) const
   if (*dst == nullptr) {
     *dst = new WaypointList;
   }
-    
+
   foreach (const Waypoint* wpt_old, *this) {
     (*dst)->waypt_add(new Waypoint(*wpt_old));
   }

--- a/waypt.cc
+++ b/waypt.cc
@@ -521,12 +521,6 @@ Waypoint::GetUrlLink() const
   return urls.GetUrlLink();
 }
 
-[[deprecated]] const QList<UrlLink>
-Waypoint::GetUrlLinks() const
-{
-  return urls;
-}
-
 void
 Waypoint::AddUrlLink(const UrlLink& l)
 {

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -194,17 +194,23 @@ XcsvStyle::xcsv_get_char_from_constant_table(const QString& key)
 
 // Remove outer quotes.
 // Should probably be in csv_util.
-QString XcsvStyle::dequote(const QString& in) {
+QString XcsvStyle::dequote(const QString& in)
+{
   QString r = in.simplified();
-  if (r.startsWith("\"")) r = r.mid(1);
-  if (r.endsWith("\"")) r.chop(1);
+  if (r.startsWith("\"")) {
+    r = r.mid(1);
+  }
+  if (r.endsWith("\"")) {
+    r.chop(1);
+  }
   return r;
 }
 
-void XcsvStyle::validate_fieldmap(const field_map& fmp, bool is_output) {
+void XcsvStyle::validate_fieldmap(const field_map& fmp, bool is_output)
+{
   if (fmp.key.isEmpty()) {
     fatal(FatalMsg() << MYNAME << ": xcsv style is missing" <<
-            (is_output ? "output" : "input") << "field type.");
+          (is_output ? "output" : "input") << "field type.");
   }
   if (fmp.val.isNull()) {
     fatal(FatalMsg() << MYNAME << ": xcsv style" << fmp.key.constData() << "is missing default.");
@@ -351,8 +357,8 @@ XcsvFormat::writehms(const char* format, time_t t, int gmt)
   }
 
   return QString::asprintf(format,
-                            stmp->tm_hour, stmp->tm_min, stmp->tm_sec,
-                            (stmp->tm_hour >= 12 ? "PM" : "AM"));
+                           stmp->tm_hour, stmp->tm_min, stmp->tm_sec,
+                           (stmp->tm_hour >= 12 ? "PM" : "AM"));
 }
 
 QString
@@ -383,9 +389,9 @@ XcsvFormat::gmsd_init(Waypoint* wpt)
 /* xcsv_parse_val() - parse incoming data into the waypt structure.          */
 /* usage: xcsv_parse_val("-123.34", *waypt, *field_map)                      */
 /*****************************************************************************/
-void 
+void
 XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle::field_map& fmp,
-               xcsv_parse_data* parse_data, const int line_no)
+                           xcsv_parse_data* parse_data, const int line_no)
 {
   const char* enclosure = "";
   geocache_data* gc_data = nullptr;
@@ -440,7 +446,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     wpt->icon_descr = value.trimmed();
     break;
 
-    /* LATITUDE CONVERSIONS**************************************************/
+  /* LATITUDE CONVERSIONS**************************************************/
   case XcsvStyle::XT_LAT_DECIMAL:
     /* latitude as a pure decimal value */
     wpt->latitude = atof(s);
@@ -463,8 +469,8 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   case XcsvStyle::XT_LAT_NMEA:
     wpt->latitude = ddmm2degrees(atof(s));
     break;
-    // XT_LAT_10E is handled outside the switch.
-    /* LONGITUDE CONVERSIONS ***********************************************/
+  // XT_LAT_10E is handled outside the switch.
+  /* LONGITUDE CONVERSIONS ***********************************************/
   case XcsvStyle::XT_LON_DECIMAL:
     /* longitude as a pure decimal value */
     wpt->longitude = atof(s);
@@ -487,12 +493,12 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   case XcsvStyle::XT_LON_NMEA:
     wpt->longitude = ddmm2degrees(atof(s));
     break;
-    // case XcsvStyle::XT_LON_10E is handled outside the switch.
-    /* LAT AND LON CONVERSIONS ********************************************/
+  // case XcsvStyle::XT_LON_10E is handled outside the switch.
+  /* LAT AND LON CONVERSIONS ********************************************/
   case XcsvStyle::XT_LATLON_HUMAN_READABLE:
     human_to_dec(s, &wpt->latitude, &wpt->longitude, 0);
     break;
-    /* DIRECTIONS **********************************************************/
+  /* DIRECTIONS **********************************************************/
   case XcsvStyle::XT_LAT_DIR:
     /* latitude N/S. */
     if (*s == 'n' || *s == 'N') {
@@ -506,14 +512,14 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   case XcsvStyle::XT_LON_DIR:
     /* longitude E/W. */
     if (*s == 'e' || *s == 'E') {
-      parse_data->lon_dir_positive = true; 
+      parse_data->lon_dir_positive = true;
     } else if (*s == 'w' || *s == 'W') {
       parse_data->lon_dir_positive = false;
     } else {
       warning("parse of string '%s' on line number %d as LON_DIR failed.  Expected 'e', 'E', 'w' or 'W'.\n", s, line_no);
     }
     break;
-    /* SPECIAL COORDINATES/GRID */
+  /* SPECIAL COORDINATES/GRID */
   case XcsvStyle::XT_MAP_EN_BNG:
     parse_coordinates(s, DATUM_OSGB36, grid_bng,
                       &wpt->latitude, &wpt->longitude, MYNAME);
@@ -550,7 +556,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   break;
   /* ALTITUDE CONVERSIONS ************************************************/
   case XcsvStyle::XT_ALT_FEET: {
-    char *endptr;
+    char* endptr;
     double val = strtod(s, &endptr);
     if ((val == 0 && s==endptr)) {
       wpt->altitude = unknown_alt;
@@ -563,7 +569,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   }
   break;
   case XcsvStyle::XT_ALT_METERS: {
-    char *endptr;
+    char* endptr;
     double val = strtod(s, &endptr);
     if ((val == 0 && s==endptr)) {
       wpt->altitude = unknown_alt;
@@ -576,7 +582,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   }
   break;
 
-    /* PATH CONVERSIONS ************************************************/
+  /* PATH CONVERSIONS ************************************************/
   case XcsvStyle::XT_PATH_SPEED:
     WAYPT_SET(wpt, speed, atof(s));
     break;
@@ -593,7 +599,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     WAYPT_SET(wpt, course, atof(s));
     break;
 
-    /* TIME CONVERSIONS ***************************************************/
+  /* TIME CONVERSIONS ***************************************************/
   case XcsvStyle::XT_EXCEL_TIME:
     /* Time as Excel Time  */
     wpt->SetCreationTime(excel_to_timet(atof(s)));
@@ -630,8 +636,8 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
       wpt->creation_time = wpt->creation_time.addSecs(sscanftime(s, fmp.printfc.constData(), 1));
     }
     break;
-    /* Useful when time and date are in separate fields
-    	GMT / Local offset is handled by the two cases above */
+  /* Useful when time and date are in separate fields
+  	GMT / Local offset is handled by the two cases above */
   case XcsvStyle::XT_HMSG_TIME:
   case XcsvStyle::XT_HMSL_TIME:
     wpt->creation_time = wpt->creation_time.addSecs(addhms(s, fmp.printfc.constData()));
@@ -650,7 +656,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     wpt->AllocGCData()->last_found = yyyymmdd_to_time(s);
     break;
 
-    /* GEOCACHING STUFF ***************************************************/
+  /* GEOCACHING STUFF ***************************************************/
   case XcsvStyle::XT_GEOCACHE_DIFF:
     /* Geocache Difficulty as an int */
     wpt->AllocGCData()->diff = atof(s) * 10;
@@ -693,7 +699,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     }
     break;
 
-    /* GPS STUFF *******************************************************/
+  /* GPS STUFF *******************************************************/
   case XcsvStyle::XT_GPS_HDOP:
     wpt->hdop = atof(s);
     break;
@@ -720,7 +726,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
       }
     }
     break;
-    /* Tracks and routes *********************************************/
+  /* Tracks and routes *********************************************/
   case XcsvStyle::XT_ROUTE_NAME:
     parse_data->rte_name = csv_stringtrim(s, enclosure);
     break;
@@ -731,7 +737,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     parse_data->trk_name = csv_stringtrim(s, enclosure);
     break;
 
-    /* OTHER STUFF ***************************************************/
+  /* OTHER STUFF ***************************************************/
   case XcsvStyle::XT_PATH_DISTANCE_METERS:
     wpt->odometer_distance = atof(s);
     break;
@@ -756,7 +762,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   case XcsvStyle::XT_TEMPERATURE_F:
     wpt->temperature = (FAHRENHEIT_TO_CELSIUS(atof(s)));
     break;
-    /* GMSD ****************************************************************/
+  /* GMSD ****************************************************************/
   case XcsvStyle::XT_COUNTRY: {
     garmin_fs_t* gmsd = gmsd_init(wpt);
     garmin_fs_t::set_country(gmsd, csv_stringtrim(value, enclosure, 0));
@@ -826,7 +832,7 @@ XcsvFormat::read()
 
   while (true) {
     QString buff = xcsv_file->stream.readLine();
-    if (buff.isNull()) { 
+    if (buff.isNull()) {
       break;
     }
     linecount++;
@@ -834,8 +840,8 @@ XcsvFormat::read()
      * is whitespace and we have leading whitespace.
      */
     // This could be hoisted out as a generic rtrim() if we need such a thing.
-    while(buff.size() > 0 && buff.at(buff.size() - 1).isSpace()) {
-      buff.chop(1); 
+    while (buff.size() > 0 && buff.at(buff.size() - 1).isSpace()) {
+      buff.chop(1);
     }
 
     /* skip over x many lines on the top for the prologue... */
@@ -847,18 +853,18 @@ XcsvFormat::read()
      * pre-read the file to know how many data lines we should be seeing,
      * we take this cheap shot at the data and cross our fingers.
      */
-    for(const auto& ogp : qAsConst(xcsv_style->epilogue)) {
-       if (ogp.startsWith(buff)) {
-         buff.clear();
-         break;
-       }
+    for (const auto& ogp : qAsConst(xcsv_style->epilogue)) {
+      if (ogp.startsWith(buff)) {
+        buff.clear();
+        break;
+      }
     }
     if (!buff.isEmpty()) {
       auto* wpt_tmp = new Waypoint;
       // initialize parse data for accumulation of line results from all fields in this line.
       xcsv_parse_data parse_data;
       const QStringList values = csv_linesplit(buff, xcsv_style->field_delimiter,
-                        xcsv_style->field_encloser, linecount);
+                                 xcsv_style->field_encloser, linecount);
 
       if (xcsv_style->ifields.isEmpty()) {
         fatal(MYNAME ": attempt to read, but style '%s' has no IFIELDs in it.\n", qPrintable(xcsv_style->description)? qPrintable(xcsv_style->description) : "unknown");
@@ -1060,12 +1066,11 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
     }
     break;
     case XcsvStyle::XT_SHORTNAME:
-		buff = QString::asprintf(fmp.printfc.constData(),
-                shortname.isEmpty() ? fmp.val.constData() : CSTR(shortname));
+      buff = QString::asprintf(fmp.printfc.constData(),
+                               shortname.isEmpty() ? fmp.val.constData() : CSTR(shortname));
 
       break;
-    case XcsvStyle::XT_ANYNAME:
-      {
+    case XcsvStyle::XT_ANYNAME: {
       QString anyname = wpt->shortname;
       if (anyname.isEmpty()) {
         anyname = mkshort(xcsv_file->mkshort_handle, wpt->description);
@@ -1080,16 +1085,16 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
         anyname = fmp.val.constData();
       }
       buff = QString::asprintf(fmp.printfc.constData(), CSTR(anyname));
-      }
+    }
 
-      break;
+    break;
     case XcsvStyle::XT_DESCRIPTION:
       buff = QString::asprintf(fmp.printfc.constData(),
-                description.isEmpty() ? fmp.val.constData() : CSTR(description));
+                               description.isEmpty() ? fmp.val.constData() : CSTR(description));
       break;
     case XcsvStyle::XT_NOTES:
       buff = QString::asprintf(fmp.printfc.constData(),
-                wpt->notes.isEmpty() ? fmp.val.constData() : CSTR(wpt->notes));
+                               wpt->notes.isEmpty() ? fmp.val.constData() : CSTR(wpt->notes));
       break;
     case XcsvStyle::XT_URL: {
       if (xcsv_urlbase) {
@@ -1107,16 +1112,16 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
       if (wpt->HasUrlLink()) {
         UrlLink l = wpt->GetUrlLink();
         buff = QString::asprintf(fmp.printfc.constData(),
-                 !l.url_link_text_.isEmpty() ? CSTR(l.url_link_text_) : fmp.val.constData());
+                                 !l.url_link_text_.isEmpty() ? CSTR(l.url_link_text_) : fmp.val.constData());
       }
       break;
     case XcsvStyle::XT_ICON_DESCR:
       buff = QString::asprintf(fmp.printfc.constData(),
-                (!wpt->icon_descr.isNull()) ?
-                CSTR(wpt->icon_descr) : fmp.val.constData());
+                               (!wpt->icon_descr.isNull()) ?
+                               CSTR(wpt->icon_descr) : fmp.val.constData());
       break;
 
-      /* LATITUDE CONVERSION***********************************************/
+    /* LATITUDE CONVERSION***********************************************/
     case XcsvStyle::XT_LAT_DECIMAL:
       /* latitude as a pure decimal value */
       buff = QString::asprintf(fmp.printfc.constData(), lat);
@@ -1124,18 +1129,18 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
     case XcsvStyle::XT_LAT_DECIMALDIR:
       /* latitude as a decimal value with N/S after it */
       buff = QString::asprintf(fmp.printfc.constData(), fabs(lat),
-               lat_dir(lat));
+                               lat_dir(lat));
       break;
     case XcsvStyle::XT_LAT_DIRDECIMAL:
       /* latitude as a decimal value with N/S before it */
       buff = QString::asprintf(fmp.printfc.constData(),
-               lat_dir(lat),
-               fabs(lat));
+                               lat_dir(lat),
+                               fabs(lat));
       break;
     case XcsvStyle::XT_LAT_INT32DEG:
       /* latitude as an integer offset from 0 degrees */
       buff = QString::asprintf(fmp.printfc.constData(),
-                dec_to_intdeg(lat));
+                               dec_to_intdeg(lat));
       break;
     case XcsvStyle::XT_LAT_DDMMDIR:
       /*latitude as (degrees * 100) + decimal minutes, with N/S after it */
@@ -1147,8 +1152,8 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
     case XcsvStyle::XT_LAT_NMEA:
       buff = QString::asprintf(fmp.printfc.constData(), degrees2ddmm(lat));
       break;
-      // case XcsvStyle::XT_LAT_10E is handled outside the switch.
-      /* LONGITUDE CONVERSIONS*********************************************/
+    // case XcsvStyle::XT_LAT_10E is handled outside the switch.
+    /* LONGITUDE CONVERSIONS*********************************************/
     case XcsvStyle::XT_LON_DECIMAL:
       /* longitude as a pure decimal value */
       buff = QString::asprintf(fmp.printfc.constData(), lon);
@@ -1156,19 +1161,19 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
     case XcsvStyle::XT_LON_DECIMALDIR:
       /* latitude as a decimal value with N/S after it */
       buff = QString::asprintf(fmp.printfc.constData(),
-               fabs(lon),
-               lon_dir(lon));
+                               fabs(lon),
+                               lon_dir(lon));
       break;
     case XcsvStyle::XT_LON_DIRDECIMAL:
       /* latitude as a decimal value with N/S before it */
       buff = QString::asprintf(fmp.printfc.constData(),
-               lon_dir(lon),
-               fabs(lon));
+                               lon_dir(lon),
+                               fabs(lon));
       break;
     case XcsvStyle::XT_LON_INT32DEG:
       /* longitude as an integer offset from 0 degrees */
       buff = QString::asprintf(fmp.printfc.constData(),
-                dec_to_intdeg(lon));
+                               dec_to_intdeg(lon));
       break;
     case XcsvStyle::XT_LON_DDMMDIR:
       /* longitude as (degrees * 100) + decimal minutes, with W/E after it*/
@@ -1179,7 +1184,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
       break;
     case XcsvStyle::XT_LATLON_HUMAN_READABLE:
       buff = dec_to_human(fmp.printfc.constData(), "SN", lat);
-        buff += " ";
+      buff += " ";
       buff += dec_to_human(fmp.printfc.constData(), "WE", lon);
       // Tidy up leading, trailing, middle whitespace.
       buff = buff.simplified();
@@ -1187,20 +1192,20 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
     case XcsvStyle::XT_LON_NMEA:
       buff = QString::asprintf(fmp.printfc.constData(), degrees2ddmm(lon));
       break;
-      // case XcsvStyle::XT_LON_10E is handled outside the switch.
-      /* DIRECTIONS *******************************************************/
+    // case XcsvStyle::XT_LON_10E is handled outside the switch.
+    /* DIRECTIONS *******************************************************/
     case XcsvStyle::XT_LAT_DIR:
       /* latitude N/S as a char */
       buff = QString::asprintf(fmp.printfc.constData(),
-                lat_dir(lat));
+                               lat_dir(lat));
       break;
     case XcsvStyle::XT_LON_DIR:
       /* longitude E/W as a char */
       buff = QString::asprintf(fmp.printfc.constData(),
-                lon_dir(lon));
+                               lon_dir(lon));
       break;
 
-      /* SPECIAL COORDINATES */
+    /* SPECIAL COORDINATES */
     case XcsvStyle::XT_MAP_EN_BNG: {
       char map[3];
       double north, east;
@@ -1249,25 +1254,25 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
       buff = QString::asprintf(fmp.printfc.constData(), utme);
       break;
 
-      /* ALTITUDE CONVERSIONS**********************************************/
+    /* ALTITUDE CONVERSIONS**********************************************/
     case XcsvStyle::XT_ALT_FEET:
       /* altitude in feet as a decimal value */
       if (wpt->altitude != unknown_alt) {
         buff = QString::asprintf(fmp.printfc.constData(),
-                  METERS_TO_FEET(wpt->altitude));
+                                 METERS_TO_FEET(wpt->altitude));
       }
       break;
     case XcsvStyle::XT_ALT_METERS:
       /* altitude in meters as a decimal value */
       if (wpt->altitude != unknown_alt) {
         buff = QString::asprintf(fmp.printfc.constData(),
-                  wpt->altitude);
+                                 wpt->altitude);
       }
       break;
 
-      /* DISTANCE CONVERSIONS**********************************************/
-      /* prefer odometer distance. */
-      /* if not available, use calculated distance from positions */
+    /* DISTANCE CONVERSIONS**********************************************/
+    /* prefer odometer distance. */
+    /* if not available, use calculated distance from positions */
     case XcsvStyle::XT_PATH_DISTANCE_MILES:
       /* path (route/track) distance in miles */
       if (wpt->odometer_distance) {
@@ -1308,15 +1313,15 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
       buff = QString::asprintf(fmp.printfc.constData(), wpt->course);
       break;
 
-      /* HEART RATE CONVERSION***********************************************/
+    /* HEART RATE CONVERSION***********************************************/
     case XcsvStyle::XT_HEART_RATE:
       buff = QString::asprintf(fmp.printfc.constData(), wpt->heartrate);
       break;
-      /* CADENCE CONVERSION***********************************************/
+    /* CADENCE CONVERSION***********************************************/
     case XcsvStyle::XT_CADENCE:
       buff = QString::asprintf(fmp.printfc.constData(), wpt->cadence);
       break;
-      /* POWER CONVERSION***********************************************/
+    /* POWER CONVERSION***********************************************/
     case XcsvStyle::XT_POWER:
       buff = QString::asprintf(fmp.printfc.constData(), wpt->power);
       break;
@@ -1326,7 +1331,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
     case XcsvStyle::XT_TEMPERATURE_F:
       buff = QString::asprintf(fmp.printfc.constData(), CELSIUS_TO_FAHRENHEIT(wpt->temperature));
       break;
-      /* TIME CONVERSIONS**************************************************/
+    /* TIME CONVERSIONS**************************************************/
     case XcsvStyle::XT_EXCEL_TIME:
       /* creation time as an excel (double) time */
       buff = QString::asprintf(fmp.printfc.constData(), timet_to_excel(wpt->GetCreationTime().toTime_t()));
@@ -1363,7 +1368,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
     case XcsvStyle::XT_GEOCACHE_LAST_FOUND:
       buff = QString::asprintf(fmp.printfc.constData(), time_to_yyyymmdd(wpt->gc_data->last_found));
       break;
-      /* GEOCACHE STUFF **************************************************/
+    /* GEOCACHE STUFF **************************************************/
     case XcsvStyle::XT_GEOCACHE_DIFF:
       /* Geocache Difficulty as a double */
       buff = QString::asprintf(fmp.printfc.constData(), wpt->gc_data->diff / 10.0);
@@ -1410,7 +1415,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
         buff = QString::asprintf(fmp.printfc.constData(), "Unknown");
       }
       break;
-      /* Tracks and Routes ***********************************************/
+    /* Tracks and Routes ***********************************************/
     case XcsvStyle::XT_TRACK_NEW:
       if (csv_track) {
         if (WAYPT_HAS(wpt,new_trkseg)) {
@@ -1431,7 +1436,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
       }
       break;
 
-      /* GPS STUFF *******************************************************/
+    /* GPS STUFF *******************************************************/
     case XcsvStyle::XT_GPS_HDOP:
       buff = QString::asprintf(fmp.printfc.constData(), wpt->hdop);
       field_is_unknown = !wpt->hdop;
@@ -1567,25 +1572,26 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
 
 // return |original| after performing token replacement.
 QString
-XcsvFormat::xcsv_replace_tokens(const QString& original) const {
+XcsvFormat::xcsv_replace_tokens(const QString& original) const
+{
   QString replacement = original;
-    // Don't do potentially expensive replacements if token prefix
-    // isn't present;
-    if (original.contains("__")) {
-      replacement.replace("__FILE__", xcsv_file->fname);
-      replacement.replace("__VERSION__", gpsbabel_testmode()? "" : gpsbabel_version);
+  // Don't do potentially expensive replacements if token prefix
+  // isn't present;
+  if (original.contains("__")) {
+    replacement.replace("__FILE__", xcsv_file->fname);
+    replacement.replace("__VERSION__", gpsbabel_testmode()? "" : gpsbabel_version);
 
-      QDateTime dt = current_time().toUTC();
+    QDateTime dt = current_time().toUTC();
 
-      QString dts = dt.toString("ddd MMM dd hh:mm:ss yyyy");
-      replacement.replace("__DATE_AND_TIME__", dts);
+    QString dts = dt.toString("ddd MMM dd hh:mm:ss yyyy");
+    replacement.replace("__DATE_AND_TIME__", dts);
 
-      QString d = dt.toString("MM/dd/yyyy");
-      replacement.replace("__DATE__", d);
+    QString d = dt.toString("MM/dd/yyyy");
+    replacement.replace("__DATE__", d);
 
-      QString t = dt.toString("hh:mm:ss");
-      replacement.replace("__TIME__", t);
-    }
+    QString t = dt.toString("hh:mm:ss");
+    replacement.replace("__TIME__", t);
+  }
   return replacement;
 }
 
@@ -1601,7 +1607,7 @@ XcsvFormat::write()
 
   /* output prologue lines, if any. */
   for (const auto& line : qAsConst(xcsv_style->prologue)) {
-   QString line_to_write = xcsv_replace_tokens(line);
+    QString line_to_write = xcsv_replace_tokens(line);
     xcsv_file->stream << line_to_write <<  xcsv_style->record_delimiter;
   }
 
@@ -1658,7 +1664,7 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
     style->field_delimiter = cp;
 
     char* p = csv_stringtrim(CSTR(style->field_delimiter), " ", 0);
-      /* field delimiters are always bad characters */
+    /* field delimiters are always bad characters */
     if (0 == strcmp(p, "\\w")) {
       style->badchars = " \n\r";
     } else {
@@ -1668,136 +1674,136 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
 
   } else
 
-  if (op == "FIELD_ENCLOSER") {
-    auto cp = xcsv_get_char_from_constant_table(tokens[0]);
-    style->field_encloser = cp;
+    if (op == "FIELD_ENCLOSER") {
+      auto cp = xcsv_get_char_from_constant_table(tokens[0]);
+      style->field_encloser = cp;
 
-    char* p = csv_stringtrim(CSTR(style->field_encloser), " ", 0);
-    style->badchars += p;
-    xfree(p);
-  } else
+      char* p = csv_stringtrim(CSTR(style->field_encloser), " ", 0);
+      style->badchars += p;
+      xfree(p);
+    } else
 
-  if (op == "RECORD_DELIMITER") {
-    auto cp = xcsv_get_char_from_constant_table(tokens[0]);
-    style->record_delimiter = cp;
+      if (op == "RECORD_DELIMITER") {
+        auto cp = xcsv_get_char_from_constant_table(tokens[0]);
+        style->record_delimiter = cp;
 
-      // Record delimiters are always bad characters.
-    auto p = csv_stringtrim(CSTR(style->record_delimiter), " ", 0);
-    style->badchars += p;
-    xfree(p);
+        // Record delimiters are always bad characters.
+        auto* p = csv_stringtrim(CSTR(style->record_delimiter), " ", 0);
+        style->badchars += p;
+        xfree(p);
 
-  } else
+      } else
 
-  if (op == "FORMAT_TYPE") {
-    if (tokens[0] == "INTERNAL") {
-      style->type = ff_type_internal;
-    }
-      // this is almost inconceivable...
-    if (tokens[0] == "SERIAL") {
-      style->type = ff_type_serial;
-    }
-  } else
+        if (op == "FORMAT_TYPE") {
+          if (tokens[0] == "INTERNAL") {
+            style->type = ff_type_internal;
+          }
+          // this is almost inconceivable...
+          if (tokens[0] == "SERIAL") {
+            style->type = ff_type_serial;
+          }
+        } else
 
-  if (op == "DESCRIPTION") {
-    style->description = tokens[0];
-  } else
+          if (op == "DESCRIPTION") {
+            style->description = tokens[0];
+          } else
 
-  if (op == "EXTENSION") {
-    style->extension = tokens[0];
-  } else
+            if (op == "EXTENSION") {
+              style->extension = tokens[0];
+            } else
 
-  if (op == "SHORTLEN") {
-    style->shortlen = tokens[0].toInt();
-  } else
+              if (op == "SHORTLEN") {
+                style->shortlen = tokens[0].toInt();
+              } else
 
-  if (op == "SHORTWHITE") {
-    style->whitespace_ok = tokens[0].toInt();
-  } else
+                if (op == "SHORTWHITE") {
+                  style->whitespace_ok = tokens[0].toInt();
+                } else
 
-  if (op == "BADCHARS") {
-    char* sp = csv_stringtrim(CSTR(tokenstr), "\"", 1);
-    QString cp = xcsv_get_char_from_constant_table(sp);
-    style->badchars += cp;
-    xfree(sp);
-  } else
+                  if (op == "BADCHARS") {
+                    char* sp = csv_stringtrim(CSTR(tokenstr), "\"", 1);
+                    QString cp = xcsv_get_char_from_constant_table(sp);
+                    style->badchars += cp;
+                    xfree(sp);
+                  } else
 
-  if (op =="PROLOGUE") {
-    style->prologue.append(tokenstr);
-  } else
+                    if (op =="PROLOGUE") {
+                      style->prologue.append(tokenstr);
+                    } else
 
-  if (op == "EPILOGUE") {
-    style->epilogue.append(tokenstr);
-  } else
+                      if (op == "EPILOGUE") {
+                        style->epilogue.append(tokenstr);
+                      } else
 
-  if (op == "ENCODING") {
-    style->codecname = tokens[0];
-  } else
+                        if (op == "ENCODING") {
+                          style->codecname = tokens[0];
+                        } else
 
-  if (op == "DATUM") {
-    style->gps_datum_name = tokens[0];
-  } else
+                          if (op == "DATUM") {
+                            style->gps_datum_name = tokens[0];
+                          } else
 
-  if (op == "DATATYPE") {
-    QString p = tokens[0].toUpper();
-    if (p == "TRACK") {
-      style->datatype = trkdata;
-    } else if (p == "ROUTE") {
-      style->datatype = rtedata;
-    } else if (p == "WAYPOINT") {
-      style->datatype = wptdata;
-    } else {
-      fatal(FatalMsg() << MYNAME << ": Unknown data type" << p);
-    }
-  } else
+                            if (op == "DATATYPE") {
+                              QString p = tokens[0].toUpper();
+                              if (p == "TRACK") {
+                                style->datatype = trkdata;
+                              } else if (p == "ROUTE") {
+                                style->datatype = rtedata;
+                              } else if (p == "WAYPOINT") {
+                                style->datatype = wptdata;
+                              } else {
+                                fatal(FatalMsg() << MYNAME << ": Unknown data type" << p);
+                              }
+                            } else
 
-  if (op == "IFIELD") {
-    if (tokens.size() < 3) {
-      fatal(FatalMsg() << "Invalid IFIELD line: " << tokenstr);
-    }
+                              if (op == "IFIELD") {
+                                if (tokens.size() < 3) {
+                                  fatal(FatalMsg() << "Invalid IFIELD line: " << tokenstr);
+                                }
 
-    // The key ("LAT_DIR") should never contain quotes.
+                                // The key ("LAT_DIR") should never contain quotes.
 
-    const QString key = tokens[0].simplified();
-    const QString val = dequote(tokens[1]);
-    const QString pfc = dequote(tokens[2]);
-    xcsv_ifield_add(style, key, val, pfc);
-  } else
+                                const QString key = tokens[0].simplified();
+                                const QString val = dequote(tokens[1]);
+                                const QString pfc = dequote(tokens[2]);
+                                xcsv_ifield_add(style, key, val, pfc);
+                              } else
 
-      //
-      //  as OFIELDs are implemented as an after-thought, I'll
-      //  leave this as it's own parsing for now.  We could
-      //  change the world on ifield vs ofield format later..
-      //
-  if (op == "OFIELD") {
-    unsigned options = 0;
-      // Note: simplified() has to run after split().
-    if (tokens.size() < 3) {
-      fatal(FatalMsg() << "Invalid OFIELD line: " << tokenstr);
-    }
+                                //
+                                //  as OFIELDs are implemented as an after-thought, I'll
+                                //  leave this as it's own parsing for now.  We could
+                                //  change the world on ifield vs ofield format later..
+                                //
+                                if (op == "OFIELD") {
+                                  unsigned options = 0;
+                                  // Note: simplified() has to run after split().
+                                  if (tokens.size() < 3) {
+                                    fatal(FatalMsg() << "Invalid OFIELD line: " << tokenstr);
+                                  }
 
-    // The key ("LAT_DIR") should never contain quotes.
-    const QString key = tokens[0].simplified();
-    const QString val = dequote(tokens[1]);
-    const QString pfc = dequote(tokens[2]);
+                                  // The key ("LAT_DIR") should never contain quotes.
+                                  const QString key = tokens[0].simplified();
+                                  const QString val = dequote(tokens[1]);
+                                  const QString pfc = dequote(tokens[2]);
 
-    // This is pretty lazy way to parse write options.
-    // They've very rarely used, so we'll go for simple.
-    // We may have split the optional fourth and final field which can contain
-    // option[s], so look at all the remaining tokens.
-    for (int token_idx = 3; token_idx < tokens.size(); ++token_idx) {
-      QString options_string = tokens[token_idx].simplified();
-      if (options_string.contains("no_delim_before")) {
-        options |= options_nodelim;
-      }
-      if (options_string.contains("absolute")) {
-        options |= options_absolute;
-      }
-      if (options_string.contains("optional")) {
-        options |= options_optional;
-      }
-    }
-    xcsv_ofield_add(style, key, val, pfc, options);
-  }
+                                  // This is pretty lazy way to parse write options.
+                                  // They've very rarely used, so we'll go for simple.
+                                  // We may have split the optional fourth and final field which can contain
+                                  // option[s], so look at all the remaining tokens.
+                                  for (int token_idx = 3; token_idx < tokens.size(); ++token_idx) {
+                                    QString options_string = tokens[token_idx].simplified();
+                                    if (options_string.contains("no_delim_before")) {
+                                      options |= options_nodelim;
+                                    }
+                                    if (options_string.contains("absolute")) {
+                                      options |= options_absolute;
+                                    }
+                                    if (options_string.contains("optional")) {
+                                      options |= options_optional;
+                                    }
+                                  }
+                                  xcsv_ofield_add(style, key, val, pfc, options);
+                                }
 }
 
 
@@ -1822,7 +1828,7 @@ XcsvStyle::xcsv_read_style(const char* fname)
 {
   gbfile* fp = gbfopen(fname, "rb", MYNAME);
   XcsvStyle style;
-  for  (QString sbuff = gbfgetstr(fp); !sbuff.isNull(); sbuff = gbfgetstr(fp)) {
+  for (QString sbuff = gbfgetstr(fp); !sbuff.isNull(); sbuff = gbfgetstr(fp)) {
     sbuff = sbuff.trimmed();
     xcsv_parse_style_line(&style, sbuff);
   }


### PR DESCRIPTION
readability-make-member-function-const
readability-convert-member-functions-to-static
readability-const-return-type
readability-qualified-auto

astyle was used to match our formatting standards for readability-qualified-auto, which resulted in some formatting changes in geojson.cc
