### PR TITLE
drop support for QtWebKit.

### DIFF
--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -362,7 +362,10 @@ equals(PWD, $${OUT_PWD}) {
 QMAKE_EXTRA_TARGETS += gpsbabel.pdf
 
 gui.depends = $(TARGET) FORCE
-gui.commands += cd gui; $(QMAKE) app.pro && $(MAKE)
+disable-mappreview {
+  guiconfig = "CONFIG+=disable-mappreview"
+}
+gui.commands += cd gui; $(QMAKE) $${guiconfig} app.pro && $(MAKE)
 QMAKE_EXTRA_TARGETS += gui
 
 unix-gui.depends = gui FORCE

--- a/INSTALL
+++ b/INSTALL
@@ -32,11 +32,17 @@ WITH_ZLIB=no|pkgconfig|included*|custom
   custom: build with user supplied zlib. LIBS and INCLUDEPATH may need to be
     set, e.g. LIBS+=... INCLUDEPATH+=...
 
+CONFIG+=disable-mappreview
+  This options disables the map preview feature.  With the feature disabled
+  QtWebEngine and QtWebEngineWdigets are not used. Note that QtWebKit and
+  QtWebKitWidgets are not longer supported.
+
 DOCVERSION=...
   string appended to documentation location for www.gpsbabel.org.  The default
   value is the version string, e.g. "1.7.0".  This is used by the gpsbabel.org
   target, you are unlikely to need it unless you are maintaining
   www.gpsbabel.org.
+
 WEB=DIR
   Path where the documentation will be stored for www.gpsbabel.org.  This is
   used by the gpsbabel.org target, you are unlikely to need it unless you are

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 # hard code webengine instead of webkit for now
 find_package(Qt5 COMPONENTS WebEngineWidgets WebChannel REQUIRED)
 list(APPEND QT_LIBRARIES Qt5::WebEngineWidgets Qt5::WebChannel)
-add_definitions(-DHAVE_WEBENGINE)
 
 if(APPLE)
   find_library(IOKIT_LIBRARIES IOKit)

--- a/gui/app.pro
+++ b/gui/app.pro
@@ -18,12 +18,7 @@ QT += core \
 disable-mappreview {
   DEFINES += DISABLE_MAPPREVIEW
 } else {
-  qtHaveModule(webenginewidgets) {
-    QT += webenginewidgets webchannel
-    DEFINES += HAVE_WEBENGINE
-  } else {
-    QT += webkit webkitwidgets 
-  }
+  QT += webenginewidgets webchannel
 }
 
 unix:DESTDIR = objects

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -25,15 +25,9 @@
 #include <QNetworkRequest>
 #include <QMessageBox>
 #include <QNetworkAccessManager>
-#if HAVE_WEBENGINE
 #include <QWebEngineView>
 #include <QWebEnginePage>
 #include <QWebChannel>
-#else
-#include <QWebView>
-#include <QWebFrame>
-#include <QWebPage>
-#endif
 #include <QApplication>
 #include <QCursor>
 #include <QFile>
@@ -62,11 +56,7 @@ static QString stripDoubleQuotes(const QString& s)
 //------------------------------------------------------------------------
 Map::Map(QWidget* parent,
          const Gpx&  gpx, QPlainTextEdit* te):
-#if HAVE_WEBENGINE
   QWebEngineView(parent),
-#else
-  QWebView(parent),
-#endif
   gpx_(gpx),
   mapPresent_(false),
   busyCursor_(false),
@@ -80,7 +70,6 @@ Map::Map(QWidget* parent,
           this,SLOT(loadFinishedX(bool)));
   this->logTime("Start map constructor");
 
-#if HAVE_WEBENGINE
   auto* mclicker = new MarkerClicker(this);
   auto* channel = new QWebChannel(this->page());
   this->page()->setWebChannel(channel);
@@ -88,7 +77,6 @@ Map::Map(QWidget* parent,
   channel->registerObject(QStringLiteral("mclicker"), mclicker);
   connect(mclicker, SIGNAL(markerClicked(int,int)), this, SLOT(markerClicked(int,int)));
   connect(mclicker, SIGNAL(logTime(QString)), this, SLOT(logTime(QString)));
-#endif
 
   // We search the following locations:
   // 1. In the file system in the same directory as the executable.
@@ -177,15 +165,6 @@ static QString makePath(const vector <LatLng>& pts)
 //------------------------------------------------------------------------
 void Map::showGpxData()
 {
-
-#if !defined(HAVE_WEBENGINE)
-  // Historically this was done here in showGpxData.
-  MarkerClicker* mclicker = new MarkerClicker(this);
-  this->page()->mainFrame()->addToJavaScriptWindowObject("mclicker", mclicker);
-  connect(mclicker, SIGNAL(markerClicked(int,int)), this, SLOT(markerClicked(int,int)));
-  connect(mclicker, SIGNAL(logTime(QString)), this, SLOT(logTime(QString)));
-#endif
-
   this->logTime("Start defining JS string");
   QStringList scriptStr;
   scriptStr
@@ -406,11 +385,7 @@ void Map::panTo(const LatLng& loc)
 //------------------------------------------------------------------------
 void Map::resizeEvent(QResizeEvent* ev)
 {
-#if HAVE_WEBENGINE
   QWebEngineView::resizeEvent(ev);
-#else
-  QWebView::resizeEvent(ev);
-#endif
   if (mapPresent_) {
     evaluateJS(QString("google.maps.event.trigger(map, 'resize');"));
   }
@@ -461,11 +436,7 @@ void Map::evaluateJS(const QString& s, bool upd)
   *dbgout_ << s << '\n';
   dbgout_->flush();
 #endif
-#if HAVE_WEBENGINE
   this->page()->runJavaScript(s);
-#else
-  this->page()->mainFrame()->evaluateJavaScript(s);
-#endif
   if (upd) {
     this->update();
   }

--- a/gui/map.h
+++ b/gui/map.h
@@ -22,11 +22,7 @@
 //------------------------------------------------------------------------
 #ifndef MAP_H
 #define MAP_H
-#if HAVE_WEBENGINE
 #include <QWebEngineView>
-#else
-#include <QWebView>
-#endif
 #include <QPlainTextEdit>
 #include <QElapsedTimer>
 #include <QFile>
@@ -62,11 +58,7 @@ signals:
 
 
 
-#if HAVE_WEBENGINE
 class Map : public QWebEngineView
-#else
-class Map : public QWebView
-#endif
 {
   Q_OBJECT
 public:


### PR DESCRIPTION
Our QtWebKit build didn't work any longer on Ubuntu bionic or focal,
but went into an infinite loop if map preview was used.
I observed this behavior with builds of 1.7.0 as well.

Document exisiting gui configuration option disable-mappreview.

I note that latest fedora build spec falls back to QtWebKit on some
architectures where QtWebEngine is not available.  This change will
require them to fall back to disabling the map preview instead.
https://src.fedoraproject.org/rpms/gpsbabel/blob/rawhide/f/gpsbabel.spec

QtWebEngine appears to be coming to Qt6 with or after 6.2.
https://bugreports.qt.io/browse/QTBUG-63235