### PR TITLE
fixes for #722, Mechanically remove QStringRef use for QStringView to help with Qt6.

### DIFF
--- a/gpx.cc
+++ b/gpx.cc
@@ -894,7 +894,7 @@ void
 GpxFormat::gpx_cdata(const QStringView& s)
 {
   QString* cdata;
-  cdatastr += s;
+  cdatastr += s.toString();
 
   if (!cur_tag) {
     return;

--- a/maggeo.cc
+++ b/maggeo.cc
@@ -194,7 +194,7 @@ static QDateTime maggeo_parsedate(char* dmy)
   int d = date.midRef(0,2).toInt();
   int m = date.midRef(2,2).toInt();
   int y = date.midRef(4,3).toInt();
-  QDateTime r(QDate(y + 1900, m, d)::startOfDay());
+  QDateTime r(QDate(y + 1900, m, d).startOfDay());
   return r;
 }
 

--- a/maggeo.cc
+++ b/maggeo.cc
@@ -194,7 +194,7 @@ static QDateTime maggeo_parsedate(char* dmy)
   int d = date.midRef(0,2).toInt();
   int m = date.midRef(2,2).toInt();
   int y = date.midRef(4,3).toInt();
-  QDateTime r(QDate(y + 1900, m, d).startOfDay());
+  QDateTime r(QDate(y + 1900, m, d));
   return r;
 }
 

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -258,7 +258,7 @@ QDateTime
 XcsvFormat::yyyymmdd_to_time(const char* s)
 {
   QDate d = QDate::fromString(s, "yyyyMMdd");
-  return QDateTime(d.startOfDay());
+  return QDateTime(d);
 }
 
 


### PR DESCRIPTION
This contains cherry-picks of the 3 commits in the stringview branch that were added after #722 was merged.

This fixes CI of the master branch.