### PR TITLE
make src/core and jeeps includes relative to top cli directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,6 @@ if(UNIX)
   set(SOURCES ${SOURCES} gbser_posix.cc)
   set(HEADERS ${HEADERS} gbser_posix.h)
   set(JEEPS ${JEEPS} jeeps/gpslibusb.cc)
-  include_directories(AFTER jeeps)
   add_compile_options(-O2 -Wall)
 endif()
 

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -224,7 +224,6 @@ macx|linux|openbsd {
   }
   SOURCES += gbser_posix.cc
   HEADERS += gbser_posix.h
-  INCLUDEPATH += jeeps
 }
 
 win32 {

--- a/jeeps/garminusb.h
+++ b/jeeps/garminusb.h
@@ -19,7 +19,7 @@
 
  */
 #include <cstdio>
-#include "gpsdevice.h"
+#include "jeeps/gpsdevice.h"
 
 /* This structure is a bit funny looking to avoid variable length
  * arrays which aren't present in C89.   This contains the visible

--- a/jeeps/gps.h
+++ b/jeeps/gps.h
@@ -1,8 +1,8 @@
 #ifndef gps_h
 #define gps_h
 
-#include "../defs.h"
-#include "gpsport.h"
+#include "defs.h"
+#include "jeeps/gpsport.h"
 #include <ctime>
 
 #define FRAMING_ERROR  -1
@@ -249,17 +249,17 @@ typedef struct GPS_SCourse_Limits {
 
 typedef int (*pcb_fn)(int, struct GPS_SWay**);
 
-#include "gpsdevice.h"
-#include "gpssend.h"
-#include "gpsread.h"
-#include "gpsutil.h"
-#include "gpsapp.h"
-#include "gpsprot.h"
-#include "gpscom.h"
-#include "gpsfmt.h"
-#include "gpsmath.h"
-#include "gpsmem.h"
-#include "gpsrqst.h"
+#include "jeeps/gpsdevice.h"
+#include "jeeps/gpssend.h"
+#include "jeeps/gpsread.h"
+#include "jeeps/gpsutil.h"
+#include "jeeps/gpsapp.h"
+#include "jeeps/gpsprot.h"
+#include "jeeps/gpscom.h"
+#include "jeeps/gpsfmt.h"
+#include "jeeps/gpsmath.h"
+#include "jeeps/gpsmem.h"
+#include "jeeps/gpsrqst.h"
 
 extern time_t gps_save_time;
 extern double gps_save_lat;

--- a/jeeps/gpsapp.cc
+++ b/jeeps/gpsapp.cc
@@ -23,7 +23,7 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
@@ -36,9 +36,9 @@
  * This violates the layering design, but is needed for device discovery.
  * See the use of gps_is_usb and GPS_Packet_Read_usb below.
  */
-#include "garminusb.h"
-#include "gpsserial.h"
-#include "gpsusbint.h"
+#include "jeeps/garminusb.h"
+#include "jeeps/gpsserial.h"
+#include "jeeps/gpsusbint.h"
 
 time_t gps_save_time;
 double gps_save_lat;

--- a/jeeps/gpsapp.h
+++ b/jeeps/gpsapp.h
@@ -2,7 +2,7 @@
 #define gpsapp_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
   int32  GPS_Init(const char* port);
 

--- a/jeeps/gpscom.cc
+++ b/jeeps/gpscom.cc
@@ -24,7 +24,7 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cfloat>
 #include <cstdio>
 #include <cstdlib>

--- a/jeeps/gpscom.h
+++ b/jeeps/gpscom.h
@@ -2,7 +2,7 @@
 #define gpscom_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <ctime>
 
   int32  GPS_Command_Off(const char* port);

--- a/jeeps/gpsdevice.cc
+++ b/jeeps/gpsdevice.cc
@@ -19,9 +19,9 @@
 
  */
 
-#include "gps.h"
-#include "gpsdevice.h"
-#include "gpsserial.h"
+#include "jeeps/gps.h"
+#include "jeeps/gpsdevice.h"
+#include "jeeps/gpsserial.h"
 
 extern gps_device_ops gps_serial_ops;
 extern gps_device_ops gps_usb_ops;

--- a/jeeps/gpsdevice.h
+++ b/jeeps/gpsdevice.h
@@ -24,7 +24,7 @@
 
   typedef struct gpsdevh gpsdevh;
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
 #define usecDELAY 180000	/* Microseconds before GPS sends A001 */
 

--- a/jeeps/gpsdevice_ser.cc
+++ b/jeeps/gpsdevice_ser.cc
@@ -19,10 +19,10 @@
 
  */
 
-#include "gps.h"
-#include "gpsdevice.h"
-#include "gpsread.h"
-#include "gpsserial.h"
+#include "jeeps/gps.h"
+#include "jeeps/gpsdevice.h"
+#include "jeeps/gpsread.h"
+#include "jeeps/gpsserial.h"
 
 gps_device_ops  gps_serial_ops = {
   GPS_Serial_On,

--- a/jeeps/gpsdevice_usb.cc
+++ b/jeeps/gpsdevice_usb.cc
@@ -19,11 +19,11 @@
 
  */
 
-#include "gps.h"
-#include "garminusb.h"
-#include "gpsdevice.h"
-#include "gpsusbcommon.h"
-#include "gpsusbint.h"
+#include "jeeps/gps.h"
+#include "jeeps/garminusb.h"
+#include "jeeps/gpsdevice.h"
+#include "jeeps/gpsusbcommon.h"
+#include "jeeps/gpsusbint.h"
 
 garmin_unit_info_t garmin_unit_info[GUSB_MAX_UNITS];
 

--- a/jeeps/gpsfmt.cc
+++ b/jeeps/gpsfmt.cc
@@ -21,7 +21,7 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cstdio>
 #include <ctime>
 

--- a/jeeps/gpsfmt.h
+++ b/jeeps/gpsfmt.h
@@ -2,7 +2,7 @@
 #define gpsfmt_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cstdio>
 #include <ctime>
 

--- a/jeeps/gpslibusb.cc
+++ b/jeeps/gpslibusb.cc
@@ -25,7 +25,7 @@
 #include <cstdlib>
 #include <cstring>
 #if HAVE_CONFIG_H
-#include "config.h"
+#include "jeeps/config.h"
 #endif
 #if HAVE_LIBUSB_1_0
 #ifdef LIBUSB_H_INCLUDE
@@ -43,11 +43,11 @@
 #    include <libusb-1.0/libusb.h>
 #  endif
 #endif
-#include "../defs.h"
-#include "garminusb.h"
-#include "gpsdevice.h"
-#include "gpsusbcommon.h"
-#include "../garmin_device_xml.h"
+#include "defs.h"
+#include "jeeps/garminusb.h"
+#include "jeeps/gpsdevice.h"
+#include "jeeps/gpsusbcommon.h"
+#include "garmin_device_xml.h"
 
 #define GARMIN_VID 0x91e
 

--- a/jeeps/gpsmath.cc
+++ b/jeeps/gpsmath.cc
@@ -21,8 +21,8 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
-#include "gpsdatum.h"
+#include "jeeps/gps.h"
+#include "jeeps/gpsdatum.h"
 #include <cmath>
 #include <cstdlib>
 #include <cstring>

--- a/jeeps/gpsmath.h
+++ b/jeeps/gpsmath.h
@@ -1,7 +1,7 @@
 #ifndef gpsmath_h
 #define gpsmath_h
 
-#include "gpsport.h"
+#include "jeeps/gpsport.h"
 
 #define GPS_PI 3.141592653589
 #define GPS_FLTMIN 1.75494351E-38

--- a/jeeps/gpsmem.cc
+++ b/jeeps/gpsmem.cc
@@ -24,7 +24,7 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cerrno>
 #include <climits>
 #include <cstdio>

--- a/jeeps/gpsmem.h
+++ b/jeeps/gpsmem.h
@@ -2,7 +2,7 @@
 #define gpsmem_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
   GPS_PPvt_Data     GPS_Pvt_New();
   void              GPS_Pvt_Del(GPS_PPvt_Data* thys);
   GPS_PAlmanac      GPS_Almanac_New();

--- a/jeeps/gpsproj.cc
+++ b/jeeps/gpsproj.cc
@@ -21,7 +21,7 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cmath>
 #include <cstring>
 

--- a/jeeps/gpsproj.h
+++ b/jeeps/gpsproj.h
@@ -2,7 +2,7 @@
 #define gpsproj_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
   void GPS_Math_Albers_LatLon_To_EN(double phi, double lambda, double* E,
                                     double* N, double phi1, double phi2,

--- a/jeeps/gpsprot.cc
+++ b/jeeps/gpsprot.cc
@@ -23,7 +23,7 @@
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
 #define COMMON
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cstdio>
 
 #define GPS_TAGUNK  20

--- a/jeeps/gpsprot.h
+++ b/jeeps/gpsprot.h
@@ -5,7 +5,7 @@
 #define COMMON extern
 #endif
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
   /*
    *  Link protocols

--- a/jeeps/gpsread.cc
+++ b/jeeps/gpsread.cc
@@ -28,8 +28,8 @@
 #include <cstdlib>
 #include <ctime>
 
-#include "gps.h"
-#include "gpsserial.h"
+#include "jeeps/gps.h"
+#include "jeeps/gpsserial.h"
 
 
 /* @func GPS_Time_Now ***********************************************

--- a/jeeps/gpsread.h
+++ b/jeeps/gpsread.h
@@ -2,7 +2,7 @@
 #define gpsread_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
   time_t GPS_Time_Now();
   int32  GPS_Serial_Packet_Read(gpsdevh* fd, GPS_PPacket* packet);

--- a/jeeps/gpsrqst.cc
+++ b/jeeps/gpsrqst.cc
@@ -22,7 +22,7 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
+#include "jeeps/gps.h"
 
 
 static int32 GPS_A600_Rqst(gpsdevh* fd, time_t Time);

--- a/jeeps/gpsrqst.h
+++ b/jeeps/gpsrqst.h
@@ -2,7 +2,7 @@
 #define gpsrqst_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
   int32 GPS_Rqst_Send_Time(gpsdevh* fd, time_t Time);
   int32 GPS_Rqst_Send_Position(gpsdevh* fd, double lat, double lon);

--- a/jeeps/gpssend.cc
+++ b/jeeps/gpssend.cc
@@ -27,8 +27,8 @@
 #include <cerrno>
 #include <cstdio>
 
-#include "gps.h"
-#include "gpsserial.h"
+#include "jeeps/gps.h"
+#include "jeeps/gpsserial.h"
 
 /* @funcstatic Build_Serial_Packet *************************************
 **

--- a/jeeps/gpssend.h
+++ b/jeeps/gpssend.h
@@ -2,7 +2,7 @@
 #define gpssend_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
 #define GPS_ARB_LEN 1024
 

--- a/jeeps/gpsserial.cc
+++ b/jeeps/gpsserial.cc
@@ -23,9 +23,9 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
-#include "../gbser.h"
-#include "gpsserial.h"
+#include "jeeps/gps.h"
+#include "gbser.h"
+#include "jeeps/gpsserial.h"
 #include <QtCore/QThread>
 #include <cerrno>
 #include <cstdio>

--- a/jeeps/gpsserial.h
+++ b/jeeps/gpsserial.h
@@ -2,7 +2,7 @@
 #define gpsserial_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
 #define usecDELAY 180000	/* Microseconds before GPS sends A001 */
 #define DEFAULT_BAUD 9600

--- a/jeeps/gpsusbcommon.cc
+++ b/jeeps/gpsusbcommon.cc
@@ -19,9 +19,9 @@
 
  */
 
-#include "gps.h"
-#include "garminusb.h"
-#include "gpsusbcommon.h"
+#include "jeeps/gps.h"
+#include "jeeps/garminusb.h"
+#include "jeeps/gpsusbcommon.h"
 
 /*
  * This receive logic is a little convoluted as we go to some efforts here

--- a/jeeps/gpsusbread.cc
+++ b/jeeps/gpsusbread.cc
@@ -18,9 +18,9 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
-#include "garminusb.h"
-#include "gps.h"
-#include "gpsusbint.h"
+#include "jeeps/garminusb.h"
+#include "jeeps/gps.h"
+#include "jeeps/gpsusbint.h"
 #include <cctype>
 
 /*

--- a/jeeps/gpsusbsend.cc
+++ b/jeeps/gpsusbsend.cc
@@ -19,9 +19,9 @@
 
  */
 
-#include "gps.h"
-#include "garminusb.h"
-#include "gpsusbint.h"
+#include "jeeps/gps.h"
+#include "jeeps/garminusb.h"
+#include "jeeps/gpsusbint.h"
 #include <cerrno>
 #include <cstdio>
 

--- a/jeeps/gpsusbstub.cc
+++ b/jeeps/gpsusbstub.cc
@@ -21,10 +21,10 @@
 
 
 #if HAVE_CONFIG_H
-#include "config.h"
+#include "jeeps/config.h"
 #endif
 
-#include "../defs.h"
+#include "defs.h"
 
 #if !HAVE_LIBUSB_1_0
 

--- a/jeeps/gpsusbwin.cc
+++ b/jeeps/gpsusbwin.cc
@@ -27,11 +27,11 @@
 #include <setupapi.h>
 #include <winioctl.h>
 
-#include "../garmin_device_xml.h"
-#include "garminusb.h"
-#include "gps.h"
-#include "gpsapp.h"
-#include "gpsusbcommon.h"
+#include "garmin_device_xml.h"
+#include "jeeps/garminusb.h"
+#include "jeeps/gps.h"
+#include "jeeps/gpsapp.h"
+#include "jeeps/gpsusbcommon.h"
 
 /* Constants from Garmin doc. */
 

--- a/jeeps/gpsutil.h
+++ b/jeeps/gpsutil.h
@@ -2,7 +2,7 @@
 #define gpsutil_h
 
 
-#include "gps.h"
+#include "jeeps/gps.h"
 
   int32  GPS_Util_Little();
 

--- a/jeeps/jgpsutil.cc
+++ b/jeeps/jgpsutil.cc
@@ -21,7 +21,7 @@
 ** Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ** Boston, MA  02110-1301, USA.
 ********************************************************************/
-#include "gps.h"
+#include "jeeps/gps.h"
 #include <cstdarg>
 #include <cstdlib>
 #include <fcntl.h>

--- a/src/core/usasciicodec.cc
+++ b/src/core/usasciicodec.cc
@@ -17,7 +17,7 @@
 
  */
 
-#include "usasciicodec.h"
+#include "src/core/usasciicodec.h"
 #include <QtCore/QByteArray>
 #include <QtCore/QChar>
 #include <QtCore/QLatin1Char>


### PR DESCRIPTION
Don't use unix directory aliases in includes as suggested in https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes
Note that we mostly already did this in src/core.

We intentionally don't do this for libusb, shapelib and zlib.  Ideally those third party sources would be compiled as separate archives or libraries.  We also resist modifying them to simplify syncing with the upstream sources.