### PR TITLE
cleanup FormatLoad class header file.

### DIFF
--- a/gui/formatload.h
+++ b/gui/formatload.h
@@ -33,15 +33,22 @@
 class FormatLoad
 {
 public:
-  FormatLoad() : currentLine_(0) {}
-  ~FormatLoad() {}
+
+  /* Member Functions */
 
   bool getFormats(QList<Format>& formatList);
+
 private:
-  QStringList lines_;
-  int currentLine_;
+
+  /* Member Functions */
+
   bool skipToValidLine();
   bool processFormat(Format& format);
+
+  /* Data Members */
+
+  QStringList lines_;
+  int currentLine_{0};
 };
 
 #endif


### PR DESCRIPTION
clang-tidy modernize-use-default-member-init

This allows the use of the implicitly-defined default ctor.
Use implicitly-defined dtor as well.