### PR TITLE
Introduce RunMachine to manage gpsbabel process.

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SOURCES
   optionsdlg.cc
   preferences.cc
   processwait.cc
+  runmachine.cc
   upgrade.cc
   version_mismatch.cc
 )
@@ -125,6 +126,7 @@ set(HEADERS
   optionsdlg.h
   preferences.h
   processwait.h
+  runmachine.h
   setting.h
   upgrade.h
   version_mismatch.h

--- a/gui/app.pro
+++ b/gui/app.pro
@@ -92,6 +92,7 @@ SOURCES += mainwindow.cc
 SOURCES += optionsdlg.cc
 SOURCES += preferences.cc
 SOURCES += processwait.cc
+SOURCES += runmachine.cc
 SOURCES += upgrade.cc
 SOURCES += version_mismatch.cc
 unix:!mac {
@@ -124,6 +125,7 @@ HEADERS += mainwindow.h
 HEADERS += optionsdlg.h
 HEADERS += preferences.h
 HEADERS += processwait.h
+HEADERS += runmachine.h
 HEADERS += setting.h
 HEADERS += upgrade.h
 HEADERS += version_mismatch.h

--- a/gui/processwait.h
+++ b/gui/processwait.h
@@ -23,18 +23,19 @@
 #ifndef PROCESSWAIT_H
 #define PROCESSWAIT_H
 
+#include <QtCore/QByteArray>           // for QByteArray
+#include <QtCore/QObject>              // for QObject
+#include <QtCore/QProcess>             // for QProcess, QProcess::ExitStatus, QProcess::ProcessError
+#include <QtCore/QString>              // for QString
+#include <QtCore/QTimer>               // for QTimer
+#include <QtGui/QCloseEvent>           // for QCloseEvent
+#include <QtWidgets/QDialog>           // for QDialog
+#include <QtWidgets/QDialogButtonBox>  // for QDialogButtonBox
+#include <QtWidgets/QPlainTextEdit>    // for QPlainTextEdit
+#include <QtWidgets/QProgressBar>      // for QProgressBar
+#include <QtWidgets/QWidget>           // for QWidget
 
-#include <QProcess>
-#include <QDialog>
-#include <vector>
-#include <string>
-using std::string;
-using std::vector;
 
-class QProgressBar;
-class QPlainTextEdit;
-class QDialogButtonBox;
-class QTimer;
 //------------------------------------------------------------------------
 class ProcessWaitDialog: public QDialog
 {
@@ -42,45 +43,28 @@ class ProcessWaitDialog: public QDialog
   Q_OBJECT
 
 public:
-  //
-  ProcessWaitDialog(QWidget* parent, QProcess* process_);
+  ProcessWaitDialog(QWidget* parent, QProcess* process);
 
-  bool getExitedNormally();
-  int getExitCode();
-  QString getErrorString();
-  QString getOutputString() const
+  QString getOutputString()
   {
-    return outputString_;
+    return QString::fromLocal8Bit(outputString_);
   }
 
 protected:
-  void closeEvent(QCloseEvent* event);
-  void appendToText(const char*);
-  QString processErrorString(QProcess::ProcessError err);
-
+  void closeEvent(QCloseEvent* event) override;
+  void appendToText(const QByteArray& text);
 
 private slots:
-  void errorX(QProcess::ProcessError);
-  void finishedX(int exitCode, QProcess::ExitStatus);
-  void readyReadStandardErrorX();
-  void readyReadStandardOutputX();
   void timeoutX();
-  void stopClickedX();
 
 private:
-  vector <int> progressVals_;
-  int          progressIndex_;
-  int          stopCount_;
-  string       bufferedOut_;
-  QProcess::ExitStatus exitStatus_;
-  int                  ecode_;
-  QProcess*     process_;
-  QProgressBar* progressBar_;
-  QPlainTextEdit* textEdit_;
-  QDialogButtonBox* buttonBox_;
-  QTimer*           timer_;
-  QString          errorString_;
-  QString          outputString_;
+  int progressIndex_{0};
+  QProcess* process_{nullptr};
+  QProgressBar* progressBar_{nullptr};
+  QPlainTextEdit* textEdit_{nullptr};
+  QDialogButtonBox* buttonBox_{nullptr};
+  QTimer* timer_{nullptr};
+  QByteArray outputString_;
 };
 
 #endif

--- a/gui/runmachine.cc
+++ b/gui/runmachine.cc
@@ -1,0 +1,218 @@
+/*
+    Copyright (C) 2021 Robert Lipe, gpsbabel.org
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ */
+
+#include "runmachine.h"
+
+#include <QtCore/QDebug>             // for qDebug
+#include <QtCore/QEventLoop>         // for QEventLoop
+#include <QtCore/QNonConstOverload>  // for QNonConstOverload
+#include <QtCore/QtGlobal>           // for QOverload, qOverload
+#include <QtWidgets/QDialog>         // for QDialog
+
+#include "appname.h"                 // for appName
+
+
+QString RunMachine::decodeProcessError(QProcess::ProcessError err)
+{
+  switch (err) {
+  case QProcess::FailedToStart:
+    return tr("Process failed to start");
+    break;
+  case QProcess::Crashed:
+    return tr("Process crashed");
+    break;
+  case QProcess::Timedout:
+    return tr("Process timedout");
+    break;
+  case QProcess::WriteError:
+    return tr("Error while trying to write to process");
+    break;
+  case QProcess::ReadError:
+    return tr("Error while trying to read from process");
+    break;
+  case QProcess::UnknownError:
+  default:
+    return tr("Unknown process error");
+  }
+}
+
+RunMachine::RunMachine(QWidget* parent,
+                       const QString& program,
+                       const QStringList& args) :
+  QWidget(parent), program_(program), args_(args)
+{
+  process_ = new QProcess(this);
+  progress_ = new ProcessWaitDialog(this, process_);
+  // It is important that at least some of the fowarded signals are
+  // QueuedConnections to avoid reentrant use of RunMachine::execute which it
+  // is not designed for.
+  connect(process_, &QProcess::errorOccurred,
+  this, [this](QProcess::ProcessError error) {
+    execute(processErrorOccurred,
+            std::optional<QProcess::ProcessError>(error),
+            std::nullopt,
+            std::nullopt);
+  }, Qt::QueuedConnection);
+  // TODO: Qt6 combined the obsolete overloaded signal QProcess::finished(int exitCode)
+  connect(process_, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+  this, [this](int exitCode, QProcess::ExitStatus exitStatus) {
+    execute(processFinished,
+            std::nullopt,
+            std::optional<int>(exitCode),
+            std::optional<QProcess::ExitStatus>(exitStatus));
+  }, Qt::QueuedConnection);
+  connect(process_, &QProcess::started,
+  this, [this]() {
+    execute(processStarted,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt);
+  }, Qt::QueuedConnection);
+  connect(progress_, &ProcessWaitDialog::rejected,
+  this, [this]() {
+    execute(abortRequested,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt);
+  }, Qt::QueuedConnection);
+}
+
+int RunMachine::exec()
+{
+  open();
+
+  // block until complete.
+  QEventLoop loop;
+  connect(this, &RunMachine::finished, &loop, &QEventLoop::quit);
+  loop.exec();
+
+  return getRetStatus();
+}
+
+void RunMachine::open()
+{
+  execute(start, std::nullopt, std::nullopt, std::nullopt);
+}
+
+void RunMachine::execute(SignalId id,
+                         std::optional<QProcess::ProcessError> error,
+                         std::optional<int> exitCode,
+                         std::optional<QProcess::ExitStatus> exitStatus)
+{
+  if constexpr(debug) {
+    QDebug debugStream = qDebug();
+    debugStream << "exec entering" << state_ << id;
+    if (error.has_value()) {
+      debugStream << *error;
+    }
+    if (exitStatus.has_value()) {
+      debugStream << *exitStatus;
+    }
+    if (exitCode.has_value()) {
+      debugStream << *exitCode;
+    }
+  }
+
+  switch (state_) {
+  case init:
+    process_->start(program_, args_);
+    state_ = starting;
+    break;
+
+  case starting:
+    switch (id) {
+    case processErrorOccurred:
+      errorString_ = QString(tr("Process \"%1\" did not start")).arg(appName);
+      state_ = done;
+      emit finished();
+      break;
+    case processStarted:
+      progress_->show();
+      progress_->open();
+      state_ = running;
+      break;
+    default:
+      if constexpr(debug) {
+        qDebug() << "signal" << id << "UNEXPECTED in starting state!";
+      }
+      break;
+    };
+    break;
+
+  case running:
+    switch (id) {
+    case processErrorOccurred:
+      if constexpr(finishOnRunningError) {
+        progress_->accept();
+        errorString_ = decodeProcessError(*error);
+        state_ = done;
+        emit finished();
+      }
+      break;
+    case processFinished:
+      progress_->accept();
+      if (*exitStatus == QProcess::NormalExit) {
+        if (*exitCode != 0) {
+          errorString_ =
+            QString(tr("Process exited unsuccessfully with code %1"))
+            .arg(*exitCode);
+        }
+      } else {
+        errorString_ = tr("Process crashed while running");
+      }
+      state_ = done;
+      emit finished();
+      break;
+    case abortRequested:
+      if constexpr(finishOnAbort) {
+        // To avoid a message from ~QProcess we need to close the process
+        // instead of killing it.
+        // QProcess: Destroyed while process (".../gpsbabel") is still running."
+        process_->close();
+        errorString_ = tr("Process crashed while running");
+        state_ = done;
+        emit finished();
+      } else {
+        // Console applications on Windows that do not run an event loop, or
+        // whose event loop does not handle the WM_CLOSE message, can only be
+        // terminated
+        process_->kill();
+      }
+      break;
+    default:
+      if constexpr(debug) {
+        qDebug() << "signal" << id << "UNEXPECTED in running state!";
+      }
+      break;
+    };
+    break;
+
+  case done:
+    break;
+
+  default:
+    if constexpr(debug) {
+      qDebug() << "UNEXPECTED State!";
+    }
+    break;
+  };
+  if constexpr(debug) {
+    qDebug() << "exec leaving" << state_ << id;
+  }
+}

--- a/gui/runmachine.cc
+++ b/gui/runmachine.cc
@@ -191,7 +191,7 @@ void RunMachine::execute(SignalId id,
       } else {
         // Console applications on Windows that do not run an event loop, or
         // whose event loop does not handle the WM_CLOSE message, can only be
-        // terminated
+        // terminated by calling kill().
         process_->kill();
       }
       break;

--- a/gui/runmachine.cc
+++ b/gui/runmachine.cc
@@ -131,8 +131,17 @@ void RunMachine::execute(SignalId id,
 
   switch (state_) {
   case init:
-    process_->start(program_, args_);
-    state_ = starting;
+    switch (id) {
+    case start:
+      process_->start(program_, args_);
+      state_ = starting;
+      break;
+    default:
+      if constexpr(debug) {
+        qDebug() << "signal" << id << "UNEXPECTED in init state!";
+      }
+      break;
+    };
     break;
 
   case starting:

--- a/gui/runmachine.h
+++ b/gui/runmachine.h
@@ -1,0 +1,109 @@
+/*
+    Copyright (C) 2021 Robert Lipe, gpsbabel.org
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ */
+
+#ifndef RUNMACHINE_H
+#define RUNMACHINE_H
+
+#include <QtCore/QObject>      // for QObject
+#include <QtCore/QProcess>     // for QProcess, QProcess::ExitStatus, QProcess::ProcessError, qt_getEnumName
+#include <QtCore/QString>      // for QString
+#include <QtCore/QStringList>  // for QStringList
+#include <QtWidgets/QWidget>   // for QWidget
+
+#include <optional>            // for optional, nullopt
+
+#include "processwait.h"       // for ProcessWaitDialog
+
+
+class RunMachine : public QWidget
+{
+  Q_OBJECT
+
+public:
+
+  /* Types */
+
+  enum SignalId {
+    start,
+    processErrorOccurred,
+    processStarted,
+    processFinished,
+    abortRequested
+  };
+  Q_ENUM(SignalId)
+
+  enum State {
+    init,
+    starting,
+    running,
+    done
+  };
+  Q_ENUM(State)
+
+  /* Special Member Functions */
+
+  RunMachine(QWidget* parent, const QString& program, const QStringList& args);
+
+  /* Member Functions */
+
+  static QString decodeProcessError(QProcess::ProcessError err);
+  int exec();
+  void open();
+  QString getOutputString()
+  {
+    return progress_->getOutputString();
+  }
+  QString getErrorString()
+  {
+    return errorString_;
+  }
+  bool getRetStatus() const
+  {
+    return errorString_.isEmpty();
+  }
+
+Q_SIGNALS:
+  void finished();
+
+private:
+
+  /* Constants */
+
+  static constexpr bool debug = false;
+  static constexpr bool finishOnAbort = false;
+  static constexpr bool finishOnRunningError = false;
+
+  /* Member Functions */
+
+  void execute(SignalId id,
+               std::optional<QProcess::ProcessError> error,
+               std::optional<int> exitCode,
+               std::optional<QProcess::ExitStatus> exitStatus);
+
+  /* Data Members */
+
+  QProcess* process_{nullptr};
+  ProcessWaitDialog* progress_{nullptr};
+  State state_{init};
+  QString program_;
+  QStringList args_;
+  QString errorString_;
+
+};
+#endif // RUNMACHINE_H


### PR DESCRIPTION
This is a recommended alternative to #693.

This resolves #696, implementing the suggested enhancement.

This fixes #697, with a few caveats:

- the process wait dialog intentionally ignores close events (pressing the x button in the title bar doesn't appear to do anything.)  This doesn't seem like good interface design, but that is what we have always done.  Pushing the "Stop process" button, or pressing enter (the default button), or pressing escape all result in the process being aborted and the process wait dialog closing.
- If the user selects '-' for the output file, and the file is very large, e.g. "-i gpx -f big.gpx -o gpx -F -", there will be a delay of many seconds after the process wait dialog closes while the output is converted to a QString and appended to the output window.  In process wait we now truncate the plain text window to the last 16384 characters which keeps it speedy.  We could do something similar in mainwindow, perhaps keeping the first and last 16384 characters with a "..." indication in between.  Unlike with process wait the mainwindow output window stays open and the user does have an opportunity to scroll back and see the entire window contents.

Additionally, the proper codec is used to translate standard output and error before display.  This was another unreported bug.
