### PR TITLE
Qt 6 compatiblity changes

### DIFF
--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -24,7 +24,6 @@
 #include "formatload.h"
 #include <QByteArray>                      // for QByteArray
 #include <QChar>                           // for operator==, QChar
-#include <QCharRef>                        // for QCharRef
 #include <QCoreApplication>                // for QCoreApplication
 #ifdef GENERATE_CORE_STRINGS
 #include <QDebug>                          // for QDebug, operator<<

--- a/igo8.cc
+++ b/igo8.cc
@@ -61,7 +61,6 @@
 
 */
 
-#include <algorithm>
 #include <cstdio>               // for SEEK_SET
 #include <cstdint>
 #include <cstdlib>              // for atoi
@@ -70,7 +69,6 @@
 #include <QChar>                // for QChar
 #include <QString>              // for QString
 #include <QVector>              // for QVector
-#include <QtGlobal>             // for ushort
 
 #include "defs.h"
 #include "gbfile.h"             // for gbfwrite, gbfclose, gbfseek, gbfgetint32, gbfread, gbfile, gbfopen_le
@@ -261,7 +259,7 @@ static unsigned int print_unicode(char* dst, int dst_max_length, const QString& 
   }
   // Write as many characters from the source as possible
   // while leaving space for a terminator.
-  int n_src_qchars = std::min(max_qchars - 1, src.size());
+  int n_src_qchars =  src.size() > (max_qchars - 1) ? max_qchars - 1 : src.size();
   for (int i = 0; i < n_src_qchars; ++i) {
     le_write16(dst, src.at(i).unicode());
     dst += 2;


### PR DESCRIPTION
I missed a couple of cases in previous commits.

don't include QCharRef

avoid std::min with QString::size