### PR TITLE
rework progresswait

### DIFF
--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -862,21 +862,14 @@ bool MainWindow::isOkToGo()
 bool MainWindow::runGpsbabel(const QStringList& args, QString& errorString,
                              QString& outputString)
 {
-  auto* proc = new QProcess(nullptr);
   QString name = "gpsbabel";
-  proc->start(QApplication::applicationDirPath() + '/' + name, args);
-  auto* waitDlg = new ProcessWaitDialog(nullptr, proc);
-
-  if (proc->state() == QProcess::NotRunning) {
-    errorString = QString(tr("Process \"%1\" did not start")).arg(name);
-    return false;
-  }
-
-  waitDlg->show();
-  waitDlg->exec();
+  QString program = QApplication::applicationDirPath() + '/' + name;
+  ProcessWaitDialog waitDlg = ProcessWaitDialog(nullptr, program, args);
+  waitDlg.show();
+  waitDlg.exec();
   bool retStatus = false;
-  if (waitDlg->getExitedNormally()) {
-    int exitCode = waitDlg->getExitCode();
+  if (waitDlg.getExitedNormally()) {
+    int exitCode = waitDlg.getExitCode();
     if (exitCode == 0) {
       retStatus = true;
     } else  {
@@ -887,11 +880,9 @@ bool MainWindow::runGpsbabel(const QStringList& args, QString& errorString,
     }
   } else {
     retStatus = false;
-    errorString = waitDlg->getErrorString();
+    errorString = waitDlg.getErrorString();
   }
-  outputString = waitDlg->getOutputString();
-  delete proc;
-  delete waitDlg;
+  outputString = waitDlg.getOutputString();
   return retStatus;
 }
 

--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -68,6 +68,8 @@ ProcessWaitDialog::ProcessWaitDialog(QWidget* parent, const QString& program,
 {
   this->resize(400, 220);
   this->setWindowTitle(QString(appName) + tr(" ... Process GPSBabel"));
+  // turn off Help Button which can appear on windows as a '?'.
+  this->setWindowFlag(Qt::WindowContextHelpButtonHint, false);
   auto* layout = new QVBoxLayout(this);
 
   textEdit_ = new QPlainTextEdit(this);

--- a/gui/processwait.h
+++ b/gui/processwait.h
@@ -23,18 +23,21 @@
 #ifndef PROCESSWAIT_H
 #define PROCESSWAIT_H
 
+#include <QtCore/QObject>              // for QObject
+#include <QtCore/QProcess>             // for QProcess, QProcess::ExitStatus, QProcess::ProcessError
+#include <QtCore/QString>              // for QString
+#include <QtCore/QStringList>          // for QStringList
+#include <QtCore/QTimer>               // for QTimer
+#include <QtGui/QCloseEvent>           // for QCloseEvent
+#include <QtWidgets/QDialog>           // for QDialog
+#include <QtWidgets/QDialogButtonBox>  // for QDialogButtonBox
+#include <QtWidgets/QPlainTextEdit>    // for QPlainTextEdit
+#include <QtWidgets/QProgressBar>      // for QProgressBar
+#include <QtWidgets/QWidget>           // for QWidget
 
-#include <QProcess>
-#include <QDialog>
-#include <vector>
-#include <string>
-using std::string;
-using std::vector;
+#include <string>                      // for string
 
-class QProgressBar;
-class QPlainTextEdit;
-class QDialogButtonBox;
-class QTimer;
+
 //------------------------------------------------------------------------
 class ProcessWaitDialog: public QDialog
 {
@@ -42,45 +45,43 @@ class ProcessWaitDialog: public QDialog
   Q_OBJECT
 
 public:
-  //
-  ProcessWaitDialog(QWidget* parent, QProcess* process_);
+  ProcessWaitDialog(QWidget* parent, const QString& program,
+                    const QStringList& arguments);
 
   bool getExitedNormally();
-  int getExitCode();
+  [[nodiscard]] int getExitCode() const;
   QString getErrorString();
-  QString getOutputString() const
+  QString getOutputString()
   {
     return outputString_;
   }
 
 protected:
-  void closeEvent(QCloseEvent* event);
-  void appendToText(const char*);
-  QString processErrorString(QProcess::ProcessError err);
-
+  void closeEvent(QCloseEvent* event) override;
+  void appendToText(const char* ptr);
+  static QString processErrorString(QProcess::ProcessError err);
 
 private slots:
-  void errorX(QProcess::ProcessError);
-  void finishedX(int exitCode, QProcess::ExitStatus);
+  void errorX(QProcess::ProcessError err);
+  void finishedX(int exitCode, QProcess::ExitStatus es);
   void readyReadStandardErrorX();
   void readyReadStandardOutputX();
   void timeoutX();
   void stopClickedX();
 
 private:
-  vector <int> progressVals_;
-  int          progressIndex_;
-  int          stopCount_;
-  string       bufferedOut_;
+  int progressIndex_;
+  int stopCount_;
+  std::string bufferedOut_;
   QProcess::ExitStatus exitStatus_;
-  int                  ecode_;
-  QProcess*     process_;
+  int ecode_;
+  QProcess* process_;
   QProgressBar* progressBar_;
   QPlainTextEdit* textEdit_;
   QDialogButtonBox* buttonBox_;
-  QTimer*           timer_;
-  QString          errorString_;
-  QString          outputString_;
+  QTimer* timer_;
+  QString errorString_;
+  QString outputString_;
 };
 
 #endif


### PR DESCRIPTION
eliminate potential memory leak in runGpsbabel that could occur
if the process immediately returned NotRunning after being started.

eliminate potential race condition (that apparently never happens)
in checking process state after staring.  It seems best to hook up
all the signals and then start the process, ensuring that any errors
or finished signals will be caught.  This also simplifies the logic,
the start check is repaced by normal signal handling.