### PR TITLE
pass QStringViews by value, not const reference.

### DIFF
--- a/gpx.cc
+++ b/gpx.cc
@@ -213,7 +213,7 @@ GpxFormat::tag_gs_cache(const QXmlStreamAttributes& attr) const
 }
 
 void
-GpxFormat::start_something_else(const QStringView& el, const QXmlStreamAttributes& attr)
+GpxFormat::start_something_else(QStringView el, const QXmlStreamAttributes& attr)
 {
   if (!fs_ptr) {
     return;
@@ -308,7 +308,7 @@ GpxFormat::tag_log_wpt(const QXmlStreamAttributes& attr) const
 }
 
 void
-GpxFormat::gpx_start(const QStringView& el, const QXmlStreamAttributes& attr)
+GpxFormat::gpx_start(QStringView el, const QXmlStreamAttributes& attr)
 {
   /*
    * Reset end-of-string without actually emptying/reallocing cdatastr.
@@ -551,7 +551,7 @@ xml_parse_time(const QString& dateTimeString)
 }
 
 void
-GpxFormat::gpx_end(const QStringView& /*unused*/)
+GpxFormat::gpx_end(QStringView /*unused*/)
 {
   static QDateTime gc_log_date;
 
@@ -891,7 +891,7 @@ GpxFormat::gpx_end(const QStringView& /*unused*/)
 
 
 void
-GpxFormat::gpx_cdata(const QStringView& s)
+GpxFormat::gpx_cdata(QStringView s)
 {
   QString* cdata;
   cdatastr += s.toString();

--- a/gpx.h
+++ b/gpx.h
@@ -197,12 +197,12 @@ private:
   void tag_wpt(const QXmlStreamAttributes& attr);
   void tag_cache_desc(const QXmlStreamAttributes& attr);
   void tag_gs_cache(const QXmlStreamAttributes& attr) const;
-  void start_something_else(const QStringView& el, const QXmlStreamAttributes& attr);
+  void start_something_else(QStringView el, const QXmlStreamAttributes& attr);
   void end_something_else();
   void tag_log_wpt(const QXmlStreamAttributes& attr) const;
-  void gpx_start(const QStringView& el, const QXmlStreamAttributes& attr);
-  void gpx_end(const QStringView& unused);
-  void gpx_cdata(const QStringView& s);
+  void gpx_start(QStringView el, const QXmlStreamAttributes& attr);
+  void gpx_end(QStringView unused);
+  void gpx_cdata(QStringView s);
   void write_attributes(const QXmlStreamAttributes& attributes) const;
   void fprint_xml_chain(xml_tag* tag, const Waypoint* wpt) const;
   void write_gpx_url(const UrlList& urls) const;

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -273,7 +273,7 @@ tef_item_start(xg_string, const QXmlStreamAttributes* attrv)
 }
 
 static double
-tef_read_comma_float(const QStringView& value)
+tef_read_comma_float(QStringView value)
 {
   QString svalue = value.toString();
 

--- a/xmlgeneric.cc
+++ b/xmlgeneric.cc
@@ -153,7 +153,7 @@ xml_deinit()
 }
 
 static xg_shortcut
-xml_shortcut(const QStringView& name)
+xml_shortcut(QStringView name)
 {
    QString key = name.toString();
    if (xg_shortcut_taglist->contains(key)) {


### PR DESCRIPTION
As recommended in the QStringView documentation.