### PR TITLE
don't set gpsbabel::XmlStreamWriter codec in mapfactor

### DIFF
--- a/mapfactor.cc
+++ b/mapfactor.cc
@@ -102,9 +102,6 @@ mapfactor_wr_init(const QString& fname)
   oqfile->open(QIODevice::WriteOnly | QIODevice::Text);
   writer = new gpsbabel::XmlStreamWriter(oqfile);
 
-  // Override the "UTF-8-XML" with ... the default.
-  writer->setCodec("utf-8");
-
   writer->setAutoFormatting(true);
   writer->setAutoFormattingIndent(2);
   writer->writeStartDocument();


### PR DESCRIPTION
We use utf-8 by default as of #671.

Note QXmlStreamWriter::setCodec doesn't exist in Qt 6, so what was unnecessary becomes problematic.