### PR TITLE
prefer implicitly-defined dtors instead of user defaulted dtors or dtors with empty bodies.

### DIFF
--- a/gui/filterdlg.h
+++ b/gui/filterdlg.h
@@ -33,7 +33,6 @@ class FilterDialog: public QDialog
   Q_OBJECT
 public:
   FilterDialog(QWidget* parent, AllFiltersData& fd_);
-  ~FilterDialog() {}
 
   void runDialog();
 

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -61,10 +61,6 @@ QVariant getOptionValue(QList<FormatOption> opts, int k)
 }
 
 //------------------------------------------------------------------------
-FileDlgManager::~FileDlgManager()
-  = default;
-
-//------------------------------------------------------------------------
 void FileDlgManager::buttonClicked()
 {
   QString str;

--- a/gui/optionsdlg.h
+++ b/gui/optionsdlg.h
@@ -40,8 +40,6 @@ public:
                  QLineEdit* le,
                  QToolButton* tb, bool isInFile);
 
-  ~FileDlgManager();
-
 private:
   QLineEdit* le;
   QToolButton* tb;

--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -119,9 +119,6 @@ ProcessWaitDialog::ProcessWaitDialog(QWidget* parent, QProcess* process):
 }
 
 //------------------------------------------------------------------------
-ProcessWaitDialog::~ProcessWaitDialog()
-= default;
-//------------------------------------------------------------------------
 bool ProcessWaitDialog::getExitedNormally()
 {
   return (errorString_.length() == 0);

--- a/gui/processwait.h
+++ b/gui/processwait.h
@@ -44,7 +44,6 @@ class ProcessWaitDialog: public QDialog
 public:
   //
   ProcessWaitDialog(QWidget* parent, QProcess* process_);
-  ~ProcessWaitDialog();
 
   bool getExitedNormally();
   int getExitCode();


### PR DESCRIPTION
Not only is this simpler, it avoids clang-tidy complaining about
warning: class * defines a non-default destructor but does not define a copy
constructor, a copy assignment operator, a move constructor or a move
assignment operator [cppcoreguidelines-special-member-functions]