### PR TITLE
use new style connect, i.e. function pointers

### DIFF
--- a/gui/advdlg.cc
+++ b/gui/advdlg.cc
@@ -43,8 +43,8 @@ AdvDlg::AdvDlg(QWidget* parent,
   ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":/images/ok.png"));
   ui_.buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":/images/cancel.png"));
 #endif // Q_OS_WIN
-  connect(ui_.buttonBox, SIGNAL(accepted()), this, SLOT(acceptClicked()));
-  connect(ui_.buttonBox, SIGNAL(rejected()), this, SLOT(rejectClicked()));
+  connect(ui_.buttonBox, &QDialogButtonBox::accepted, this, &AdvDlg::acceptClicked);
+  connect(ui_.buttonBox, &QDialogButtonBox::rejected, this, &AdvDlg::rejectClicked);
 
 #ifdef DISABLE_MAPPREVIEW
   ui_.previewGmap->hide();

--- a/gui/donate.cc
+++ b/gui/donate.cc
@@ -27,7 +27,7 @@
 Donate::Donate(QWidget* parent) : QDialog(parent)
 {
   ui_.setupUi(this);
-  connect(ui_.contributeButton, SIGNAL(clicked()), this, SLOT(contributeClicked()));
+  connect(ui_.contributeButton, &QAbstractButton::clicked, this, &Donate::contributeClicked);
 }
 
 void Donate::contributeClicked()

--- a/gui/filterdlg.cc
+++ b/gui/filterdlg.cc
@@ -50,14 +50,14 @@ FilterDialog::FilterDialog(QWidget* parent, AllFiltersData& fd): QDialog(parent)
   addFilterPage(tr("Miscellaneous"),
                 new MiscFltWidget(widgetStack_, fd.miscFltFilterData), &fd.miscFltFilterData.inUse_);
 
-  connect(ui_.filterList, SIGNAL(currentRowChanged(int)),
-          this, SLOT(pageSelectionChanged(int)));
+  connect(ui_.filterList, &QListWidget::currentRowChanged,
+          this, &FilterDialog::pageSelectionChanged);
 
-  connect(ui_.filterList, SIGNAL(itemClicked(QListWidgetItem*)),
-          this, SLOT(itemClickedX(QListWidgetItem*)));
+  connect(ui_.filterList, &QListWidget::itemClicked,
+          this, &FilterDialog::itemClickedX);
 
-  connect(ui_.helpButton, SIGNAL(clicked()), this, SLOT(helpX()));
-  connect(ui_.resetButton, SIGNAL(clicked()), this, SLOT(resetX()));
+  connect(ui_.helpButton, &QAbstractButton::clicked, this, &FilterDialog::helpX);
+  connect(ui_.resetButton, &QAbstractButton::clicked, this, &FilterDialog::resetX);
 
 #if defined (Q_OS_WIN)
   ui_.buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon(":/images/ok.png"));

--- a/gui/filterwidgets.cc
+++ b/gui/filterwidgets.cc
@@ -50,14 +50,14 @@ TrackWidget::TrackWidget(QWidget* parent, TrackFilterData& tfd): FilterWidget(pa
                    <<ui.splitDistSpin
                    <<ui.splitDistCombo));
 
-  connect(ui.mergeCheck, SIGNAL(clicked()), this, SLOT(mergeCheckX()));
-  connect(ui.packCheck,  SIGNAL(clicked()),  this, SLOT(packCheckX()));
-  connect(ui.startCheck, SIGNAL(clicked()),  this, SLOT(otherCheckX()));
-  connect(ui.stopCheck,   SIGNAL(clicked()), this, SLOT(otherCheckX()));
+  connect(ui.mergeCheck, &QAbstractButton::clicked, this, &TrackWidget::mergeCheckX);
+  connect(ui.packCheck,  &QAbstractButton::clicked,  this, &TrackWidget::packCheckX);
+  connect(ui.startCheck, &QAbstractButton::clicked,  this, &TrackWidget::otherCheckX);
+  connect(ui.stopCheck,   &QAbstractButton::clicked, this, &TrackWidget::otherCheckX);
 
-  connect(ui.splitDateCheck,   SIGNAL(clicked()), this, SLOT(splitDateX()));
-  connect(ui.splitTimeCheck,   SIGNAL(clicked()), this, SLOT(splitTimeX()));
-  connect(ui.splitDistanceCheck,   SIGNAL(clicked()), this, SLOT(splitDistanceX()));
+  connect(ui.splitDateCheck,   &QAbstractButton::clicked, this, &TrackWidget::splitDateX);
+  connect(ui.splitTimeCheck,   &QAbstractButton::clicked, this, &TrackWidget::splitTimeX);
+  connect(ui.splitDistanceCheck,   &QAbstractButton::clicked, this, &TrackWidget::splitDistanceX);
 
   ui.startEdit->setDisplayFormat("dd MMM yyyy hh:mm:ss AP");
   ui.stopEdit->setDisplayFormat("dd MMM yyyy hh:mm:ss AP");
@@ -183,8 +183,8 @@ WayPtsWidget::WayPtsWidget(QWidget* parent, WayPtsFilterData& wfd): FilterWidget
   fopts << new ComboFilterOption(wfd.positionUnit, ui.positionUnitCombo);
   fopts << new ComboFilterOption(wfd.radiusUnit, ui.radiusUnitCombo);
 
-  connect(ui.shortNamesCheck, SIGNAL(clicked()), this, SLOT(shortNamesCkX()));
-  connect(ui.locationsCheck, SIGNAL(clicked()), this, SLOT(locationsCkX()));
+  connect(ui.shortNamesCheck, &QAbstractButton::clicked, this, &WayPtsWidget::shortNamesCkX);
+  connect(ui.locationsCheck, &QAbstractButton::clicked, this, &WayPtsWidget::locationsCkX);
   setWidgetValues();
   checkChecks();
 }

--- a/gui/filterwidgets.h
+++ b/gui/filterwidgets.h
@@ -40,7 +40,7 @@ public:
   CheckEnabler(QObject* parent, QAbstractButton* ck, QWidget* w): QObject(parent), checkBox(ck)
   {
     widgetList << w;
-    connect(ck, SIGNAL(clicked()), this, SLOT(checkStatusChanged()));
+    connect(ck, &QAbstractButton::clicked, this, &CheckEnabler::checkStatusChanged);
     checkStatusChanged();
     fixWhatsThis();
   }
@@ -48,7 +48,7 @@ public:
     QObject(parent), checkBox(ck)
   {
     widgetList = wl;
-    connect(ck, SIGNAL(clicked()), this, SLOT(checkStatusChanged()));
+    connect(ck, &QAbstractButton::clicked, this, &CheckEnabler::checkStatusChanged);
     checkStatusChanged();
     fixWhatsThis();
   }

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -39,16 +39,6 @@ public:
 };
 
 //------------------------------------------------------------------------
-class TreeAction: public QAction
-{
-public:
-  TreeAction(const QString& text,
-             QObject* obj, const char* member,  QObject* parent): QAction(text, parent)
-  {
-    connect(this, SIGNAL(triggered()), obj, member);
-  }
-};
-//------------------------------------------------------------------------
 QString GMapDialog::formatLength(double l)
 {
   double metricLength = l;
@@ -538,38 +528,38 @@ void GMapDialog::showContextMenu(const QPoint& pt)
   int j;
   if (model_->indexFromItem(wptItem_) == idx) {
     QMenu menu(this);
-    menu.addAction(new TreeAction(tr("Show All Waypoints"), this, SLOT(showAllWaypoints()), &menu));
-    menu.addAction(new TreeAction(tr("Hide All Waypoints"), this, SLOT(hideAllWaypoints()),&menu));
-    menu.addAction(new TreeAction(tr("Expand All"), this, SLOT(expandAllWaypoints()),&menu));
-    menu.addAction(new TreeAction(tr("Collapse All"), this, SLOT(collapseAllWaypoints()),&menu));
+    menu.addAction(tr("Show All Waypoints"), this, SLOT(showAllWaypoints()));
+    menu.addAction(tr("Hide All Waypoints"), this, SLOT(hideAllWaypoints()));
+    menu.addAction(tr("Expand All"), this, SLOT(expandAllWaypoints()));
+    menu.addAction(tr("Collapse All"), this, SLOT(collapseAllWaypoints()));
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if (model_->indexFromItem(rteItem_) == idx) {
     QMenu menu(this);
-    menu.addAction(new TreeAction(tr("Show All Routes"), this, SLOT(showAllRoutes()), &menu));
-    menu.addAction(new TreeAction(tr("Hide All Routes"), this, SLOT(hideAllRoutes()),&menu));
-    menu.addAction(new TreeAction(tr("Expand All"), this, SLOT(expandAllRoutes()),&menu));
-    menu.addAction(new TreeAction(tr("Collapse All"), this, SLOT(collapseAllRoutes()),&menu));
+    menu.addAction(tr("Show All Routes"), this, SLOT(showAllRoutes()));
+    menu.addAction(tr("Hide All Routes"), this, SLOT(hideAllRoutes()));
+    menu.addAction(tr("Expand All"), this, SLOT(expandAllRoutes()));
+    menu.addAction(tr("Collapse All"), this, SLOT(collapseAllRoutes()));
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if (model_->indexFromItem(trkItem_) == idx) {
     QMenu menu(this);
-    menu.addAction(new TreeAction(tr("Show All Tracks"), this, SLOT(showAllTracks()), &menu));
-    menu.addAction(new TreeAction(tr("Hide All Tracks"), this, SLOT(hideAllTracks()),&menu));
-    menu.addAction(new TreeAction(tr("Expand All"), this, SLOT(expandAllTracks()),&menu));
-    menu.addAction(new TreeAction(tr("Collapse All"), this, SLOT(collapseAllTracks()),&menu));
+    menu.addAction(tr("Show All Tracks"), this, SLOT(showAllTracks()));
+    menu.addAction(tr("Hide All Tracks"), this, SLOT(hideAllTracks()));
+    menu.addAction(tr("Expand All"), this, SLOT(expandAllTracks()));
+    menu.addAction(tr("Collapse All"), this, SLOT(collapseAllTracks()));
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if ((j = waypointIndex(it)) >=0) {
     QMenu menu(this);
-    menu.addAction(new TreeAction(tr("Show Only This Waypoint"), this, SLOT(showOnlyThisWaypoint()), &menu));
+    menu.addAction(tr("Show Only This Waypoint"), this, SLOT(showOnlyThisWaypoint()));
     menuIndex_ = j;
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if ((j = trackIndex(it)) >=0) {
     QMenu menu(this);
-    menu.addAction(new TreeAction(tr("Show Only This Track"), this, SLOT(showOnlyThisTrack()), &menu));
+    menu.addAction(tr("Show Only This Track"), this, SLOT(showOnlyThisTrack()));
     menuIndex_ = j;
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if ((j = routeIndex(it)) >=0) {
     QMenu menu(this);
-    menu.addAction(new TreeAction(tr("Show Only This Route"), this, SLOT(showOnlyThisRoute()), &menu));
+    menu.addAction(tr("Show Only This Route"), this, SLOT(showOnlyThisRoute()));
     menuIndex_ = j;
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else {

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -528,38 +528,38 @@ void GMapDialog::showContextMenu(const QPoint& pt)
   int j;
   if (model_->indexFromItem(wptItem_) == idx) {
     QMenu menu(this);
-    menu.addAction(tr("Show All Waypoints"), this, SLOT(showAllWaypoints()));
-    menu.addAction(tr("Hide All Waypoints"), this, SLOT(hideAllWaypoints()));
-    menu.addAction(tr("Expand All"), this, SLOT(expandAllWaypoints()));
-    menu.addAction(tr("Collapse All"), this, SLOT(collapseAllWaypoints()));
+    menu.addAction(tr("Show All Waypoints"), this, &GMapDialog::showAllWaypoints);
+    menu.addAction(tr("Hide All Waypoints"), this, &GMapDialog::hideAllWaypoints);
+    menu.addAction(tr("Expand All"), this, &GMapDialog::expandAllWaypoints);
+    menu.addAction(tr("Collapse All"), this, &GMapDialog::collapseAllWaypoints);
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if (model_->indexFromItem(rteItem_) == idx) {
     QMenu menu(this);
-    menu.addAction(tr("Show All Routes"), this, SLOT(showAllRoutes()));
-    menu.addAction(tr("Hide All Routes"), this, SLOT(hideAllRoutes()));
-    menu.addAction(tr("Expand All"), this, SLOT(expandAllRoutes()));
-    menu.addAction(tr("Collapse All"), this, SLOT(collapseAllRoutes()));
+    menu.addAction(tr("Show All Routes"), this, &GMapDialog::showAllRoutes);
+    menu.addAction(tr("Hide All Routes"), this, &GMapDialog::hideAllRoutes);
+    menu.addAction(tr("Expand All"), this, &GMapDialog::expandAllRoutes);
+    menu.addAction(tr("Collapse All"), this, &GMapDialog::collapseAllRoutes);
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if (model_->indexFromItem(trkItem_) == idx) {
     QMenu menu(this);
-    menu.addAction(tr("Show All Tracks"), this, SLOT(showAllTracks()));
-    menu.addAction(tr("Hide All Tracks"), this, SLOT(hideAllTracks()));
-    menu.addAction(tr("Expand All"), this, SLOT(expandAllTracks()));
-    menu.addAction(tr("Collapse All"), this, SLOT(collapseAllTracks()));
+    menu.addAction(tr("Show All Tracks"), this, &GMapDialog::showAllTracks);
+    menu.addAction(tr("Hide All Tracks"), this, &GMapDialog::hideAllTracks);
+    menu.addAction(tr("Expand All"), this, &GMapDialog::expandAllTracks);
+    menu.addAction(tr("Collapse All"), this, &GMapDialog::collapseAllTracks);
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if ((j = waypointIndex(it)) >=0) {
     QMenu menu(this);
-    menu.addAction(tr("Show Only This Waypoint"), this, SLOT(showOnlyThisWaypoint()));
+    menu.addAction(tr("Show Only This Waypoint"), this, &GMapDialog::showOnlyThisWaypoint);
     menuIndex_ = j;
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if ((j = trackIndex(it)) >=0) {
     QMenu menu(this);
-    menu.addAction(tr("Show Only This Track"), this, SLOT(showOnlyThisTrack()));
+    menu.addAction(tr("Show Only This Track"), this, &GMapDialog::showOnlyThisTrack);
     menuIndex_ = j;
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else if ((j = routeIndex(it)) >=0) {
     QMenu menu(this);
-    menu.addAction(tr("Show Only This Route"), this, SLOT(showOnlyThisRoute()));
+    menu.addAction(tr("Show Only This Route"), this, &GMapDialog::showOnlyThisRoute);
     menuIndex_ = j;
     menu.exec(ui_.treeView->mapToGlobal(pt));
   } else {

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -201,21 +201,21 @@ GMapDialog::GMapDialog(QWidget* parent, const QString& gpxFileName, QPlainTextEd
   ui_.treeView->header()->hide();
   ui_.treeView->setModel(model_);
   ui_.treeView->setExpandsOnDoubleClick(false);
-  connect(model_, SIGNAL(itemChanged(QStandardItem*)),
-          this,  SLOT(itemChangedX(QStandardItem*)));
-  connect(mapWidget_, SIGNAL(waypointClicked(int)), this, SLOT(waypointClickedX(int)));
-  connect(mapWidget_, SIGNAL(routeClicked(int)), this, SLOT(routeClickedX(int)));
-  connect(mapWidget_, SIGNAL(trackClicked(int)), this, SLOT(trackClickedX(int)));
-  connect(ui_.treeView, SIGNAL(doubleClicked(QModelIndex)),
-          this, SLOT(treeDoubleClicked(QModelIndex)));
-  connect(ui_.treeView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
-          this, SLOT(selectionChangedX(QItemSelection,QItemSelection)));
+  connect(model_, &QStandardItemModel::itemChanged,
+          this,  &GMapDialog::itemChangedX);
+  connect(mapWidget_, &Map::waypointClicked, this, &GMapDialog::waypointClickedX);
+  connect(mapWidget_, &Map::routeClicked, this, &GMapDialog::routeClickedX);
+  connect(mapWidget_, &Map::trackClicked, this, &GMapDialog::trackClickedX);
+  connect(ui_.treeView, &QAbstractItemView::doubleClicked,
+          this, &GMapDialog::treeDoubleClicked);
+  connect(ui_.treeView->selectionModel(), &QItemSelectionModel::selectionChanged,
+          this, &GMapDialog::selectionChangedX);
 
   ui_.treeView->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(ui_.treeView, SIGNAL(customContextMenuRequested(QPoint)),
-          this, SLOT(showContextMenu(QPoint)));
+  connect(ui_.treeView, &QWidget::customContextMenuRequested,
+          this, &GMapDialog::showContextMenu);
 
-  connect(ui_.copyButton, SIGNAL(clicked()), this, SLOT(copyButtonClickedX()));
+  connect(ui_.copyButton, &QAbstractButton::clicked, this, &GMapDialog::copyButtonClickedX);
 
   ui_.copyButton->hide(); // Hide for now, not working
 }

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -177,8 +177,12 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
   connect(ui_.actionUpgradeCheck, &QAction::triggered, this, &MainWindow::upgradeCheckActionX);
   connect(ui_.actionPreferences, &QAction::triggered, this, &MainWindow::preferencesActionX);
 
+// TODO: Qt6 deleted the obsolete overloaded signal QComboBox::currentIndexChanged(const QString &text)
+// that required using qOverload.
   connect(ui_.inputFormatCombo,  qOverload<int>(&QComboBox::currentIndexChanged),
           this,                 &MainWindow::inputFormatChanged);
+// TODO: Qt6 deleted the obsolete overloaded signal QComboBox::currentIndexChanged(const QString &text)
+// that required using qOverload.
   connect(ui_.outputFormatCombo, qOverload<int>(&QComboBox::currentIndexChanged),
           this,                 &MainWindow::outputFormatChanged);
   connect(ui_.inputOptionsBtn,   &QAbstractButton::clicked,

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -159,43 +159,43 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
   fmtChgInterlock_ = false;
   loadDeviceNameCombos();
 
-  connect(ui_.inputFileOptBtn,        SIGNAL(clicked()), this, SLOT(inputFileOptBtnClicked()));
-  connect(ui_.inputDeviceOptBtn,      SIGNAL(clicked()), this, SLOT(inputDeviceOptBtnClicked()));
-  connect(ui_.inputFileNameBrowseBtn, SIGNAL(clicked()), this, SLOT(browseInputFile()));
+  connect(ui_.inputFileOptBtn,        &QAbstractButton::clicked, this, &MainWindow::inputFileOptBtnClicked);
+  connect(ui_.inputDeviceOptBtn,      &QAbstractButton::clicked, this, &MainWindow::inputDeviceOptBtnClicked);
+  connect(ui_.inputFileNameBrowseBtn, &QAbstractButton::clicked, this, &MainWindow::browseInputFile);
 
   ui_.outputFileOptBtn->setAutoExclusive(false);
   ui_.outputDeviceOptBtn->setAutoExclusive(false);
-  connect(ui_.outputFileOptBtn,        SIGNAL(clicked()), this, SLOT(outputFileOptBtnClicked()));
-  connect(ui_.outputDeviceOptBtn,      SIGNAL(clicked()), this, SLOT(outputDeviceOptBtnClicked()));
-  connect(ui_.outputFileNameBrowseBtn, SIGNAL(clicked()), this, SLOT(browseOutputFile()));
+  connect(ui_.outputFileOptBtn,        &QAbstractButton::clicked, this, &MainWindow::outputFileOptBtnClicked);
+  connect(ui_.outputDeviceOptBtn,      &QAbstractButton::clicked, this, &MainWindow::outputDeviceOptBtnClicked);
+  connect(ui_.outputFileNameBrowseBtn, &QAbstractButton::clicked, this, &MainWindow::browseOutputFile);
 
-  connect(ui_.actionQuit, SIGNAL(triggered()), this, SLOT(closeActionX()));
-  connect(ui_.actionHelp, SIGNAL(triggered()), this, SLOT(helpActionX()));
-  connect(ui_.actionAbout, SIGNAL(triggered()), this, SLOT(aboutActionX()));
-  connect(ui_.actionVisit_Website, SIGNAL(triggered()), this, SLOT(visitWebsiteActionX()));
-  connect(ui_.actionMake_a_Donation, SIGNAL(triggered()), this, SLOT(donateActionX()));
-  connect(ui_.actionUpgradeCheck, SIGNAL(triggered()), this, SLOT(upgradeCheckActionX()));
-  connect(ui_.actionPreferences, SIGNAL(triggered()), this, SLOT(preferencesActionX()));
+  connect(ui_.actionQuit, &QAction::triggered, this, &MainWindow::closeActionX);
+  connect(ui_.actionHelp, &QAction::triggered, this, &MainWindow::helpActionX);
+  connect(ui_.actionAbout, &QAction::triggered, this, &MainWindow::aboutActionX);
+  connect(ui_.actionVisit_Website, &QAction::triggered, this, &MainWindow::visitWebsiteActionX);
+  connect(ui_.actionMake_a_Donation, &QAction::triggered, this, &MainWindow::donateActionX);
+  connect(ui_.actionUpgradeCheck, &QAction::triggered, this, &MainWindow::upgradeCheckActionX);
+  connect(ui_.actionPreferences, &QAction::triggered, this, &MainWindow::preferencesActionX);
 
-  connect(ui_.inputFormatCombo,  SIGNAL(currentIndexChanged(int)),
-          this,                 SLOT(inputFormatChanged(int)));
-  connect(ui_.outputFormatCombo, SIGNAL(currentIndexChanged(int)),
-          this,                 SLOT(outputFormatChanged(int)));
-  connect(ui_.inputOptionsBtn,   SIGNAL(clicked()),
-          this,                 SLOT(inputOptionButtonClicked()));
-  connect(ui_.outputOptionsBtn, SIGNAL(clicked()),
-          this,                 SLOT(outputOptionButtonClicked()));
-  connect(ui_.moreOptionButton, SIGNAL(clicked()),
-          this,                 SLOT(moreOptionButtonClicked()));
+  connect(ui_.inputFormatCombo,  qOverload<int>(&QComboBox::currentIndexChanged),
+          this,                 &MainWindow::inputFormatChanged);
+  connect(ui_.outputFormatCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+          this,                 &MainWindow::outputFormatChanged);
+  connect(ui_.inputOptionsBtn,   &QAbstractButton::clicked,
+          this,                 &MainWindow::inputOptionButtonClicked);
+  connect(ui_.outputOptionsBtn, &QAbstractButton::clicked,
+          this,                 &MainWindow::outputOptionButtonClicked);
+  connect(ui_.moreOptionButton, &QAbstractButton::clicked,
+          this,                 &MainWindow::moreOptionButtonClicked);
 
-  connect(ui_.buttonBox, SIGNAL(accepted()), this, SLOT(applyActionX()));
-  connect(ui_.buttonBox, SIGNAL(rejected()), this, SLOT(closeActionX()));
-  connect(ui_.buttonBox, SIGNAL(helpRequested()), this, SLOT(helpActionX()));
+  connect(ui_.buttonBox, &QDialogButtonBox::accepted, this, &MainWindow::applyActionX);
+  connect(ui_.buttonBox, &QDialogButtonBox::rejected, this, &MainWindow::closeActionX);
+  connect(ui_.buttonBox, &QDialogButtonBox::helpRequested, this, &MainWindow::helpActionX);
 
-  connect(ui_.xlateFiltersBtn, SIGNAL(clicked()), this, SLOT(filtersClicked()));
+  connect(ui_.xlateFiltersBtn, &QAbstractButton::clicked, this, &MainWindow::filtersClicked);
 
-  connect(ui_.inputFileNameText, SIGNAL(textEdited(QString)), this, SLOT(inputFileNameEdited()));
-  connect(ui_.outputFileNameText, SIGNAL(textEdited(QString)), this, SLOT(outputFileNameEdited()));
+  connect(ui_.inputFileNameText, &QLineEdit::textEdited, this, &MainWindow::inputFileNameEdited);
+  connect(ui_.outputFileNameText, &QLineEdit::textEdited, this, &MainWindow::outputFileNameEdited);
 
 #if defined (Q_OS_WIN)
   // Windows users like the colored buttons.  They look out of place elsewhere.
@@ -1170,8 +1170,8 @@ void MainWindow::moreOptionButtonClicked()
 {
   AdvDlg advDlg(nullptr, babelData_.synthShortNames_,
                 babelData_.previewGmap_, babelData_.debugLevel_);
-  connect(advDlg.formatButton(), SIGNAL(clicked()),
-          this, SLOT(resetFormatDefaults()));
+  connect(advDlg.formatButton(), &QAbstractButton::clicked,
+          this, &MainWindow::resetFormatDefaults);
   advDlg.exec();
 }
 //------------------------------------------------------------------------

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -66,8 +66,8 @@ Map::Map(QWidget* parent,
   stopWatch_.start();
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
   manager_ = new QNetworkAccessManager(this);
-  connect(this,SIGNAL(loadFinished(bool)),
-          this,SLOT(loadFinishedX(bool)));
+  connect(this,&QWebEngineView::loadFinished,
+          this,&Map::loadFinishedX);
   this->logTime("Start map constructor");
 
   auto* mclicker = new MarkerClicker(this);
@@ -75,8 +75,8 @@ Map::Map(QWidget* parent,
   this->page()->setWebChannel(channel);
   // Note: A current limitation is that objects must be registered before any client is initialized.
   channel->registerObject(QStringLiteral("mclicker"), mclicker);
-  connect(mclicker, SIGNAL(markerClicked(int,int)), this, SLOT(markerClicked(int,int)));
-  connect(mclicker, SIGNAL(logTime(QString)), this, SLOT(logTime(QString)));
+  connect(mclicker, &MarkerClicker::markerClicked, this, &Map::markerClicked);
+  connect(mclicker, &MarkerClicker::logTime, this, &Map::logTime);
 
   // We search the following locations:
   // 1. In the file system in the same directory as the executable.

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -47,7 +47,7 @@ FileDlgManager::FileDlgManager(QObject* parent,
                                QToolButton* tb, bool isInFile):
   QObject(parent), le(le), tb(tb), isInFile(isInFile)
 {
-  connect(tb, SIGNAL(clicked()), this, SLOT(buttonClicked()));
+  connect(tb, &QAbstractButton::clicked, this, &FileDlgManager::buttonClicked);
 }
 
 //------------------------------------------------------------------------
@@ -214,9 +214,9 @@ OptionsDlg::OptionsDlg(QWidget* parent,  const QString& fmtName, QList<FormatOpt
   buttonBox_->button(QDialogButtonBox::Cancel)->setIcon(QIcon(":/images/cancel.png"));
 #endif // Q_OS_WIN
 
-  connect(buttonBox_, SIGNAL(accepted()), this, SLOT(acceptClicked()));
-  connect(buttonBox_, SIGNAL(rejected()), this, SLOT(rejectClicked()));
-  connect(helpButton, SIGNAL(clicked()), this,  SLOT(helpClicked()));
+  connect(buttonBox_, &QDialogButtonBox::accepted, this, &OptionsDlg::acceptClicked);
+  connect(buttonBox_, &QDialogButtonBox::rejected, this, &OptionsDlg::rejectClicked);
+  connect(helpButton, &QAbstractButton::clicked, this,  &OptionsDlg::helpClicked);
 }
 
 //------------------------------------------------------------------------

--- a/gui/preferences.cc
+++ b/gui/preferences.cc
@@ -49,11 +49,11 @@ Preferences::Preferences(QWidget* parent, QList<Format>& formatList,
     babelData_.ignoreVersionMismatch_ = false;
   }
 
-  connect(ui_.buttonBox, SIGNAL(accepted()), this, SLOT(acceptClicked()));
-  connect(ui_.buttonBox, SIGNAL(rejected()), this, SLOT(rejectClicked()));
+  connect(ui_.buttonBox, &QDialogButtonBox::accepted, this, &Preferences::acceptClicked);
+  connect(ui_.buttonBox, &QDialogButtonBox::rejected, this, &Preferences::rejectClicked);
 
-  connect(ui_.enableAllButton, SIGNAL(clicked()), this, SLOT(enableAllClicked()));
-  connect(ui_.disableAllButton, SIGNAL(clicked()), this, SLOT(disableAllClicked()));
+  connect(ui_.enableAllButton, &QAbstractButton::clicked, this, &Preferences::enableAllClicked);
+  connect(ui_.disableAllButton, &QAbstractButton::clicked, this, &Preferences::disableAllClicked);
 
   for (int i = 0; i < formatList_.size(); i++) {
     auto* item = new FormatListEntry(formatList[i]);

--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -84,6 +84,8 @@ ProcessWaitDialog::ProcessWaitDialog(QWidget* parent, QProcess* process):
 
   connect(process, &QProcess::errorOccurred,
           this,    &ProcessWaitDialog::errorX);
+// TODO: Qt6 combined the obsolete overloaded signal QProcess::finished(int exitCode)
+// that required using qOverload.
   connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
           this,    &ProcessWaitDialog::finishedX);
   connect(process, &QProcess::readyReadStandardError,

--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -82,16 +82,16 @@ ProcessWaitDialog::ProcessWaitDialog(QWidget* parent, QProcess* process):
   btn->setText(tr("Stop Process"));
   layout->addWidget(buttonBox_);
 
-  connect(process, SIGNAL(errorOccurred(QProcess::ProcessError)),
-          this,    SLOT(errorX(QProcess::ProcessError)));
-  connect(process, SIGNAL(finished(int,QProcess::ExitStatus)),
-          this,    SLOT(finishedX(int,QProcess::ExitStatus)));
-  connect(process, SIGNAL(readyReadStandardError()),
-          this,    SLOT(readyReadStandardErrorX()));
-  connect(process, SIGNAL(readyReadStandardOutput()),
-          this,    SLOT(readyReadStandardOutputX()));
-  connect(btn,     SIGNAL(clicked()),
-          this,    SLOT(stopClickedX()));
+  connect(process, &QProcess::errorOccurred,
+          this,    &ProcessWaitDialog::errorX);
+  connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+          this,    &ProcessWaitDialog::finishedX);
+  connect(process, &QProcess::readyReadStandardError,
+          this,    &ProcessWaitDialog::readyReadStandardErrorX);
+  connect(process, &QProcess::readyReadStandardOutput,
+          this,    &ProcessWaitDialog::readyReadStandardOutputX);
+  connect(btn,     &QAbstractButton::clicked,
+          this,    &ProcessWaitDialog::stopClickedX);
   exitStatus_ = QProcess::CrashExit;  // Assume all errors are crashes for now.
 
   bufferedOut_ = "";
@@ -108,7 +108,7 @@ ProcessWaitDialog::ProcessWaitDialog(QWidget* parent, QProcess* process):
   timer_ = new QTimer(this);
   timer_->setInterval(100);
   timer_->setSingleShot(false);
-  connect(timer_, SIGNAL(timeout()), this, SLOT(timeoutX()));
+  connect(timer_, &QTimer::timeout, this, &ProcessWaitDialog::timeoutX);
   stopCount_ = -1;
   ecode_ = 0;
   timer_->start();

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -111,8 +111,8 @@ UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
 
   manager_ = new QNetworkAccessManager;
 
-  connect(manager_, SIGNAL(finished(QNetworkReply*)),
-          this, SLOT(httpRequestFinished(QNetworkReply*)));
+  connect(manager_, &QNetworkAccessManager::finished,
+          this, &UpgradeCheck::httpRequestFinished);
 
   QNetworkRequest request = QNetworkRequest(upgradeUrl_);
 


### PR DESCRIPTION
This was mostly done by clazy, but manual intervention was required in two areas:
1. If the signal had overloads.  This occurred in 3 connections.  This were flagged by clazy, e.g.
`warning: FixIt failed, requires manual intervention:  Too many overloads (2) for method currentIndexChanged for record QComboBox [-Wclazy-old-style-connect]`
2. If the connection was made with our TreeAction class.  All clazy had to say here was
`warning: TreeAction is missing a Q_OBJECT macro [-Wclazy-missing-qobject-macro]
class TreeAction: public QAction`
A historical question is "why was our class TreeAction ever created?"  It appears to have been unnecessary in Qt4.3 as a method was provided: QMenu::addAction(const QString &text, const QObject *receiver, const char *member, const QKeySequence &shortcut = 0)

I note that uic is still producing code using the old SIGNAL SLOT connection method (in gui/tmp).  This appears to have changed in Qt 6.0.0 https://github.com/qt/qtbase/commit/da3cb1deb6c752f8e4c05434e3451432e5d787ba