### PR TITLE
Don't use Qt module names in include directives.

### DIFF
--- a/arcdist.cc
+++ b/arcdist.cc
@@ -24,9 +24,9 @@
 #include <cstdlib>              // for strtod
 #include <cstring>              // for strchr, strlen, strncmp, strspn
 
-#include <QtCore/QByteArray>    // for QByteArray
-#include <QtCore/QString>       // for QString
-#include <QtCore/QtGlobal>      // for foreach, qPrintable, qint64
+#include <QByteArray>           // for QByteArray
+#include <QString>              // for QString
+#include <QtGlobal>             // for foreach, qPrintable, qint64
 
 #include "defs.h"
 #include "arcdist.h"

--- a/arcdist.h
+++ b/arcdist.h
@@ -22,7 +22,7 @@
 #ifndef ARCDIST_H_INCLUDED_
 #define ARCDIST_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for ARG_NOMINMAX, ARGTYPE_BOOL, Waypoint (ptr only)
 #include "filter.h"  // for Filter

--- a/bcr.cc
+++ b/bcr.cc
@@ -30,9 +30,9 @@
 #include <cstdio>           // for printf, snprintf, sscanf
 #include <cstdlib>          // for atof, atoi
 
-#include <QtCore/QString>   // for QString, operator+
-#include <QtCore/Qt>        // for CaseInsensitive
-#include <QtCore/QtGlobal>  // for foreach
+#include <QString>          // for QString, operator+
+#include <Qt>               // for CaseInsensitive
+#include <QtGlobal>         // for foreach
 
 #include "defs.h"
 #include "csv_util.h"       // for csv_stringclean

--- a/bend.cc
+++ b/bend.cc
@@ -23,8 +23,8 @@
 #include <cmath>            // macos wants abs from here!
 #include <cstdlib>          // for strtod, abs
 
-#include <QtCore/QString>   // for QString
-#include <QtCore/QtGlobal>  // for qAsConst, QAddConst<>::Type, foreach
+#include <QString>          // for QString
+#include <QtGlobal>         // for qAsConst, QAddConst<>::Type, foreach
 
 #include "defs.h"
 #include "bend.h"

--- a/bend.h
+++ b/bend.h
@@ -23,7 +23,7 @@
 #ifndef BEND_H_INCLUDED_
 #define BEND_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for route_head (ptr only), ARGTYPE_FLOAT, ARG_NOMINMAX
 #include "filter.h"  // for Filter

--- a/cet_util.cc
+++ b/cet_util.cc
@@ -19,9 +19,9 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#include <QtCore/QByteArray>     // for QByteArray
-#include <QtCore/QDebug>         // for QDebug
-#include <QtCore/QTextCodec>     // for QTextCodec
+#include <QByteArray>            // for QByteArray
+#include <QDebug>                // for QDebug
+#include <QTextCodec>            // for QTextCodec
 
 #include "defs.h"
 #include "cet_util.h"

--- a/cet_util.h
+++ b/cet_util.h
@@ -22,7 +22,7 @@
 #ifndef CET_UTIL_H_INCLUDED_
 #define CET_UTIL_H_INCLUDED_
 
-#include <QtCore/QString>
+#include <QString>
 #include "defs.h"
 
 

--- a/coverity_model.cc
+++ b/coverity_model.cc
@@ -7,12 +7,12 @@ void fatal(const char *msg, ...) {
 }
 
 // Forward decls to make the signature match.
-class Waypoint; 
+class Waypoint;
 class route_head;
 class QString;
 class route;
 
-// These functions "claim" their arguments 
+// These functions "claim" their arguments
 void
 waypt_add(Waypoint* wpt) {
   __coverity_escape__(wpt);
@@ -31,7 +31,7 @@ void route_add_wpt(route_head* rte, Waypoint* wpt) {
 void track_add_wpt(route_head* rte, Waypoint* wpt) {
   __coverity_escape__(wpt);
 }
-void route_add_wpt_named(route_head* rte, Waypoint* wpt, 
+void route_add_wpt_named(route_head* rte, Waypoint* wpt,
                          const QString& namepart, int number_digits) {
   __coverity_escape__(wpt);
 }

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -26,8 +26,8 @@
 #include <cctype>          // for isspace
 #include <cstring>         // for strlen, strchr, strncmp, strcmp, memmove, strcpy, strcspn, strncpy
 
-#include <QtCore/QRegExp>  // for QRegExp
-#include <QtCore/QString>  // for QString
+#include <QRegExp>         // for QRegExp
+#include <QString>         // for QString
 
 #include "defs.h"
 #include "csv_util.h"

--- a/csv_util.h
+++ b/csv_util.h
@@ -21,7 +21,7 @@
 #ifndef CSV_UTIL_H_INCLUDED_
 #define CSV_UTIL_H_INCLUDED_
 
-#include <QtCore/QString>      // for QString
+#include <QString>             // for QString
 
 #include "defs.h"
 

--- a/defs.h
+++ b/defs.h
@@ -35,14 +35,14 @@
 #include "zlib.h"                 // doesn't really belong here, but is missing elsewhere.
 #endif
 
-#include <QtCore/QDebug>          // for QDebug
-#include <QtCore/QList>           // for QList, QList<>::const_reverse_iterator, QList<>::reverse_iterator
-#include <QtCore/QScopedPointer>  // for QScopedPointer
-#include <QtCore/QString>         // for QString
-#include <QtCore/QTextCodec>      // for QTextCodec
-#include <QtCore/QVector>         // for QVector
-#include <QtCore/Qt>              // for CaseInsensitive
-#include <QtCore/QtGlobal>        // for foreach
+#include <QDebug>                 // for QDebug
+#include <QList>                  // for QList, QList<>::const_reverse_iterator, QList<>::reverse_iterator
+#include <QScopedPointer>         // for QScopedPointer
+#include <QString>                // for QString
+#include <QTextCodec>             // for QTextCodec
+#include <QVector>                // for QVector
+#include <Qt>                     // for CaseInsensitive
+#include <QtGlobal>               // for foreach
 
 #include "formspec.h"             // for FormatSpecificData
 #include "inifile.h"              // for inifile_t
@@ -742,7 +742,7 @@ public:
   void disp_all(std::nullptr_t /* rh */, std::nullptr_t /* rt */, T3 wc);
 
   // Only expose methods from our underlying container that won't corrupt our private data.
-  // Our contained element (route_head) also contains a container (waypoint_list), 
+  // Our contained element (route_head) also contains a container (waypoint_list),
   // and we maintain a total count the elements in these contained containers, i.e.
   // the total number of waypoints in all the routes in the RouteList.
   // public types

--- a/destinator.cc
+++ b/destinator.cc
@@ -21,7 +21,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
-#include <QtCore/QDebug>
+#include <QDebug>
 
 #include <cassert>                 // for assert
 #include <cmath>                   // for fabs, lround
@@ -30,14 +30,14 @@
 #include <cstring>                 // for strcmp, memmove, memset, strlen
 #include <ctime>                   // for gmtime
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QScopedPointer>   // for QScopedPointer
-#include <QtCore/QString>          // for QString
-#include <QtCore/QTextCodec>       // for QTextCodec, QTextCodec::IgnoreHeader
-#include <QtCore/QTextDecoder>     // for QTextDecoder
-#include <QtCore/QTextEncoder>     // for QTextEncoder
-#include <QtCore/QTime>            // for QTime
-#include <QtCore/QVector>          // for QVector
+#include <QByteArray>              // for QByteArray
+#include <QScopedPointer>          // for QScopedPointer
+#include <QString>                 // for QString
+#include <QTextCodec>              // for QTextCodec, QTextCodec::IgnoreHeader
+#include <QTextDecoder>            // for QTextDecoder
+#include <QTextEncoder>            // for QTextEncoder
+#include <QTime>                   // for QTime
+#include <QVector>                 // for QVector
 
 #include "defs.h"
 #include "garmin_fs.h"             // for garmin_fs_t, garmin_fs_flags_t, GMSD_GET, GMSD_SETSTRQ, garmin_fs_alloc, GMSD_FIND
@@ -109,7 +109,7 @@ read_until_wcstr(const QString& str)
   QScopedPointer<QTextEncoder> encoder(utf16le_codec->makeEncoder(QTextCodec::IgnoreHeader));
   QByteArray target = encoder->fromUnicode(str).append(2, 0);
   assert((target.size() % 2) == 0);
-  
+
   int eos = 0;
 
   int sz = target.size();

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -36,15 +36,15 @@
 #include <cstdlib>                     // for abs
 #include <cstring>                     // for memcpy, memcmp, strcmp
 
-#include <QtCore/QByteArray>           // for QByteArray
-#include <QtCore/QDate>                // for QDate
-#include <QtCore/QDateTime>            // for QDateTime
-#include <QtCore/QList>                // for QList
-#include <QtCore/QScopedArrayPointer>  // for QScopedArrayPointer
-#include <QtCore/QString>              // for QString
-#include <QtCore/QTime>                // for QTime
-#include <QtCore/Qt>                   // for TextDate, UTC
-#include <QtCore/QtGlobal>             // for qPrintable
+#include <QByteArray>                  // for QByteArray
+#include <QDate>                       // for QDate
+#include <QDateTime>                   // for QDateTime
+#include <QList>                       // for QList
+#include <QScopedArrayPointer>         // for QScopedArrayPointer
+#include <QString>                     // for QString
+#include <QTime>                       // for QTime
+#include <Qt>                          // for TextDate, UTC
+#include <QtGlobal>                    // for qPrintable
 
 #include "defs.h"
 #include "dg-100.h"

--- a/dg-100.h
+++ b/dg-100.h
@@ -33,10 +33,10 @@
 #include <cstdint>           // for uint8_t, int16_t, uint16_t
 #include <cstdio>            // for size_t
 
-#include <QtCore/QDateTime>  // for QDateTime
-#include <QtCore/QList>      // for QList
-#include <QtCore/QString>    // for QString
-#include <QtCore/QVector>    // for QVector
+#include <QDateTime>         // for QDateTime
+#include <QList>             // for QList
+#include <QString>           // for QString
+#include <QVector>           // for QVector
 
 #include "defs.h"
 #include "format.h"          // for Format

--- a/discard.cc
+++ b/discard.cc
@@ -23,7 +23,7 @@
 #include "discard.h"
 #include <cstdlib>
 // Can't use QRegularExpression because Linux won't get Qt 5 for years.
-#include <QtCore/QRegExp>
+#include <QRegExp>
 #include <cstdio>
 #include <cstdlib>
 

--- a/discard.h
+++ b/discard.h
@@ -23,8 +23,8 @@
 #define DISCARD_H_INCLUDED_
 
 // Can't use QRegularExpression because Linux won't get Qt 5 for years.
-#include <QtCore/QRegExp>  // for QRegExp
-#include <QtCore/QVector>  // for QVector
+#include <QRegExp>         // for QRegExp
+#include <QVector>         // for QVector
 
 #include "defs.h"          // for ARG_NOMINMAX, ARGTYPE_BEGIN_REQ, ARGTYPE_S...
 #include "filter.h"        // for Filter

--- a/dmtlog.cc
+++ b/dmtlog.cc
@@ -25,10 +25,10 @@
 #include <cstdlib>                      // for atoi
 #include <cstring>                      // for strncmp, memcpy, strcmp, strlen
 
-#include <QtCore/QByteArray>            // for QByteArray
-#include <QtCore/QString>               // for QString, operator+
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
-#include <QtCore/QtGlobal>              // for qPrintable
+#include <QByteArray>                   // for QByteArray
+#include <QString>                      // for QString, operator+
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
+#include <QtGlobal>                     // for qPrintable
 
 #include "defs.h"
 #include "gbfile.h"                     // for gbfgetdbl, gbfgetint32, gbfputint32, gbfgetint16, gbfputdbl, gbfputc, gbfread, gbfseek, gbfgetc, gbfile, gbfclose, gbfungetc, gbfeof, gbfputs, gbfwrite, gbfopen_le, gbfgetuint32, gbfputuint16, gbfputuint32
@@ -707,7 +707,7 @@ write_header(const route_head* trk)
     write_str(trk->rte_name, fout);
   }
 
-  // This fails for internationalization, but as this text is in the 
+  // This fails for internationalization, but as this text is in the
   // file itself, it shouldn't be localized.
   QString cout = QString::number(count) + " trackpoints and " +
                  QString::number(waypt_count()) + " waypoints";

--- a/duplicate.cc
+++ b/duplicate.cc
@@ -23,8 +23,8 @@
 #include <cstdlib>              // for qsort
 #include <cstring>              // for memset, strncpy
 
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QtGlobal>      // for foreach
+#include <QDateTime>            // for QDateTime
+#include <QtGlobal>             // for foreach
 
 #include "defs.h"
 #include "duplicate.h"

--- a/duplicate.h
+++ b/duplicate.h
@@ -22,7 +22,7 @@
 #ifndef DUPLICATE_H_INCLUDED_
 #define DUPLICATE_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for ARGTYPE_BOOL, ARG_NOMINMAX, Waypoint (ptr only)
 #include "filter.h"  // for Filter

--- a/energympro.cc
+++ b/energympro.cc
@@ -23,13 +23,13 @@
 #include <cstdint>              // for int32_t
 #include <cstdio>               // for printf, SEEK_SET, SEEK_CUR, SEEK_END
 
-#include <QtCore/QDate>         // for QDate
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QDebug>        // for QDebug
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTime>         // for QTime
-#include <QtCore/QTimeZone>     // for QTimeZone
-#include <QtCore/Qt>            // for UTC
+#include <QDate>                // for QDate
+#include <QDateTime>            // for QDateTime
+#include <QDebug>               // for QDebug
+#include <QString>              // for QString
+#include <QTime>                // for QTime
+#include <QTimeZone>            // for QTimeZone
+#include <Qt>                   // for UTC
 
 #include "defs.h"
 #include "energympro.h"

--- a/energympro.h
+++ b/energympro.h
@@ -24,9 +24,9 @@
 
 #include <cstdint>              // for uint8_t, uint16_t, uint32_t, int16_t
 
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTimeZone>     // for QTimeZone
-#include <QtCore/QVector>       // for QVector
+#include <QString>              // for QString
+#include <QTimeZone>            // for QTimeZone
+#include <QVector>              // for QVector
 
 #include "defs.h"
 #include "format.h"             // for Format

--- a/enigma.cc
+++ b/enigma.cc
@@ -26,7 +26,7 @@
 #include <cstdlib>         // for abs
 #include <cstring>         // for strlen, memcpy, memset
 
-#include <QtCore/QString>  // for QString
+#include <QString>         // for QString
 
 #include "defs.h"
 #include "gbfile.h"        // for gbfclose, gbfopen_le, gbfread, gbfwrite, gbfile

--- a/exif.cc
+++ b/exif.cc
@@ -40,22 +40,22 @@
 #include "jeeps/gpsmath.h"                 // for GPS_Math_WGS84_To_Known_Datum_M
 #include "src/core/datetime.h"             // for DateTime
 
-#include <QtCore/QByteArray>               // for QByteArray
-#include <QtCore/QDate>                    // for QDate
-#include <QtCore/QDateTime>                // for QDateTime
-#include <QtCore/QFile>                    // for QFile
-#include <QtCore/QFileInfo>                // for QFileInfo
-#include <QtCore/QList>                    // for QList<>::iterator, QList
-#include <QtCore/QPair>                    // for QPair
-#include <QtCore/QRegularExpression>       // for QRegularExpression
-#include <QtCore/QRegularExpressionMatch>  // for QRegularExpressionMatch
-#include <QtCore/QString>                  // for QString
-#include <QtCore/QTextCodec>               // for QTextCodec
-#include <QtCore/QTime>                    // for QTime
-#include <QtCore/QVariant>                 // for QVariant
-#include <QtCore/QVector>                  // for QVector
-#include <QtCore/Qt>                       // for UTC, ISODate
-#include <QtCore/QtGlobal>                 // for qSwap, qPrintable, qint64
+#include <QByteArray>                      // for QByteArray
+#include <QDate>                           // for QDate
+#include <QDateTime>                       // for QDateTime
+#include <QFile>                           // for QFile
+#include <QFileInfo>                       // for QFileInfo
+#include <QList>                           // for QList<>::iterator, QList
+#include <QPair>                           // for QPair
+#include <QRegularExpression>              // for QRegularExpression
+#include <QRegularExpressionMatch>         // for QRegularExpressionMatch
+#include <QString>                         // for QString
+#include <QTextCodec>                      // for QTextCodec
+#include <QTime>                           // for QTime
+#include <QVariant>                        // for QVariant
+#include <QVector>                         // for QVector
+#include <Qt>                              // for UTC, ISODate
+#include <QtGlobal>                        // for qSwap, qPrintable, qint64
 
 #include <algorithm>                       // for sort, min
 #include <cassert>                         // for assert

--- a/f90g_track.cc
+++ b/f90g_track.cc
@@ -28,8 +28,8 @@
 
 #include "defs.h"
 #include "gbfile.h"
-#include <QtCore/QDebug>
-#include <QtCore/QFileInfo>
+#include <QDebug>
+#include <QFileInfo>
 
 #define MYNAME "f90g_track"
 #define TTRECORDSIZE      249

--- a/filter_vecs.cc
+++ b/filter_vecs.cc
@@ -19,12 +19,12 @@
 
  */
 
-#include <QtCore/QByteArray>   // for QByteArray
-#include <QtCore/QString>      // for QString
-#include <QtCore/QStringList>  // for QStringList
-#include <QtCore/QVector>      // for QVector<>::iterator, QVector
-#include <QtCore/Qt>           // for CaseInsensitive
-#include <QtCore/QtGlobal>     // for qPrintable
+#include <QByteArray>          // for QByteArray
+#include <QString>             // for QString
+#include <QStringList>         // for QStringList
+#include <QVector>             // for QVector<>::iterator, QVector
+#include <Qt>                  // for CaseInsensitive
+#include <QtGlobal>            // for qPrintable
 
 #include <algorithm>           // for sort
 #include <cassert>             // for assert

--- a/filter_vecs.h
+++ b/filter_vecs.h
@@ -21,8 +21,8 @@
 #ifndef FILTER_VECS_H_INCLUDED_
 #define FILTER_VECS_H_INCLUDED_
 
-#include <QtCore/QString>      // for QString
-#include <QtCore/QVector>      // for QVector<>::iterator, QVector
+#include <QString>             // for QString
+#include <QVector>             // for QVector<>::iterator, QVector
 
 #include "defs.h"           // for arglist_t
 #include "arcdist.h"        // for ArcDistanceFilter

--- a/formspec.cc
+++ b/formspec.cc
@@ -19,7 +19,7 @@
 
  */
 
-#include <QtCore/QList>  // for QList
+#include <QList>         // for QList
 
 #include "defs.h"
 #include "formspec.h"    // for FormatSpecificData, FsChainAdd, FsChainCopy, FsChainDestroy, FsChainFind

--- a/formspec.h
+++ b/formspec.h
@@ -21,7 +21,7 @@
 #ifndef FORMSPEC_H_INCLUDED_
 #define FORMSPEC_H_INCLUDED_
 
-#include <QtCore/QList>  // for QList
+#include <QList>         // for QList
 
 enum FsType {
   kFsUnknown = 0L,

--- a/garmin.cc
+++ b/garmin.cc
@@ -28,11 +28,11 @@
 #include <cstring>              // for memcpy, strlen, strncpy, strchr
 #include <ctime>                // for time_t
 
-#include <QtCore/QByteArray>    // for QByteArray
-#include <QtCore/QChar>         // for QChar
-#include <QtCore/QString>       // for QString
-#include <QtCore/Qt>            // for CaseInsensitive
-#include <QtCore/QtGlobal>      // for qPrintable, foreach
+#include <QByteArray>           // for QByteArray
+#include <QChar>                // for QChar
+#include <QString>              // for QString
+#include <Qt>                   // for CaseInsensitive
+#include <QtGlobal>             // for qPrintable, foreach
 
 #include "defs.h"
 #include "cet_util.h"           // for cet_convert_init, cet_cs_vec_utf8
@@ -357,7 +357,7 @@ rw_deinit()
       gps_baud_rate = baud;
     }
   }
-  
+
   if (mkshort_handle) {
     mkshort_del_handle(&mkshort_handle);
   }

--- a/garmin_device_xml.cc
+++ b/garmin_device_xml.cc
@@ -28,8 +28,8 @@
 #include "defs.h"
 #include "garmin_device_xml.h"
 #include "xmlgeneric.h"
-#include <QtCore/QXmlStreamAttributes>
-#include <QtCore/QFile>
+#include <QXmlStreamAttributes>
+#include <QFile>
 #include <cstdio>
 
 #define MYNAME "whatever"

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -30,13 +30,13 @@
 #include <utility>             // for pair
 #include <vector>              // for vector
 
-#include <QtCore/QByteArray>   // for QByteArray
-#include <QtCore/QDateTime>    // for QDateTime
-#include <QtCore/QFileInfo>    // for QFileInfo
-#include <QtCore/QLatin1Char>  // for QLatin1Char
-#include <QtCore/QString>      // for QString
-#include <QtCore/Qt>           // for CaseInsensitive
-#include <QtCore/QtGlobal>     // for qint64
+#include <QByteArray>          // for QByteArray
+#include <QDateTime>           // for QDateTime
+#include <QFileInfo>           // for QFileInfo
+#include <QLatin1Char>         // for QLatin1Char
+#include <QString>             // for QString
+#include <Qt>                  // for CaseInsensitive
+#include <QtGlobal>            // for qint64
 
 #include "defs.h"
 #include "garmin_fit.h"

--- a/garmin_fit.h
+++ b/garmin_fit.h
@@ -30,10 +30,10 @@
 #include <utility>              // for pair
 #include <vector>               // for vector
 
-#include <QtCore/QHash>         // for QHash
-#include <QtCore/QList>         // for QList
-#include <QtCore/QString>       // for QString
-#include <QtCore/QVector>       // for QVector
+#include <QHash>                // for QHash
+#include <QList>                // for QList
+#include <QString>              // for QString
+#include <QVector>              // for QVector
 
 #include "defs.h"
 #include "format.h"             // for Format

--- a/garmin_fs.cc
+++ b/garmin_fs.cc
@@ -25,11 +25,11 @@
 #include <cstdlib>                   // for atof
 #include <cstring>                   // for strncpy
 
-#include <QtCore/QByteArray>         // for QByteArray
-#include <QtCore/QStaticStringData>  // for QStaticStringData
-#include <QtCore/QString>            // for QString, QStringLiteral
-#include <QtCore/QXmlStreamWriter>   // for QXmlStreamWriter
-#include <QtCore/Qt>                 // for CaseInsensitive
+#include <QByteArray>                // for QByteArray
+#include <QStaticStringData>         // for QStaticStringData
+#include <QString>                   // for QString, QStringLiteral
+#include <QXmlStreamWriter>          // for QXmlStreamWriter
+#include <Qt>                        // for CaseInsensitive
 
 #include "defs.h"
 #include "garmin_fs.h"

--- a/garmin_fs.h
+++ b/garmin_fs.h
@@ -27,8 +27,8 @@
 #include <cstddef>                  // for size_t
 #include <cstdint>                  // for int32_t, int16_t, uint16_t
 
-#include <QtCore/QString>           // for QString
-#include <QtCore/QXmlStreamWriter>  // for QXmlStreamWriter
+#include <QString>                  // for QString
+#include <QXmlStreamWriter>         // for QXmlStreamWriter
 
 #include "defs.h"
 #include "formspec.h"               // for FsChainFind, kFsGmsd, FormatSpecificData

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -52,14 +52,14 @@
 #include <cstring>                 // for strlen, strncmp
 #include <ctime>                   // for time, time_t, gmtime
 
-#include <QtCore/QByteArray>       // for QByteArray, operator==
-#include <QtCore/QByteRef>         // for QByteRef
-#include <QtCore/QList>            // for QList<>::iterator, QList
-#include <QtCore/QString>          // for QString, operator+, operator<
-#include <QtCore/QThread>          // for QThread
-#include <QtCore/QVector>          // for QVector
-#include <QtCore/Qt>               // for CaseInsensitive
-#include <QtCore/QtGlobal>         // for foreach, Q_UNUSED
+#include <QByteArray>              // for QByteArray, operator==
+#include <QByteRef>                // for QByteRef
+#include <QList>                   // for QList<>::iterator, QList
+#include <QString>                 // for QString, operator+, operator<
+#include <QThread>                 // for QThread
+#include <QVector>                 // for QVector
+#include <Qt>                      // for CaseInsensitive
+#include <QtGlobal>                // for foreach, Q_UNUSED
 
 #include "defs.h"
 #include "garmin_gpi.h"

--- a/garmin_tables.cc
+++ b/garmin_tables.cc
@@ -22,9 +22,9 @@
 
 #include <cstdint>               // for int32_t
 #include <cstring>               // for strncpy, strchr, strlen, strncmp
-#include <QtCore/QChar>          // for operator==, QChar
-#include <QtCore/QDebug>         // for QDebug
-#include <QtCore/Qt>             // for CaseInsensitive
+#include <QChar>                 // for operator==, QChar
+#include <QDebug>                // for QDebug
+#include <Qt>                    // for CaseInsensitive
 #include "defs.h"
 #include "garmin_tables.h"
 #include "jeeps/gpsmath.h"       // for GPS_Lookup_Datum_Index, GPS_Math_Get_Datum_Name

--- a/garmin_tables.h
+++ b/garmin_tables.h
@@ -24,7 +24,7 @@
 #define GARMIN_TABLES_H
 
 #include <cstdint>              // for uint32_t
-#include <QtCore/QString>       // for QString
+#include <QString>              // for QString
 #include "defs.h"               // for grid_type
 
 #define DEFAULT_ICON_DESCR "Waypoint"

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -31,14 +31,14 @@
 #include <cstring>                 // for memset, strstr, strcat, strchr, strlen, strcmp, strcpy, strncpy
 #include <ctime>                   // for gmtime, localtime, strftime
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QChar>            // for QChar, QChar::Other_Control
-#include <QtCore/QIODevice>        // for QIODevice, QIODevice::ReadOnly, QIODevice::WriteOnly
-#include <QtCore/QString>          // for QString, operator!=
-#include <QtCore/QTextStream>      // for QTextStream
-#include <QtCore/QVector>          // for QVector
-#include <QtCore/Qt>               // for CaseInsensitive
-#include <QtCore/QtGlobal>         // for qPrintable
+#include <QByteArray>              // for QByteArray
+#include <QChar>                   // for QChar, QChar::Other_Control
+#include <QIODevice>               // for QIODevice, QIODevice::ReadOnly, QIODevice::WriteOnly
+#include <QString>                 // for QString, operator!=
+#include <QTextStream>             // for QTextStream
+#include <QVector>                 // for QVector
+#include <Qt>                      // for CaseInsensitive
+#include <QtGlobal>                // for qPrintable
 
 #include "csv_util.h"              // for csv_lineparse
 #include "garmin_fs.h"             // for garmin_fs_t, garmin_fs_alloc, garmin_fs_convert_category, GMSD_SECTION_CATEGORIES

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -20,9 +20,9 @@
 
  */
 
-#include <QtCore/QByteArray>   // for QByteArray
-#include <QtCore/QString>      // for QString
-#include <QtCore/QtGlobal>     // for qPrintable
+#include <QByteArray>          // for QByteArray
+#include <QString>             // for QString
+#include <QtGlobal>            // for qPrintable
 
 #include <cassert>             // for assert
 #include <cctype>              // for tolower
@@ -647,7 +647,7 @@ gbfgetc(gbfile* file)
  * gbfgets: (as fgets)
  */
 
-QString 
+QString
 gbfgets(char* buf, int len, gbfile* file)
 {
   char* result = buf;
@@ -695,8 +695,8 @@ gbfread(void* buf, const gbsize_t size, const gbsize_t members, gbfile* file)
 
 // goofy) calling signature.
 gbsize_t
-gbfread(QString& buf, const gbsize_t size, 
-        const gbsize_t members, gbfile* file) 
+gbfread(QString& buf, const gbsize_t size,
+        const gbsize_t members, gbfile* file)
 {
   QByteArray tmp;
   tmp.resize(members * size);
@@ -1018,7 +1018,7 @@ gbfgetcstr(gbfile* file)
   char* result = gbfgetcstr_old(file);
   QString rv(result);
   xfree(result);
-  return rv; 
+  return rv;
 }
 
 QByteArray
@@ -1027,7 +1027,7 @@ gbfgetnativecstr(gbfile* file)
   char* result = gbfgetcstr_old(file);
   QByteArray rv(result);
   xfree(result);
-  return rv; 
+  return rv;
 }
 
 /*

--- a/gbfile.h
+++ b/gbfile.h
@@ -23,8 +23,8 @@
 #ifndef GBFILE_H
 #define GBFILE_H
 
-#include <QtCore/QByteArray>    // for QByteArray
-#include <QtCore/QString>       // for QString
+#include <QByteArray>           // for QByteArray
+#include <QString>              // for QString
 
 #include <cstdarg>             // for va_list
 #include <cstdint>             // for int32_t, int16_t, uint32_t

--- a/gbser_win.cc
+++ b/gbser_win.cc
@@ -70,7 +70,7 @@ DWORD mkspeed(unsigned br)
     return CBR_115200;
   case 230400:
   // Per https://msdn.microsoft.com/en-us/library/windows/desktop/aa363214
-  // "This member can be an actual baud rate value, or one of the 
+  // "This member can be an actual baud rate value, or one of the
   // following indexes."
   // They provide a CBR_25600, which would be programmable on a 16450 only
   // with a bizarre oscillator crystal, but don't provide a 230400, such

--- a/gdb.cc
+++ b/gdb.cc
@@ -31,12 +31,12 @@
 #include <ctime>                   // for strftime
 #include <iterator>                // for next
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QList>            // for QList
-#include <QtCore/QString>          // for QString, operator!=, operator==
-#include <QtCore/QVector>          // for QVector
-#include <QtCore/Qt>               // for CaseInsensitive
-#include <QtCore/QtGlobal>         // for qPrintable, Q_UNUSED, foreach
+#include <QByteArray>              // for QByteArray
+#include <QList>                   // for QList
+#include <QString>                 // for QString, operator!=, operator==
+#include <QVector>                 // for QVector
+#include <Qt>                      // for CaseInsensitive
+#include <QtGlobal>                // for qPrintable, Q_UNUSED, foreach
 
 #include "defs.h"
 

--- a/geo.cc
+++ b/geo.cc
@@ -18,9 +18,9 @@
  */
 #include "defs.h"
 #include "src/core/file.h"
-#include <QtCore/QDebug>
-#include <QtCore/QXmlStreamReader>
-#include <QtCore/QXmlStreamWriter>
+#include <QDebug>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
 
 static char* deficon = nullptr;
 static char* nuke_placer;

--- a/geojson.cc
+++ b/geojson.cc
@@ -17,14 +17,14 @@
 
  */
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QIODevice>        // for operator|, QIODevice, QIODevice::ReadOnly, QIODevice::Text
-#include <QtCore/QJsonArray>       // for QJsonArray
-#include <QtCore/QJsonDocument>    // for QJsonDocument, QJsonDocument::Compact, QJsonDocument::Indented, QJsonDocument::JsonFormat
-#include <QtCore/QJsonObject>      // for QJsonObject
-#include <QtCore/QJsonParseError>  // for QJsonParseError
-#include <QtCore/QJsonValue>       // for QJsonValue
-#include <QtCore/QJsonValueRef>    // for QJsonValueRef
+#include <QByteArray>              // for QByteArray
+#include <QIODevice>               // for operator|, QIODevice, QIODevice::ReadOnly, QIODevice::Text
+#include <QJsonArray>              // for QJsonArray
+#include <QJsonDocument>           // for QJsonDocument, QJsonDocument::Compact, QJsonDocument::Indented, QJsonDocument::JsonFormat
+#include <QJsonObject>             // for QJsonObject
+#include <QJsonParseError>         // for QJsonParseError
+#include <QJsonValue>              // for QJsonValue
+#include <QJsonValueRef>           // for QJsonValueRef
 
 #include "defs.h"
 #include "geojson.h"

--- a/geojson.h
+++ b/geojson.h
@@ -19,11 +19,11 @@
 #ifndef GEOJSON_H_INCLUDED_
 #define GEOJSON_H_INCLUDED_
 
-#include <QtCore/QJsonArray>         // for QJsonArray
-#include <QtCore/QJsonObject>        // for QJsonObject
-#include <QtCore/QStaticStringData>  // for QStaticStringData
-#include <QtCore/QString>            // for QString, QStringLiteral
-#include <QtCore/QVector>            // for QVector
+#include <QJsonArray>                // for QJsonArray
+#include <QJsonObject>               // for QJsonObject
+#include <QStaticStringData>         // for QStaticStringData
+#include <QString>                   // for QString, QStringLiteral
+#include <QVector>                   // for QVector
 
 #include "defs.h"
 #include "format.h"                  // for Format

--- a/ggv_bin.cc
+++ b/ggv_bin.cc
@@ -21,11 +21,11 @@
 
 */
 
-#include <QtCore/QByteArray>
-#include <QtCore/QDataStream>
-#include <QtCore/QDebug>
-#include <QtCore/QFile>
-#include <QtCore/QtEndian>
+#include <QByteArray>
+#include <QDataStream>
+#include <QDebug>
+#include <QFile>
+#include <QtEndian>
 
 #include "ggv_bin.h"
 

--- a/ggv_log.cc
+++ b/ggv_log.cc
@@ -26,9 +26,9 @@
 #include <cstdint>                 // for int16_t
 #include <ctime>                   // for gmtime
 
-#include <QtCore/QString>          // for QString
-#include <QtCore/QTime>            // for QTime
-#include <QtCore/QtGlobal>         // for foreach
+#include <QString>                 // for QString
+#include <QTime>                   // for QTime
+#include <QtGlobal>                // for foreach
 
 #include "defs.h"
 #include "gbfile.h"                // for gbfputint16, gbfclose, gbfopen, gbfputflt, gbfgetc, gbfputcstr, gbfputdbl, gbfread, gbfile

--- a/ggv_ovl.cc
+++ b/ggv_ovl.cc
@@ -22,9 +22,9 @@
 
 #include <cmath>            // for sin, cos, acos
 
-#include <QtCore/QString>   // for QString
-#include <QtCore/QVector>   // for QVector
-#include <QtCore/QtGlobal>  // for foreach
+#include <QString>          // for QString
+#include <QVector>          // for QVector
+#include <QtGlobal>         // for foreach
 
 #include "defs.h"
 #include "gbfile.h"         // for gbfprintf, gbfclose, gbfopen, gbfile
@@ -356,7 +356,7 @@ write_bounds()
 }
 
 static void
-draw_symbol_basics(const OVL_SYMBOL_TYP typ, const int art, 
+draw_symbol_basics(const OVL_SYMBOL_TYP typ, const int art,
                    const OVL_COLOR_TYP point_color, const Waypoint* wpt)
 {
   symbol_ct++;

--- a/globalsat_sport.cc
+++ b/globalsat_sport.cc
@@ -39,14 +39,14 @@
 #include <cstdio>               // for printf
 #include <cstdlib>              // for free, malloc
 
-#include <QtCore/QByteArray>    // for QByteArray
-#include <QtCore/QDate>         // for QDate
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTime>         // for QTime
-#include <QtCore/QTimeZone>     // for QTimeZone
-#include <QtCore/Qt>            // for LocalTime
-#include <QtCore/QtGlobal>      // for qPrintable
+#include <QByteArray>           // for QByteArray
+#include <QDate>                // for QDate
+#include <QDateTime>            // for QDateTime
+#include <QString>              // for QString
+#include <QTime>                // for QTime
+#include <QTimeZone>            // for QTimeZone
+#include <Qt>                   // for LocalTime
+#include <QtGlobal>             // for qPrintable
 
 #include "defs.h"
 #include "globalsat_sport.h"

--- a/globalsat_sport.h
+++ b/globalsat_sport.h
@@ -39,9 +39,9 @@
 
 #include <cstdint>           // for uint32_t, uint8_t, uint16_t, int16_t
 
-#include <QtCore/QString>    // for QString
-#include <QtCore/QTimeZone>  // for QTimeZone
-#include <QtCore/QVector>    // for QVector
+#include <QString>           // for QString
+#include <QTimeZone>         // for QTimeZone
+#include <QVector>           // for QVector
 
 #include "defs.h"
 #include "format.h"          // for Format

--- a/glogbook.cc
+++ b/glogbook.cc
@@ -23,8 +23,8 @@
 #include "src/core/file.h"
 #include "xmlgeneric.h"
 
-#include <QtCore/QXmlStreamAttributes>
-#include <QtCore/QXmlStreamWriter>
+#include <QXmlStreamAttributes>
+#include <QXmlStreamWriter>
 
 static gbfile* ofd;
 static QString ostring;

--- a/googledir.cc
+++ b/googledir.cc
@@ -28,7 +28,7 @@
 
 #include "defs.h"
 #include "xmlgeneric.h"
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 
 static QString encoded_points;
 static QString instructions;

--- a/gopal.cc
+++ b/gopal.cc
@@ -57,8 +57,8 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <QtCore/QDateTime>
-#include <QtCore/QString>
+#include <QDateTime>
+#include <QString>
 
 #define MYNAME "gopal"
 
@@ -174,7 +174,7 @@ gopal_read()
   char tbuffer[64];
   struct tm tm2;
   double lat_old = 0;
-  
+
 
   auto* route = new route_head;
   QDateTime qtx = QDateTime::fromSecsSinceEpoch(tx, Qt::UTC);

--- a/gpx.cc
+++ b/gpx.cc
@@ -24,25 +24,25 @@
 #include <cstdlib>                                 // for atoi, strtod
 #include <cstring>                                 // for strchr, strncpy
 
-#include <QtCore/QDate>                            // for QDate
-#include <QtCore/QDateTime>                        // for QDateTime
-#include <QtCore/QHash>                            // for QHash
-#include <QtCore/QIODevice>                        // for QIODevice, operator|, QIODevice::ReadOnly, QIODevice::Text, QIODevice::WriteOnly
-#include <QtCore/QLatin1Char>                      // for QLatin1Char
-#include <QtCore/QLatin1String>                    // for QLatin1String
-#include <QtCore/QStaticStringData>                // for QStaticStringData
-#include <QtCore/QString>                          // for QString, QStringLiteral, operator+, operator==
-#include <QtCore/QStringList>                      // for QStringList
-#include <QtCore/QStringView>                      // for QStringView
-#include <QtCore/QTime>                            // for QTime
-#include <QtCore/QVersionNumber>                   // for QVersionNumber
-#include <QtCore/QXmlStreamAttribute>              // for QXmlStreamAttribute
-#include <QtCore/QXmlStreamAttributes>             // for QXmlStreamAttributes
-#include <QtCore/QXmlStreamNamespaceDeclaration>   // for QXmlStreamNamespaceDeclaration
-#include <QtCore/QXmlStreamNamespaceDeclarations>  // for QXmlStreamNamespaceDeclarations
-#include <QtCore/QXmlStreamReader>                 // for QXmlStreamReader, QXmlStreamReader::Characters, QXmlStreamReader::EndDocument, QXmlStreamReader::EndElement, QXmlStreamReader::Invalid, QXmlStreamReader::StartElement
-#include <QtCore/Qt>                               // for CaseInsensitive, UTC
-#include <QtCore/QtGlobal>                         // for qAsConst, QAddConst<>::Type
+#include <QDate>                                   // for QDate
+#include <QDateTime>                               // for QDateTime
+#include <QHash>                                   // for QHash
+#include <QIODevice>                               // for QIODevice, operator|, QIODevice::ReadOnly, QIODevice::Text, QIODevice::WriteOnly
+#include <QLatin1Char>                             // for QLatin1Char
+#include <QLatin1String>                           // for QLatin1String
+#include <QStaticStringData>                       // for QStaticStringData
+#include <QString>                                 // for QString, QStringLiteral, operator+, operator==
+#include <QStringList>                             // for QStringList
+#include <QStringView>                             // for QStringView
+#include <QTime>                                   // for QTime
+#include <QVersionNumber>                          // for QVersionNumber
+#include <QXmlStreamAttribute>                     // for QXmlStreamAttribute
+#include <QXmlStreamAttributes>                    // for QXmlStreamAttributes
+#include <QXmlStreamNamespaceDeclaration>          // for QXmlStreamNamespaceDeclaration
+#include <QXmlStreamNamespaceDeclarations>         // for QXmlStreamNamespaceDeclarations
+#include <QXmlStreamReader>                        // for QXmlStreamReader, QXmlStreamReader::Characters, QXmlStreamReader::EndDocument, QXmlStreamReader::EndElement, QXmlStreamReader::Invalid, QXmlStreamReader::StartElement
+#include <Qt>                                      // for CaseInsensitive, UTC
+#include <QtGlobal>                                // for qAsConst, QAddConst<>::Type
 
 #include "defs.h"
 #include "gpx.h"

--- a/gpx.h
+++ b/gpx.h
@@ -21,14 +21,14 @@
 #ifndef GPX_H_INCLUDED_
 #define GPX_H_INCLUDED_
 
-#include <QtCore/QHash>                 // for QHash
-#include <QtCore/QString>               // for QString
-#include <QtCore/QStringList>           // for QStringList
-#include <QtCore/QStringView>           // for QStringView
-#include <QtCore/QVector>               // for QVector
-#include <QtCore/QVersionNumber>        // for QVersionNumber
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
-#include <QtCore/QXmlStreamReader>      // for QXmlStreamReader
+#include <QHash>                        // for QHash
+#include <QString>                      // for QString
+#include <QStringList>                  // for QStringList
+#include <QStringView>                  // for QStringView
+#include <QVector>                      // for QVector
+#include <QVersionNumber>               // for QVersionNumber
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
+#include <QXmlStreamReader>             // for QXmlStreamReader
 
 #include "defs.h"
 #include "format.h"                     // for Format

--- a/gtm.cc
+++ b/gtm.cc
@@ -26,7 +26,7 @@
 
 #include "defs.h"
 #include "jeeps/gpsmath.h"
-#include <QtCore/QList>
+#include <QList>
 
 static gbfile* file_in, *file_out;
 static int indatum;

--- a/gtrnctr.cc
+++ b/gtrnctr.cc
@@ -24,7 +24,7 @@
  * http://www8.garmin.com/xmlschemas/ActivityExtensionv2.xsd
  */
 
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 
 #include "defs.h"
 #include "xmlgeneric.h"

--- a/gui/aboutdlg.cc
+++ b/gui/aboutdlg.cc
@@ -21,9 +21,9 @@
 //
 
 #include "aboutdlg.h"
-#include <QtGui/QTextCursor>          // for QTextCursor
-#include <QtGui/QTextDocument>        // for QTextDocument
-#include <QtWidgets/QTextEdit>        // for QTextEdit
+#include <QTextCursor>                // for QTextCursor
+#include <QTextDocument>              // for QTextDocument
+#include <QTextEdit>                  // for QTextEdit
 #include "appname.h"                  // for appName
 #include "upgrade.h"                  // for UpgradeCheck
 

--- a/gui/aboutdlg.h
+++ b/gui/aboutdlg.h
@@ -23,9 +23,9 @@
 #ifndef ABOUTDLG_H
 #define ABOUTDLG_H
 
-#include <QtCore/QString>     // for QString
-#include <QtWidgets/QDialog>  // for QDialog
-#include <QtWidgets/QWidget>  // for QWidget
+#include <QString>            // for QString
+#include <QDialog>            // for QDialog
+#include <QWidget>            // for QWidget
 #include "ui_aboutui.h"       // for Ui_AboutDlg
 
 class AboutDlg: public QDialog

--- a/gui/coretool/coretool.cc
+++ b/gui/coretool/coretool.cc
@@ -1,5 +1,5 @@
-#include <QtCore/QList>
-#include <QtWidgets/QApplication>
+#include <QList>
+#include <QApplication>
 
 #include "format.h"
 #include "formatload.h"

--- a/gui/filterdata.cc
+++ b/gui/filterdata.cc
@@ -227,7 +227,7 @@ QStringList MiscFltFilterData::makeOptionString()
       s += QString(",%1").arg(trkopts.at(sortTrkBy_));
     }
     args << s;
-    
+
   }
   return args;
 }

--- a/gui/filterdata.h
+++ b/gui/filterdata.h
@@ -136,7 +136,7 @@ public:
 class WayPtsFilterData: public FilterData
 {
 public:
-  WayPtsFilterData(): 
+  WayPtsFilterData():
     duplicates(false), shortNames(true), locations(false),
     position(false), radius(false),
     positionVal(0.0), radiusVal(0.0),
@@ -175,7 +175,7 @@ public:
 class RtTrkFilterData: public FilterData
 {
 public:
-  RtTrkFilterData(): 
+  RtTrkFilterData():
     simplify_(false),
     reverse_(false),
     limitTo_(100)
@@ -200,7 +200,7 @@ public:
 class MiscFltFilterData: public FilterData
 {
 public:
-  MiscFltFilterData(): 
+  MiscFltFilterData():
     nukeRoutes_(false),
     nukeTracks_(false),
     nukeWaypoints_(false),

--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -22,22 +22,22 @@
 //------------------------------------------------------------------------
 
 #include "formatload.h"
-#include <QtCore/QByteArray>               // for QByteArray
-#include <QtCore/QChar>                    // for operator==, QChar
-#include <QtCore/QCharRef>                 // for QCharRef
-#include <QtCore/QCoreApplication>         // for QCoreApplication
+#include <QByteArray>                      // for QByteArray
+#include <QChar>                           // for operator==, QChar
+#include <QCharRef>                        // for QCharRef
+#include <QCoreApplication>                // for QCoreApplication
 #ifdef GENERATE_CORE_STRINGS
-#include <QtCore/QDebug>                   // for QDebug, operator<<
+#include <QDebug>                          // for QDebug, operator<<
 #endif
-#include <QtCore/QObject>                  // for QObject
-#include <QtCore/QProcess>                 // for QProcess
-#include <QtCore/QRegularExpression>       // for QRegularExpression
-#include <QtCore/QRegularExpressionMatch>  // for QRegularExpressionMatch
-#include <QtCore/QString>                  // for QString, operator+
-#include <QtCore/QTextStream>              // for QTextStream
-#include <QtCore/QVariant>                 // for QVariant
-#include <QtWidgets/QApplication>          // for QApplication
-#include <QtWidgets/QMessageBox>           // for QMessageBox
+#include <QObject>                         // for QObject
+#include <QProcess>                        // for QProcess
+#include <QRegularExpression>              // for QRegularExpression
+#include <QRegularExpressionMatch>         // for QRegularExpressionMatch
+#include <QString>                         // for QString, operator+
+#include <QTextStream>                     // for QTextStream
+#include <QVariant>                        // for QVariant
+#include <QApplication>                    // for QApplication
+#include <QMessageBox>                     // for QMessageBox
 #include "appname.h"                       // for appName
 
 

--- a/gui/formatload.h
+++ b/gui/formatload.h
@@ -25,8 +25,8 @@
 #ifndef FORMATLOAD_H
 #define FORMATLOAD_H
 
-#include <QtCore/QList>        // for QList
-#include <QtCore/QStringList>  // for QStringList
+#include <QList>               // for QList
+#include <QStringList>         // for QStringList
 
 #include "format.h"            // for Format
 

--- a/gui/gpx.h
+++ b/gui/gpx.h
@@ -373,7 +373,7 @@ private:
 class GpxWaypoint: public GpxItem
 {
 public:
-  GpxWaypoint(): 
+  GpxWaypoint():
     location_(LatLng(0, 0)),
     elevation_(-1.0E-100),
     name_(QString()),

--- a/gui/help.cc
+++ b/gui/help.cc
@@ -22,10 +22,10 @@
 //------------------------------------------------------------------------
 #include "help.h"
 
-#include <QtCore/QRegularExpression>  // for QRegularExpression
-#include <QtCore/QString>             // for QString
-#include <QtCore/QUrl>                // for QUrl
-#include <QtGui/QDesktopServices>     // for QDesktopServices
+#include <QRegularExpression>         // for QRegularExpression
+#include <QString>                    // for QString
+#include <QUrl>                       // for QUrl
+#include <QDesktopServices>           // for QDesktopServices
 
 #include "format.h"                   // for Format
 

--- a/gui/help.h
+++ b/gui/help.h
@@ -22,7 +22,7 @@
 
 #ifndef HELP_H
 #define HELP_H
-#include <QtCore/QString>  // for QString
+#include <QString>         // for QString
 
 extern void ShowHelp(const QString& name);
 

--- a/gui/main.cc
+++ b/gui/main.cc
@@ -20,9 +20,9 @@
 //  USA.
 //
 //------------------------------------------------------------------------
-#include <QtCore/QtGlobal>         // for QT_VERSION, QT_VERSION_CHECK
-#include <QtGui/QIcon>             // for QIcon
-#include <QtWidgets/QApplication>  // for QApplication
+#include <QtGlobal>                // for QT_VERSION, QT_VERSION_CHECK
+#include <QIcon>                   // for QIcon
+#include <QApplication>            // for QApplication
 
 #include "mainwindow.h"             // for MainWindow
 

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -19,41 +19,41 @@
 //  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 //  USA.
 //
-#include <QtCore/QByteArray>           // for QByteArray
-#include <QtCore/QDate>                // for QDate
-#include <QtCore/QDateTime>            // for QDateTime
-#include <QtCore/QDir>                 // for QDir
-#include <QtCore/QEvent>               // for QEvent (& QEvent::LanguageChange, QEvent::LocaleChange)
-#include <QtCore/QFile>                // for QFile
-#include <QtCore/QFileInfo>            // for QFileInfo
-#include <QtCore/QLibraryInfo>         // for QLibraryInfo, QLibraryInfo::TranslationsPath
-#include <QtCore/QLocale>              // for QLocale
-#include <QtCore/QMimeData>            // for QMimeData
-#include <QtCore/QProcess>             // for QProcess, QProcess::NotRunning
-#include <QtCore/QSettings>            // for QSettings
-#include <QtCore/QString>              // for QString
-#include <QtCore/QStringList>          // for QStringList
-#include <QtCore/QTemporaryFile>       // for QTemporaryFile
-#include <QtCore/QTime>                // for QTime
-#include <QtCore/QUrl>                 // for QUrl
-#include <QtCore/QVariant>             // for QVariant
-#include <QtCore/Qt>                   // for SmoothTransformation, WaitCursor
-#include <QtCore/QtGlobal>             // for foreach
-#include <QtGui/QCursor>               // for QCursor
-#include <QtGui/QDesktopServices>      // for QDesktopServices
-#include <QtGui/QIcon>                 // for QIcon
-#include <QtGui/QImage>                // for QImage
-#include <QtGui/QTextCharFormat>       // for QTextCharFormat
-#include <QtWidgets/QAbstractButton>   // for QAbstractButton
-#include <QtWidgets/QApplication>      // for QApplication, qApp
-#include <QtWidgets/QCheckBox>         // for QCheckBox
-#include <QtWidgets/QDialogButtonBox>  // for QDialogButtonBox
-#include <QtWidgets/QFileDialog>       // for QFileDialog
-#include <QtWidgets/QMessageBox>       // for QMessageBox, operator|, QMessageBox::Yes, QMessageBox::No
-#include <QtWidgets/QPlainTextEdit>    // for QPlainTextEdit
-#include <QtWidgets/QPushButton>       // for QPushButton
-#include <QtWidgets/QRadioButton>      // for QRadioButton
-#include <QtWidgets/QStackedWidget>    // for QStackedWidget
+#include <QByteArray>                  // for QByteArray
+#include <QDate>                       // for QDate
+#include <QDateTime>                   // for QDateTime
+#include <QDir>                        // for QDir
+#include <QEvent>                      // for QEvent (& QEvent::LanguageChange, QEvent::LocaleChange)
+#include <QFile>                       // for QFile
+#include <QFileInfo>                   // for QFileInfo
+#include <QLibraryInfo>                // for QLibraryInfo, QLibraryInfo::TranslationsPath
+#include <QLocale>                     // for QLocale
+#include <QMimeData>                   // for QMimeData
+#include <QProcess>                    // for QProcess, QProcess::NotRunning
+#include <QSettings>                   // for QSettings
+#include <QString>                     // for QString
+#include <QStringList>                 // for QStringList
+#include <QTemporaryFile>              // for QTemporaryFile
+#include <QTime>                       // for QTime
+#include <QUrl>                        // for QUrl
+#include <QVariant>                    // for QVariant
+#include <Qt>                          // for SmoothTransformation, WaitCursor
+#include <QtGlobal>                    // for foreach
+#include <QCursor>                     // for QCursor
+#include <QDesktopServices>            // for QDesktopServices
+#include <QIcon>                       // for QIcon
+#include <QImage>                      // for QImage
+#include <QTextCharFormat>             // for QTextCharFormat
+#include <QAbstractButton>             // for QAbstractButton
+#include <QApplication>                // for QApplication, qApp
+#include <QCheckBox>                   // for QCheckBox
+#include <QDialogButtonBox>            // for QDialogButtonBox
+#include <QFileDialog>                 // for QFileDialog
+#include <QMessageBox>                 // for QMessageBox, operator|, QMessageBox::Yes, QMessageBox::No
+#include <QPlainTextEdit>              // for QPlainTextEdit
+#include <QPushButton>                 // for QPushButton
+#include <QRadioButton>                // for QRadioButton
+#include <QStackedWidget>              // for QStackedWidget
 
 #include <cstdlib>                     // for exit
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -22,22 +22,22 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-#include <QtCore/QEvent>          // for QEvent
-#include <QtCore/QList>           // for QList
-#include <QtCore/QObject>         // for QObject (& Q_OBJECT, slots)
-#include <QtCore/QString>         // for QString
-#include <QtCore/QStringList>     // for QStringList
-#include <QtCore/QTranslator>     // for QTranslator
-#include <QtGui/QCloseEvent>      // for QCloseEvent
-#include <QtGui/QDragEnterEvent>  // for QDragEnterEvent
-#include <QtGui/QDropEvent>       // for QDropEvent
-#include <QtGui/QPixmap>          // for QPixmap
-#include <QtWidgets/QAction>      // for QAction
-#include <QtWidgets/QComboBox>    // for QComboBox
-#include <QtWidgets/QLabel>       // for QLabel
-#include <QtWidgets/QLineEdit>    // for QLineEdit
-#include <QtWidgets/QMainWindow>  // for QMainWindow
-#include <QtWidgets/QWidget>      // for QWidget
+#include <QEvent>                 // for QEvent
+#include <QList>                  // for QList
+#include <QObject>                // for QObject (& Q_OBJECT, slots)
+#include <QString>                // for QString
+#include <QStringList>            // for QStringList
+#include <QTranslator>            // for QTranslator
+#include <QCloseEvent>            // for QCloseEvent
+#include <QDragEnterEvent>        // for QDragEnterEvent
+#include <QDropEvent>             // for QDropEvent
+#include <QPixmap>                // for QPixmap
+#include <QAction>                // for QAction
+#include <QComboBox>              // for QComboBox
+#include <QLabel>                 // for QLabel
+#include <QLineEdit>              // for QLineEdit
+#include <QMainWindow>            // for QMainWindow
+#include <QWidget>                // for QWidget
 
 #include "babeldata.h"            // for BabelData
 #include "filterdata.h"           // for AllFiltersData

--- a/gui/processwait.cc
+++ b/gui/processwait.cc
@@ -22,12 +22,12 @@
 //------------------------------------------------------------------------
 #include "processwait.h"
 
-#include <QtCore/QByteArray>          // for QByteArray
-#include <QtCore/Qt>                  // for Horizontal, WindowContextHelpButtonHint
-#include <QtGui/QTextCursor>          // for QTextCursor, QTextCursor::End
-#include <QtWidgets/QAbstractButton>  // for QAbstractButton
-#include <QtWidgets/QPushButton>      // for QPushButton
-#include <QtWidgets/QVBoxLayout>      // for QVBoxLayout
+#include <QByteArray>                 // for QByteArray
+#include <Qt>                         // for Horizontal, WindowContextHelpButtonHint
+#include <QTextCursor>                // for QTextCursor, QTextCursor::End
+#include <QAbstractButton>            // for QAbstractButton
+#include <QPushButton>                // for QPushButton
+#include <QVBoxLayout>                // for QVBoxLayout
 
 #include <cstdlib>                    // for abs
 #include <string>                     // for string

--- a/gui/processwait.h
+++ b/gui/processwait.h
@@ -23,17 +23,17 @@
 #ifndef PROCESSWAIT_H
 #define PROCESSWAIT_H
 
-#include <QtCore/QByteArray>           // for QByteArray
-#include <QtCore/QObject>              // for QObject
-#include <QtCore/QProcess>             // for QProcess, QProcess::ExitStatus, QProcess::ProcessError
-#include <QtCore/QString>              // for QString
-#include <QtCore/QTimer>               // for QTimer
-#include <QtGui/QCloseEvent>           // for QCloseEvent
-#include <QtWidgets/QDialog>           // for QDialog
-#include <QtWidgets/QDialogButtonBox>  // for QDialogButtonBox
-#include <QtWidgets/QPlainTextEdit>    // for QPlainTextEdit
-#include <QtWidgets/QProgressBar>      // for QProgressBar
-#include <QtWidgets/QWidget>           // for QWidget
+#include <QByteArray>                  // for QByteArray
+#include <QObject>                     // for QObject
+#include <QProcess>                    // for QProcess, QProcess::ExitStatus, QProcess::ProcessError
+#include <QString>                     // for QString
+#include <QTimer>                      // for QTimer
+#include <QCloseEvent>                 // for QCloseEvent
+#include <QDialog>                     // for QDialog
+#include <QDialogButtonBox>            // for QDialogButtonBox
+#include <QPlainTextEdit>              // for QPlainTextEdit
+#include <QProgressBar>                // for QProgressBar
+#include <QWidget>                     // for QWidget
 
 
 //------------------------------------------------------------------------

--- a/gui/runmachine.cc
+++ b/gui/runmachine.cc
@@ -19,11 +19,11 @@
 
 #include "runmachine.h"
 
-#include <QtCore/QDebug>             // for qDebug
-#include <QtCore/QEventLoop>         // for QEventLoop
-#include <QtCore/QNonConstOverload>  // for QNonConstOverload
-#include <QtCore/QtGlobal>           // for QOverload, qOverload
-#include <QtWidgets/QDialog>         // for QDialog
+#include <QDebug>                    // for qDebug
+#include <QEventLoop>                // for QEventLoop
+#include <QNonConstOverload>         // for QNonConstOverload
+#include <QtGlobal>                  // for QOverload, qOverload
+#include <QDialog>                   // for QDialog
 
 #include "appname.h"                 // for appName
 

--- a/gui/runmachine.h
+++ b/gui/runmachine.h
@@ -20,11 +20,11 @@
 #ifndef RUNMACHINE_H
 #define RUNMACHINE_H
 
-#include <QtCore/QObject>      // for QObject
-#include <QtCore/QProcess>     // for QProcess, QProcess::ExitStatus, QProcess::ProcessError, qt_getEnumName
-#include <QtCore/QString>      // for QString
-#include <QtCore/QStringList>  // for QStringList
-#include <QtWidgets/QWidget>   // for QWidget
+#include <QObject>             // for QObject
+#include <QProcess>            // for QProcess, QProcess::ExitStatus, QProcess::ProcessError, qt_getEnumName
+#include <QString>             // for QString
+#include <QStringList>         // for QStringList
+#include <QWidget>             // for QWidget
 
 #include <optional>            // for optional, nullopt
 

--- a/gui/serial_unix.cc
+++ b/gui/serial_unix.cc
@@ -23,11 +23,11 @@
 #ifdef HAVE_UDEV
 #include <libudev.h>            // for udev_device_get_property_value, udev_device_get_devnode, udev_device_new_from_syspath, udev_device_unref, udev_enumerate_add_match_subsystem, udev_enumerate_get_list_entry, udev_enumerate_new, udev_enumerate_scan_devices, udev_enumerate_unref, udev_list_ent...
 
-#include <QtCore/QDebug>        // for QDebug
-#include <QtCore/QSet>          // for QSet
-#include <QtCore/QString>       // for QString, operator==
-#include <QtCore/QStringList>   // for QStringList
-#include <QtWidgets/QComboBox>  // for QComboBox
+#include <QDebug>               // for QDebug
+#include <QSet>                 // for QSet
+#include <QString>              // for QString, operator==
+#include <QStringList>          // for QStringList
+#include <QComboBox>            // for QComboBox
 
 #include "mainwindow.h"         // for MainWindow
 

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -20,20 +20,20 @@
  */
 
 #include "upgrade.h"
-#include <QtCore/qglobal.h>                 // for qDebug
-#include <QtCore/QByteArray>                // for QByteArray
-#include <QtCore/QDebug>                    // for QDebug
-#include <QtCore/QLocale>                   // for QLocale
-#include <QtCore/QSysInfo>                  // for QSysInfo
-#include <QtCore/QUrl>                      // for QUrl
-#include <QtCore/QVariant>                  // for QVariant
-#include <QtCore/QVersionNumber>            // for QVersionNumber, operator<, operator==
-#include <QtCore/Qt>                        // for ISODate, RichText
-#include <QtGui/QDesktopServices>           // for QDesktopServices
-#include <QtNetwork/QNetworkAccessManager>  // for QNetworkAccessManager
-#include <QtNetwork/QNetworkReply>          // for QNetworkReply, QNetworkReply::NoError
-#include <QtNetwork/QNetworkRequest>        // for QNetworkRequest, QNetworkRequest::ContentTypeHeader, QNetworkRequest::HttpReasonPhraseAttribute, QNetworkRequest::HttpStatusCodeAttribute, QNetworkRequest::NoLessSafeRedirectPolicy, QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::Redi...
-#include <QtWidgets/QMessageBox>            // for QMessageBox, QMessageBox::Yes, operator|, QMessageBox::No
+#include <qglobal.h>                        // for qDebug
+#include <QByteArray>                       // for QByteArray
+#include <QDebug>                           // for QDebug
+#include <QLocale>                          // for QLocale
+#include <QSysInfo>                         // for QSysInfo
+#include <QUrl>                             // for QUrl
+#include <QVariant>                         // for QVariant
+#include <QVersionNumber>                   // for QVersionNumber, operator<, operator==
+#include <Qt>                               // for ISODate, RichText
+#include <QDesktopServices>                 // for QDesktopServices
+#include <QNetworkAccessManager>            // for QNetworkAccessManager
+#include <QNetworkReply>                    // for QNetworkReply, QNetworkReply::NoError
+#include <QNetworkRequest>                  // for QNetworkRequest, QNetworkRequest::ContentTypeHeader, QNetworkRequest::HttpReasonPhraseAttribute, QNetworkRequest::HttpStatusCodeAttribute, QNetworkRequest::NoLessSafeRedirectPolicy, QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::Redi...
+#include <QMessageBox>                      // for QMessageBox, QMessageBox::Yes, operator|, QMessageBox::No
 #include <QtXml/QDomDocument>               // for QDomDocument
 #include <QtXml/QDomElement>                // for QDomElement
 #include <QtXml/QDomNode>                   // for QDomNode

--- a/gui/upgrade.h
+++ b/gui/upgrade.h
@@ -19,14 +19,14 @@
 
  */
 
-#include <QtCore/QDateTime>                 // for QDateTime
-#include <QtCore/QList>                     // for QList
-#include <QtCore/QObject>                   // for QObject
-#include <QtCore/QString>                   // for QString
-#include <QtCore/QUrl>                      // for QUrl
-#include <QtNetwork/QNetworkAccessManager>  // for QNetworkAccessManager
-#include <QtNetwork/QNetworkReply>          // for QNetworkReply
-#include <QtWidgets/QWidget>                // for QWidget
+#include <QDateTime>                        // for QDateTime
+#include <QList>                            // for QList
+#include <QObject>                          // for QObject
+#include <QString>                          // for QString
+#include <QUrl>                             // for QUrl
+#include <QNetworkAccessManager>            // for QNetworkAccessManager
+#include <QNetworkReply>                    // for QNetworkReply
+#include <QWidget>                          // for QWidget
 #include "babeldata.h"                      // for BabelData
 #include "format.h"                         // for Format
 

--- a/height.h
+++ b/height.h
@@ -26,7 +26,7 @@
 
 #include <cstdint>         // for int8_t in heightgrid.h
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"          // for arglist_t, ARG_NOMINMAX, ARGTYPE_BEGIN_REQ, ARGTYPE_BOOL, ARGTYPE_END_REQ, ARGTYPE_FLOAT, Waypoint
 #include "filter.h"        // for Filter

--- a/hiketech.cc
+++ b/hiketech.cc
@@ -22,7 +22,7 @@
 #include "defs.h"
 #include "src/core/xmlstreamwriter.h"
 #include "xmlgeneric.h"
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 #include <cstdio>
 
 static gbfile* ofd;
@@ -134,9 +134,9 @@ hiketech_format_time(const QDateTime& t)
 static void
 hiketech_trkpt_pr(const Waypoint* waypointp)
 {
-  writer.writeStartElement(QStringLiteral("pnt")); 
+  writer.writeStartElement(QStringLiteral("pnt"));
   if (waypointp->creation_time.isValid()) {
-    writer.writeTextElement(QStringLiteral("utc"), 
+    writer.writeTextElement(QStringLiteral("utc"),
                             hiketech_format_time(waypointp->GetCreationTime()));
   }
   writer.writeTextElement(QStringLiteral("lat"), QString::number(waypointp->latitude,'f', 6));
@@ -150,13 +150,13 @@ hiketech_trkpt_pr(const Waypoint* waypointp)
 static void
 hiketech_waypt_pr(const Waypoint* wpt)
 {
-  writer.writeStartElement(QStringLiteral("wpt")); 
+  writer.writeStartElement(QStringLiteral("wpt"));
   writer.setAutoFormattingIndent(-1);
   writer.writeTextElement(QStringLiteral("ident"), wpt->shortname);
   writer.writeTextElement(QStringLiteral("sym"), wpt->icon_descr);
   writer.writeTextElement(QStringLiteral("lat"), QString::number(wpt->latitude, 'f', 6));
   writer.writeTextElement(QStringLiteral("long"), QString::number(wpt->longitude, 'f', 6));
-  writer.writeStartElement(QStringLiteral("color")); 
+  writer.writeStartElement(QStringLiteral("color"));
   writer.writeTextElement(QStringLiteral("lbl"), QStringLiteral("FAFFB4"));
   writer.writeTextElement(QStringLiteral("obj"), QStringLiteral("FF8000"));
   writer.writeEndElement(); // color

--- a/html.cc
+++ b/html.cc
@@ -22,9 +22,9 @@
 #include <cstdint>
 #include <ctime>                   // for localtime
 
-#include <QtCore/QString>          // for QString, operator!=
-#include <QtCore/QVector>          // for QVector
-#include <QtCore/Qt>               // for CaseInsensitive
+#include <QString>                 // for QString, operator!=
+#include <QVector>                 // for QVector
+#include <Qt>                      // for CaseInsensitive
 
 #include "defs.h"
 #include "formspec.h"              // for FsChainFind, kFsGpx

--- a/humminbird.cc
+++ b/humminbird.cc
@@ -20,7 +20,7 @@
  */
 
 #include "defs.h"
-#include <QtCore/QMap>
+#include <QMap>
 #include <cmath>
 #include <cstdio>
 

--- a/igc.cc
+++ b/igc.cc
@@ -31,11 +31,11 @@
 #include <iterator>                  // for reverse_iterator, operator==, prev, next
 #include <optional>                  // for optional
 
-#include <QtCore/QByteArray>         // for QByteArray
-#include <QtCore/QList>              // for QList<>::const_iterator
-#include <QtCore/QStaticStringData>  // for QStaticStringData
-#include <QtCore/QString>            // for QString, operator+, QStringLiteral
-#include <QtCore/QtGlobal>           // for foreach, qPrintable
+#include <QByteArray>                // for QByteArray
+#include <QList>                     // for QList<>::const_iterator
+#include <QStaticStringData>         // for QStaticStringData
+#include <QString>                   // for QString, operator+, QStringLiteral
+#include <QtGlobal>                  // for foreach, qPrintable
 
 #include "defs.h"
 #include "cet_util.h"                // for cet_convert_init
@@ -501,7 +501,7 @@ static void detect_other_track(const route_head* rh)
   }
   // Find other track with the most waypoints
   if (rh->rte_waypt_ct > max_waypt_ct &&
-      (rh->rte_name.isEmpty() || 
+      (rh->rte_name.isEmpty() ||
        (!rh->rte_name.startsWith(PRESTRKNAME) &&
        !rh->rte_name.startsWith(GNSSTRKNAME)))) {
     head = rh;
@@ -683,7 +683,7 @@ static void wr_task_hdr(const route_head* rte)
   }
 
   if (!rte->rte_desc.isEmpty()) {
-    // desc will be something like "IGCDATE160701: 500KTri" 
+    // desc will be something like "IGCDATE160701: 500KTri"
     sscanf(CSTR(rte->rte_desc), DATEMAGIC "%6[0-9]: %s", flight_date, task_desc);
   }
 

--- a/ignrando.cc
+++ b/ignrando.cc
@@ -21,7 +21,7 @@
 
 #include "defs.h"
 #include "xmlgeneric.h"
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 #include <cstdio>
 
 #define MYNAME "IGNRando"

--- a/igo8.cc
+++ b/igo8.cc
@@ -67,10 +67,10 @@
 #include <cstdlib>              // for atoi
 #include <cstring>              // for memset
 
-#include <QtCore/QChar>         // for QChar
-#include <QtCore/QString>       // for QString
-#include <QtCore/QVector>       // for QVector
-#include <QtCore/QtGlobal>      // for ushort
+#include <QChar>                // for QChar
+#include <QString>              // for QString
+#include <QVector>              // for QVector
+#include <QtGlobal>             // for ushort
 
 #include "defs.h"
 #include "gbfile.h"             // for gbfwrite, gbfclose, gbfseek, gbfgetint32, gbfread, gbfile, gbfopen_le

--- a/ik3d.cc
+++ b/ik3d.cc
@@ -23,7 +23,7 @@
 
 #include "defs.h"
 #include "xmlgeneric.h"
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 
 static QVector<arglist_t> ikt_args = {
 };

--- a/inifile.cc
+++ b/inifile.cc
@@ -21,16 +21,16 @@
 #include "defs.h"              // for fatal, ugetenv, warning
 #include "inifile.h"
 #include "src/core/file.h"     // for File
-#include <QtCore/QByteArray>   // for QByteArray
-#include <QtCore/QChar>        // for operator==, QChar
-#include <QtCore/QDir>         // for QDir
-#include <QtCore/QFile>        // for QFile
-#include <QtCore/QFileInfo>    // for QFileInfo
-#include <QtCore/QHash>        // for QHash
-#include <QtCore/QIODevice>    // for QIODevice::ReadOnly, QIODevice
-#include <QtCore/QTextStream>  // for QTextStream
-#include <QtCore/Qt>           // for CaseInsensitive
-#include <QtCore/QtGlobal>     // for qPrintable
+#include <QByteArray>          // for QByteArray
+#include <QChar>               // for operator==, QChar
+#include <QDir>                // for QDir
+#include <QFile>               // for QFile
+#include <QFileInfo>           // for QFileInfo
+#include <QHash>               // for QHash
+#include <QIODevice>           // for QIODevice::ReadOnly, QIODevice
+#include <QTextStream>         // for QTextStream
+#include <Qt>                  // for CaseInsensitive
+#include <QtGlobal>            // for qPrintable
 #include <utility>
 
 #define MYNAME "inifile"

--- a/inifile.h
+++ b/inifile.h
@@ -21,9 +21,9 @@
 #ifndef HAVE_INIFILE_H
 #define HAVE_INIFILE_H
 
-#include <QtCore/QHash>    // for QHash
-#include <QtCore/QList>    // for QList
-#include <QtCore/QString>  // for QString
+#include <QHash>           // for QHash
+#include <QList>           // for QList
+#include <QString>         // for QString
 
 class InifileSection;
 struct inifile_t {

--- a/internal_styles.cc
+++ b/internal_styles.cc
@@ -1,7 +1,7 @@
 /* This file is machine-generated from the contents of style/ */
 /* by mkstyle.sh.   Editing it by hand is an exceedingly bad idea. */
 
-#include <QtCore/QVector>
+#include <QVector>
 #include "defs.h"
 #if CSVFMTS_ENABLED
 static char arc[] =

--- a/interpolate.cc
+++ b/interpolate.cc
@@ -24,8 +24,8 @@
 #include <cstdlib>              // for abs, atoi, strtod
 #include <optional>             // for optional
 
-#include <QtCore/QString>       // for QString
-#include <QtCore/QtGlobal>      // for qAsConst, QAddConst<>::Type
+#include <QString>              // for QString
+#include <QtGlobal>             // for qAsConst, QAddConst<>::Type
 
 #include "defs.h"
 #include "interpolate.h"

--- a/interpolate.h
+++ b/interpolate.h
@@ -24,8 +24,8 @@
 
 #include <optional>             // for optional
 
-#include <QtCore/QVector>       // for QVector
-#include <QtCore/QtGlobal>      // for qint64
+#include <QVector>              // for QVector
+#include <QtGlobal>             // for qint64
 
 #include "defs.h"               // for ARG_NOMINMAX, arglist_t, ARGTYPE_BEGIN_EXCL, ARG...
 #include "filter.h"             // for Filter

--- a/itracku.cc
+++ b/itracku.cc
@@ -36,13 +36,13 @@
 #include <cstring>                 // for memcpy, strcmp, strlen, strncmp
 #include <ctime>                   // for gmtime
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QDate>            // for QDate
-#include <QtCore/QDateTime>        // for QDateTime
-#include <QtCore/QString>          // for QString
-#include <QtCore/QTime>            // for QTime
-#include <QtCore/Qt>               // for UTC
-#include <QtCore/QtGlobal>         // for qPrintable
+#include <QByteArray>              // for QByteArray
+#include <QDate>                   // for QDate
+#include <QDateTime>               // for QDateTime
+#include <QString>                 // for QString
+#include <QTime>                   // for QTime
+#include <Qt>                      // for UTC
+#include <QtGlobal>                // for qPrintable
 
 #include "defs.h"
 #include "gbser.h"                 // for gbser_read_line, gbser_write, gbser_deinit, gbser_flush, gbser_init, gbser_is_serial, gbser_read_wait, gbser_ERROR, gbser_OK
@@ -276,7 +276,7 @@ decode_itracku_time(uint32_t date)
   int day = (date >> 17) & 31;
   int month = ((date >> 22) & 15);
   int year = ((date >> 26) & 63) + 2000;
-  QDate qdate(year, month, day); 
+  QDate qdate(year, month, day);
 
   return QDateTime(qdate, qtime, Qt::UTC);
 }

--- a/jeeps/gpsapp.cc
+++ b/jeeps/gpsapp.cc
@@ -30,7 +30,7 @@
 #include <cstring>
 #include <ctime>
 
-#include <QtCore/QDateTime>
+#include <QDateTime>
 
 /*
  * This violates the layering design, but is needed for device discovery.
@@ -329,7 +329,7 @@ static int32 GPS_A000(const char* port)
 
         // Garmin 276C serial - not USB - sees a zero here, so we changed
         // <= 0 to <0 on 2014-06-29 per Pierre Brial.
-         
+
         if (GPS_Packet_Read(fd, &rec) < 0) {
           goto carry_on;
         }
@@ -7590,7 +7590,7 @@ int32 GPS_Set_Baud_Rate(const char* port, int br)
 {
 
   gpsdevh* fd;
-  
+
   if (!GPS_Device_On(port, &fd)) {
     return gps_errno;
   }
@@ -7601,7 +7601,7 @@ int32 GPS_Set_Baud_Rate(const char* port, int br)
   if (!GPS_Device_Off(fd)) {
     return gps_errno;
   }
-  
+
   return 0;
 
 }

--- a/jeeps/gpsserial.cc
+++ b/jeeps/gpsserial.cc
@@ -26,7 +26,7 @@
 #include "jeeps/gps.h"
 #include "gbser.h"
 #include "jeeps/gpsserial.h"
-#include <QtCore/QThread>
+#include <QThread>
 #include <cerrno>
 #include <cstdio>
 #include <ctime>

--- a/jeeps/gpsusbread.cc
+++ b/jeeps/gpsusbread.cc
@@ -75,7 +75,7 @@ do_over:
    * haven't been observed so far.
    * 484 = Forerunner 305
    * 450 = Edge 205, confirmed with Ian Dent on 2015/11/16.
-   * All Edge, Forerunner, and Foretracker [23]05 are probably 
+   * All Edge, Forerunner, and Foretracker [23]05 are probably
    * similarly affected, but we don't know their device ID.
    */
   if ((gps_save_id == 484 || gps_save_id == 450)

--- a/jogmap.cc
+++ b/jogmap.cc
@@ -25,7 +25,7 @@
 #include "garmin_tables.h"
 #include "jeeps/gpsmath.h"
 #include "xmlgeneric.h"
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 
 static route_head* trk;
 

--- a/jtr.cc
+++ b/jtr.cc
@@ -21,7 +21,7 @@
  */
 #include "defs.h"
 #include "csv_util.h"
-#include <QtCore/QHash>
+#include <QHash>
 //#include <cassert>
 #include <cmath>
 #include <cstdio>

--- a/kml.cc
+++ b/kml.cc
@@ -28,20 +28,20 @@
 #include <optional>                     // for optional
 #include <tuple>                        // for tuple, make_tuple, tie
 
-#include <QtCore/QByteArray>            // for QByteArray
-#include <QtCore/QChar>                 // for QChar
-#include <QtCore/QDate>                 // for QDate
-#include <QtCore/QDateTime>             // for QDateTime
-#include <QtCore/QFile>                 // for QFile
-#include <QtCore/QIODevice>             // for operator|, QIODevice, QIODevice::Text, QIODevice::WriteOnly
-#include <QtCore/QList>                 // for QList
-#include <QtCore/QStaticStringData>     // for QStaticStringData
-#include <QtCore/QString>               // for QString, QStringLiteral, operator+, operator!=
-#include <QtCore/QStringList>           // for QStringList
-#include <QtCore/QVector>               // for QVector
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
-#include <QtCore/Qt>                    // for ISODate
-#include <QtCore/QtGlobal>              // for foreach, qint64, qPrintable
+#include <QByteArray>                   // for QByteArray
+#include <QChar>                        // for QChar
+#include <QDate>                        // for QDate
+#include <QDateTime>                    // for QDateTime
+#include <QFile>                        // for QFile
+#include <QIODevice>                    // for operator|, QIODevice, QIODevice::Text, QIODevice::WriteOnly
+#include <QList>                        // for QList
+#include <QStaticStringData>            // for QStaticStringData
+#include <QString>                      // for QString, QStringLiteral, operator+, operator!=
+#include <QStringList>                  // for QStringList
+#include <QVector>                      // for QVector
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
+#include <Qt>                           // for ISODate
+#include <QtGlobal>                     // for foreach, qint64, qPrintable
 
 #include "defs.h"
 #include "kml.h"

--- a/kml.h
+++ b/kml.h
@@ -24,10 +24,10 @@
 
 #include <tuple>                        // for tuple, make_tuple, tie
 
-#include <QtCore/QList>                 // for QList
-#include <QtCore/QString>               // for QString, QStringLiteral, operator+, operator!=
-#include <QtCore/QVector>               // for QVector
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QList>                        // for QList
+#include <QString>                      // for QString, QStringLiteral, operator+, operator!=
+#include <QVector>                      // for QVector
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 #include "defs.h"
 #include "format.h"

--- a/lmx.cc
+++ b/lmx.cc
@@ -26,8 +26,8 @@
  * we don't implement that at this time in GPSBabel.
  */
 
-#include <QtCore/QString>               // for QString
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QString>                      // for QString
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 #include "defs.h"
 #include "gbfile.h"                     // for gbfputc, gbfprintf, gbfclose, gbfopen, gbfputcstr, gbfputs, gbfile, gbfputuint16

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -92,18 +92,18 @@
 #include <cstring>                // for strcmp, strlen
 #include <ctime>                  // for time_t
 
-#include <QtCore/QByteArray>      // for QByteArray
-#include <QtCore/QDate>           // for QDate
-#include <QtCore/QDateTime>       // for QDateTime
-#include <QtCore/QLatin1String>   // for QLatin1String
-#include <QtCore/QList>           // for QList
-#include <QtCore/QScopedPointer>  // for QScopedPointer
-#include <QtCore/QString>         // for QString, operator+, operator==, operator!=
-#include <QtCore/QTextCodec>      // for QTextCodec, QTextCodec::IgnoreHeader
-#include <QtCore/QTextEncoder>    // for QTextEncoder
-#include <QtCore/QTime>           // for QTime
-#include <QtCore/Qt>              // for CaseInsensitive, UTC
-#include <QtCore/QtGlobal>        // for qPrintable, uint, qAsConst, QAddConst<>::Type
+#include <QByteArray>             // for QByteArray
+#include <QDate>                  // for QDate
+#include <QDateTime>              // for QDateTime
+#include <QLatin1String>          // for QLatin1String
+#include <QList>                  // for QList
+#include <QScopedPointer>         // for QScopedPointer
+#include <QString>                // for QString, operator+, operator==, operator!=
+#include <QTextCodec>             // for QTextCodec, QTextCodec::IgnoreHeader
+#include <QTextEncoder>           // for QTextEncoder
+#include <QTime>                  // for QTime
+#include <Qt>                     // for CaseInsensitive, UTC
+#include <QtGlobal>               // for qPrintable, uint, qAsConst, QAddConst<>::Type
 
 #include "defs.h"
 #include "lowranceusr.h"

--- a/lowranceusr.h
+++ b/lowranceusr.h
@@ -90,12 +90,12 @@
 #include <cmath>                  // for M_PI, round, atan, exp, log, tan
 #include <ctime>                  // for time_t
 
-#include <QtCore/QList>         // for QList
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTextCodec>    // for QTextCodec
-#include <QtCore/QVector>       // for QVector
-#include <QtCore/Qt>            // for CaseInsensitive
-#include <QtCore/QtGlobal>      // for uint
+#include <QList>                // for QList
+#include <QString>              // for QString
+#include <QTextCodec>           // for QTextCodec
+#include <QVector>              // for QVector
+#include <Qt>                   // for CaseInsensitive
+#include <QtGlobal>             // for uint
 
 #include "defs.h"
 #include "format.h"

--- a/magellan.h
+++ b/magellan.h
@@ -20,7 +20,7 @@
 #ifndef MAGELLAN_H_INCLUDED_
 #define MAGELLAN_H_INCLUDED_
 
-#include <QtCore/QString>
+#include <QString>
 #include "defs.h"
 
 /*

--- a/maggeo.cc
+++ b/maggeo.cc
@@ -22,7 +22,7 @@
 #include "defs.h"
 #include "csv_util.h"
 #include "magellan.h"
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/magproto.cc
+++ b/magproto.cc
@@ -27,20 +27,20 @@
 #include <cstdlib>                 // for atoi, atof, strtoul
 #include <cstring>                 // for strchr, strncmp, strlen, memmove, strrchr, memset
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QDateTime>        // for QDateTime
-#include <QtCore/QDir>             // for QDir, operator|, QDir::Files, QDir::Name, QDir::Readable
-#include <QtCore/QFileInfo>        // for QFileInfo
-#include <QtCore/QFileInfoList>    // for QFileInfoList
-#include <QtCore/QLatin1String>    // for QLatin1String
-#include <QtCore/QList>            // for QList
-#include <QtCore/QScopedPointer>   // for QScopedPointer
-#include <QtCore/QString>          // for QString, operator==
-#include <QtCore/QStringList>      // for QStringList
-#include <QtCore/QTime>            // for QTime
-#include <QtCore/QVector>          // for QVector
-#include <QtCore/Qt>               // for CaseInsensitive
-#include <QtCore/QtGlobal>         // for qPrintable, foreach
+#include <QByteArray>              // for QByteArray
+#include <QDateTime>               // for QDateTime
+#include <QDir>                    // for QDir, operator|, QDir::Files, QDir::Name, QDir::Readable
+#include <QFileInfo>               // for QFileInfo
+#include <QFileInfoList>           // for QFileInfoList
+#include <QLatin1String>           // for QLatin1String
+#include <QList>                   // for QList
+#include <QScopedPointer>          // for QScopedPointer
+#include <QString>                 // for QString, operator==
+#include <QStringList>             // for QStringList
+#include <QTime>                   // for QTime
+#include <QVector>                 // for QVector
+#include <Qt>                      // for CaseInsensitive
+#include <QtGlobal>                // for qPrintable, foreach
 
 #include "defs.h"
 #include "explorist_ini.h"         // for explorist_ini_done, explorist_ini_get, mag_info
@@ -1409,7 +1409,7 @@ void mag_track_disp(const Waypoint* waypointp)
 
   double ilat = waypointp->latitude;
   double ilon = waypointp->longitude;
-  
+
   QByteArray dmy("");
   QByteArray hms("");
   if (waypointp->creation_time.isValid()) {

--- a/main.cc
+++ b/main.cc
@@ -22,21 +22,21 @@
 #include <cstdio>                     // for printf, fflush, fgetc, fprintf, stderr, stdin, stdout
 #include <cstring>                    // for strcmp
 
-#include <QtCore/QByteArray>          // for QByteArray
-#include <QtCore/QChar>               // for QChar
-#include <QtCore/QCoreApplication>    // for QCoreApplication
-#include <QtCore/QFile>               // for QFile
-#include <QtCore/QIODevice>           // for QIODevice::ReadOnly
-#include <QtCore/QLocale>             // for QLocale
-#include <QtCore/QMessageLogContext>  // for QMessageLogContext
-#include <QtCore/QStack>              // for QStack
-#include <QtCore/QString>             // for QString
-#include <QtCore/QStringList>         // for QStringList
-#include <QtCore/QSysInfo>            // for QSysInfo
-#include <QtCore/QTextCodec>          // for QTextCodec
-#include <QtCore/QTextStream>         // for QTextStream
-#include <QtCore/QtConfig>            // for QT_VERSION_STR
-#include <QtCore/QtGlobal>            // for qPrintable, qVersion, QT_VERSION, QT_VERSION_CHECK
+#include <QByteArray>                 // for QByteArray
+#include <QChar>                      // for QChar
+#include <QCoreApplication>           // for QCoreApplication
+#include <QFile>                      // for QFile
+#include <QIODevice>                  // for QIODevice::ReadOnly
+#include <QLocale>                    // for QLocale
+#include <QMessageLogContext>         // for QMessageLogContext
+#include <QStack>                     // for QStack
+#include <QString>                    // for QString
+#include <QStringList>                // for QStringList
+#include <QSysInfo>                   // for QSysInfo
+#include <QTextCodec>                 // for QTextCodec
+#include <QTextStream>                // for QTextStream
+#include <QtConfig>                   // for QT_VERSION_STR
+#include <QtGlobal>                   // for qPrintable, qVersion, QT_VERSION, QT_VERSION_CHECK
 
 #ifdef AFL_INPUT_FUZZING
 #include "argv-fuzz-inl.h"
@@ -231,7 +231,7 @@ public:
              qPrintable(wpt->shortname),
              qPrintable(wpt->description));
     }
-  
+
     if (wpt->altitude != unknown_alt) {
       printf(" %f", wpt->altitude);
     }

--- a/mapasia.cc
+++ b/mapasia.cc
@@ -23,12 +23,12 @@
 #include <cmath>                // for fabs
 #include <cstring>              // for memset
 
-#include <QtCore/QDate>         // for QDate
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTime>         // for QTime
-#include <QtCore/Qt>            // for UTC
-#include <QtCore/QtGlobal>      // for foreach
+#include <QDate>                // for QDate
+#include <QDateTime>            // for QDateTime
+#include <QString>              // for QString
+#include <QTime>                // for QTime
+#include <Qt>                   // for UTC
+#include <QtGlobal>             // for foreach
 
 #include "defs.h"
 #include "gbfile.h"             // for gbfclose, gbfeof, gbfgetint32, gbfputint32, gbfread, gbfwrite, gbfile, gbfopen_le

--- a/mapbar_track.cc
+++ b/mapbar_track.cc
@@ -23,11 +23,11 @@
 
 #include <cstdio>               // for SEEK_CUR
 
-#include <QtCore/QChar>         // for QChar
-#include <QtCore/QDate>         // for QDate
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTime>         // for QTime
-#include <QtCore/QVector>       // for QVector
+#include <QChar>                // for QChar
+#include <QDate>                // for QDate
+#include <QString>              // for QString
+#include <QTime>                // for QTime
+#include <QVector>              // for QVector
 
 #include "defs.h"
 #include "gbfile.h"             // for gbfgetint16, gbfgetint32, gbfseek, gbfclose, gbfopen, gbfile

--- a/mapfactor.cc
+++ b/mapfactor.cc
@@ -19,9 +19,9 @@
 #include "defs.h"
 #include "src/core/file.h"
 #include "src/core/xmlstreamwriter.h"
-#include <QtCore/QDebug>
-#include <QtCore/QXmlStreamReader>
-#include <QtCore/QXmlStreamWriter>
+#include <QDebug>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
 
 static gpsbabel::File* oqfile;
 static QXmlStreamWriter* writer;

--- a/mapsend.cc
+++ b/mapsend.cc
@@ -24,10 +24,10 @@
 #include <cstring>              // for strncpy
 #include <ctime>
 
-#include <QtCore/QCharRef>      // for QCharRef
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTime>         // for QTime
-#include <QtCore/QtGlobal>      // for Q_UNUSED
+#include <QCharRef>             // for QCharRef
+#include <QString>              // for QString
+#include <QTime>                // for QTime
+#include <QtGlobal>             // for Q_UNUSED
 
 #include "defs.h"
 #include "mapsend.h"

--- a/mkicondoc.cc
+++ b/mkicondoc.cc
@@ -6,7 +6,7 @@
 #include <cstdio>                // for printf
 #include <cstring>               // for strcmp
 
-#include <QtCore/QVector>        // for QVector<>::iterator, QVector
+#include <QVector>               // for QVector<>::iterator, QVector
 
 #include "garmin_icon_tables.h"  // for garmin_icon_table, garmin_smart_icon_table
 #include "garmin_tables.h"       // for icon_mapping_t
@@ -21,7 +21,7 @@ int main()
   for (const icon_mapping_t* entry = garmin_smart_icon_table; entry->icon; entry++) {
     table.append(*entry);
   }
-  
+
   auto sort_lambda = [](const icon_mapping_t& a, const icon_mapping_t& b)->bool {
     return strcmp(a.icon, b.icon) < 0;
   };

--- a/mkshort.cc
+++ b/mkshort.cc
@@ -23,9 +23,9 @@
 #include <cstdio>           // for sprintf, size_t
 #include <cstring>          // for strlen, memmove, strchr, strcpy, strncmp, strcat, strncpy
 
-#include <QtCore/QList>     // for QList
-#include <QtCore/QString>   // for QString
-#include <QtCore/QtGlobal>  // for foreach
+#include <QList>            // for QList
+#include <QString>          // for QString
+#include <QtGlobal>         // for foreach
 
 #include "defs.h"
 #include "cet.h"            // for cet_utf8_strdup, cet_utf8_strlen, cet_utf8_strndup

--- a/mkstyle.sh
+++ b/mkstyle.sh
@@ -2,7 +2,7 @@
 
 echo "/* This file is machine-generated from the contents of style/ */"
 echo "/* by mkstyle.sh.   Editing it by hand is an exceedingly bad idea. */"
-echo 
+echo
 
 # set the locale for sorting so that the collate order doesn't depend
 # on the users environment.
@@ -30,7 +30,7 @@ else
   exit 1
 fi
 
-echo "#include <QtCore/QVector>"
+echo "#include <QVector>"
 echo "#include \"defs.h\""
 echo "#if CSVFMTS_ENABLED"
 for i in "$(dirname "$0")"/style/*.style

--- a/mmo.cc
+++ b/mmo.cc
@@ -29,19 +29,19 @@
 #include <cstring>               // for strcmp, strlen, memset, strchr, strncmp
 #include <ctime>
 
-#include <QtCore/QByteArray>     // for QByteArray
-#include <QtCore/QChar>          // for operator==, QChar
-#include <QtCore/QCharRef>       // for QCharRef
-#include <QtCore/QDateTime>      // for QDateTime
-#include <QtCore/QHash>          // for QHash, QHash<>::const_iterator
-#include <QtCore/QLatin1String>  // for QLatin1String
-#include <QtCore/QScopedPointer> // for QScopedPointer
-#include <QtCore/QString>        // for QString, operator==
-#include <QtCore/QTextCodec>     // for QTextCodec, QTextCodec::IgnoreHeader
-#include <QtCore/QTextEncoder>   // for QTextEncoder
-#include <QtCore/QVector>        // for QVector
-#include <QtCore/Qt>             // for CaseInsensitive
-#include <QtCore/QtGlobal>       // for qAsConst, QAddConst<>::Type, foreach, Q_UNUSED
+#include <QByteArray>            // for QByteArray
+#include <QChar>                 // for operator==, QChar
+#include <QCharRef>              // for QCharRef
+#include <QDateTime>             // for QDateTime
+#include <QHash>                 // for QHash, QHash<>::const_iterator
+#include <QLatin1String>         // for QLatin1String
+#include <QScopedPointer>        // for QScopedPointer
+#include <QString>               // for QString, operator==
+#include <QTextCodec>            // for QTextCodec, QTextCodec::IgnoreHeader
+#include <QTextEncoder>          // for QTextEncoder
+#include <QVector>               // for QVector
+#include <Qt>                    // for CaseInsensitive
+#include <QtGlobal>              // for qAsConst, QAddConst<>::Type, foreach, Q_UNUSED
 
 #include "defs.h"
 #include "gbfile.h"              // for gbfputc, gbfgetuint16, gbfgetc, gbfgetdbl, gbfgetuint32, gbfputflt, gbfputuint32, gbfgetint16, gbfputdbl, gbfputuint16, gbfclose, gbfread, gbfseek, gbfputint16, gbfwrite, gbfcopyfrom, gbfeof, gbfgetflt, gbfgetint32, gbfile, gbfopen, gbfrewind, gbsize_t

--- a/mtk_logger.cc
+++ b/mtk_logger.cc
@@ -57,9 +57,9 @@
 #include "defs.h"
 #include "gbfile.h" /* used for csv output */
 #include "gbser.h"
-#include <QtCore/QDir>
-#include <QtCore/QFile>
-#include <QtCore/QThread>
+#include <QDir>
+#include <QFile>
+#include <QThread>
 #include <cerrno>
 #include <cmath>
 #include <cstdlib>

--- a/mynav.cc
+++ b/mynav.cc
@@ -23,12 +23,12 @@
 
  */
 
-#include <QtCore/QChar>
-#include <QtCore/QDebug>
-#include <QtCore/QIODevice>
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QtGlobal>
+#include <QChar>
+#include <QDebug>
+#include <QIODevice>
+#include <QString>
+#include <QStringList>
+#include <QtGlobal>
 
 #include <src/core/textstream.h>
 

--- a/mynav.h
+++ b/mynav.h
@@ -23,8 +23,8 @@
 #ifndef MYNAV_H_INCLUDED_
 #define MYNAV_H_INCLUDED_
 
-#include <QtCore/QString>
-#include <QtCore/QVector>
+#include <QString>
+#include <QVector>
 
 #include "defs.h"
 #include "format.h"

--- a/navicache.cc
+++ b/navicache.cc
@@ -19,7 +19,7 @@
 #include "defs.h"
 #include "cet_util.h"
 #include "src/core/file.h"
-#include <QtCore/QXmlStreamReader>
+#include <QXmlStreamReader>
 
 static char* noretired = nullptr;
 static QString read_fname;

--- a/navilink.cc
+++ b/navilink.cc
@@ -26,7 +26,7 @@
 #include "gbser.h"
 #include "jeeps/gpsmath.h"
 #include "navilink.h"
-#include <QtCore/QThread>
+#include <QThread>
 
 #define MYNAME "NAVILINK"
 

--- a/nmea.cc
+++ b/nmea.cc
@@ -27,18 +27,18 @@
 #include <cstring>                 // for strncmp, strchr, strlen, strstr, memset, strrchr
 #include <iterator>                // for operator!=, reverse_iterator
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QChar>            // for QChar, operator==, operator!=
-#include <QtCore/QDateTime>        // for QDateTime
-#include <QtCore/QDebug>           // for QDebug
-#include <QtCore/QList>            // for QList
-#include <QtCore/QString>          // for QString
-#include <QtCore/QStringList>      // for QStringList
-#include <QtCore/QTextStream>      // for hex
-#include <QtCore/QThread>          // for QThread
-#include <QtCore/QTime>            // for QTime
-#include <QtCore/Qt>               // for UTC
-#include <QtCore/QtGlobal>         // for qPrintable, foreach
+#include <QByteArray>              // for QByteArray
+#include <QChar>                   // for QChar, operator==, operator!=
+#include <QDateTime>               // for QDateTime
+#include <QDebug>                  // for QDebug
+#include <QList>                   // for QList
+#include <QString>                 // for QString
+#include <QStringList>             // for QStringList
+#include <QTextStream>             // for hex
+#include <QThread>                 // for QThread
+#include <QTime>                   // for QTime
+#include <Qt>                      // for UTC
+#include <QtGlobal>                // for qPrintable, foreach
 
 #include "defs.h"
 #include "nmea.h"
@@ -643,7 +643,7 @@ NmeaFormat::gpgsa_parse(const QString& ibuf) const
     fix = fields[2][0];
   }
 
-  // 12 fields, index 3 through 14. 
+  // 12 fields, index 3 through 14.
   for (int cnt = 0; cnt <= 11; cnt++) {
     if (nfields > cnt + 3) prn[cnt] = fields[cnt + 3].toInt();
   }

--- a/nmea.h
+++ b/nmea.h
@@ -22,13 +22,13 @@
 #ifndef NMEA_H_INCLUDED_
 #define NMEA_H_INCLUDED_
 
-#include <QtCore/QByteArray>  // for QByteArray
-#include <QtCore/QDate>       // for QDate
-#include <QtCore/QDateTime>   // for QDateTime
-#include <QtCore/QList>       // for QList
-#include <QtCore/QString>     // for QString
-#include <QtCore/QTime>       // for QTime
-#include <QtCore/QVector>     // for QVector
+#include <QByteArray>         // for QByteArray
+#include <QDate>              // for QDate
+#include <QDateTime>          // for QDateTime
+#include <QList>              // for QList
+#include <QString>            // for QString
+#include <QTime>              // for QTime
+#include <QVector>            // for QVector
 
 #include "defs.h"
 #include "format.h"           // for Format

--- a/nukedata.h
+++ b/nukedata.h
@@ -23,7 +23,7 @@
 #ifndef NUKEDATA_H_INCLUDED_
 #define NUKEDATA_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for ARGTYPE_BOOL, ARG_NOMINMAX, arglist_t, ARG_TERMI...
 #include "filter.h"  // for Filter

--- a/osm.cc
+++ b/osm.cc
@@ -22,13 +22,13 @@
 
 #include <cstring>                      // for strlen, strchr, strcmp
 
-#include <QtCore/QByteArray>            // for QByteArray
-#include <QtCore/QHash>                 // for QHash
-#include <QtCore/QLatin1String>         // for QLatin1String
-#include <QtCore/QPair>                 // for QPair, operator==
-#include <QtCore/QString>               // for QString, operator==, operator+
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
-#include <QtCore/QtGlobal>              // for qPrintable, QAddConst<>::Type
+#include <QByteArray>                   // for QByteArray
+#include <QHash>                        // for QHash
+#include <QLatin1String>                // for QLatin1String
+#include <QPair>                        // for QPair, operator==
+#include <QString>                      // for QString, operator==, operator+
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
+#include <QtGlobal>                     // for qPrintable, QAddConst<>::Type
 
 #include "defs.h"
 #include "osm.h"

--- a/osm.h
+++ b/osm.h
@@ -22,12 +22,12 @@
 #ifndef OSM_H_INCLUDED_
 #define OSM_H_INCLUDED_
 
-#include <QtCore/QHash>                 // for QHash
-#include <QtCore/QList>                 // for QList
-#include <QtCore/QPair>                 // for QPair
-#include <QtCore/QString>               // for QString
-#include <QtCore/QVector>               // for QVector
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QHash>                        // for QHash
+#include <QList>                        // for QList
+#include <QPair>                        // for QPair
+#include <QString>                      // for QString
+#include <QVector>                      // for QVector
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 #include "defs.h"
 #include "format.h"                     // for Format

--- a/ozi.cc
+++ b/ozi.cc
@@ -40,18 +40,18 @@
 #include <cmath>                  // for lround
 #include <cstdlib>                // for atoi
 
-#include <QtCore/QByteArray>      // for QByteArray
-#include <QtCore/QChar>           // for operator==, QChar
-#include <QtCore/QCharRef>        // for QCharRef
-#include <QtCore/QFile>           // for QFile
-#include <QtCore/QFileInfo>       // for QFileInfo
-#include <QtCore/QIODevice>       // for operator|, QIODevice::WriteOnly, QIODevice::ReadOnly, QIODevice, QIODevice::OpenModeFlag
-#include <QtCore/QString>         // for QString
-#include <QtCore/QStringList>     // for QStringList
-#include <QtCore/QTextStream>     // for QTextStream, operator<<, qSetRealNumberPrecision, QTextStream::FixedNotation
-#include <QtCore/QVector>         // for QVector
-#include <QtCore/Qt>              // for CaseInsensitive
-#include <QtCore/QtGlobal>        // for qPrintable
+#include <QByteArray>             // for QByteArray
+#include <QChar>                  // for operator==, QChar
+#include <QCharRef>               // for QCharRef
+#include <QFile>                  // for QFile
+#include <QFileInfo>              // for QFileInfo
+#include <QIODevice>              // for operator|, QIODevice::WriteOnly, QIODevice::ReadOnly, QIODevice, QIODevice::OpenModeFlag
+#include <QString>                // for QString
+#include <QStringList>            // for QStringList
+#include <QTextStream>            // for QTextStream, operator<<, qSetRealNumberPrecision, QTextStream::FixedNotation
+#include <QVector>                // for QVector
+#include <Qt>                     // for CaseInsensitive
+#include <QtGlobal>               // for qPrintable
 
 #include "defs.h"
 #include "csv_util.h"             // for csv_stringclean
@@ -263,7 +263,7 @@ ozi_openfile(const QString& fname)
   if (stream != nullptr) {
     ozi_close_io();
   }
- 
+
   ozi_open_io(tmpname, QFile::WriteOnly);
 }
 

--- a/pcx.cc
+++ b/pcx.cc
@@ -23,17 +23,17 @@
 #include <cstdlib>                    // for atoi
 #include <cstring>                    // for strstr, strncmp
 
-#include <QtCore/QChar>               // for operator==, QChar
-#include <QtCore/QCharRef>            // for QCharRef
-#include <QtCore/QDate>               // for QDate
-#include <QtCore/QDateTime>           // for QDateTime
-#include <QtCore/QList>               // for QList
-#include <QtCore/QRegularExpression>  // for QRegularExpression
-#include <QtCore/QString>             // for QString, QString::SectionSkipEmpty
-#include <QtCore/QStringList>         // for QStringList
-#include <QtCore/QTime>               // for QTime
-#include <QtCore/QVector>             // for QVector
-#include <QtCore/Qt>                  // for CaseInsensitive, UTC
+#include <QChar>                      // for operator==, QChar
+#include <QCharRef>                   // for QCharRef
+#include <QDate>                      // for QDate
+#include <QDateTime>                  // for QDateTime
+#include <QList>                      // for QList
+#include <QRegularExpression>         // for QRegularExpression
+#include <QString>                    // for QString, QString::SectionSkipEmpty
+#include <QStringList>                // for QStringList
+#include <QTime>                      // for QTime
+#include <QVector>                    // for QVector
+#include <Qt>                         // for CaseInsensitive, UTC
 
 #include "defs.h"
 #include "cet_util.h"                 // for cet_convert_init

--- a/pocketfms_fp.cc
+++ b/pocketfms_fp.cc
@@ -19,8 +19,8 @@
 
  */
 
-#include <QtCore/QString>               // for QString
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QString>                      // for QString
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 #include "defs.h"
 #include "xmlgeneric.h"                 // for cb_cdata, xg_callback, xg_string, cb_start, cb_end, xg_cb_type, xml_deinit, xml_init, xml_read, xg_tag_mapping

--- a/polygon.cc
+++ b/polygon.cc
@@ -22,7 +22,7 @@
 #include <cstdio>           // for sscanf
 #include <cstring>          // for strchr, strlen, strspn
 
-#include <QtCore/QtGlobal>  // for foreach
+#include <QtGlobal>         // for foreach
 
 #include "defs.h"
 #include "polygon.h"

--- a/polygon.h
+++ b/polygon.h
@@ -22,7 +22,7 @@
 #ifndef POLYGON_H_INCLUDED_
 #define POLYGON_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for ARG_NOMINMAX, arglist_t, ARGTYPE_BOOL, ARGTYPE_FILE
 #include "filter.h"  // for Filter

--- a/position.cc
+++ b/position.cc
@@ -22,8 +22,8 @@
 #include <cmath>            // for fabs
 #include <cstdlib>          // for strtod
 
-#include <QtCore/QList>     // for QList
-#include <QtCore/QtGlobal>  // for qAsConst, QAddConst<>::Type
+#include <QList>            // for QList
+#include <QtGlobal>         // for qAsConst, QAddConst<>::Type
 
 #include "defs.h"
 #include "grtcirc.h"        // for RAD, gcdist, radtometers

--- a/position.h
+++ b/position.h
@@ -22,7 +22,7 @@
 #ifndef POSITION_H_INCLUDED_
 #define POSITION_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for route_head (ptr only), ARG_NOMINMAX, ARGTYPE_FLOAT
 #include "filter.h"  // for Filter

--- a/qstarz_bl_1000.cc
+++ b/qstarz_bl_1000.cc
@@ -26,11 +26,11 @@
 #include "qstarz_bl_1000.h"
 
 #include <cmath>               // for round
-#include <QtCore/QChar>        // for QChar
-#include <QtCore/QDataStream>  // for QDataStream, QDataStream::SinglePrecision, QDataStream::DoublePrecision, QDataStream::LittleEndian, QDataStream::Ok
-#include <QtCore/QDebug>       // for QDebug
-#include <QtCore/QFile>        // for QFile
-#include <QtCore/QIODevice>    // for QIODevice, QIODevice::ReadOnly
+#include <QChar>               // for QChar
+#include <QDataStream>         // for QDataStream, QDataStream::SinglePrecision, QDataStream::DoublePrecision, QDataStream::LittleEndian, QDataStream::Ok
+#include <QDebug>              // for QDebug
+#include <QFile>               // for QFile
+#include <QIODevice>           // for QIODevice, QIODevice::ReadOnly
 #include "defs.h"              // for Waypoint, ddmm2degrees, route_head, track_add_head, track_add_wpt, waypt_add, waypt_count, wp_flags, fix_unknown, fix_2d, fix_3d, fix_dgps, fix_none, fix_pps, fix_type, global_options, global_opts
 #include "src/core/logging.h"  // for Fatal
 

--- a/qstarz_bl_1000.h
+++ b/qstarz_bl_1000.h
@@ -26,10 +26,10 @@
 #ifndef QSTARZ_BL1000_H_INCLUDED_
 #define QSTARZ_BL1000_H_INCLUDED_
 
-#include <QtCore/QDataStream>  // for QDataStream
-#include <QtCore/QString>      // for QString
-#include <QtCore/QVector>      // for QVector
-#include <QtCore/QtGlobal>     // for qint8, quint16, quint8
+#include <QDataStream>         // for QDataStream
+#include <QString>             // for QString
+#include <QVector>             // for QVector
+#include <QtGlobal>            // for qint8, quint16, quint8
 
 #include "defs.h"              // for ff_cap, ff_cap_read, ff_cap_none, CET_CHARSET_ASCII, ff_type, ff_type_file, route_head
 #include "format.h"            // for Format

--- a/radius.cc
+++ b/radius.cc
@@ -21,8 +21,8 @@
 
 #include <cstdlib>          // for atoi, strtod
 
-#include <QtCore/QString>   // for QString
-#include <QtCore/QtGlobal>  // for qAsConst, QAddConst<>::Type, foreach
+#include <QString>          // for QString
+#include <QtGlobal>         // for qAsConst, QAddConst<>::Type, foreach
 
 #include "defs.h"           // for Waypoint, waypt_del, route_add_head, route_add_wpt, route_head, waypt_add, waypt_count, xcalloc, xfree, kMilesPerKilometer
 #include "radius.h"

--- a/radius.h
+++ b/radius.h
@@ -22,7 +22,7 @@
 #ifndef RADIUS_H_INCLUDED_
 #define RADIUS_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for ARG_NOMINMAX, ARGTYPE_FLOAT, ARGTYPE_REQUIRED
 #include "filter.h"  // for Filter

--- a/random.cc
+++ b/random.cc
@@ -21,11 +21,11 @@
 #include <cstdlib>              // for atoi
 #include <random>               // for mt19937
 
-#include <QtCore/QByteArray>    // for QByteArray
-#include <QtCore/QByteRef>      // for QByteRef
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QString>       // for QString
-#include <QtCore/QThread>       // for QThread
+#include <QByteArray>           // for QByteArray
+#include <QByteRef>             // for QByteRef
+#include <QDateTime>            // for QDateTime
+#include <QString>              // for QString
+#include <QThread>              // for QThread
 
 #include "defs.h"
 #include "random.h"

--- a/random.h
+++ b/random.h
@@ -22,9 +22,9 @@
 
 #include <random>            // for mt19937
 
-#include <QtCore/QDateTime>  // for QDateTime
-#include <QtCore/QString>    // for QString
-#include <QtCore/QVector>    // for QVector
+#include <QDateTime>         // for QDateTime
+#include <QString>           // for QString
+#include <QVector>           // for QVector
 
 #include "defs.h"
 #include "format.h"

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -47,7 +47,7 @@
 #include "csv_util.h"
 #include "inifile.h"
 
-#include <QtCore/QString>
+#include <QString>
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>

--- a/reverse_route.cc
+++ b/reverse_route.cc
@@ -20,7 +20,7 @@
  */
 #include <algorithm>     // for reverse
 
-#include <QtCore/QList>  // for QList<>::iterator
+#include <QList>         // for QList<>::iterator
 
 #include "defs.h"
 #include "reverse_route.h"

--- a/reverse_route.h
+++ b/reverse_route.h
@@ -21,7 +21,7 @@
 #ifndef REVERSE_ROUTE_H_INCLUDED_
 #define REVERSE_ROUTE_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for Waypoint (ptr only), arglist_t, route_head (ptr ...
 #include "filter.h"  // for Filter

--- a/route.cc
+++ b/route.cc
@@ -23,10 +23,10 @@
 #include <iterator>
 #include <optional>             // for optional, operator>, operator<
 
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QList>         // for QList<>::iterator
-#include <QtCore/QString>       // for QString
-#include <QtCore/QtGlobal>      // for foreach
+#include <QDateTime>            // for QDateTime
+#include <QList>                // for QList<>::iterator
+#include <QString>              // for QString
+#include <QtGlobal>             // for foreach
 
 #include "defs.h"
 #include "grtcirc.h"            // for RAD, gcdist, heading_true_degrees, radtometers

--- a/session.cc
+++ b/session.cc
@@ -22,7 +22,7 @@
 #include "defs.h"
 #include "session.h"
 
-#include <QtCore/QList>  // for QList
+#include <QList>         // for QList
 
 static QList<session_t> session_list;
 

--- a/session.h
+++ b/session.h
@@ -22,7 +22,7 @@
 #ifndef SESSION_H_INCLUDED_
 #define SESSION_H_INCLUDED_
 
-#include <QtCore/QString>  // for QString
+#include <QString>         // for QString
 #include <utility>
 
 struct session_t {

--- a/shape.cc
+++ b/shape.cc
@@ -22,13 +22,13 @@
 
 #include <cassert>               // for assert
 
-#include <QtCore/QByteArray>     // for QByteArray
-#include <QtCore/QLatin1String>  // for QLatin1String
-#include <QtCore/QString>        // for QString, QString::SkipEmptyParts
-#include <QtCore/QStringList>    // for QStringList
-#include <QtCore/QVector>        // for QVector
-#include <QtCore/Qt>             // for CaseInsensitive
-#include <QtCore/QtGlobal>       // for qPrintable
+#include <QByteArray>            // for QByteArray
+#include <QLatin1String>         // for QLatin1String
+#include <QString>               // for QString, QString::SkipEmptyParts
+#include <QStringList>           // for QStringList
+#include <QVector>               // for QVector
+#include <Qt>                    // for CaseInsensitive
+#include <QtGlobal>              // for qPrintable
 
 #include "defs.h"
 #include "shape.h"

--- a/shape.h
+++ b/shape.h
@@ -22,8 +22,8 @@
 #ifndef SHAPE_H_INCLUDED_
 #define SHAPE_H_INCLUDED_
 
-#include <QtCore/QString>       // for QString
-#include <QtCore/QVector>       // for QVector
+#include <QString>              // for QString
+#include <QVector>              // for QVector
 
 #include "defs.h"               // for arglist_t, ARGTYPE_STRING, Waypoint, route_head, CET_CHARSET_ASCII, FF_CAP_RW_ALL, ff_cap, ff_type, ff_type_file
 #include "format.h"             // for Format

--- a/shortname.cc
+++ b/shortname.cc
@@ -1,5 +1,5 @@
-#include <QtCore/QString>
-#include <QtCore/QRegexp>
+#include <QString>
+#include <QRegexp>
 
 #include "shortname.h"
 

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -25,7 +25,7 @@
 
 #include "defs.h"
 #include "gbser.h"
-#include <QtCore/QThread>
+#include <QThread>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -59,7 +59,7 @@
 #include <cstdlib>              // for qsort, strtol
 #include <utility>              // for swap
 
-#include <QtCore/QDateTime>     // for QDateTime
+#include <QDateTime>            // for QDateTime
 
 #include "defs.h"
 #include "smplrout.h"

--- a/smplrout.h
+++ b/smplrout.h
@@ -59,7 +59,7 @@
 #ifndef SMPLROUT_H_INCLUDED_
 #define SMPLROUT_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for route_head (ptr only), Waypoint (ptr only), ARGT...
 #include "filter.h"  // for Filter

--- a/sort.cc
+++ b/sort.cc
@@ -19,8 +19,8 @@
 
  */
 
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QString>       // for operator<, QString
+#include <QDateTime>            // for QDateTime
+#include <QString>              // for operator<, QString
 
 #include "defs.h"
 #include "src/core/datetime.h"  // for DateTime
@@ -85,7 +85,7 @@ void SortFilter::process()
       fatal(MYNAME ": unknown waypoint sort mode.");
     }
   }
-  
+
   if (rte_sort_mode != SortModeRteHd::none) {
     switch (rte_sort_mode)  {
     case SortModeRteHd::description:

--- a/sort.h
+++ b/sort.h
@@ -22,7 +22,7 @@
 #ifndef SORT_H_INCLUDED_
 #define SORT_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for ARGTYPE_BOOL, ARG_NOMINMAX, arglist_t, ARG_TERMI...
 #include "filter.h"  // for Filter

--- a/src/core/datetime.h
+++ b/src/core/datetime.h
@@ -25,14 +25,14 @@
 
 #include <ctime>
 
-#include <QtCore/QtGlobal>
-#include <QtCore/QDateTime>
-#include <QtCore/QString>
+#include <QtGlobal>
+#include <QDateTime>
+#include <QString>
 
 // As this code began in C, we have several hundred places that set and
 // read creation_time as a time_t.  Provide some operator overloads to make
 // that less painful.
-// Probably all of these should eventually go away and be replaced by 
+// Probably all of these should eventually go away and be replaced by
 // "Better" code in the callers.
 
 // Consider putting in a namespace instead of prefixing 'gb'.

--- a/src/core/file.h
+++ b/src/core/file.h
@@ -20,10 +20,10 @@
 #ifndef SRC_CORE_FILE_INCLUDED_H_
 #define SRC_CORE_FILE_INCLUDED_H_
 
-#include <QtCore/QFile>
-#include <QtCore/QFileInfo>
-#include <QtCore/QStringBuilder>
-#include <QtCore/QIODevice>
+#include <QFile>
+#include <QFileInfo>
+#include <QStringBuilder>
+#include <QIODevice>
 #include <cstdio>
 #include "src/core/logging.h"
 #include "defs.h"

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -22,8 +22,8 @@
 // A wrapper for QDebug that provides a sensible Warning() and FatalMsg()
 // with convenient functions, stream operators and manipulators.
 
-#include <QtCore/QDebug>     // for QDebug
-#include <QtCore/QtGlobal>   // for QtCriticalMsg, QtWarningMsg
+#include <QDebug>            // for QDebug
+#include <QtGlobal>          // for QtCriticalMsg, QtWarningMsg
 
 
 class Warning : public QDebug
@@ -41,7 +41,7 @@ public:
  *    tools such as cppcheck.
  * 2) allows fatal to throw an exception instead of calling exit.
  *    This could be caught by main for a cleaner exit from a fatal error.
- */ 
+ */
 class FatalMsg : public QDebug
 {
 public:

--- a/src/core/optionaldouble.h
+++ b/src/core/optionaldouble.h
@@ -27,7 +27,7 @@ STATUS: experimental
 // As this code began in C, we have several hundred places that set and
 // read creation_time as a time_t.  Provide some operator overloads to make
 // that less painful.
-// Probably all of these should eventually go away and be replaced by 
+// Probably all of these should eventually go away and be replaced by
 // "Better" code in the callers.
 
 // Consider putting in a namespace instead of prefixing 'gb'.

--- a/src/core/textstream.cc
+++ b/src/core/textstream.cc
@@ -17,9 +17,9 @@
 
  */
 
-#include <QtCore/QFile>        // for QFile
-#include <QtCore/QFlags>     // for QFlags
-#include <QtCore/QIODevice>  // for QIODevice, QIODevice::OpenMode, QIODevice::ReadOnly, QIODevice::WriteOnly
+#include <QFile>               // for QFile
+#include <QFlags>            // for QFlags
+#include <QIODevice>         // for QIODevice, QIODevice::OpenMode, QIODevice::ReadOnly, QIODevice::WriteOnly
 
 #include "defs.h"              // for fatal, list_codecs
 #include "src/core/textstream.h"

--- a/src/core/textstream.h
+++ b/src/core/textstream.h
@@ -19,10 +19,10 @@
 #ifndef SRC_CORE_TEXTSTREAM_INCLUDED_H_
 #define SRC_CORE_TEXTSTREAM_INCLUDED_H_
 
-#include <QtCore/QIODevice>    // for QIODevice, QIODevice::OpenMode
-#include <QtCore/QString>      // for QString
-#include <QtCore/QTextCodec>   // for QTextCodec
-#include <QtCore/QTextStream>  // for QTextStream
+#include <QIODevice>           // for QIODevice, QIODevice::OpenMode
+#include <QString>             // for QString
+#include <QTextCodec>          // for QTextCodec
+#include <QTextStream>         // for QTextStream
 
 #include "src/core/file.h"     // for File
 

--- a/src/core/usasciicodec.cc
+++ b/src/core/usasciicodec.cc
@@ -18,11 +18,11 @@
  */
 
 #include "src/core/usasciicodec.h"
-#include <QtCore/QByteArray>
-#include <QtCore/QChar>
-#include <QtCore/QLatin1Char>
-#include <QtCore/QList>
-#include <QtCore/QString>
+#include <QByteArray>
+#include <QChar>
+#include <QLatin1Char>
+#include <QList>
+#include <QString>
 
 // The availability of a US-ASCII codec is not promised by QTextCodec.
 // On Mac OS X is is likely one will not be available.

--- a/src/core/usasciicodec.h
+++ b/src/core/usasciicodec.h
@@ -20,7 +20,7 @@
 #ifndef QUSASCIICODEC_H
 #define QUSASCIICODEC_H
 
-#include <QtCore/QTextCodec>
+#include <QTextCodec>
 
 namespace gpsbabel
 {

--- a/src/core/xmlstreamwriter.cc
+++ b/src/core/xmlstreamwriter.cc
@@ -19,9 +19,9 @@
 
 #include "src/core/xmlstreamwriter.h"
 
-#include <QtCore/QString>           // for QString
-#include <QtCore/QXmlStreamWriter>  // for QXmlStreamWriter
-#include <QtCore/QtGlobal>          // for QT_VERSION, QT_VERSION_CHECK
+#include <QString>                  // for QString
+#include <QXmlStreamWriter>         // for QXmlStreamWriter
+#include <QtGlobal>                 // for QT_VERSION, QT_VERSION_CHECK
 
 // As this code began in C, we have several hundred places that write
 // c strings.  Add a test that the string contains anything useful

--- a/src/core/xmlstreamwriter.h
+++ b/src/core/xmlstreamwriter.h
@@ -20,8 +20,8 @@
 #ifndef XMLSTREAMWRITER_H
 #define XMLSTREAMWRITER_H
 
-#include <QtCore/QString>           // for QString
-#include <QtCore/QXmlStreamWriter>  // for QXmlStreamWriter
+#include <QString>                  // for QString
+#include <QXmlStreamWriter>         // for QXmlStreamWriter
 
 namespace gpsbabel
 {

--- a/src/core/xmltag.h
+++ b/src/core/xmltag.h
@@ -19,8 +19,8 @@
 #ifndef SRC_CORE_XMLTAG_H
 #define SRC_CORE_XMLTAG_H
 
-#include <QtCore/QString>                          // for QString
-#include <QtCore/QXmlStreamAttributes>             // for QXmlStreamAttributes
+#include <QString>                                 // for QString
+#include <QXmlStreamAttributes>                    // for QXmlStreamAttributes
 
 #include "defs.h"
 

--- a/src/core/ziparchive.cc
+++ b/src/core/ziparchive.cc
@@ -29,8 +29,8 @@
 #include "zlib/contrib/minizip/zip.h"
 #endif
 
-#include <QtCore/QFile>
-#include <QtCore/QDebug>
+#include <QFile>
+#include <QDebug>
 
 ZipArchive::ZipArchive(QString filename)
 : filename_(filename), valid_(false) {

--- a/src/core/ziparchive.h
+++ b/src/core/ziparchive.h
@@ -19,8 +19,8 @@
 
  */
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
+#include <QString>
+#include <QStringList>
 #include "defs.h"
 #ifdef HAVE_LIBMINIZIP
 #include <minizip/zip.h>

--- a/stackfilter.h
+++ b/stackfilter.h
@@ -22,7 +22,7 @@
 #ifndef STACKFILTER_H_INCLUDED_
 #define STACKFILTER_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for ARGTYPE_BOOL, ARG_NOMINMAX, ARGTYPE_BEGIN_EXCL
 #include "filter.h"  // for Filter

--- a/stmsdf.cc
+++ b/stmsdf.cc
@@ -36,14 +36,14 @@
 #include <cstring>                    // for strchr
 #include <ctime>                      // for localtime, strftime
 
-#include <QtCore/QDate>               // for QDate
-#include <QtCore/QDateTime>           // for QDateTime
-#include <QtCore/QList>               // for QList<>::iterator, QList
-#include <QtCore/QRegularExpression>  // for QRegularExpression
-#include <QtCore/QString>             // for QString, operator+
-#include <QtCore/QStringList>         // for QStringList
-#include <QtCore/QTime>               // for QTime
-#include <QtCore/QtGlobal>            // for qAsConst, QAddConst<>::Type
+#include <QDate>                      // for QDate
+#include <QDateTime>                  // for QDateTime
+#include <QList>                      // for QList<>::iterator, QList
+#include <QRegularExpression>         // for QRegularExpression
+#include <QString>                    // for QString, operator+
+#include <QStringList>                // for QStringList
+#include <QTime>                      // for QTime
+#include <QtGlobal>                   // for qAsConst, QAddConst<>::Type
 
 #include "cet_util.h"                 // for cet_convert_init
 #include "csv_util.h"                 // for csv_lineparse

--- a/stmwpp.cc
+++ b/stmwpp.cc
@@ -25,10 +25,10 @@
 #include <cstring>                 // for memset
 #include <ctime>                   // for tm
 
-#include <QtCore/QDateTime>        // for QDateTime
-#include <QtCore/QString>          // for QString
-#include <QtCore/QTime>            // for QTime
-#include <QtCore/QVector>          // for QVector
+#include <QDateTime>               // for QDateTime
+#include <QString>                 // for QString
+#include <QTime>                   // for QTime
+#include <QVector>                 // for QVector
 
 #include "defs.h"
 #include "cet_util.h"              // for cet_convert_init

--- a/subrip.cc
+++ b/subrip.cc
@@ -19,12 +19,12 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
-#include <QtCore/QDate>         // for QDate
-#include <QtCore/QDateTime>     // for QDateTime, operator<<
-#include <QtCore/QDebug>        // for QDebug
-#include <QtCore/QString>       // for QString
-#include <QtCore/QTime>         // for QTime
-#include <QtCore/Qt>            // for UTC
+#include <QDate>                // for QDate
+#include <QDateTime>            // for QDateTime, operator<<
+#include <QDebug>               // for QDebug
+#include <QString>              // for QString
+#include <QTime>                // for QTime
+#include <Qt>                   // for UTC
 
 #include "defs.h"
 #include "subrip.h"

--- a/subrip.h
+++ b/subrip.h
@@ -22,10 +22,10 @@
 #ifndef SUBRIP_H_INCLUDED_
 #define SUBRIP_H_INCLUDED_
 
-#include <QtCore/QDateTime>  // for QDateTime, operator<<
-#include <QtCore/QString>    // for QString
-#include <QtCore/QTime>      // for QTime
-#include <QtCore/QVector>    // for QVector
+#include <QDateTime>         // for QDateTime, operator<<
+#include <QString>           // for QString
+#include <QTime>             // for QTime
+#include <QVector>           // for QVector
 
 #include "defs.h"
 #include "format.h"          // for Format

--- a/swapdata.h
+++ b/swapdata.h
@@ -23,7 +23,7 @@
 #ifndef SWAPDATA_H_INCLUDED_
 #define SWAPDATA_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for arglist_t, Waypoint
 #include "filter.h"  // for Filter

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -23,13 +23,13 @@
 
 */
 
-#include <QtCore/QLatin1String>         // for QLatin1String
-#include <QtCore/QString>               // for QString
-#include <QtCore/QStringView>           // for QStringView
-#include <QtCore/QVector>               // for QVector
-#include <QtCore/QXmlStreamAttribute>   // for QXmlStreamAttribute
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
-#include <QtCore/Qt>                    // for CaseInsensitive
+#include <QLatin1String>                // for QLatin1String
+#include <QString>                      // for QString
+#include <QStringView>                  // for QStringView
+#include <QVector>                      // for QVector
+#include <QXmlStreamAttribute>          // for QXmlStreamAttribute
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
+#include <Qt>                           // for CaseInsensitive
 
 #include "defs.h"
 #include "xmlgeneric.h"                 // for cb_start, cb_end, xg_callback, xg_string, xg_cb_type, xml_deinit, xml_init, xml_read, xg_tag_mapping
@@ -121,7 +121,7 @@ tef_list_start(xg_string, const QXmlStreamAttributes* attrv)
 
 /*
  * TODO: this whole horrible mess is not covered at all in the test suite,
- * so just stub it all out until someone cares. (TEF is rarely used from 
+ * so just stub it all out until someone cares. (TEF is rarely used from
  * what we can tell.)
  */
 
@@ -184,7 +184,7 @@ Xfix_notes(const QString& name, const QString& notes)
   return r;
 }
 #else
-static QString 
+static QString
 fix_notes(const QString&, const QString& notes){
     return notes;
 }

--- a/text.cc
+++ b/text.cc
@@ -22,9 +22,9 @@
 #include <cstdint>
 #include <ctime>                   // for localtime
 
-#include <QtCore/QString>          // for QString, operator!=
-#include <QtCore/QVector>          // for QVector
-#include <QtCore/Qt>               // for CaseInsensitive
+#include <QString>                 // for QString, operator!=
+#include <QVector>                 // for QVector
+#include <Qt>                      // for CaseInsensitive
 
 #include "defs.h"
 #include "formspec.h"              // for FsChainFind, kFsGpx

--- a/tomtom.cc
+++ b/tomtom.cc
@@ -41,8 +41,8 @@
 #include <cstdlib>          // for qsort
 #include <cstring>          // for strlen
 
-#include <QtCore/QString>   // for QString
-#include <QtCore/QtGlobal>  // for foreach
+#include <QString>          // for QString
+#include <QtGlobal>         // for foreach
 
 #include "defs.h"
 #include "gbfile.h"         // for gbfgetint32, gbfputint32, gbfclose, gbfgetc, gbfputc, gbfseek, gbfile, gbfeof, gbfread, gbftell, gbfwrite, gbfopen_le

--- a/tpo.cc
+++ b/tpo.cc
@@ -77,12 +77,12 @@
 #include <cstring>                     // for strncmp, strlen, memset
 #include <vector>                      // for vector
 
-#include <QtCore/QByteArray>           // for QByteArray
-#include <QtCore/QChar>                // for operator==, QChar
-#include <QtCore/QCharRef>             // for QCharRef
-#include <QtCore/QScopedArrayPointer>  // for QScopedArrayPointer
-#include <QtCore/QString>              // for QString
-#include <QtCore/QtGlobal>             // for qPrintable, Q_UNUSED
+#include <QByteArray>                  // for QByteArray
+#include <QChar>                       // for operator==, QChar
+#include <QCharRef>                    // for QCharRef
+#include <QScopedArrayPointer>         // for QScopedArrayPointer
+#include <QString>                     // for QString
+#include <QtGlobal>                    // for qPrintable, Q_UNUSED
 
 #include "defs.h"
 #include "gbfile.h"                    // for gbfread, gbfgetc, gbfgetint32, gbfwrite, gbfputint16, gbfseek, gbfgetdbl, gbfgetint16, gbfputdbl, gbfclose, gbfputint32, gbfile, gbfopen_le, gbfgetuint16
@@ -644,13 +644,13 @@ static void tpo_process_tracks()
     track_temp->line_width = styles[track_style].wide;
 
     if (DEBUG) printf("Track Name: %s, ?Type?: %u, Style Name: %s, Width: %d, Dashed: %d, Color: #%s\n",
-                        qPrintable(track_name), line_type, 
+                        qPrintable(track_name), line_type,
                         qPrintable(styles[track_style].name),
                         styles[track_style].wide,
                         styles[track_style].dash,rgb);
 
     // Track description
-    track_temp->rte_desc = 
+    track_temp->rte_desc =
       QString("Style=%1, Width=%2, Dashed=%3, Color=#%4")
                          .arg(styles[track_style].name)
                          .arg(styles[track_style].wide)

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -32,20 +32,20 @@
 
 #include <algorithm>                       // for sort, stable_sort
 
-#include <QtCore/QByteArray>               // for QByteArray
-#include <QtCore/QChar>                    // for QChar
-#include <QtCore/QDate>                    // for QDate
-#include <QtCore/QDateTime>                // for QDateTime
+#include <QByteArray>                      // for QByteArray
+#include <QChar>                           // for QChar
+#include <QDate>                           // for QDate
+#include <QDateTime>                       // for QDateTime
 #ifdef TRACKF_DBG
-#include <QtCore/QDebug>
+#include <QDebug>
 #endif
-#include <QtCore/QList>                    // for QList<>::iterator, QList, QList<>::const_iterator
-#include <QtCore/QRegExp>                  // for QRegExp, QRegExp::WildcardUnix
-#include <QtCore/QRegularExpression>       // for QRegularExpression, QRegularExpression::CaseInsensitiveOption, QRegularExpression::PatternOptions
-#include <QtCore/QRegularExpressionMatch>  // for QRegularExpressionMatch
-#include <QtCore/QString>                  // for QString
-#include <QtCore/Qt>                       // for UTC, CaseInsensitive
-#include <QtCore/QtGlobal>                 // for qAsConst, foreach, qPrintable, QAddConst<>::Type, qint64
+#include <QList>                           // for QList<>::iterator, QList, QList<>::const_iterator
+#include <QRegExp>                         // for QRegExp, QRegExp::WildcardUnix
+#include <QRegularExpression>              // for QRegularExpression, QRegularExpression::CaseInsensitiveOption, QRegularExpression::PatternOptions
+#include <QRegularExpressionMatch>         // for QRegularExpressionMatch
+#include <QString>                         // for QString
+#include <Qt>                              // for UTC, CaseInsensitive
+#include <QtGlobal>                        // for qAsConst, foreach, qPrintable, QAddConst<>::Type, qint64
 
 #include "defs.h"
 #include "trackfilter.h"

--- a/trackfilter.h
+++ b/trackfilter.h
@@ -22,10 +22,10 @@
 #ifndef TRACKFILTER_H_INCLUDED_
 #define TRACKFILTER_H_INCLUDED_
 
-#include <QtCore/QDateTime>  // for QDateTime
-#include <QtCore/QList>      // for QList
-#include <QtCore/QVector>    // for QVector
-#include <QtCore/QtGlobal>   // for qint64
+#include <QDateTime>         // for QDateTime
+#include <QList>             // for QList
+#include <QVector>           // for QVector
+#include <QtGlobal>          // for qint64
 
 #include "defs.h"            // for ARG_NOMINMAX, route_head (ptr only), ARG...
 #include "filter.h"          // for Filter

--- a/transform.cc
+++ b/transform.cc
@@ -23,7 +23,7 @@
 #include <cctype>           // for toupper
 #include <cstdlib>          // for atoi
 
-#include <QtCore/QtGlobal>  // for foreach
+#include <QtGlobal>         // for foreach
 
 #include "defs.h"
 #include "transform.h"

--- a/transform.h
+++ b/transform.h
@@ -23,8 +23,8 @@
 #ifndef TRANSFORM_H_INCLUDED_
 #define TRANSFORM_H_INCLUDED_
 
-#include <QtCore/QString>  // for QString
-#include <QtCore/QVector>  // for QVector
+#include <QString>         // for QString
+#include <QVector>         // for QVector
 
 #include "defs.h"          // for route_head (ptr only), ARG_NOMINMAX, ARGTY...
 #include "filter.h"        // for Filter

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -26,20 +26,20 @@
 #include <cstring>                 // for memset, strchr, strncpy
 #include <ctime>                   // for gmtime
 
-#include <QtCore/QByteArray>       // for QByteArray
-#include <QtCore/QChar>            // for QChar
-#include <QtCore/QCharRef>         // for QCharRef
-#include <QtCore/QDateTime>        // for QDateTime
-#include <QtCore/QIODevice>        // for QIODevice, QIODevice::ReadOnly, QIODevice::WriteOnly
-#include <QtCore/QLatin1Char>      // for QLatin1Char
-#include <QtCore/QLatin1String>    // for QLatin1String
-#include <QtCore/QString>          // for QString, operator!=, operator==
-#include <QtCore/QStringList>      // for QStringList
-#include <QtCore/QTextStream>      // for QTextStream, operator<<, qSetRealNumberPrecision, qSetFieldWidth, QTextStream::FixedNotation
-#include <QtCore/QTime>            // for QTime
-#include <QtCore/QVector>          // for QVector
-#include <QtCore/Qt>               // for CaseInsensitive
-#include <QtCore/QtGlobal>         // for qPrintable
+#include <QByteArray>              // for QByteArray
+#include <QChar>                   // for QChar
+#include <QCharRef>                // for QCharRef
+#include <QDateTime>               // for QDateTime
+#include <QIODevice>               // for QIODevice, QIODevice::ReadOnly, QIODevice::WriteOnly
+#include <QLatin1Char>             // for QLatin1Char
+#include <QLatin1String>           // for QLatin1String
+#include <QString>                 // for QString, operator!=, operator==
+#include <QStringList>             // for QStringList
+#include <QTextStream>             // for QTextStream, operator<<, qSetRealNumberPrecision, qSetFieldWidth, QTextStream::FixedNotation
+#include <QTime>                   // for QTime
+#include <QVector>                 // for QVector
+#include <Qt>                      // for CaseInsensitive
+#include <QtGlobal>                // for qPrintable
 
 #include "defs.h"
 #include "unicsv.h"

--- a/unicsv.h
+++ b/unicsv.h
@@ -24,9 +24,9 @@
 #include <cstdint>
 #include <ctime>                  // for gmtime
 
-#include <QtCore/QDateTime>       // for QDateTime
-#include <QtCore/QString>         // for QString, operator!=, operator==
-#include <QtCore/QVector>         // for QVector
+#include <QDateTime>              // for QDateTime
+#include <QString>                // for QString, operator!=, operator==
+#include <QVector>                // for QVector
 
 #include "defs.h"
 #include "format.h"               // for Format

--- a/util.cc
+++ b/util.cc
@@ -30,21 +30,21 @@
 #include <cstring>                      // for strlen, strcat, strstr, memcpy, strcmp, strcpy, strdup, strchr, strerror
 #include <ctime>                        // for mktime, localtime
 
-#include <QtCore/QByteArray>            // for QByteArray
-#include <QtCore/QChar>                 // for QChar, operator<=, operator>=
-#include <QtCore/QCharRef>              // for QCharRef
-#include <QtCore/QDateTime>             // for QDateTime
-#include <QtCore/QFileInfo>             // for QFileInfo
-#include <QtCore/QList>                 // for QList
-#include <QtCore/QScopedPointer>        // for QScopedPointer
-#include <QtCore/QString>               // for QString
-#include <QtCore/QTextCodec>            // for QTextCodec
-#include <QtCore/QTextStream>           // for operator<<, QTextStream, qSetFieldWidth, endl, QTextStream::AlignLeft
-#include <QtCore/QXmlStreamAttribute>   // for QXmlStreamAttribute
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
-#include <QtCore/Qt>                    // for CaseInsensitive
-#include <QtCore/QTimeZone>             // for QTimeZone
-#include <QtCore/QtGlobal>              // for qAsConst, QAddConst<>::Type, qPrintable
+#include <QByteArray>                   // for QByteArray
+#include <QChar>                        // for QChar, operator<=, operator>=
+#include <QCharRef>                     // for QCharRef
+#include <QDateTime>                    // for QDateTime
+#include <QFileInfo>                    // for QFileInfo
+#include <QList>                        // for QList
+#include <QScopedPointer>               // for QScopedPointer
+#include <QString>                      // for QString
+#include <QTextCodec>                   // for QTextCodec
+#include <QTextStream>                  // for operator<<, QTextStream, qSetFieldWidth, endl, QTextStream::AlignLeft
+#include <QXmlStreamAttribute>          // for QXmlStreamAttribute
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
+#include <Qt>                           // for CaseInsensitive
+#include <QTimeZone>                    // for QTimeZone
+#include <QtGlobal>                     // for qAsConst, QAddConst<>::Type, qPrintable
 
 #include "defs.h"
 #include "cet.h"                        // for cet_utf8_to_ucs4

--- a/v900.cc
+++ b/v900.cc
@@ -191,10 +191,10 @@ bintime2utc(int date, int time) {
   int day = date % 100;
   date /= 100;
   int month = date % 100;
-  date /= 100; 
+  date /= 100;
   // What's left in 'date' is year.
   QDate dt(date + 2000, month, day);
-  
+
   return QDateTime(dt, tm, Qt::UTC);
 }
 

--- a/validate.h
+++ b/validate.h
@@ -23,7 +23,7 @@
 #ifndef VALIDATE_H_INCLUDED_
 #define VALIDATE_H_INCLUDED_
 
-#include <QtCore/QVector>  // for QVector
+#include <QVector>         // for QVector
 
 #include "defs.h"    // for route_head (ptr only), ARGTYPE_BOOL, ARG_NOMINMAX
 #include "filter.h"  // for Filter

--- a/vecs.cc
+++ b/vecs.cc
@@ -19,12 +19,12 @@
 
  */
 
-#include <QtCore/QByteArray>    // for QByteArray
-#include <QtCore/QString>       // for QString
-#include <QtCore/QStringList>   // for QStringList
-#include <QtCore/QVector>       // for QVector<>::iterator, QVector
-#include <QtCore/Qt>            // for CaseInsensitive
-#include <QtCore/QtGlobal>      // for qPrintable
+#include <QByteArray>           // for QByteArray
+#include <QString>              // for QString
+#include <QStringList>          // for QStringList
+#include <QVector>              // for QVector<>::iterator, QVector
+#include <Qt>                   // for CaseInsensitive
+#include <QtGlobal>             // for qPrintable
 
 #include <algorithm>            // for sort
 #include <cassert>              // for assert

--- a/vecs.h
+++ b/vecs.h
@@ -23,9 +23,9 @@
 
 #include <cstdint>
 
-#include <QtCore/QString>       // for QString
-#include <QtCore/QStringList>   // for QStringList
-#include <QtCore/QVector>       // for QVector<>::iterator, QVector
+#include <QString>              // for QString
+#include <QStringList>          // for QStringList
+#include <QVector>              // for QVector<>::iterator, QVector
 
 #include "defs.h"
 #include "dg-100.h"

--- a/waypt.cc
+++ b/waypt.cc
@@ -24,12 +24,12 @@
 #include <cstdio>               // for printf, fflush, fprintf, stdout
 #include <algorithm>            // for stable_sort
 
-#include <QtCore/QChar>         // for QChar
-#include <QtCore/QDateTime>     // for QDateTime
-#include <QtCore/QList>         // for QList
-#include <QtCore/QString>       // for QString, operator==
-#include <QtCore/QTime>         // for QTime
-#include <QtCore/QtGlobal>      // for qPrintable
+#include <QChar>                // for QChar
+#include <QDateTime>            // for QDateTime
+#include <QList>                // for QList
+#include <QString>              // for QString, operator==
+#include <QTime>                // for QTime
+#include <QtGlobal>             // for qPrintable
 
 #include "defs.h"
 #include "garmin_fs.h"          // for garmin_ilink_t, garmin_fs_t, GMSD_FIND

--- a/wfff_xml.cc
+++ b/wfff_xml.cc
@@ -19,7 +19,7 @@
 
 #include "defs.h"
 #include "xmlgeneric.h"
-#include <QtCore/QXmlStreamAttributes>
+#include <QXmlStreamAttributes>
 #include <cstdio>
 
 /* argument storage */
@@ -107,8 +107,8 @@ void wfff_s(xg_string, const QXmlStreamAttributes*)
   ap_lon=0.0;
 }
 
-void wfff_mac(const QString& args, const QXmlStreamAttributes*) { 
-  ap_mac = args; 
+void wfff_mac(const QString& args, const QXmlStreamAttributes*) {
+  ap_mac = args;
 }
 void wfff_ssid(const QString& args, const QXmlStreamAttributes*) {
   ap_ssid = args;

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -32,19 +32,19 @@
 #include <ctime>                      // for gmtime, localtime, time_t, mktime, strftime
 #include <optional>                   // for optional
 
-#include <QtCore/QByteArray>          // for QByteArray
-#include <QtCore/QChar>               // for QChar
-#include <QtCore/QDate>               // for QDate
-#include <QtCore/QDateTime>           // for QDateTime
-#include <QtCore/QDebug>              // for QDebug
-#include <QtCore/QHash>               // for QHash
-#include <QtCore/QIODevice>           // for QIODevice, operator|, QIODevice::ReadOnly, QIODevice::Text, QIODevice::WriteOnly
-#include <QtCore/QList>               // for QList
-#include <QtCore/QRegularExpression>  // for QRegularExpression
-#include <QtCore/QString>             // for QString, operator+, operator==
-#include <QtCore/QStringList>         // for QStringList
-#include <QtCore/QTextStream>         // for QTextStream
-#include <QtCore/QtGlobal>            // for qAsConst, qPrintable
+#include <QByteArray>                 // for QByteArray
+#include <QChar>                      // for QChar
+#include <QDate>                      // for QDate
+#include <QDateTime>                  // for QDateTime
+#include <QDebug>                     // for QDebug
+#include <QHash>                      // for QHash
+#include <QIODevice>                  // for QIODevice, operator|, QIODevice::ReadOnly, QIODevice::Text, QIODevice::WriteOnly
+#include <QList>                      // for QList
+#include <QRegularExpression>         // for QRegularExpression
+#include <QString>                    // for QString, operator+, operator==
+#include <QStringList>                // for QStringList
+#include <QTextStream>                // for QTextStream
+#include <QtGlobal>                   // for qAsConst, qPrintable
 
 #include "defs.h"
 #include "csv_util.h"                 // for csv_stringtrim, dec_to_human, csv_stringclean, human_to_dec, ddmmdir_to_degrees, dec_to_intdeg, decdir_to_dec, intdeg_to_dec, csv_linesplit

--- a/xcsv.h
+++ b/xcsv.h
@@ -25,13 +25,13 @@
 #include <optional>               // for optional
 #include <utility>                // for move
 
-#include <QtCore/QByteArray>      // for QByteArray
-#include <QtCore/QDateTime>       // for QDateTime
-#include <QtCore/QHash>           // for QHash
-#include <QtCore/QList>           // for QList
-#include <QtCore/QString>         // for QString
-#include <QtCore/QStringList>     // for QStringList
-#include <QtCore/QVector>         // for QVector
+#include <QByteArray>             // for QByteArray
+#include <QDateTime>              // for QDateTime
+#include <QHash>                  // for QHash
+#include <QList>                  // for QList
+#include <QString>                // for QString
+#include <QStringList>            // for QStringList
+#include <QVector>                // for QVector
 
 #include "defs.h"
 #include "format.h"

--- a/xmlgeneric.cc
+++ b/xmlgeneric.cc
@@ -19,16 +19,16 @@
 
  */
 
-#include <QtCore/QByteArray>            // for QByteArray
-#include <QtCore/QHash>                 // for QHash
-#include <QtCore/QIODevice>             // for QIODevice, QIODevice::ReadOnly
-#include <QtCore/QLatin1Char>           // for QLatin1Char
-#include <QtCore/QList>
-#include <QtCore/QStringView>           // for QStringView
-#include <QtCore/QTextCodec>            // for QTextCodec
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
-#include <QtCore/QXmlStreamReader>      // for QXmlStreamReader, QXmlStreamReader::Characters, QXmlStreamReader::EndElement, QXmlStreamReader::IncludeChildElements, QXmlStreamReader::StartDocument, QXmlStreamReader::StartElement
-#include <QtCore/QtGlobal>              // for qPrintable
+#include <QByteArray>                   // for QByteArray
+#include <QHash>                        // for QHash
+#include <QIODevice>                    // for QIODevice, QIODevice::ReadOnly
+#include <QLatin1Char>                  // for QLatin1Char
+#include <QList>
+#include <QStringView>                  // for QStringView
+#include <QTextCodec>                   // for QTextCodec
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
+#include <QXmlStreamReader>             // for QXmlStreamReader, QXmlStreamReader::Characters, QXmlStreamReader::EndElement, QXmlStreamReader::IncludeChildElements, QXmlStreamReader::StartDocument, QXmlStreamReader::StartElement
+#include <QtGlobal>                     // for qPrintable
 
 #include "defs.h"
 #include "xmlgeneric.h"
@@ -36,7 +36,7 @@
 
 #define DEBUG_TAG 0
 #if DEBUG_TAG
-#include <QtCore/QDebug>
+#include <QDebug>
 #endif
 
 enum xg_shortcut {

--- a/xmlgeneric.h
+++ b/xmlgeneric.h
@@ -22,8 +22,8 @@
 #ifndef XMLGENERIC_H_INCLUDED_
 #define XMLGENERIC_H_INCLUDED_
 
-#include <QtCore/QString>               // for QString
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QString>                      // for QString
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 // Maybe the XmlGeneric string callback really shouldn't have a type
 // of its own; this was a crutch during the move from char* to QString.
@@ -81,7 +81,7 @@ private:
 };
 
 // xml processing uses a QList<xg_tag_map_entry>.
-// You may generated this yourself.  See method 1 below. 
+// You may generated this yourself.  See method 1 below.
 // Or it may be generated for you using one of the subsequent
 // methods.
 struct xg_tag_map_entry {
@@ -147,7 +147,7 @@ QList<xg_tag_map_entry>* build_xg_tag_map(MyFormat* instance, const QList<my_fun
  *    You must set the dynamic_tbl parameter to true to free the generated table
  *    resources when xml_deinit is called.
  *
- */ 
+ */
 void xml_init(const QString& fname, QList<xg_tag_map_entry>* tbl, const char* encoding,
               const char** ignorelist = nullptr,
               const char** skiplist = nullptr, bool dynamic_tbl = false);

--- a/xmltag.cc
+++ b/xmltag.cc
@@ -19,8 +19,8 @@
 
  */
 
-#include <QtCore/QString>               // for QString
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QString>                      // for QString
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 #include "defs.h"
 #include "src/core/xmltag.h"

--- a/xol.cc
+++ b/xol.cc
@@ -27,8 +27,8 @@
 #include "src/core/xmlstreamwriter.h"
 #include "xmlgeneric.h"
 
-#include <QtCore/QXmlStreamAttributes>
-#include <QtCore/QXmlStreamWriter>
+#include <QXmlStreamAttributes>
+#include <QXmlStreamWriter>
 
 static Waypoint* wpt_;
 static route_head* trk_;

--- a/yahoo.cc
+++ b/yahoo.cc
@@ -20,7 +20,7 @@
  */
 
 
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 #include "defs.h"
 #include "yahoo.h"

--- a/yahoo.h
+++ b/yahoo.h
@@ -21,10 +21,10 @@
 #ifndef YAHOO_H_INCLUDED_
 #define YAHOO_H_INCLUDED_
 
-#include <QtCore/QList>                 // for QList
-#include <QtCore/QString>               // for QString
-#include <QtCore/QVector>               // for QVector
-#include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
+#include <QList>                        // for QList
+#include <QString>                      // for QString
+#include <QVector>                      // for QVector
+#include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 
 #include "defs.h"
 #include "format.h"                     // for Format


### PR DESCRIPTION
This simplifies migration to Qt6 where some classes moved.  Both our qmake and cmake build systems add the necessary include paths already.  This also brings us into compliance with the Qt documentation, but strangely Qt generated files use the longer paths that include the module name.

This also cleaned up a fair amount of trailing white space.

This was done mostly by an ed script, although mkstyle.sh took some
hand holding.
```
1,$g/#include <QtCore\// s/<QtCore\/\([^>]*\)>/<\1>       /
1,$g/#include <QtGui\// s/<QtGui\/\([^>]*\)>/<\1>      /
1,$g/#include <QtNetwork\// s/<QtNetwork\/\([^>]*\)>/<\1>          /
1,$g/#include <QtWidgets\// s/<QtWidgets\/\([^>]*\)>/<\1>          /
1,$g/ *$/ s/ *$//
w
q
```