### PR TITLE
PVS-Studio fixes

### DIFF
--- a/brauniger_iq.cc
+++ b/brauniger_iq.cc
@@ -54,7 +54,7 @@ inline state_t& operator++(state_t& s) // prefix
 inline state_t operator++(state_t& s, int) // postfix
 {
   state_t ret(s);
-  s = ++s;
+  ++s;
   return ret;
 }
 

--- a/garmin_device_xml.cc
+++ b/garmin_device_xml.cc
@@ -79,7 +79,7 @@ void dir_s(xg_string args, const QXmlStreamAttributes*)
   if (type) {
     return;
   }
-  if ((args == "OutputFromUnit")) {
+  if (args == "OutputFromUnit") {
     xasprintf(&my_gdx_info->from_device.path,  "%s%c%s",
               mountpoint, GB_PATHSEP, path);
     my_gdx_info->from_device.basename = xstrdup(base);
@@ -88,7 +88,7 @@ void dir_s(xg_string args, const QXmlStreamAttributes*)
               my_gdx_info->from_device.path,
               my_gdx_info->from_device.basename,
               my_gdx_info->from_device.extension);
-  } if ((args == "InputToUnit")) {
+  } else if (args == "InputToUnit") {
     xasprintf(&my_gdx_info->to_device.path,  "%s%c%s",
               mountpoint, GB_PATHSEP, path);
     my_gdx_info->to_device.basename = xstrdup(base);

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -912,23 +912,20 @@ wdata_compute_size(writer_data_t* data)
     wpt->extra_data = dt;
 
     if (alerts) {
-      int pidx;
-      if ((pidx = wpt->shortname.indexOf('@')) != -1) {
-        const char* pos = CSTR(wpt->shortname.mid(pidx));
-        double speed, scale;
+      if (int pidx = wpt->shortname.indexOf('@'); pidx != -1) {
+        double scale;
         if (units == 's') {
           scale = MPH_TO_MPS(1);
         } else {
           scale = KPH_TO_MPS(1);
         }
-        parse_speed(pos + 1, &speed, scale, MYNAME);
+        double speed = 0;
+        parse_speed(wpt->shortname.mid(pidx + 1), &speed, scale, MYNAME);
         if (speed > 0) {
           WAYPT_SET(wpt, speed, speed);
         }
 #if 0
-        if (pos > wpt->shortname) {
-          wpt->shortname[pos - wpt->shortname] = '\0';
-        }
+        wpt->shortname.truncate(pidx);
 #endif
       } else if ((opt_speed) && (! WAYPT_HAS(wpt, speed))) {
         WAYPT_SET(wpt, speed, defspeed);

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -94,7 +94,7 @@ inline header_type& operator++(header_type& s) // prefix
 inline header_type operator++(header_type& s, int) // postfix
 {
   header_type ret(s);
-  s = ++s;
+  ++s;
   return ret;
 }
 
@@ -105,7 +105,7 @@ inline gt_display_modes_e& operator++(gt_display_modes_e& s) // prefix
 inline gt_display_modes_e operator++(gt_display_modes_e& s, int) // postfix
 {
   gt_display_modes_e ret(s);
-  s = ++s;
+  ++s;
   return ret;
 }
 

--- a/igc.cc
+++ b/igc.cc
@@ -156,7 +156,7 @@ inline state_t& operator++(state_t& s) // prefix
 inline state_t operator++(state_t& s, int) // postfix
 {
   state_t ret(s);
-  s = ++s;
+  ++s;
   return ret;
 }
 

--- a/mtk_logger.cc
+++ b/mtk_logger.cc
@@ -901,7 +901,7 @@ static int add_trackpoint(int idx, unsigned long bmask, struct data_item* itm)
     /* Button press -- create waypoint, start count at 1 */
     auto* w = new Waypoint(*trk);
 
-    w->shortname = QString::asprintf("WP%06d", waypt_count()+1);
+    w->shortname = QString("WP%1").arg(waypt_count() + 1, 6, 10, QLatin1Char('0'));
     waypt_add(w);
   }
   // In theory we would not add the waypoint to the list of

--- a/ozi.cc
+++ b/ozi.cc
@@ -822,13 +822,9 @@ data_read()
         }
         break;
       case rtedata:
-        if (linecount > 5 && wpt_tmp) {/* skipping over file header */
+        if ((linecount > 5) && !header) {/* skipping over file header */
           ozi_convert_datum(wpt_tmp);
-          if (!header) {
-            route_add_wpt(rte_head, wpt_tmp);
-          } else {
-            delete wpt_tmp;
-          }
+          route_add_wpt(rte_head, wpt_tmp);
         } else {
           delete wpt_tmp;
         }

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -219,7 +219,7 @@ raymarine_read()
     if (!str.isEmpty()) {
       unsigned int symbol = str.toInt();
 
-      if ((symbol < 3) && (symbol >= RAYMARINE_SYMBOL_CT)) {
+      if ((symbol < 3) || (symbol >= RAYMARINE_SYMBOL_CT)) {
         symbol = RAYMARINE_STD_SYMBOL;
       }
       wpt->icon_descr = raymarine_symbols[symbol].name;

--- a/reference/track/vpl_reference.gpx
+++ b/reference/track/vpl_reference.gpx
@@ -7,6 +7,7 @@
       <trkpt lat="40.741192491" lon="-88.737399089">
         <ele>225.000</ele>
         <time>2009-07-06T21:14:11Z</time>
+        <course>359.000214</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -15,6 +16,7 @@
       <trkpt lat="40.741453993" lon="-88.737407769">
         <ele>225.000</ele>
         <time>2009-07-06T21:14:12Z</time>
+        <course>358.632172</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -23,6 +25,7 @@
       <trkpt lat="40.741716580" lon="-88.737415365">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:13Z</time>
+        <course>358.692596</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -31,6 +34,7 @@
       <trkpt lat="40.741978082" lon="-88.737422960">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:14Z</time>
+        <course>358.654144</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -39,6 +43,7 @@
       <trkpt lat="40.742238498" lon="-88.737430556">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:15Z</time>
+        <course>358.720062</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -47,6 +52,7 @@
       <trkpt lat="40.742500000" lon="-88.737439236">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:16Z</time>
+        <course>358.643158</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -55,6 +61,7 @@
       <trkpt lat="40.742762587" lon="-88.737446832">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:17Z</time>
+        <course>358.747528</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -63,6 +70,7 @@
       <trkpt lat="40.743024089" lon="-88.737453342">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:18Z</time>
+        <course>358.835419</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -71,6 +79,7 @@
       <trkpt lat="40.743285590" lon="-88.737460938">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:19Z</time>
+        <course>358.753021</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -79,6 +88,7 @@
       <trkpt lat="40.743548177" lon="-88.737467448">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:20Z</time>
+        <course>358.725555</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -87,6 +97,7 @@
       <trkpt lat="40.743809679" lon="-88.737475043">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:21Z</time>
+        <course>358.868378</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -95,6 +106,7 @@
       <trkpt lat="40.744072266" lon="-88.737479384">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:22Z</time>
+        <course>359.176025</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -103,6 +115,7 @@
       <trkpt lat="40.744333767" lon="-88.737483724">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:23Z</time>
+        <course>359.225464</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -111,6 +124,7 @@
       <trkpt lat="40.744596354" lon="-88.737489149">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:24Z</time>
+        <course>359.115601</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -119,6 +133,7 @@
       <trkpt lat="40.744857856" lon="-88.737494575">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:25Z</time>
+        <course>358.989227</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -127,6 +142,7 @@
       <trkpt lat="40.745120443" lon="-88.737500000">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:26Z</time>
+        <course>359.082642</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -135,6 +151,7 @@
       <trkpt lat="40.745383030" lon="-88.737503255">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:27Z</time>
+        <course>359.527588</course>
         <speed>29.364941</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -143,6 +160,7 @@
       <trkpt lat="40.745646701" lon="-88.737502170">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:28Z</time>
+        <course>0.329595</course>
         <speed>29.392879</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -151,6 +169,7 @@
       <trkpt lat="40.745909288" lon="-88.737491319">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:29Z</time>
+        <course>1.884184</course>
         <speed>29.364941</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -159,6 +178,7 @@
       <trkpt lat="40.746171875" lon="-88.737469618">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:30Z</time>
+        <course>3.493706</course>
         <speed>29.364941</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -167,6 +187,7 @@
       <trkpt lat="40.746434462" lon="-88.737437066">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:31Z</time>
+        <course>5.421835</course>
         <speed>29.364941</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -175,6 +196,7 @@
       <trkpt lat="40.746694878" lon="-88.737394748">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:32Z</time>
+        <course>7.091783</course>
         <speed>29.392879</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -183,6 +205,7 @@
       <trkpt lat="40.746955295" lon="-88.737342665">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:33Z</time>
+        <course>8.723278</course>
         <speed>29.392879</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -191,6 +214,7 @@
       <trkpt lat="40.747214627" lon="-88.737279731">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:34Z</time>
+        <course>10.420691</course>
         <speed>29.392879</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -199,6 +223,7 @@
       <trkpt lat="40.747471788" lon="-88.737207031">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:35Z</time>
+        <course>12.140078</course>
         <speed>29.392879</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -207,6 +232,7 @@
       <trkpt lat="40.747726780" lon="-88.737124566">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:36Z</time>
+        <course>14.090180</course>
         <speed>29.364941</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -215,6 +241,7 @@
       <trkpt lat="40.747979601" lon="-88.737030165">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:37Z</time>
+        <course>15.787595</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -223,6 +250,7 @@
       <trkpt lat="40.748230252" lon="-88.736927083">
         <ele>227.000</ele>
         <time>2009-07-06T21:14:38Z</time>
+        <course>17.127947</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -231,6 +259,7 @@
       <trkpt lat="40.748478733" lon="-88.736816406">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:39Z</time>
+        <course>18.688030</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -239,6 +268,7 @@
       <trkpt lat="40.748723958" lon="-88.736694878">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:40Z</time>
+        <course>20.715038</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -247,6 +277,7 @@
       <trkpt lat="40.748965929" lon="-88.736563585">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:41Z</time>
+        <course>22.324560</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -255,6 +286,7 @@
       <trkpt lat="40.749204644" lon="-88.736423611">
         <ele>226.000</ele>
         <time>2009-07-06T21:14:42Z</time>
+        <course>23.934080</course>
         <speed>29.169359</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -263,6 +295,7 @@
       <trkpt lat="40.749439019" lon="-88.736273872">
         <ele>225.000</ele>
         <time>2009-07-06T21:14:43Z</time>
+        <course>25.752346</course>
         <speed>29.141420</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -271,6 +304,7 @@
       <trkpt lat="40.749670139" lon="-88.736114366">
         <ele>225.000</ele>
         <time>2009-07-06T21:14:44Z</time>
+        <course>27.724422</course>
         <speed>29.141420</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -279,6 +313,7 @@
       <trkpt lat="40.749899089" lon="-88.735947266">
         <ele>225.000</ele>
         <time>2009-07-06T21:14:45Z</time>
+        <course>29.086748</course>
         <speed>29.141420</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -287,6 +322,7 @@
       <trkpt lat="40.750123698" lon="-88.735773655">
         <ele>224.000</ele>
         <time>2009-07-06T21:14:46Z</time>
+        <course>30.482033</course>
         <speed>29.141420</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -295,6 +331,7 @@
       <trkpt lat="40.750343967" lon="-88.735589193">
         <ele>224.000</ele>
         <time>2009-07-06T21:14:47Z</time>
+        <course>32.459602</course>
         <speed>29.113480</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -303,6 +340,7 @@
       <trkpt lat="40.750559896" lon="-88.735397135">
         <ele>224.000</ele>
         <time>2009-07-06T21:14:48Z</time>
+        <course>34.294346</course>
         <speed>29.141420</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -311,6 +349,7 @@
       <trkpt lat="40.750770399" lon="-88.735194227">
         <ele>224.000</ele>
         <time>2009-07-06T21:14:49Z</time>
+        <course>36.255436</course>
         <speed>29.169359</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -319,6 +358,7 @@
       <trkpt lat="40.750975477" lon="-88.734981554">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:50Z</time>
+        <course>38.205540</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -327,6 +367,7 @@
       <trkpt lat="40.751177300" lon="-88.734761285">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:51Z</time>
+        <course>39.864498</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -335,6 +376,7 @@
       <trkpt lat="40.751373698" lon="-88.734526910">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:52Z</time>
+        <course>41.375141</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -343,6 +385,7 @@
       <trkpt lat="40.751565755" lon="-88.734289280">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:53Z</time>
+        <course>42.841839</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -351,6 +394,7 @@
       <trkpt lat="40.751752387" lon="-88.734047309">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:54Z</time>
+        <course>44.215153</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -359,6 +403,7 @@
       <trkpt lat="40.751937934" lon="-88.733803168">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:55Z</time>
+        <course>45.105057</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -367,6 +412,7 @@
       <trkpt lat="40.752121311" lon="-88.733556858">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:56Z</time>
+        <course>45.511559</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -375,6 +421,7 @@
       <trkpt lat="40.752303602" lon="-88.733309462">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:57Z</time>
+        <course>45.835659</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -383,6 +430,7 @@
       <trkpt lat="40.752485894" lon="-88.733062066">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:58Z</time>
+        <course>45.802700</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -391,6 +439,7 @@
       <trkpt lat="40.752668186" lon="-88.732814670">
         <ele>223.000</ele>
         <time>2009-07-06T21:14:59Z</time>
+        <course>45.983978</course>
         <speed>29.281120</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -399,6 +448,7 @@
       <trkpt lat="40.752850477" lon="-88.732566189">
         <ele>223.000</ele>
         <time>2009-07-06T21:15:00Z</time>
+        <course>46.044403</course>
         <speed>29.281120</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -407,6 +457,7 @@
       <trkpt lat="40.753033854" lon="-88.732318793">
         <ele>223.000</ele>
         <time>2009-07-06T21:15:01Z</time>
+        <course>45.758755</course>
         <speed>29.309059</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -415,6 +466,7 @@
       <trkpt lat="40.753216146" lon="-88.732072483">
         <ele>223.000</ele>
         <time>2009-07-06T21:15:02Z</time>
+        <course>45.852139</course>
         <speed>29.281120</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -423,6 +475,7 @@
       <trkpt lat="40.753399523" lon="-88.731825087">
         <ele>223.000</ele>
         <time>2009-07-06T21:15:03Z</time>
+        <course>45.698330</course>
         <speed>29.281120</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -431,6 +484,7 @@
       <trkpt lat="40.753582899" lon="-88.731578776">
         <ele>223.000</ele>
         <time>2009-07-06T21:15:04Z</time>
+        <course>45.786221</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -439,6 +493,7 @@
       <trkpt lat="40.753765191" lon="-88.731332465">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:05Z</time>
+        <course>45.703823</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -447,6 +502,7 @@
       <trkpt lat="40.753948568" lon="-88.731087240">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:06Z</time>
+        <course>45.599449</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -455,6 +511,7 @@
       <trkpt lat="40.754131944" lon="-88.730840929">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:07Z</time>
+        <course>45.670864</course>
         <speed>29.225241</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -463,6 +520,7 @@
       <trkpt lat="40.754314236" lon="-88.730594618">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:08Z</time>
+        <course>45.896088</course>
         <speed>29.225241</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -471,6 +529,7 @@
       <trkpt lat="40.754496528" lon="-88.730347222">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:09Z</time>
+        <course>46.011444</course>
         <speed>29.225241</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -479,6 +538,7 @@
       <trkpt lat="40.754680990" lon="-88.730103082">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:10Z</time>
+        <course>45.868618</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -487,6 +547,7 @@
       <trkpt lat="40.754865451" lon="-88.729857856">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:11Z</time>
+        <course>45.879608</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -495,6 +556,7 @@
       <trkpt lat="40.755049913" lon="-88.729612630">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:12Z</time>
+        <course>45.874111</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -503,6 +565,7 @@
       <trkpt lat="40.755234375" lon="-88.729367405">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:13Z</time>
+        <course>45.896088</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -511,6 +574,7 @@
       <trkpt lat="40.755416667" lon="-88.729121094">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:14Z</time>
+        <course>45.918060</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -519,6 +583,7 @@
       <trkpt lat="40.755600043" lon="-88.728873698">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:15Z</time>
+        <course>45.879608</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -527,6 +592,7 @@
       <trkpt lat="40.755783420" lon="-88.728627387">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:16Z</time>
+        <course>45.962006</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -535,6 +601,7 @@
       <trkpt lat="40.755965712" lon="-88.728381076">
         <ele>222.000</ele>
         <time>2009-07-06T21:15:17Z</time>
+        <course>45.967499</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -543,6 +610,7 @@
       <trkpt lat="40.756148003" lon="-88.728133681">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:18Z</time>
+        <course>45.934540</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -551,6 +619,7 @@
       <trkpt lat="40.756330295" lon="-88.727886285">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:19Z</time>
+        <course>45.896088</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -559,6 +628,7 @@
       <trkpt lat="40.756512587" lon="-88.727639974">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:20Z</time>
+        <course>45.934540</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -567,6 +637,7 @@
       <trkpt lat="40.756695964" lon="-88.727393663">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:21Z</time>
+        <course>45.824673</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -575,6 +646,7 @@
       <trkpt lat="40.756878255" lon="-88.727147352">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:22Z</time>
+        <course>45.912567</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -583,6 +655,7 @@
       <trkpt lat="40.757060547" lon="-88.726902127">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:23Z</time>
+        <course>45.659878</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -591,6 +664,7 @@
       <trkpt lat="40.757243924" lon="-88.726655816">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:24Z</time>
+        <course>45.643398</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -599,6 +673,7 @@
       <trkpt lat="40.757427300" lon="-88.726410590">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:25Z</time>
+        <course>45.714809</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -607,6 +682,7 @@
       <trkpt lat="40.757609592" lon="-88.726164280">
         <ele>221.000</ele>
         <time>2009-07-06T21:15:26Z</time>
+        <course>45.775234</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -615,6 +691,7 @@
       <trkpt lat="40.757791884" lon="-88.725917969">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:27Z</time>
+        <course>45.819180</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -623,6 +700,7 @@
       <trkpt lat="40.757975260" lon="-88.725671658">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:28Z</time>
+        <course>45.670864</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -631,6 +709,7 @@
       <trkpt lat="40.758157552" lon="-88.725424262">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:29Z</time>
+        <course>45.786221</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -639,6 +718,7 @@
       <trkpt lat="40.758339844" lon="-88.725177951">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:30Z</time>
+        <course>45.709316</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -647,6 +727,7 @@
       <trkpt lat="40.758522135" lon="-88.724930556">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:31Z</time>
+        <course>46.016937</course>
         <speed>29.281120</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -655,6 +736,7 @@
       <trkpt lat="40.758704427" lon="-88.724682075">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:32Z</time>
+        <course>45.923553</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -663,6 +745,7 @@
       <trkpt lat="40.758887804" lon="-88.724435764">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:33Z</time>
+        <course>45.791714</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -671,6 +754,7 @@
       <trkpt lat="40.759070095" lon="-88.724188368">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:34Z</time>
+        <course>45.819180</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -679,6 +763,7 @@
       <trkpt lat="40.759251302" lon="-88.723940972">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:35Z</time>
+        <course>45.929047</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -687,6 +772,7 @@
       <trkpt lat="40.759433594" lon="-88.723694661">
         <ele>220.000</ele>
         <time>2009-07-06T21:15:36Z</time>
+        <course>45.857632</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -695,6 +781,7 @@
       <trkpt lat="40.759615885" lon="-88.723447266">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:37Z</time>
+        <course>45.797207</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -703,6 +790,7 @@
       <trkpt lat="40.759798177" lon="-88.723200955">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:38Z</time>
+        <course>45.753262</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -711,6 +799,7 @@
       <trkpt lat="40.759980469" lon="-88.722953559">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:39Z</time>
+        <course>45.780727</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -719,6 +808,7 @@
       <trkpt lat="40.760161675" lon="-88.722706163">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:40Z</time>
+        <course>46.016937</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -727,6 +817,7 @@
       <trkpt lat="40.760343967" lon="-88.722458767">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:41Z</time>
+        <course>45.956512</course>
         <speed>29.225241</speed>
         <sat>9</sat>
         <hdop>1.000000</hdop>
@@ -735,6 +826,7 @@
       <trkpt lat="40.760527344" lon="-88.722214627">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:42Z</time>
+        <course>45.654385</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -743,6 +835,7 @@
       <trkpt lat="40.760709635" lon="-88.721969401">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:43Z</time>
+        <course>45.626919</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -751,6 +844,7 @@
       <trkpt lat="40.760890842" lon="-88.721722005">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:44Z</time>
+        <course>45.643398</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.125000</hdop>
@@ -759,6 +853,7 @@
       <trkpt lat="40.761073134" lon="-88.721475694">
         <ele>219.000</ele>
         <time>2009-07-06T21:15:45Z</time>
+        <course>45.593956</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -767,6 +862,7 @@
       <trkpt lat="40.761256510" lon="-88.721231554">
         <ele>218.000</ele>
         <time>2009-07-06T21:15:46Z</time>
+        <course>45.000687</course>
         <speed>29.225241</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -775,6 +871,7 @@
       <trkpt lat="40.761444227" lon="-88.720990668">
         <ele>218.000</ele>
         <time>2009-07-06T21:15:47Z</time>
+        <course>44.094299</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -783,6 +880,7 @@
       <trkpt lat="40.761636285" lon="-88.720757378">
         <ele>218.000</ele>
         <time>2009-07-06T21:15:48Z</time>
+        <course>42.962692</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -791,6 +889,7 @@
       <trkpt lat="40.761833767" lon="-88.720529514">
         <ele>218.000</ele>
         <time>2009-07-06T21:15:49Z</time>
+        <course>41.984894</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -799,6 +898,7 @@
       <trkpt lat="40.762031250" lon="-88.720301649">
         <ele>218.000</ele>
         <time>2009-07-06T21:15:50Z</time>
+        <course>41.259785</course>
         <speed>29.281120</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -807,6 +907,7 @@
       <trkpt lat="40.762230903" lon="-88.720079210">
         <ele>218.000</ele>
         <time>2009-07-06T21:15:51Z</time>
+        <course>40.298466</course>
         <speed>29.281120</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -815,6 +916,7 @@
       <trkpt lat="40.762434896" lon="-88.719862196">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:52Z</time>
+        <course>39.007553</course>
         <speed>29.281120</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -823,6 +925,7 @@
       <trkpt lat="40.762641059" lon="-88.719649523">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:53Z</time>
+        <course>37.952850</course>
         <speed>29.281120</speed>
         <sat>9</sat>
         <hdop>1.000000</hdop>
@@ -831,6 +934,7 @@
       <trkpt lat="40.762848307" lon="-88.719439019">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:54Z</time>
+        <course>37.463951</course>
         <speed>29.281120</speed>
         <sat>9</sat>
         <hdop>1.000000</hdop>
@@ -839,6 +943,7 @@
       <trkpt lat="40.763057726" lon="-88.719232856">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:55Z</time>
+        <course>36.557564</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.000000</hdop>
@@ -847,6 +952,7 @@
       <trkpt lat="40.763270399" lon="-88.719032118">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:56Z</time>
+        <course>35.623711</course>
         <speed>29.197300</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -855,6 +961,7 @@
       <trkpt lat="40.763484158" lon="-88.718838976">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:57Z</time>
+        <course>34.601967</course>
         <speed>29.141420</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -863,6 +970,7 @@
       <trkpt lat="40.763703342" lon="-88.718648003">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:58Z</time>
+        <course>33.519798</course>
         <speed>29.225241</speed>
         <sat>8</sat>
         <hdop>1.000000</hdop>
@@ -871,6 +979,7 @@
       <trkpt lat="40.763925781" lon="-88.718462457">
         <ele>217.000</ele>
         <time>2009-07-06T21:15:59Z</time>
+        <course>32.794689</course>
         <speed>29.281120</speed>
         <sat>6</sat>
         <hdop>1.750000</hdop>
@@ -879,6 +988,7 @@
       <trkpt lat="40.764146050" lon="-88.718273655">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:00Z</time>
+        <course>31.602655</course>
         <speed>29.225241</speed>
         <sat>8</sat>
         <hdop>1.250000</hdop>
@@ -887,6 +997,7 @@
       <trkpt lat="40.764366319" lon="-88.718091363">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:01Z</time>
+        <course>30.800640</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.000000</hdop>
@@ -895,6 +1006,7 @@
       <trkpt lat="40.764589844" lon="-88.717914497">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:02Z</time>
+        <course>29.625086</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -903,6 +1015,7 @@
       <trkpt lat="40.764817708" lon="-88.717745226">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:03Z</time>
+        <course>28.647287</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -911,6 +1024,7 @@
       <trkpt lat="40.765048828" lon="-88.717581380">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:04Z</time>
+        <course>27.839781</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -919,6 +1033,7 @@
       <trkpt lat="40.765281033" lon="-88.717425130">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:05Z</time>
+        <course>26.812542</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -927,6 +1042,7 @@
       <trkpt lat="40.765514323" lon="-88.717274306">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:06Z</time>
+        <course>26.027008</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -935,6 +1051,7 @@
       <trkpt lat="40.765748698" lon="-88.717124566">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:07Z</time>
+        <course>25.790798</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -943,6 +1060,7 @@
       <trkpt lat="40.765984158" lon="-88.716975911">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:08Z</time>
+        <course>25.439232</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -951,6 +1069,7 @@
       <trkpt lat="40.766219618" lon="-88.716828342">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:09Z</time>
+        <course>25.395285</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -959,6 +1078,7 @@
       <trkpt lat="40.766455078" lon="-88.716680773">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:10Z</time>
+        <course>25.323874</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -967,6 +1087,7 @@
       <trkpt lat="40.766691623" lon="-88.716534288">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:11Z</time>
+        <course>25.224995</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -975,6 +1096,7 @@
       <trkpt lat="40.766927083" lon="-88.716387804">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:12Z</time>
+        <course>25.257954</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -983,6 +1105,7 @@
       <trkpt lat="40.767162543" lon="-88.716240234">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:13Z</time>
+        <course>25.378805</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -991,6 +1114,7 @@
       <trkpt lat="40.767398003" lon="-88.716092665">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:14Z</time>
+        <course>25.516136</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -999,6 +1123,7 @@
       <trkpt lat="40.767633464" lon="-88.715942925">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:15Z</time>
+        <course>25.636988</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1007,6 +1132,7 @@
       <trkpt lat="40.767870009" lon="-88.715796441">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:16Z</time>
+        <course>25.389791</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1015,6 +1141,7 @@
       <trkpt lat="40.768106554" lon="-88.715647786">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:17Z</time>
+        <course>25.400778</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1023,6 +1150,7 @@
       <trkpt lat="40.768342014" lon="-88.715500217">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:18Z</time>
+        <course>25.411764</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1031,6 +1159,7 @@
       <trkpt lat="40.768578559" lon="-88.715352648">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:19Z</time>
+        <course>25.455711</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1039,6 +1168,7 @@
       <trkpt lat="40.768814019" lon="-88.715202908">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:20Z</time>
+        <course>25.626001</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1047,6 +1177,7 @@
       <trkpt lat="40.769050564" lon="-88.715054253">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:21Z</time>
+        <course>25.669947</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1055,6 +1186,7 @@
       <trkpt lat="40.769287109" lon="-88.714905599">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:22Z</time>
+        <course>25.658960</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1063,6 +1195,7 @@
       <trkpt lat="40.769522569" lon="-88.714756944">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:23Z</time>
+        <course>25.675440</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1071,6 +1204,7 @@
       <trkpt lat="40.769759115" lon="-88.714608290">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:24Z</time>
+        <course>25.669947</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1079,6 +1213,7 @@
       <trkpt lat="40.769995660" lon="-88.714460720">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:25Z</time>
+        <course>25.312885</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1087,6 +1222,7 @@
       <trkpt lat="40.770233290" lon="-88.714315321">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:26Z</time>
+        <course>25.159075</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1095,6 +1231,7 @@
       <trkpt lat="40.770469835" lon="-88.714167752">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:27Z</time>
+        <course>25.274433</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1103,6 +1240,7 @@
       <trkpt lat="40.770706380" lon="-88.714021267">
         <ele>218.000</ele>
         <time>2009-07-06T21:16:28Z</time>
+        <course>25.208515</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1111,6 +1249,7 @@
       <trkpt lat="40.770942925" lon="-88.713874783">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:29Z</time>
+        <course>25.312885</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1119,6 +1258,7 @@
       <trkpt lat="40.771179470" lon="-88.713726128">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:30Z</time>
+        <course>25.642481</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1127,6 +1267,7 @@
       <trkpt lat="40.771414931" lon="-88.713577474">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:31Z</time>
+        <course>25.845732</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1135,6 +1276,7 @@
       <trkpt lat="40.771651476" lon="-88.713428819">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:32Z</time>
+        <course>25.664454</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1143,6 +1285,7 @@
       <trkpt lat="40.771888021" lon="-88.713280165">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:33Z</time>
+        <course>25.565577</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1151,6 +1294,7 @@
       <trkpt lat="40.772124566" lon="-88.713131510">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:34Z</time>
+        <course>25.560081</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1159,6 +1303,7 @@
       <trkpt lat="40.772361111" lon="-88.712982856">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:35Z</time>
+        <course>25.444725</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1167,6 +1312,7 @@
       <trkpt lat="40.772597656" lon="-88.712836372">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:36Z</time>
+        <course>25.274433</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1175,6 +1321,7 @@
       <trkpt lat="40.772834201" lon="-88.712688802">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:37Z</time>
+        <course>25.384298</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1183,6 +1330,7 @@
       <trkpt lat="40.773070747" lon="-88.712541233">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:38Z</time>
+        <course>25.505150</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1191,6 +1339,7 @@
       <trkpt lat="40.773307292" lon="-88.712394748">
         <ele>217.000</ele>
         <time>2009-07-06T21:16:39Z</time>
+        <course>25.241474</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1199,6 +1348,7 @@
       <trkpt lat="40.773544922" lon="-88.712249349">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:40Z</time>
+        <course>25.109636</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1207,6 +1357,7 @@
       <trkpt lat="40.773781467" lon="-88.712101780">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:41Z</time>
+        <course>25.400778</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1215,6 +1366,7 @@
       <trkpt lat="40.774016927" lon="-88.711954210">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:42Z</time>
+        <course>25.571070</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1223,6 +1375,7 @@
       <trkpt lat="40.774253472" lon="-88.711805556">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:43Z</time>
+        <course>25.510643</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1231,6 +1384,7 @@
       <trkpt lat="40.774490017" lon="-88.711659071">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:44Z</time>
+        <course>25.400778</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1239,6 +1393,7 @@
       <trkpt lat="40.774726562" lon="-88.711510417">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:45Z</time>
+        <course>25.631495</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1247,6 +1402,7 @@
       <trkpt lat="40.774963108" lon="-88.711362847">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:46Z</time>
+        <course>25.477684</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1255,6 +1411,7 @@
       <trkpt lat="40.775199653" lon="-88.711214193">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:47Z</time>
+        <course>25.587549</course>
         <speed>29.337000</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1263,6 +1420,7 @@
       <trkpt lat="40.775436198" lon="-88.711065538">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:48Z</time>
+        <course>25.516136</course>
         <speed>29.337000</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1271,6 +1429,7 @@
       <trkpt lat="40.775673828" lon="-88.710917969">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:49Z</time>
+        <course>25.340353</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1279,6 +1438,7 @@
       <trkpt lat="40.775910373" lon="-88.710771484">
         <ele>216.000</ele>
         <time>2009-07-06T21:16:50Z</time>
+        <course>25.175554</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1287,6 +1447,7 @@
       <trkpt lat="40.776146918" lon="-88.710623915">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:51Z</time>
+        <course>25.444725</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1295,6 +1456,7 @@
       <trkpt lat="40.776382378" lon="-88.710476345">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:52Z</time>
+        <course>25.571070</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1303,6 +1465,7 @@
       <trkpt lat="40.776617839" lon="-88.710329861">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:53Z</time>
+        <course>25.411764</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1311,6 +1474,7 @@
       <trkpt lat="40.776854384" lon="-88.710182292">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:54Z</time>
+        <course>25.439232</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1319,6 +1483,7 @@
       <trkpt lat="40.777090929" lon="-88.710033637">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:55Z</time>
+        <course>25.538109</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1327,6 +1492,7 @@
       <trkpt lat="40.777327474" lon="-88.709886068">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:56Z</time>
+        <course>25.400778</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1335,6 +1501,7 @@
       <trkpt lat="40.777564019" lon="-88.709739583">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:57Z</time>
+        <course>25.214008</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1343,6 +1510,7 @@
       <trkpt lat="40.777801649" lon="-88.709594184">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:58Z</time>
+        <course>25.186541</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1351,6 +1519,7 @@
       <trkpt lat="40.778038194" lon="-88.709445530">
         <ele>215.000</ele>
         <time>2009-07-06T21:16:59Z</time>
+        <course>25.494164</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1359,6 +1528,7 @@
       <trkpt lat="40.778274740" lon="-88.709296875">
         <ele>215.000</ele>
         <time>2009-07-06T21:17:00Z</time>
+        <course>25.708401</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1367,6 +1537,7 @@
       <trkpt lat="40.778510200" lon="-88.709148220">
         <ele>215.000</ele>
         <time>2009-07-06T21:17:01Z</time>
+        <course>25.680933</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1375,6 +1546,7 @@
       <trkpt lat="40.778745660" lon="-88.708999566">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:02Z</time>
+        <course>25.675440</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1383,6 +1555,7 @@
       <trkpt lat="40.778981120" lon="-88.708849826">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:03Z</time>
+        <course>25.724880</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1391,6 +1564,7 @@
       <trkpt lat="40.779216580" lon="-88.708700087">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:04Z</time>
+        <course>25.807278</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1399,6 +1573,7 @@
       <trkpt lat="40.779453125" lon="-88.708551432">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:05Z</time>
+        <course>25.724880</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1407,6 +1582,7 @@
       <trkpt lat="40.779689670" lon="-88.708403863">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:06Z</time>
+        <course>25.334860</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1415,6 +1591,7 @@
       <trkpt lat="40.779926215" lon="-88.708258464">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:07Z</time>
+        <course>25.230488</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1423,6 +1600,7 @@
       <trkpt lat="40.780162760" lon="-88.708111979">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:08Z</time>
+        <course>25.252460</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1431,6 +1609,7 @@
       <trkpt lat="40.780399306" lon="-88.707964410">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:09Z</time>
+        <course>25.290913</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1439,6 +1618,7 @@
       <trkpt lat="40.780634766" lon="-88.707815755">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:10Z</time>
+        <course>25.647974</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1447,6 +1627,7 @@
       <trkpt lat="40.780870226" lon="-88.707667101">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:11Z</time>
+        <course>25.647974</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1455,6 +1636,7 @@
       <trkpt lat="40.781105686" lon="-88.707519531">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:12Z</time>
+        <course>25.532616</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1463,6 +1645,7 @@
       <trkpt lat="40.781342231" lon="-88.707373047">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:13Z</time>
+        <course>25.351339</course>
         <speed>29.169359</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1471,6 +1654,7 @@
       <trkpt lat="40.781577691" lon="-88.707226562">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:14Z</time>
+        <course>25.296406</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1479,6 +1663,7 @@
       <trkpt lat="40.781814236" lon="-88.707081163">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:15Z</time>
+        <course>25.104143</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1487,6 +1672,7 @@
       <trkpt lat="40.782050781" lon="-88.706934679">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:16Z</time>
+        <course>25.312885</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1495,6 +1681,7 @@
       <trkpt lat="40.782286241" lon="-88.706786024">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:17Z</time>
+        <course>25.626001</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1503,6 +1690,7 @@
       <trkpt lat="40.782522786" lon="-88.706637370">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:18Z</time>
+        <course>25.631495</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1511,6 +1699,7 @@
       <trkpt lat="40.782758247" lon="-88.706489800">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:19Z</time>
+        <course>25.499657</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1519,6 +1708,7 @@
       <trkpt lat="40.782993707" lon="-88.706341146">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:20Z</time>
+        <course>25.560081</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1527,6 +1717,7 @@
       <trkpt lat="40.783230252" lon="-88.706192491">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:21Z</time>
+        <course>25.593042</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1535,6 +1726,7 @@
       <trkpt lat="40.783466797" lon="-88.706043837">
         <ele>213.000</ele>
         <time>2009-07-06T21:17:22Z</time>
+        <course>25.505150</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1543,6 +1735,7 @@
       <trkpt lat="40.783703342" lon="-88.705896267">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:23Z</time>
+        <course>25.439232</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1551,6 +1744,7 @@
       <trkpt lat="40.783939887" lon="-88.705748698">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:24Z</time>
+        <course>25.252460</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1559,6 +1753,7 @@
       <trkpt lat="40.784176432" lon="-88.705603299">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:25Z</time>
+        <course>25.038223</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1567,6 +1762,7 @@
       <trkpt lat="40.784414062" lon="-88.705458984">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:26Z</time>
+        <course>24.758068</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1575,6 +1771,7 @@
       <trkpt lat="40.784653863" lon="-88.705320095">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:27Z</time>
+        <course>23.780270</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1583,6 +1780,7 @@
       <trkpt lat="40.784894748" lon="-88.705186632">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:28Z</time>
+        <course>22.802471</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1591,6 +1789,7 @@
       <trkpt lat="40.785138889" lon="-88.705058594">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:29Z</time>
+        <course>21.758755</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1599,6 +1798,7 @@
       <trkpt lat="40.785384115" lon="-88.704935981">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:30Z</time>
+        <course>20.841383</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1607,6 +1807,7 @@
       <trkpt lat="40.785630425" lon="-88.704819878">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:31Z</time>
+        <course>19.671320</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1615,6 +1816,7 @@
       <trkpt lat="40.785878906" lon="-88.704708116">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:32Z</time>
+        <course>18.797894</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1623,6 +1825,7 @@
       <trkpt lat="40.786128472" lon="-88.704600694">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:33Z</time>
+        <course>18.127718</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1631,6 +1834,7 @@
       <trkpt lat="40.786379123" lon="-88.704499783">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:34Z</time>
+        <course>17.144426</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1639,6 +1843,7 @@
       <trkpt lat="40.786629774" lon="-88.704402127">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:35Z</time>
+        <course>16.347906</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1647,6 +1852,7 @@
       <trkpt lat="40.786882595" lon="-88.704309896">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:36Z</time>
+        <course>15.518425</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1655,6 +1861,7 @@
       <trkpt lat="40.787135417" lon="-88.704222005">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:37Z</time>
+        <course>14.886702</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1663,6 +1870,7 @@
       <trkpt lat="40.787389323" lon="-88.704136285">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:38Z</time>
+        <course>14.359350</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1671,6 +1879,7 @@
       <trkpt lat="40.787643229" lon="-88.704052734">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:39Z</time>
+        <course>14.117647</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1679,6 +1888,7 @@
       <trkpt lat="40.787896050" lon="-88.703967014">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:40Z</time>
+        <course>14.353857</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1687,6 +1897,7 @@
       <trkpt lat="40.788149957" lon="-88.703881293">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:41Z</time>
+        <course>14.320897</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1695,6 +1906,7 @@
       <trkpt lat="40.788402778" lon="-88.703795573">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:42Z</time>
+        <course>14.392309</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1703,6 +1915,7 @@
       <trkpt lat="40.788656684" lon="-88.703710938">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:43Z</time>
+        <course>14.243992</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1711,6 +1924,7 @@
       <trkpt lat="40.788910590" lon="-88.703626302">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:44Z</time>
+        <course>14.260471</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1719,6 +1933,7 @@
       <trkpt lat="40.789164497" lon="-88.703540582">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:45Z</time>
+        <course>14.211032</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1727,6 +1942,7 @@
       <trkpt lat="40.789418403" lon="-88.703454861">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:46Z</time>
+        <course>14.370337</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1735,6 +1951,7 @@
       <trkpt lat="40.789672309" lon="-88.703368056">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:47Z</time>
+        <course>14.524147</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1743,6 +1960,7 @@
       <trkpt lat="40.789926215" lon="-88.703281250">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:48Z</time>
+        <course>14.529640</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1751,6 +1969,7 @@
       <trkpt lat="40.790180122" lon="-88.703194444">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:49Z</time>
+        <course>14.469215</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1759,6 +1978,7 @@
       <trkpt lat="40.790434028" lon="-88.703108724">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:50Z</time>
+        <course>14.408790</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1767,6 +1987,7 @@
       <trkpt lat="40.790687934" lon="-88.703023003">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:51Z</time>
+        <course>14.211032</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1775,6 +1996,7 @@
       <trkpt lat="40.790941840" lon="-88.702940538">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:52Z</time>
+        <course>13.963836</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1783,6 +2005,7 @@
       <trkpt lat="40.791196832" lon="-88.702855903">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:53Z</time>
+        <course>14.161593</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1791,6 +2014,7 @@
       <trkpt lat="40.791449653" lon="-88.702770182">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:54Z</time>
+        <course>14.425269</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1799,6 +2023,7 @@
       <trkpt lat="40.791703559" lon="-88.702684462">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:55Z</time>
+        <course>14.331883</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1807,6 +2032,7 @@
       <trkpt lat="40.791957465" lon="-88.702599826">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:56Z</time>
+        <course>14.183566</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1815,6 +2041,7 @@
       <trkpt lat="40.792212457" lon="-88.702515191">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:57Z</time>
+        <course>14.298924</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1823,6 +2050,7 @@
       <trkpt lat="40.792466363" lon="-88.702428385">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:58Z</time>
+        <course>14.480202</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1831,6 +2059,7 @@
       <trkpt lat="40.792720269" lon="-88.702342665">
         <ele>214.000</ele>
         <time>2009-07-06T21:17:59Z</time>
+        <course>14.524147</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1839,6 +2068,7 @@
       <trkpt lat="40.792974175" lon="-88.702256944">
         <ele>214.000</ele>
         <time>2009-07-06T21:18:00Z</time>
+        <course>14.375830</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1847,6 +2077,7 @@
       <trkpt lat="40.793226997" lon="-88.702171224">
         <ele>214.000</ele>
         <time>2009-07-06T21:18:01Z</time>
+        <course>14.430762</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1855,6 +2086,7 @@
       <trkpt lat="40.793480903" lon="-88.702084418">
         <ele>214.000</ele>
         <time>2009-07-06T21:18:02Z</time>
+        <course>14.441749</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1863,6 +2095,7 @@
       <trkpt lat="40.793734809" lon="-88.701999783">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:03Z</time>
+        <course>14.271458</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1871,6 +2104,7 @@
       <trkpt lat="40.793988715" lon="-88.701916233">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:04Z</time>
+        <course>14.134127</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1879,6 +2113,7 @@
       <trkpt lat="40.794242622" lon="-88.701831597">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:05Z</time>
+        <course>14.073701</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1887,6 +2122,7 @@
       <trkpt lat="40.794496528" lon="-88.701746962">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:06Z</time>
+        <course>14.370337</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1895,6 +2131,7 @@
       <trkpt lat="40.794750434" lon="-88.701660156">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:07Z</time>
+        <course>14.485695</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1903,6 +2140,7 @@
       <trkpt lat="40.795004340" lon="-88.701573351">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:08Z</time>
+        <course>14.617533</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1911,6 +2149,7 @@
       <trkpt lat="40.795258247" lon="-88.701488715">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:09Z</time>
+        <course>14.227512</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1919,6 +2158,7 @@
       <trkpt lat="40.795512153" lon="-88.701402995">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:10Z</time>
+        <course>14.386816</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1927,6 +2167,7 @@
       <trkpt lat="40.795766059" lon="-88.701318359">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:11Z</time>
+        <course>14.370337</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1935,6 +2176,7 @@
       <trkpt lat="40.796019965" lon="-88.701233724">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:12Z</time>
+        <course>14.189059</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1943,6 +2185,7 @@
       <trkpt lat="40.796273872" lon="-88.701148003">
         <ele>213.000</ele>
         <time>2009-07-06T21:18:13Z</time>
+        <course>14.298924</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1951,6 +2194,7 @@
       <trkpt lat="40.796526693" lon="-88.701063368">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:14Z</time>
+        <course>14.342870</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1959,6 +2203,7 @@
       <trkpt lat="40.796780599" lon="-88.700978733">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:15Z</time>
+        <course>14.337377</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1967,6 +2212,7 @@
       <trkpt lat="40.797034505" lon="-88.700893012">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:16Z</time>
+        <course>14.348364</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1975,6 +2221,7 @@
       <trkpt lat="40.797287326" lon="-88.700807292">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:17Z</time>
+        <course>14.370337</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1983,6 +2230,7 @@
       <trkpt lat="40.797540148" lon="-88.700720486">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:18Z</time>
+        <course>14.650492</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1991,6 +2239,7 @@
       <trkpt lat="40.797794054" lon="-88.700632595">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:19Z</time>
+        <course>14.601053</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -1999,6 +2248,7 @@
       <trkpt lat="40.798046875" lon="-88.700546875">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:20Z</time>
+        <course>14.392309</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2007,6 +2257,7 @@
       <trkpt lat="40.798300781" lon="-88.700462240">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:21Z</time>
+        <course>14.353857</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2015,6 +2266,7 @@
       <trkpt lat="40.798554688" lon="-88.700375434">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:22Z</time>
+        <course>14.469215</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2023,6 +2275,7 @@
       <trkpt lat="40.798808594" lon="-88.700290799">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:23Z</time>
+        <course>14.342870</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2031,6 +2284,7 @@
       <trkpt lat="40.799062500" lon="-88.700206163">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:24Z</time>
+        <course>14.079194</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2039,6 +2293,7 @@
       <trkpt lat="40.799317491" lon="-88.700122613">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:25Z</time>
+        <course>14.018768</course>
         <speed>29.281120</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2047,6 +2302,7 @@
       <trkpt lat="40.799570313" lon="-88.700035807">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:26Z</time>
+        <course>14.320897</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2055,6 +2311,7 @@
       <trkpt lat="40.799824219" lon="-88.699947917">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:27Z</time>
+        <course>14.419776</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.125000</hdop>
@@ -2063,6 +2320,7 @@
       <trkpt lat="40.800079210" lon="-88.699860026">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:28Z</time>
+        <course>14.304418</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2071,6 +2329,7 @@
       <trkpt lat="40.800332031" lon="-88.699776476">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:29Z</time>
+        <course>14.287938</course>
         <speed>29.281120</speed>
         <sat>9</sat>
         <hdop>1.000000</hdop>
@@ -2079,6 +2338,7 @@
       <trkpt lat="40.800583767" lon="-88.699689670">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:30Z</time>
+        <course>14.496681</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2087,6 +2347,7 @@
       <trkpt lat="40.800837674" lon="-88.699602865">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:31Z</time>
+        <course>14.738384</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2095,6 +2356,7 @@
       <trkpt lat="40.801090495" lon="-88.699516059">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:32Z</time>
+        <course>14.628519</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2103,6 +2365,7 @@
       <trkpt lat="40.801343316" lon="-88.699430339">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:33Z</time>
+        <course>14.485695</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2111,6 +2374,7 @@
       <trkpt lat="40.801597222" lon="-88.699346788">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:34Z</time>
+        <course>14.145113</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2119,6 +2383,7 @@
       <trkpt lat="40.801851128" lon="-88.699263238">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:35Z</time>
+        <course>14.029755</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2127,6 +2392,7 @@
       <trkpt lat="40.802105035" lon="-88.699180773">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:36Z</time>
+        <course>14.040742</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2135,6 +2401,7 @@
       <trkpt lat="40.802358941" lon="-88.699098307">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:37Z</time>
+        <course>14.084687</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.000000</hdop>
@@ -2143,6 +2410,7 @@
       <trkpt lat="40.802611762" lon="-88.699015842">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:38Z</time>
+        <course>14.134127</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2151,6 +2419,7 @@
       <trkpt lat="40.802865668" lon="-88.698932292">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:39Z</time>
+        <course>14.353857</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2159,6 +2428,7 @@
       <trkpt lat="40.803118490" lon="-88.698847656">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:40Z</time>
+        <course>14.573586</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2167,6 +2437,7 @@
       <trkpt lat="40.803372396" lon="-88.698760851">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:41Z</time>
+        <course>14.628519</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2175,6 +2446,7 @@
       <trkpt lat="40.803626302" lon="-88.698675130">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:42Z</time>
+        <course>14.491188</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2183,6 +2455,7 @@
       <trkpt lat="40.803880208" lon="-88.698589410">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:43Z</time>
+        <course>14.414283</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2191,6 +2464,7 @@
       <trkpt lat="40.804134115" lon="-88.698502604">
         <ele>212.000</ele>
         <time>2009-07-06T21:18:44Z</time>
+        <course>14.644999</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2199,6 +2473,7 @@
       <trkpt lat="40.804388021" lon="-88.698415799">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:45Z</time>
+        <course>14.568093</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2207,6 +2482,7 @@
       <trkpt lat="40.804640842" lon="-88.698331163">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:46Z</time>
+        <course>14.309911</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2215,6 +2491,7 @@
       <trkpt lat="40.804894748" lon="-88.698246528">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:47Z</time>
+        <course>14.145113</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2223,6 +2500,7 @@
       <trkpt lat="40.805148655" lon="-88.698164062">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:48Z</time>
+        <course>14.035249</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2231,6 +2509,7 @@
       <trkpt lat="40.805402561" lon="-88.698080512">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:49Z</time>
+        <course>14.018768</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2239,6 +2518,7 @@
       <trkpt lat="40.805656467" lon="-88.697995877">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:50Z</time>
+        <course>14.205539</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2247,6 +2527,7 @@
       <trkpt lat="40.805910373" lon="-88.697909071">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:51Z</time>
+        <course>14.573586</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2255,6 +2536,7 @@
       <trkpt lat="40.806163194" lon="-88.697822266">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:52Z</time>
+        <course>14.705424</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2263,6 +2545,7 @@
       <trkpt lat="40.806416016" lon="-88.697735460">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:53Z</time>
+        <course>14.666972</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2271,6 +2554,7 @@
       <trkpt lat="40.806669922" lon="-88.697648655">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:54Z</time>
+        <course>14.507668</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2279,6 +2563,7 @@
       <trkpt lat="40.806923828" lon="-88.697565104">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:55Z</time>
+        <course>14.178073</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2287,6 +2572,7 @@
       <trkpt lat="40.807177734" lon="-88.697480469">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:56Z</time>
+        <course>14.139620</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2295,6 +2581,7 @@
       <trkpt lat="40.807430556" lon="-88.697394748">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:57Z</time>
+        <course>14.353857</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2303,6 +2590,7 @@
       <trkpt lat="40.807684462" lon="-88.697309028">
         <ele>211.000</ele>
         <time>2009-07-06T21:18:58Z</time>
+        <course>14.408790</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2311,6 +2599,7 @@
       <trkpt lat="40.807937283" lon="-88.697224392">
         <ele>210.000</ele>
         <time>2009-07-06T21:18:59Z</time>
+        <course>14.348364</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2319,6 +2608,7 @@
       <trkpt lat="40.808191189" lon="-88.697139757">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:00Z</time>
+        <course>14.243992</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2327,6 +2617,7 @@
       <trkpt lat="40.808445095" lon="-88.697055122">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:01Z</time>
+        <course>14.222019</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2335,6 +2626,7 @@
       <trkpt lat="40.808699002" lon="-88.696970486">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:02Z</time>
+        <course>14.260471</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2343,6 +2635,7 @@
       <trkpt lat="40.808952908" lon="-88.696884766">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:03Z</time>
+        <course>14.392309</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2351,6 +2644,7 @@
       <trkpt lat="40.809206814" lon="-88.696799045">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:04Z</time>
+        <course>14.364843</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2359,6 +2653,7 @@
       <trkpt lat="40.809460720" lon="-88.696713325">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:05Z</time>
+        <course>14.348364</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2367,6 +2662,7 @@
       <trkpt lat="40.809714627" lon="-88.696627604">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:06Z</time>
+        <course>14.298924</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2375,6 +2671,7 @@
       <trkpt lat="40.809968533" lon="-88.696542969">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:07Z</time>
+        <course>14.298924</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2383,6 +2680,7 @@
       <trkpt lat="40.810221354" lon="-88.696458333">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:08Z</time>
+        <course>14.287938</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2391,6 +2689,7 @@
       <trkpt lat="40.810475260" lon="-88.696373698">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:09Z</time>
+        <course>14.233006</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2399,6 +2698,7 @@
       <trkpt lat="40.810729167" lon="-88.696287977">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:10Z</time>
+        <course>14.353857</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2407,6 +2707,7 @@
       <trkpt lat="40.810981988" lon="-88.696202257">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:11Z</time>
+        <course>14.458228</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.000000</hdop>
@@ -2415,6 +2716,7 @@
       <trkpt lat="40.811235894" lon="-88.696114366">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:12Z</time>
+        <course>14.441749</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2423,6 +2725,7 @@
       <trkpt lat="40.811489800" lon="-88.696028646">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:13Z</time>
+        <course>14.540627</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.000000</hdop>
@@ -2431,6 +2734,7 @@
       <trkpt lat="40.811743707" lon="-88.695941840">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:14Z</time>
+        <course>14.601053</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.000000</hdop>
@@ -2439,6 +2743,7 @@
       <trkpt lat="40.811996528" lon="-88.695856120">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:15Z</time>
+        <course>14.463721</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2447,6 +2752,7 @@
       <trkpt lat="40.812251519" lon="-88.695771484">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:16Z</time>
+        <course>14.128633</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2455,6 +2761,7 @@
       <trkpt lat="40.812505425" lon="-88.695689019">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:17Z</time>
+        <course>13.914397</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2463,6 +2770,7 @@
       <trkpt lat="40.812759332" lon="-88.695604384">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:18Z</time>
+        <course>14.200046</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2471,6 +2779,7 @@
       <trkpt lat="40.813012153" lon="-88.695518663">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:19Z</time>
+        <course>14.551614</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2479,6 +2788,7 @@
       <trkpt lat="40.813266059" lon="-88.695431858">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:20Z</time>
+        <course>14.606546</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2487,6 +2797,7 @@
       <trkpt lat="40.813519965" lon="-88.695345052">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:21Z</time>
+        <course>14.584573</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2495,6 +2806,7 @@
       <trkpt lat="40.813773872" lon="-88.695259332">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:22Z</time>
+        <course>14.524147</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2503,6 +2815,7 @@
       <trkpt lat="40.814026693" lon="-88.695173611">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:23Z</time>
+        <course>14.375830</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2511,6 +2824,7 @@
       <trkpt lat="40.814280599" lon="-88.695088976">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:24Z</time>
+        <course>14.205539</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2519,6 +2833,7 @@
       <trkpt lat="40.814535590" lon="-88.695005425">
         <ele>210.000</ele>
         <time>2009-07-06T21:19:25Z</time>
+        <course>14.200046</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2527,6 +2842,7 @@
       <trkpt lat="40.814789497" lon="-88.694919705">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:26Z</time>
+        <course>14.315404</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2535,6 +2851,7 @@
       <trkpt lat="40.815043403" lon="-88.694832899">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:27Z</time>
+        <course>14.524147</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2543,6 +2860,7 @@
       <trkpt lat="40.815296224" lon="-88.694746094">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:28Z</time>
+        <course>14.628519</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2551,6 +2869,7 @@
       <trkpt lat="40.815549045" lon="-88.694660373">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:29Z</time>
+        <course>14.436255</course>
         <speed>29.253180</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2559,6 +2878,7 @@
       <trkpt lat="40.815802951" lon="-88.694575738">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:30Z</time>
+        <course>14.348364</course>
         <speed>29.225241</speed>
         <sat>10</sat>
         <hdop>1.000000</hdop>
@@ -2567,6 +2887,7 @@
       <trkpt lat="40.816056858" lon="-88.694486762">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:31Z</time>
+        <course>14.754864</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2575,6 +2896,7 @@
       <trkpt lat="40.816309679" lon="-88.694398872">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:32Z</time>
+        <course>14.666972</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2583,6 +2905,7 @@
       <trkpt lat="40.816562500" lon="-88.694306641">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:33Z</time>
+        <course>15.485466</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2591,6 +2914,7 @@
       <trkpt lat="40.816813151" lon="-88.694208984">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:34Z</time>
+        <course>16.474251</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2599,6 +2923,7 @@
       <trkpt lat="40.817062717" lon="-88.694103733">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:35Z</time>
+        <course>17.682764</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2607,6 +2932,7 @@
       <trkpt lat="40.817310113" lon="-88.693990885">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:36Z</time>
+        <course>19.017624</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2615,6 +2941,7 @@
       <trkpt lat="40.817556424" lon="-88.693871528">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:37Z</time>
+        <course>20.275578</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2623,6 +2950,7 @@
       <trkpt lat="40.817799479" lon="-88.693743490">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:38Z</time>
+        <course>21.742275</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2631,6 +2959,7 @@
       <trkpt lat="40.818040365" lon="-88.693607856">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:39Z</time>
+        <course>23.033188</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2639,6 +2968,7 @@
       <trkpt lat="40.818279080" lon="-88.693468967">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:40Z</time>
+        <course>23.901121</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2647,6 +2977,7 @@
       <trkpt lat="40.818516710" lon="-88.693322483">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:41Z</time>
+        <course>25.038223</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2655,6 +2986,7 @@
       <trkpt lat="40.818751085" lon="-88.693170573">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:42Z</time>
+        <course>26.202793</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2663,6 +2995,7 @@
       <trkpt lat="40.818983290" lon="-88.693011068">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:43Z</time>
+        <course>27.707943</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2671,6 +3004,7 @@
       <trkpt lat="40.819212240" lon="-88.692846137">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:44Z</time>
+        <course>28.718700</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2679,6 +3013,7 @@
       <trkpt lat="40.819441189" lon="-88.692679036">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:45Z</time>
+        <course>28.954910</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2687,6 +3022,7 @@
       <trkpt lat="40.819669054" lon="-88.692510851">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:46Z</time>
+        <course>29.322958</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2695,6 +3031,7 @@
       <trkpt lat="40.819896918" lon="-88.692341580">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:47Z</time>
+        <course>29.443810</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2703,6 +3040,7 @@
       <trkpt lat="40.820124783" lon="-88.692172309">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:48Z</time>
+        <course>29.366903</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2711,6 +3049,7 @@
       <trkpt lat="40.820352648" lon="-88.692003038">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:49Z</time>
+        <course>29.410849</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2719,6 +3058,7 @@
       <trkpt lat="40.820581597" lon="-88.691833767">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:50Z</time>
+        <course>29.355917</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2727,6 +3067,7 @@
       <trkpt lat="40.820810547" lon="-88.691664497">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:51Z</time>
+        <course>29.339437</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2735,6 +3076,7 @@
       <trkpt lat="40.821038411" lon="-88.691495226">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:52Z</time>
+        <course>29.399862</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2743,6 +3085,7 @@
       <trkpt lat="40.821266276" lon="-88.691324870">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:53Z</time>
+        <course>29.454796</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2751,6 +3094,7 @@
       <trkpt lat="40.821494141" lon="-88.691154514">
         <ele>209.000</ele>
         <time>2009-07-06T21:19:54Z</time>
+        <course>29.625086</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2759,6 +3103,7 @@
       <trkpt lat="40.821722005" lon="-88.690985243">
         <ele>208.000</ele>
         <time>2009-07-06T21:19:55Z</time>
+        <course>29.559166</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2767,6 +3112,7 @@
       <trkpt lat="40.821949870" lon="-88.690815972">
         <ele>208.000</ele>
         <time>2009-07-06T21:19:56Z</time>
+        <course>29.279011</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2775,6 +3121,7 @@
       <trkpt lat="40.822178819" lon="-88.690648872">
         <ele>208.000</ele>
         <time>2009-07-06T21:19:57Z</time>
+        <course>29.130693</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2783,6 +3130,7 @@
       <trkpt lat="40.822407769" lon="-88.690481771">
         <ele>208.000</ele>
         <time>2009-07-06T21:19:58Z</time>
+        <course>29.009842</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2791,6 +3139,7 @@
       <trkpt lat="40.822635634" lon="-88.690312500">
         <ele>208.000</ele>
         <time>2009-07-06T21:19:59Z</time>
+        <course>29.191120</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2799,6 +3148,7 @@
       <trkpt lat="40.822863498" lon="-88.690143229">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:00Z</time>
+        <course>29.520714</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2807,6 +3157,7 @@
       <trkpt lat="40.823091363" lon="-88.689972873">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:01Z</time>
+        <course>29.608606</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2815,6 +3166,7 @@
       <trkpt lat="40.823318142" lon="-88.689802517">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:02Z</time>
+        <course>29.509727</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2823,6 +3175,7 @@
       <trkpt lat="40.823546007" lon="-88.689634332">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:03Z</time>
+        <course>29.350424</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2831,6 +3184,7 @@
       <trkpt lat="40.823773872" lon="-88.689466146">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:04Z</time>
+        <course>29.196613</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2839,6 +3193,7 @@
       <trkpt lat="40.824001736" lon="-88.689297960">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:05Z</time>
+        <course>29.229572</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2847,6 +3202,7 @@
       <trkpt lat="40.824229601" lon="-88.689129774">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:06Z</time>
+        <course>29.438316</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2855,6 +3211,7 @@
       <trkpt lat="40.824456380" lon="-88.688959418">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:07Z</time>
+        <course>29.509727</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2863,6 +3220,7 @@
       <trkpt lat="40.824684245" lon="-88.688789063">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:08Z</time>
+        <course>29.625086</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2871,6 +3229,7 @@
       <trkpt lat="40.824911024" lon="-88.688617622">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:09Z</time>
+        <course>29.822844</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2879,6 +3238,7 @@
       <trkpt lat="40.825138889" lon="-88.688448351">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:10Z</time>
+        <course>29.438316</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2887,6 +3247,7 @@
       <trkpt lat="40.825366753" lon="-88.688281250">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:11Z</time>
+        <course>29.169146</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2895,6 +3256,7 @@
       <trkpt lat="40.825595703" lon="-88.688113064">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:12Z</time>
+        <course>29.059280</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2903,6 +3265,7 @@
       <trkpt lat="40.825824653" lon="-88.687945964">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:13Z</time>
+        <course>29.064775</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2911,6 +3274,7 @@
       <trkpt lat="40.826053602" lon="-88.687777778">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:14Z</time>
+        <course>29.235065</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2919,6 +3283,7 @@
       <trkpt lat="40.826281467" lon="-88.687608507">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:15Z</time>
+        <course>29.405355</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2927,6 +3292,7 @@
       <trkpt lat="40.826508247" lon="-88.687438151">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:16Z</time>
+        <course>29.636072</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2935,6 +3301,7 @@
       <trkpt lat="40.826736111" lon="-88.687267795">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:17Z</time>
+        <course>29.658045</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2943,6 +3310,7 @@
       <trkpt lat="40.826962891" lon="-88.687098524">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:18Z</time>
+        <course>29.553673</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2951,6 +3319,7 @@
       <trkpt lat="40.827190755" lon="-88.686927083">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:19Z</time>
+        <course>29.641565</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2959,6 +3328,7 @@
       <trkpt lat="40.827418620" lon="-88.686756727">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:20Z</time>
+        <course>29.701992</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2967,6 +3337,7 @@
       <trkpt lat="40.827645399" lon="-88.686586372">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:21Z</time>
+        <course>29.553673</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2975,6 +3346,7 @@
       <trkpt lat="40.827874349" lon="-88.686418186">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:22Z</time>
+        <course>29.218586</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2983,6 +3355,7 @@
       <trkpt lat="40.828103299" lon="-88.686251085">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:23Z</time>
+        <course>29.042801</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2991,6 +3364,7 @@
       <trkpt lat="40.828331163" lon="-88.686082899">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:24Z</time>
+        <course>29.020828</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -2999,6 +3373,7 @@
       <trkpt lat="40.828560113" lon="-88.685913628">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:25Z</time>
+        <course>29.344931</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3007,6 +3382,7 @@
       <trkpt lat="40.828787977" lon="-88.685745443">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:26Z</time>
+        <course>29.311970</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3015,6 +3391,7 @@
       <trkpt lat="40.829015842" lon="-88.685575087">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:27Z</time>
+        <course>29.526207</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3023,6 +3400,7 @@
       <trkpt lat="40.829242622" lon="-88.685403646">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:28Z</time>
+        <course>29.669031</course>
         <speed>29.253180</speed>
         <sat>9</sat>
         <hdop>1.125000</hdop>
@@ -3031,6 +3409,7 @@
       <trkpt lat="40.829470486" lon="-88.685233290">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:29Z</time>
+        <course>28.971390</course>
         <speed>29.281120</speed>
         <sat>8</sat>
         <hdop>1.250000</hdop>
@@ -3039,6 +3418,7 @@
       <trkpt lat="40.829701606" lon="-88.685061849">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:30Z</time>
+        <course>29.465782</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3047,6 +3427,7 @@
       <trkpt lat="40.829930556" lon="-88.684893663">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:31Z</time>
+        <course>29.169146</course>
         <speed>29.141420</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3055,6 +3436,7 @@
       <trkpt lat="40.830162760" lon="-88.684730903">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:32Z</time>
+        <course>28.119936</course>
         <speed>29.169359</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3063,6 +3445,7 @@
       <trkpt lat="40.830397135" lon="-88.684573568">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:33Z</time>
+        <course>26.713665</course>
         <speed>29.169359</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3071,6 +3454,7 @@
       <trkpt lat="40.830634766" lon="-88.684424913">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:34Z</time>
+        <course>25.406271</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3079,6 +3463,7 @@
       <trkpt lat="40.830873481" lon="-88.684282769">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:35Z</time>
+        <course>24.142824</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3087,6 +3472,7 @@
       <trkpt lat="40.831115451" lon="-88.684144965">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:36Z</time>
+        <course>23.197987</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3095,6 +3481,7 @@
       <trkpt lat="40.831359592" lon="-88.684016927">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:37Z</time>
+        <course>21.632410</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3103,6 +3490,7 @@
       <trkpt lat="40.831606988" lon="-88.683897569">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:38Z</time>
+        <course>20.039368</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3111,6 +3499,7 @@
       <trkpt lat="40.831855469" lon="-88.683786892">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:39Z</time>
+        <course>18.583658</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3119,6 +3508,7 @@
       <trkpt lat="40.832107205" lon="-88.683681641">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:40Z</time>
+        <course>17.660791</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3127,6 +3517,7 @@
       <trkpt lat="40.832357856" lon="-88.683577474">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:41Z</time>
+        <course>17.479515</course>
         <speed>29.309059</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3135,6 +3526,7 @@
       <trkpt lat="40.832608507" lon="-88.683474392">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:42Z</time>
+        <course>17.248798</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3143,6 +3535,7 @@
       <trkpt lat="40.832859158" lon="-88.683374566">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:43Z</time>
+        <course>16.842299</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3151,6 +3544,7 @@
       <trkpt lat="40.833109809" lon="-88.683274740">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:44Z</time>
+        <course>16.661020</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3159,6 +3553,7 @@
       <trkpt lat="40.833360460" lon="-88.683174913">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:45Z</time>
+        <course>16.743420</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3167,6 +3562,7 @@
       <trkpt lat="40.833610026" lon="-88.683074002">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:46Z</time>
+        <course>17.094988</course>
         <speed>29.169359</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3175,6 +3571,7 @@
       <trkpt lat="40.833859592" lon="-88.682970920">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:47Z</time>
+        <course>17.375143</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3183,6 +3580,7 @@
       <trkpt lat="40.834110243" lon="-88.682867839">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:48Z</time>
+        <course>17.287251</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3191,6 +3589,7 @@
       <trkpt lat="40.834359809" lon="-88.682763672">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:49Z</time>
+        <course>17.424582</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3199,6 +3598,7 @@
       <trkpt lat="40.834610460" lon="-88.682659505">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:50Z</time>
+        <course>17.457542</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3207,6 +3607,7 @@
       <trkpt lat="40.834861111" lon="-88.682557509">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:51Z</time>
+        <course>17.199360</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3215,6 +3616,7 @@
       <trkpt lat="40.835110677" lon="-88.682456597">
         <ele>208.000</ele>
         <time>2009-07-06T21:20:52Z</time>
+        <course>17.133440</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>0.875000</hdop>
@@ -3223,6 +3625,7 @@
       <trkpt lat="40.835361328" lon="-88.682354601">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:53Z</time>
+        <course>17.056534</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3231,6 +3634,7 @@
       <trkpt lat="40.835611979" lon="-88.682253689">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:54Z</time>
+        <course>17.040054</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3239,6 +3643,7 @@
       <trkpt lat="40.835862630" lon="-88.682151693">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:55Z</time>
+        <course>17.089495</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3247,6 +3652,7 @@
       <trkpt lat="40.836112196" lon="-88.682049696">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:56Z</time>
+        <course>17.144426</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3255,6 +3661,7 @@
       <trkpt lat="40.836362847" lon="-88.681947700">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:57Z</time>
+        <course>17.188374</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3263,6 +3670,7 @@
       <trkpt lat="40.836612413" lon="-88.681845703">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:58Z</time>
+        <course>17.314718</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3271,6 +3679,7 @@
       <trkpt lat="40.836861979" lon="-88.681740451">
         <ele>207.000</ele>
         <time>2009-07-06T21:20:59Z</time>
+        <course>17.600367</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3279,6 +3688,7 @@
       <trkpt lat="40.837111545" lon="-88.681634115">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:00Z</time>
+        <course>17.957428</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3287,6 +3697,7 @@
       <trkpt lat="40.837360026" lon="-88.681525608">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:01Z</time>
+        <course>18.221104</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3295,6 +3706,7 @@
       <trkpt lat="40.837608507" lon="-88.681416016">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:02Z</time>
+        <course>18.616617</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3303,6 +3715,7 @@
       <trkpt lat="40.837855903" lon="-88.681299913">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:03Z</time>
+        <course>19.610895</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3311,6 +3724,7 @@
       <trkpt lat="40.838100043" lon="-88.681178385">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:04Z</time>
+        <course>20.610666</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3319,6 +3733,7 @@
       <trkpt lat="40.838343099" lon="-88.681051432">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:05Z</time>
+        <course>21.659876</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3327,6 +3742,7 @@
       <trkpt lat="40.838585069" lon="-88.680919054">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:06Z</time>
+        <course>22.703594</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3335,6 +3751,7 @@
       <trkpt lat="40.838823785" lon="-88.680779080">
         <ele>207.000</ele>
         <time>2009-07-06T21:21:07Z</time>
+        <course>23.807735</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3343,6 +3760,7 @@
       <trkpt lat="40.839061415" lon="-88.680633681">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:08Z</time>
+        <course>24.917372</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3351,6 +3769,7 @@
       <trkpt lat="40.839297960" lon="-88.680483941">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:09Z</time>
+        <course>25.752346</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3359,6 +3778,7 @@
       <trkpt lat="40.839532335" lon="-88.680329861">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:10Z</time>
+        <course>26.510414</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3367,6 +3787,7 @@
       <trkpt lat="40.839764540" lon="-88.680171441">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:11Z</time>
+        <course>27.482719</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3375,6 +3796,7 @@
       <trkpt lat="40.839995660" lon="-88.680011936">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:12Z</time>
+        <course>27.713436</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3383,6 +3805,7 @@
       <trkpt lat="40.840227865" lon="-88.679852431">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:13Z</time>
+        <course>27.559624</course>
         <speed>29.169359</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3391,6 +3814,7 @@
       <trkpt lat="40.840458984" lon="-88.679692925">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:14Z</time>
+        <course>27.653009</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3399,6 +3823,7 @@
       <trkpt lat="40.840691189" lon="-88.679532335">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:15Z</time>
+        <course>27.773861</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3407,6 +3832,7 @@
       <trkpt lat="40.840922309" lon="-88.679370660">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:16Z</time>
+        <course>27.861753</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3415,6 +3841,7 @@
       <trkpt lat="40.841153429" lon="-88.679208984">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:17Z</time>
+        <course>27.922178</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3423,6 +3850,7 @@
       <trkpt lat="40.841385634" lon="-88.679048394">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:18Z</time>
+        <course>27.828794</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3431,6 +3859,7 @@
       <trkpt lat="40.841616753" lon="-88.678887804">
         <ele>206.000</ele>
         <time>2009-07-06T21:21:19Z</time>
+        <course>27.823301</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3439,6 +3868,7 @@
       <trkpt lat="40.841848958" lon="-88.678727214">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:20Z</time>
+        <course>27.801327</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3447,6 +3877,7 @@
       <trkpt lat="40.842081163" lon="-88.678566623">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:21Z</time>
+        <course>27.696957</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3455,6 +3886,7 @@
       <trkpt lat="40.842313368" lon="-88.678407118">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:22Z</time>
+        <course>27.691463</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3463,6 +3895,7 @@
       <trkpt lat="40.842544488" lon="-88.678246528">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:23Z</time>
+        <course>27.707943</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3471,6 +3904,7 @@
       <trkpt lat="40.842776693" lon="-88.678087023">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:24Z</time>
+        <course>27.636530</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3479,6 +3913,7 @@
       <trkpt lat="40.843008898" lon="-88.677928602">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:25Z</time>
+        <course>27.510185</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3487,6 +3922,7 @@
       <trkpt lat="40.843241102" lon="-88.677769097">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:26Z</time>
+        <course>27.559624</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3495,6 +3931,7 @@
       <trkpt lat="40.843472222" lon="-88.677609592">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:27Z</time>
+        <course>27.724422</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3503,6 +3940,7 @@
       <trkpt lat="40.843704427" lon="-88.677447917">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:28Z</time>
+        <course>27.955139</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3511,6 +3949,7 @@
       <trkpt lat="40.843935547" lon="-88.677284071">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:29Z</time>
+        <course>28.185854</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3519,6 +3958,7 @@
       <trkpt lat="40.844166667" lon="-88.677122396">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:30Z</time>
+        <course>28.032043</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3527,6 +3967,7 @@
       <trkpt lat="40.844397786" lon="-88.676962891">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:31Z</time>
+        <course>27.751888</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3535,6 +3976,7 @@
       <trkpt lat="40.844628906" lon="-88.676802300">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:32Z</time>
+        <course>27.614557</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3543,6 +3985,7 @@
       <trkpt lat="40.844861111" lon="-88.676643880">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:33Z</time>
+        <course>27.647516</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3551,6 +3994,7 @@
       <trkpt lat="40.845092231" lon="-88.676484375">
         <ele>205.000</ele>
         <time>2009-07-06T21:21:34Z</time>
+        <course>27.653009</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3559,6 +4003,7 @@
       <trkpt lat="40.845324436" lon="-88.676323785">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:35Z</time>
+        <course>27.642023</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3567,6 +4012,7 @@
       <trkpt lat="40.845555556" lon="-88.676163194">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:36Z</time>
+        <course>27.834288</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3575,6 +4021,7 @@
       <trkpt lat="40.845786675" lon="-88.676001519">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:37Z</time>
+        <course>28.097963</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3583,6 +4030,7 @@
       <trkpt lat="40.846017795" lon="-88.675838759">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:38Z</time>
+        <course>28.147402</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3591,6 +4039,7 @@
       <trkpt lat="40.846248915" lon="-88.675677083">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:39Z</time>
+        <course>27.999084</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3599,6 +4048,7 @@
       <trkpt lat="40.846480035" lon="-88.675515408">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:40Z</time>
+        <course>27.916685</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3607,6 +4057,7 @@
       <trkpt lat="40.846711155" lon="-88.675354818">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:41Z</time>
+        <course>27.757381</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3615,6 +4066,7 @@
       <trkpt lat="40.846943359" lon="-88.675195312">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:42Z</time>
+        <course>27.565119</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3623,6 +4075,7 @@
       <trkpt lat="40.847174479" lon="-88.675034722">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:43Z</time>
+        <course>27.757381</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3631,6 +4084,7 @@
       <trkpt lat="40.847405599" lon="-88.674873047">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:44Z</time>
+        <course>28.004578</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3639,6 +4093,7 @@
       <trkpt lat="40.847636719" lon="-88.674710286">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:45Z</time>
+        <course>28.048523</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3647,6 +4102,7 @@
       <trkpt lat="40.847867839" lon="-88.674549696">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:46Z</time>
+        <course>27.966125</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3655,6 +4111,7 @@
       <trkpt lat="40.848098958" lon="-88.674388021">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:47Z</time>
+        <course>27.933165</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3663,6 +4120,7 @@
       <trkpt lat="40.848331163" lon="-88.674227431">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:48Z</time>
+        <course>27.729916</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3671,6 +4129,7 @@
       <trkpt lat="40.848562283" lon="-88.674069010">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:49Z</time>
+        <course>27.592585</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3679,6 +4138,7 @@
       <trkpt lat="40.848794488" lon="-88.673909505">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:50Z</time>
+        <course>27.570612</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3687,6 +4147,7 @@
       <trkpt lat="40.849025608" lon="-88.673750000">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:51Z</time>
+        <course>27.614557</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3695,6 +4156,7 @@
       <trkpt lat="40.849257812" lon="-88.673590495">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:52Z</time>
+        <course>27.526665</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3703,6 +4165,7 @@
       <trkpt lat="40.849490017" lon="-88.673433160">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:53Z</time>
+        <course>27.158617</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3711,6 +4174,7 @@
       <trkpt lat="40.849723307" lon="-88.673276910">
         <ele>204.000</ele>
         <time>2009-07-06T21:21:54Z</time>
+        <course>27.004807</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3719,6 +4183,7 @@
       <trkpt lat="40.849957682" lon="-88.673122830">
         <ele>203.000</ele>
         <time>2009-07-06T21:21:55Z</time>
+        <course>26.625772</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3727,6 +4192,7 @@
       <trkpt lat="40.850193142" lon="-88.672973090">
         <ele>203.000</ele>
         <time>2009-07-06T21:21:56Z</time>
+        <course>25.823759</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3735,6 +4201,7 @@
       <trkpt lat="40.850430773" lon="-88.672827691">
         <ele>203.000</ele>
         <time>2009-07-06T21:21:57Z</time>
+        <course>24.911879</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3743,6 +4210,7 @@
       <trkpt lat="40.850670573" lon="-88.672688802">
         <ele>203.000</ele>
         <time>2009-07-06T21:21:58Z</time>
+        <course>23.692379</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3751,6 +4219,7 @@
       <trkpt lat="40.850912543" lon="-88.672556424">
         <ele>203.000</ele>
         <time>2009-07-06T21:21:59Z</time>
+        <course>22.670633</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3759,6 +4228,7 @@
       <trkpt lat="40.851155599" lon="-88.672428385">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:00Z</time>
+        <course>21.654383</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3767,6 +4237,7 @@
       <trkpt lat="40.851400825" lon="-88.672307943">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:01Z</time>
+        <course>20.544746</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3775,6 +4246,7 @@
       <trkpt lat="40.851647135" lon="-88.672191840">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:02Z</time>
+        <course>19.572443</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3783,6 +4255,7 @@
       <trkpt lat="40.851895616" lon="-88.672081163">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:03Z</time>
+        <course>18.688030</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3791,6 +4264,7 @@
       <trkpt lat="40.852145182" lon="-88.671975911">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:04Z</time>
+        <course>17.798122</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3799,6 +4273,7 @@
       <trkpt lat="40.852395833" lon="-88.671876085">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:05Z</time>
+        <course>16.864271</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3807,6 +4282,7 @@
       <trkpt lat="40.852647569" lon="-88.671780599">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:06Z</time>
+        <course>16.018311</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3815,6 +4291,7 @@
       <trkpt lat="40.852901476" lon="-88.671690538">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:07Z</time>
+        <course>15.078965</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3823,6 +4300,7 @@
       <trkpt lat="40.853155382" lon="-88.671605903">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:08Z</time>
+        <course>14.222019</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3831,6 +4309,7 @@
       <trkpt lat="40.853410373" lon="-88.671526693">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:09Z</time>
+        <course>13.277180</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3839,6 +4318,7 @@
       <trkpt lat="40.853666450" lon="-88.671453993">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:10Z</time>
+        <course>12.205997</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3847,6 +4327,7 @@
       <trkpt lat="40.853923611" lon="-88.671385634">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:11Z</time>
+        <course>11.376516</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3855,6 +4336,7 @@
       <trkpt lat="40.854180773" lon="-88.671322700">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:12Z</time>
+        <course>10.459144</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3863,6 +4345,7 @@
       <trkpt lat="40.854439019" lon="-88.671266276">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:13Z</time>
+        <course>9.387960</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3871,6 +4354,7 @@
       <trkpt lat="40.854698351" lon="-88.671216363">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:14Z</time>
+        <course>8.393682</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3879,6 +4363,7 @@
       <trkpt lat="40.854957682" lon="-88.671170790">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:15Z</time>
+        <course>7.481803</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3887,6 +4372,7 @@
       <trkpt lat="40.855217014" lon="-88.671131727">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:16Z</time>
+        <course>6.575418</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3895,6 +4381,7 @@
       <trkpt lat="40.855478516" lon="-88.671097005">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:17Z</time>
+        <course>5.669032</course>
         <speed>29.197300</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3903,6 +4390,7 @@
       <trkpt lat="40.855738932" lon="-88.671069878">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:18Z</time>
+        <course>4.702220</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3911,6 +4399,7 @@
       <trkpt lat="40.856000434" lon="-88.671046007">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:19Z</time>
+        <course>3.773861</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3919,6 +4408,7 @@
       <trkpt lat="40.856261936" lon="-88.671028646">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:20Z</time>
+        <course>2.900435</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3927,6 +4417,7 @@
       <trkpt lat="40.856523438" lon="-88.671016710">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:21Z</time>
+        <course>1.928130</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3935,6 +4426,7 @@
       <trkpt lat="40.856786024" lon="-88.671011285">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:22Z</time>
+        <course>0.802014</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3943,6 +4435,7 @@
       <trkpt lat="40.857047526" lon="-88.671011285">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:23Z</time>
+        <course>0.000000</course>
         <speed>29.225241</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3951,6 +4444,7 @@
       <trkpt lat="40.857309028" lon="-88.671013455">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:24Z</time>
+        <course>359.719849</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3959,6 +4453,7 @@
       <trkpt lat="40.857571615" lon="-88.671015625">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:25Z</time>
+        <course>359.588013</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3967,6 +4462,7 @@
       <trkpt lat="40.857833116" lon="-88.671016710">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:26Z</time>
+        <course>359.780273</course>
         <speed>29.281120</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3975,6 +4471,7 @@
       <trkpt lat="40.858095703" lon="-88.671018880">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:27Z</time>
+        <course>359.642944</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3983,6 +4480,7 @@
       <trkpt lat="40.858357205" lon="-88.671018880">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:28Z</time>
+        <course>359.868164</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3991,6 +4489,7 @@
       <trkpt lat="40.858619792" lon="-88.671021050">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:29Z</time>
+        <course>359.725342</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>
@@ -3999,6 +4498,7 @@
       <trkpt lat="40.858882378" lon="-88.671023220">
         <ele>203.000</ele>
         <time>2009-07-06T21:22:30Z</time>
+        <course>359.648438</course>
         <speed>29.253180</speed>
         <sat>11</sat>
         <hdop>1.125000</hdop>

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -696,7 +696,7 @@ make_trackpoint(struct read_state* st, double lat, double lon, double alt)
 {
   auto* wpt = new Waypoint;
 
-  wpt->shortname = QString::asprintf("TP%04d", ++st->tpn);
+  wpt->shortname = QString("TP%1").arg(++st->tpn, 4, 10, QLatin1Char('0'));
 
   wpt->latitude       = lat;
   wpt->longitude      = lon;

--- a/vpl.cc
+++ b/vpl.cc
@@ -196,7 +196,7 @@ vpl_parse_75_sentence(const char* ibuf)
   waypt->sat       = sats;
   // Speed comes in (MPH x 0x10) which we have to convert to m/s
   WAYPT_SET(waypt, speed, (speed_raw / (double) 0x10) * 0.44704);
-  waypt->course    = hdg_raw * (double)(360/65535);
+  WAYPT_SET(waypt, course, hdg_raw * (360.0f/65535.0f));
   waypt->hdop      = hdop_raw / 8.0;
   waypt->vdop      = vdop_raw / 8.0;
 

--- a/waypt.cc
+++ b/waypt.cc
@@ -617,7 +617,7 @@ WaypointList::waypt_add(Waypoint* wpt)
     } else if (!wpt->notes.isNull()) {
       wpt->shortname = wpt->notes;
     } else {
-      wpt->shortname = QString::asprintf("WPT%03d", waypt_count());
+      wpt->shortname = QString("WPT%1").arg(waypt_count(), 3, 10, QLatin1Char('0'));
     }
   }
 


### PR DESCRIPTION
This is a set of fixes for various issues flagged by PVS-Stuido.

V1064 The '360' operand of integer division is less than the '65535' one. The result will always be zero.
V547 Expression is always false.
V758 The 'pos' reference becomes invalid when temporary object returned by a function is destroyed.
V668 There is no sense in testing the 'wpt_tmp' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error.
V567 The modification of the 's' variable is unsequenced relative to another operation on the same variable. This may lead to undefined behavior.
V646 Consider inspecting the application's logic. It's possible that 'else' keyword is missing.
V576 Incorrect format. Consider checking the second actual argument of the 'asprintf' function. The SIGNED integer type argument is expected.