### PR TITLE
compatible changes for Qt6

### DIFF
--- a/garmin_fs.cc
+++ b/garmin_fs.cc
@@ -26,7 +26,6 @@
 #include <cstring>                   // for strncpy
 
 #include <QByteArray>                // for QByteArray
-#include <QStaticStringData>         // for QStaticStringData
 #include <QString>                   // for QString, QStringLiteral
 #include <QXmlStreamWriter>          // for QXmlStreamWriter
 #include <Qt>                        // for CaseInsensitive

--- a/gpx.cc
+++ b/gpx.cc
@@ -30,7 +30,6 @@
 #include <QIODevice>                               // for QIODevice, operator|, QIODevice::ReadOnly, QIODevice::Text, QIODevice::WriteOnly
 #include <QLatin1Char>                             // for QLatin1Char
 #include <QLatin1String>                           // for QLatin1String
-#include <QStaticStringData>                       // for QStaticStringData
 #include <QString>                                 // for QString, QStringLiteral, operator+, operator==
 #include <QStringList>                             // for QStringList
 #include <QStringView>                             // for QStringView

--- a/igc.cc
+++ b/igc.cc
@@ -33,7 +33,6 @@
 
 #include <QByteArray>                // for QByteArray
 #include <QList>                     // for QList<>::const_iterator
-#include <QStaticStringData>         // for QStaticStringData
 #include <QString>                   // for QString, operator+, QStringLiteral
 #include <QtGlobal>                  // for foreach, qPrintable
 

--- a/kml.cc
+++ b/kml.cc
@@ -35,7 +35,6 @@
 #include <QFile>                        // for QFile
 #include <QIODevice>                    // for operator|, QIODevice, QIODevice::Text, QIODevice::WriteOnly
 #include <QList>                        // for QList
-#include <QStaticStringData>            // for QStaticStringData
 #include <QString>                      // for QString, QStringLiteral, operator+, operator!=
 #include <QStringList>                  // for QStringList
 #include <QVector>                      // for QVector

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -85,7 +85,6 @@
 
 */
 
-#include <algorithm>              // for min
 #include <cmath>                  // for M_PI, round, atan, exp, log, tan
 #include <cstdio>                 // for printf, sprintf, SEEK_CUR
 #include <cstdlib>                // for atoi, abs
@@ -1598,9 +1597,8 @@ LowranceusrFormat::lowranceusr_route_hdr(const route_head* rte)
   } else {
     name = QString::asprintf("Babel R%d", ++lowrance_route_count);
   }
-  int text_len = std::min(name.size(), MAXUSRSTRINGSIZE);
-  name.truncate(text_len);
-  gbfputint32(text_len, file_out);
+  name.truncate(MAXUSRSTRINGSIZE);
+  gbfputint32(name.size(), file_out);
   gbfputs(name, file_out);
 
   /* num legs */
@@ -1713,9 +1711,8 @@ LowranceusrFormat::lowranceusr_merge_trail_hdr(const route_head* trk)
       name = QString::asprintf("Babel %d", trail_count);
     }
 
-    int text_len = std::min(MAXUSRSTRINGSIZE, name.size());
-    name.truncate(text_len);
-    gbfputint32(text_len, file_out);
+    name.truncate(MAXUSRSTRINGSIZE);
+    gbfputint32(name.size(), file_out);
     gbfputs(name, file_out);
 
     if (global_opts.debug_level >= 1) {

--- a/src/core/datetime.h
+++ b/src/core/datetime.h
@@ -23,6 +23,7 @@
 #ifndef DATETIME_H_INCLUDED_
 #define DATETIME_H_INCLUDED_
 
+#include <cstdint>
 #include <ctime>
 
 #include <QtGlobal>
@@ -59,7 +60,7 @@ public:
 
   // Temporary: Override the standard, also handle time_t 0 as invalid.
   bool isValid() const {
-    return date().isValid() && time().isValid() && toTime_t() > 0;
+    return QDateTime::isValid() && (toSecsSinceEpoch() != 0);
   }
 
   // Like toString, but with subsecond time that's included only when
@@ -70,6 +71,18 @@ public:
     } else {
       return toUTC().toString(QStringLiteral("yyyy-MM-ddTHH:mm:ssZ"));
     }
+  }
+
+  // QDateTime::toTime_t was deprecated in Qt5.8, and deleted in Qt6.
+  uint32_t toTime_t() const {
+    if (!QDateTime::isValid()) {
+      return -1;
+    }
+    long long secs_since_epoch = toSecsSinceEpoch();
+    if ((secs_since_epoch < 0) || (secs_since_epoch > 0xfffffffe)) {
+      return -1;
+    }
+    return secs_since_epoch;
   }
 };
 


### PR DESCRIPTION
avoid std::min with  QString::size, which changes types in Qt6

don't include QStaticStringData.  It goes away in Qt6.  Besides, the documented include is QString,
which in Qt 5 will include qstringliteral.h just as QStaticStringData
does.

accommodate the deletion of QDateTime::toTime_t in Qt6.