### PR TITLE
use object tree to cleanup UpgradeCheck, UpgradeCheck::manager_ and UpgradeCheck::replyId.

### DIFF
--- a/gui/main.cc
+++ b/gui/main.cc
@@ -44,7 +44,5 @@ int main(int argc, char** argv)
 
   MainWindow mainWindow(nullptr);
   mainWindow.show();
-  QApplication::exec();
-
-  return 0;
+  return QApplication::exec();
 }

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -230,7 +230,7 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
   //--- Restore from registry
   restoreSettings();
 
-  upgrade = new UpgradeCheck(parent, formatList_, babelData_);
+  upgrade = new UpgradeCheck(this, formatList_, babelData_);
   if (babelData_.startupVersionCheck_) {
     upgrade->checkForUpgrade(babelVersion_, babelData_.upgradeCheckTime_,
                              allowBetaUpgrades());
@@ -242,14 +242,6 @@ MainWindow::MainWindow(QWidget* parent): QMainWindow(parent)
     vm.exec();
     babelData_.ignoreVersionMismatch_ = vm.neverAgain();
   }
-}
-
-//------------------------------------------------------------------------
-MainWindow::~MainWindow()
-{
-
-  delete upgrade;
-
 }
 
 //------------------------------------------------------------------------
@@ -1062,8 +1054,6 @@ void MainWindow::closeActionX()
     babelData_.donateSplashed_ = now;
   }
   saveSettings();
-  delete upgrade;
-  upgrade = nullptr;
   qApp->exit(0);
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -53,7 +53,6 @@ class MainWindow: public QMainWindow
 
 public:
   MainWindow(QWidget* parent);
-  ~MainWindow();
 
 
 private:

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -61,18 +61,6 @@ UpgradeCheck::UpgradeCheck(QWidget* parent, QList<Format>& formatList,
 {
 }
 
-UpgradeCheck::~UpgradeCheck()
-{
-  if (replyId_ != nullptr) {
-    replyId_->abort();
-    replyId_ = nullptr;
-  }
-  if (manager_ != nullptr) {
-    delete manager_;
-    manager_ = nullptr;
-  }
-}
-
 bool UpgradeCheck::isTestMode()
 {
   return testing;
@@ -96,11 +84,11 @@ QString UpgradeCheck::getCpuArchitecture()
 }
 
 UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
-  const QString& currentVersionIn,
+  const QString& currentVersion,
   const QDateTime& lastCheckTime,
   bool allowBeta)
 {
-  currentVersion_ = currentVersionIn;
+  currentVersion_ = currentVersion;
 
   QDateTime soonestCheckTime = lastCheckTime.addDays(1);
   if (!testing && QDateTime::currentDateTime() < soonestCheckTime) {
@@ -108,7 +96,7 @@ UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
     return updateUnknown;
   }
 
-  manager_ = new QNetworkAccessManager;
+  manager_ = new QNetworkAccessManager(this);
 
   connect(manager_, &QNetworkAccessManager::finished,
           this, &UpgradeCheck::httpRequestFinished);

--- a/gui/upgrade.h
+++ b/gui/upgrade.h
@@ -36,7 +36,6 @@ class UpgradeCheck : public QObject
   Q_OBJECT
 public:
   UpgradeCheck(QWidget* parent, QList<Format>& formatList, BabelData& bd);
-  ~UpgradeCheck();
 
   enum updateStatus {
     updateUnknown,
@@ -44,14 +43,12 @@ public:
     updateNeeded,
   };
 
-  UpgradeCheck::updateStatus checkForUpgrade(const QString& babelVersion,
+  UpgradeCheck::updateStatus checkForUpgrade(const QString& currentVersion,
       const QDateTime& lastCheckTime,
       bool allowBeta);
   QDateTime getUpgradeWarningTime();
   UpgradeCheck::updateStatus getStatus();
   static bool isTestMode();
-
-protected:
 
 private:
   QString currentVersion_;
@@ -64,14 +61,13 @@ private:
   updateStatus updateStatus_;
   BabelData& babelData_;
 
-  QString getOsName();
-  QString getOsVersion();
-  QString getCpuArchitecture();
-  bool suggestUpgrade(const QString& from, const QString& to);
+  static QString getOsName();
+  static QString getOsVersion();
+  static QString getCpuArchitecture();
+  static bool suggestUpgrade(const QString& from, const QString& to);
 
 private slots:
   void httpRequestFinished(QNetworkReply* reply);
-
 
 };
 


### PR DESCRIPTION
~QNetworkAccessManager() promises to delete any QNetworkReply objects that are returned by the class.