### PR TITLE
use default parameter instead of QString::KeepEmptyParts,

### DIFF
--- a/nmea.cc
+++ b/nmea.cc
@@ -32,7 +32,7 @@
 #include <QtCore/QDateTime>        // for QDateTime
 #include <QtCore/QDebug>           // for QDebug
 #include <QtCore/QList>            // for QList
-#include <QtCore/QString>          // for QString, QString::KeepEmptyParts
+#include <QtCore/QString>          // for QString
 #include <QtCore/QStringList>      // for QStringList
 #include <QtCore/QTextStream>      // for hex
 #include <QtCore/QThread>          // for QThread
@@ -358,7 +358,7 @@ NmeaFormat::gpgll_parse(const QString& ibuf)
     track_add_head(trk_head);
   }
 
-  const QStringList fields = ibuf.split(',', QString::KeepEmptyParts);
+  const QStringList fields = ibuf.split(',');
 
   double latdeg = 0;
   if (fields.size() > 1) latdeg = fields[1].toDouble();
@@ -405,7 +405,7 @@ NmeaFormat::gpgga_parse(const QString& ibuf)
     track_add_head(trk_head);
   }
 
-  const QStringList fields = ibuf.split(',', QString::KeepEmptyParts);
+  const QStringList fields = ibuf.split(',');
   QTime hms;
   if (fields.size() > 1) hms = nmea_parse_hms(fields[1]);
   double latdeg = 0;
@@ -495,7 +495,7 @@ NmeaFormat::gprmc_parse(const QString& ibuf)
     track_add_head(trk_head);
   }
 
-  const QStringList fields = ibuf.split(',', QString::KeepEmptyParts);
+  const QStringList fields = ibuf.split(',');
   QTime hms;
   if (fields.size() > 1) hms = nmea_parse_hms(fields[1]);
   QChar fix = 'V'; // V == "Invalid"
@@ -576,7 +576,7 @@ NmeaFormat::gprmc_parse(const QString& ibuf)
 void
 NmeaFormat::gpwpl_parse(const QString& ibuf)
 {
-  const QStringList fields = ibuf.split(',', QString::KeepEmptyParts);
+  const QStringList fields = ibuf.split(',');
 
   double latdeg = 0;
   if (fields.size() > 1) latdeg = fields[1].toDouble();
@@ -608,7 +608,7 @@ NmeaFormat::gpwpl_parse(const QString& ibuf)
 void
 NmeaFormat::gpzda_parse(const QString& ibuf)
 {
-  const QStringList fields = ibuf.split(',', QString::KeepEmptyParts);
+  const QStringList fields = ibuf.split(',');
   if (fields.size() > 4) {
     QTime time = nmea_parse_hms(fields[1]);
     QString datestr = QString("%1%2%3").arg(fields[2], fields[3], fields[4]);
@@ -634,7 +634,7 @@ NmeaFormat::gpgsa_parse(const QString& ibuf) const
   int  prn[12] = {0};
   memset(prn,0xff,sizeof(prn));
 
-  const QStringList fields = ibuf.split(',', QString::KeepEmptyParts);
+  const QStringList fields = ibuf.split(',');
   int nfields = fields.size();
   // 0 = "GPGSA"
   // 1 = Mode. Ignored
@@ -678,7 +678,7 @@ NmeaFormat::gpgsa_parse(const QString& ibuf) const
 void
 NmeaFormat::gpvtg_parse(const QString& ibuf) const
 {
-  const QStringList fields = ibuf.split(',', QString::KeepEmptyParts);
+  const QStringList fields = ibuf.split(',');
   double course = 0;
   if (fields.size() > 1) course = fields[1].toDouble();
   double speed_n = 0;

--- a/pcx.cc
+++ b/pcx.cc
@@ -29,7 +29,7 @@
 #include <QtCore/QDateTime>           // for QDateTime
 #include <QtCore/QList>               // for QList
 #include <QtCore/QRegularExpression>  // for QRegularExpression
-#include <QtCore/QString>             // for QString, QString::KeepEmptyParts, QString::SectionSkipEmpty
+#include <QtCore/QString>             // for QString, QString::SectionSkipEmpty
 #include <QtCore/QStringList>         // for QStringList
 #include <QtCore/QStringRef>          // for QStringRef
 #include <QtCore/QTime>               // for QTime
@@ -133,7 +133,7 @@ static void data_read() {
     switch (ibuf[0]) {
       case 'W': {
         QStringList tokens =
-            line.split(sep, QString::KeepEmptyParts);
+            line.split(sep);
         if (tokens.size() < 6) {
           fatal(MYNAME
                 ": Unable to parse waypoint, not all required columns "
@@ -233,7 +233,7 @@ static void data_read() {
         break;
       case 'T': {
         QStringList tokens =
-            line.split(sep, QString::KeepEmptyParts);
+            line.split(sep);
         if (tokens.size() < 6) {
           fatal(MYNAME
                 ": Unable to parse trackpoint, not all required columns "

--- a/stmsdf.cc
+++ b/stmsdf.cc
@@ -40,7 +40,7 @@
 #include <QtCore/QDateTime>           // for QDateTime
 #include <QtCore/QList>               // for QList<>::iterator, QList
 #include <QtCore/QRegularExpression>  // for QRegularExpression
-#include <QtCore/QString>             // for QString, operator+, QString::KeepEmptyParts
+#include <QtCore/QString>             // for QString, operator+
 #include <QtCore/QStringList>         // for QStringList
 #include <QtCore/QTime>               // for QTime
 #include <QtCore/QtGlobal>            // for qAsConst, QAddConst<>::Type
@@ -270,7 +270,7 @@ parse_point(char *line) {
         break;
       case 2: {
         // Date is in format dd.mm.yyyy
-        auto v = qstr.split('.', QString::KeepEmptyParts);
+        const auto v = qstr.split('.');
 
         if (v.size() == 3) {
           auto day = v[0].toInt();
@@ -284,7 +284,7 @@ parse_point(char *line) {
       }
       case 3: {
         // Time is hh:mm.ss - yes, colon and period.
-        auto v = qstr.split(QRegularExpression("[.:]"), QString::KeepEmptyParts);
+        const auto v = qstr.split(QRegularExpression("[.:]"));
         if (v.size() == 3) {
           auto hour = v[0].toInt();
           auto min = v[1].toInt();


### PR DESCRIPTION
simplifying migration to Qt6, where the enum changed to Qt::KeepEmptyParts.