### PR TITLE
replace obsolete and overloaded QProcess signal error(QProcess::Proce…

### DIFF
--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -82,7 +82,7 @@ ProcessWaitDialog::ProcessWaitDialog(QWidget* parent, QProcess* process):
   btn->setText(tr("Stop Process"));
   layout->addWidget(buttonBox_);
 
-  connect(process, SIGNAL(error(QProcess::ProcessError)),
+  connect(process, SIGNAL(errorOccurred(QProcess::ProcessError)),
           this,    SLOT(errorX(QProcess::ProcessError)));
   connect(process, SIGNAL(finished(int,QProcess::ExitStatus)),
           this,    SLOT(finishedX(int,QProcess::ExitStatus)));


### PR DESCRIPTION
…ssError error)

with the recommended replacement, QProcess signal errorOccurred(QProcess::ProcessError error).
It seems this should have caused an issue in Qt6, but we hadn't noticed it yet.