### PR TITLE
compatible changes for Qt6

### DIFF
--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -53,7 +53,6 @@
 #include <ctime>                   // for time, time_t, gmtime
 
 #include <QByteArray>              // for QByteArray, operator==
-#include <QByteRef>                // for QByteRef
 #include <QList>                   // for QList<>::iterator, QList
 #include <QString>                 // for QString, operator+, operator<
 #include <QThread>                 // for QThread

--- a/geojson.h
+++ b/geojson.h
@@ -21,7 +21,6 @@
 
 #include <QJsonArray>                // for QJsonArray
 #include <QJsonObject>               // for QJsonObject
-#include <QStaticStringData>         // for QStaticStringData
 #include <QString>                   // for QString, QStringLiteral
 #include <QVector>                   // for QVector
 

--- a/mapsend.cc
+++ b/mapsend.cc
@@ -24,7 +24,6 @@
 #include <cstring>              // for strncpy
 #include <ctime>
 
-#include <QCharRef>             // for QCharRef
 #include <QString>              // for QString
 #include <QTime>                // for QTime
 #include <QtGlobal>             // for Q_UNUSED

--- a/mmo.cc
+++ b/mmo.cc
@@ -31,7 +31,6 @@
 
 #include <QByteArray>            // for QByteArray
 #include <QChar>                 // for operator==, QChar
-#include <QCharRef>              // for QCharRef
 #include <QDateTime>             // for QDateTime
 #include <QHash>                 // for QHash, QHash<>::const_iterator
 #include <QLatin1String>         // for QLatin1String

--- a/ozi.cc
+++ b/ozi.cc
@@ -42,7 +42,6 @@
 
 #include <QByteArray>             // for QByteArray
 #include <QChar>                  // for operator==, QChar
-#include <QCharRef>               // for QCharRef
 #include <QFile>                  // for QFile
 #include <QFileInfo>              // for QFileInfo
 #include <QIODevice>              // for operator|, QIODevice::WriteOnly, QIODevice::ReadOnly, QIODevice, QIODevice::OpenModeFlag

--- a/pcx.cc
+++ b/pcx.cc
@@ -24,7 +24,6 @@
 #include <cstring>                    // for strstr, strncmp
 
 #include <QChar>                      // for operator==, QChar
-#include <QCharRef>                   // for QCharRef
 #include <QDate>                      // for QDate
 #include <QDateTime>                  // for QDateTime
 #include <QList>                      // for QList

--- a/random.cc
+++ b/random.cc
@@ -22,7 +22,6 @@
 #include <random>               // for mt19937
 
 #include <QByteArray>           // for QByteArray
-#include <QByteRef>             // for QByteRef
 #include <QDateTime>            // for QDateTime
 #include <QString>              // for QString
 #include <QThread>              // for QThread

--- a/tpo.cc
+++ b/tpo.cc
@@ -79,7 +79,6 @@
 
 #include <QByteArray>                  // for QByteArray
 #include <QChar>                       // for operator==, QChar
-#include <QCharRef>                    // for QCharRef
 #include <QScopedArrayPointer>         // for QScopedArrayPointer
 #include <QString>                     // for QString
 #include <QtGlobal>                    // for qPrintable, Q_UNUSED

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -28,7 +28,6 @@
 
 #include <QByteArray>              // for QByteArray
 #include <QChar>                   // for QChar
-#include <QCharRef>                // for QCharRef
 #include <QDateTime>               // for QDateTime
 #include <QIODevice>               // for QIODevice, QIODevice::ReadOnly, QIODevice::WriteOnly
 #include <QLatin1Char>             // for QLatin1Char

--- a/util.cc
+++ b/util.cc
@@ -32,7 +32,6 @@
 
 #include <QByteArray>                   // for QByteArray
 #include <QChar>                        // for QChar, operator<=, operator>=
-#include <QCharRef>                     // for QCharRef
 #include <QDateTime>                    // for QDateTime
 #include <QFileInfo>                    // for QFileInfo
 #include <QList>                        // for QList


### PR DESCRIPTION
    don't include QByteRef.
    It is gone in Qt6.  It was not documented as a class in Qt5.
    In Qt5 QByteRef just included qbytearray.h.

    don't include QCharRef.
    It is gone in Qt6.  It was a "helper class for QString".  It was not
    documented as a class in Qt5.  In Qt5 QCharRef just included qstring.h.

    don't include QStaticStringData.
    missed one in the previous commit.