### PR TITLE
Add ttyACMO as option in gpsbabel gui

### DIFF
--- a/gui/serial_unix.cc
+++ b/gui/serial_unix.cc
@@ -97,6 +97,7 @@ static const char* deviceNames[] = {
   "/dev/ttyS2",
   "/dev/ttyS3",
   "/dev/ttyUSB0",
+  "/dev/ttyACM0",
   "/dev/rfcomm0",
   nullptr
 };


### PR DESCRIPTION
On newer linux systems serial devices often are mapped to ttyACMx, not traditional ttyUSBx.

To facilitate the usage, instead of forcing the user to fiddle with udev/systemd device mapping, this small commit adds ttyACM0 as an option in the gui.