### PR TITLE
fix map preview bug that dropped tracks with 2 pts.

### DIFF
--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -39,12 +39,10 @@ static QDateTime decodeDateTime(const QString& s)
 static bool trackIsEmpty(const GpxTrack& trk)
 {
   int count = 0;
-  for (int i=0; i< trk.getTrackSegments().size(); i++) {
-    for (int j=0; j<trk.getTrackSegments()[i].getTrackPoints().size(); j++) {
-      count++;
-    }
+  for (const auto& segment : trk.getTrackSegments()) {
+    count += segment.getTrackPoints().size();
   }
-  return count <=2 ;
+  return count <= 1;
 }
 
 class GpxHandler
@@ -179,7 +177,7 @@ public:
 
     else if (localName == "rte") {
       state = stateStack.takeLast();
-      if (currentRte.getRoutePoints().size()>=2) {
+      if (currentRte.getRoutePoints().size() >= 2) {
         rteList << currentRte;
       }
     }


### PR DESCRIPTION
This came up with https://opendata.swiss/en/dataset/luftfahrthindernisdaten-schweiz/resource/2cca4304-023a-48c0-9a41-f2802e814795
The cited example was track 296-TI-4 although other tracks were dropped as well.