### PR TITLE
Parse empty gx:coord elements in KML reader

### DIFF
--- a/kml.cc
+++ b/kml.cc
@@ -341,7 +341,7 @@ void KmlFormat::gx_trk_coord(xg_string args, const QXmlStreamAttributes* /*attrs
 
   double lat, lon, alt;
   int n = sscanf(CSTR(args), "%lf %lf %lf", &lon, &lat, &alt);
-  if (0 != n && 2 != n && 3 != n) {
+  if (EOF != n && 2 != n && 3 != n) {
     fatal(MYNAME ": coord field decode failure on \"%s\".\n", qPrintable(args));
   }
   gx_trk_coords->append(std::make_tuple(n, lat, lon, alt));

--- a/reference/track/opentracks.kml
+++ b/reference/track/opentracks.kml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2"
+xmlns:gx="http://www.google.com/kml/ext/2.2">
+<Document>
+<name><![CDATA[Wurmlinger Kapelle]]></name>
+<Placemark>
+<name><![CDATA[Wurmlinger Kapelle]]></name>
+<gx:MultiTrack>
+<altitudeMode>absolute</altitudeMode>
+<gx:interpolate>1</gx:interpolate>
+<gx:Track>
+<when>2021-03-02T09:30:40.993Z</when>
+<when>2021-03-02T09:30:41.890Z</when>
+<when>2021-03-02T12:34:53.912Z</when>
+<when>2021-03-02T12:34:54.693Z</when>
+<gx:coord/>
+<gx:coord>8.970803 48.503537 405.01373291015625</gx:coord>
+<gx:coord>8.970829 48.503623 401.119873046875</gx:coord>
+<gx:coord/>
+</gx:Track>
+</gx:MultiTrack>
+</Placemark>
+</Document>
+</kml>

--- a/reference/track/opentracks~kml.gpx
+++ b/reference/track/opentracks~kml.gpx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
+  <time>1970-01-01T00:00:00Z</time>
+  <bounds minlat="48.503537000" minlon="8.970803000" maxlat="48.503623000" maxlon="8.970829000"/>
+  <trk>
+    <name>Wurmlinger Kapelle</name>
+    <trkseg>
+      <trkpt lat="48.503537000" lon="8.970803000">
+        <ele>405.014</ele>
+        <time>2021-03-02T09:30:41.890Z</time>
+      </trkpt>
+      <trkpt lat="48.503623000" lon="8.970829000">
+        <ele>401.120</ele>
+        <time>2021-03-02T12:34:53.912Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/testo.d/kml-read.test
+++ b/testo.d/kml-read.test
@@ -16,3 +16,6 @@ compare ${REFERENCE}/track/google_ext~kml.gpx ${TMPDIR}/google_ext~kml.gpx
 gpsbabel -i kml -f ${REFERENCE}/track/skydrop.kml -o igc -F - | grep -v "^L" > ${TMPDIR}/skydrop~kml.igc
 compare ${REFERENCE}/track/skydrop~kml.igc ${TMPDIR}/skydrop~kml.igc
 
+# Track with empty gx:coord elements.
+gpsbabel -i kml -f ${REFERENCE}/track/opentracks.kml -o gpx -F ${TMPDIR}/opentracks~kml.gpx
+compare ${REFERENCE}/track/opentracks~kml.gpx ${TMPDIR}/opentracks~kml.gpx


### PR DESCRIPTION
[OpenTracks](https://github.com/OpenTracksApp/OpenTracks) has started to use empty gx:coord elements in KML files. There's already code in gpsbabel's kml.cc that handles empty gx:coord elements, but sscanf() returns EOF, i.e. -1, and not 0 if gx:coord is empty. This pull request adds the condition `EOF != n` to the if statement shown below. I have also added a test to testo.d/kml-read.test.

```cpp
double lat, lon, alt;
int n = sscanf(CSTR(args), "%lf %lf %lf", &lon, &lat, &alt);
if (0 != n && 2 != n && 3 != n) {
  fatal(MYNAME ": coord field decode failure on \"%s\".\n", qPrintable(args));
}
```

I have kept the condition `0 != n`, but I doubt that there are sscanf() implementations that return 0 instead of EOF.