### PR TITLE
fix gui usage of duplicate filter.

### DIFF
--- a/gui/filterdata.cc
+++ b/gui/filterdata.cc
@@ -35,7 +35,7 @@ QStringList WayPtsFilterData::makeOptionString()
     args << QString("radius,distance=%1%2,lat=%3,lon=%4")
          .arg(radiusVal).arg("MK"[radiusUnit]).arg(latVal, 0, 'f', 8).arg(longVal, 0, 'f', 8);
   }
-  if (duplicates && ((shortNames ^ locations) != 0)) {
+  if (duplicates && (shortNames || locations)) {
     args << QString("-x");
     QString s = "duplicate";
     if (shortNames) {


### PR DESCRIPTION
the shortname and location options are not exclusive.

this resolves #686.