### PR TITLE
fix windows release with Qt6.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -111,10 +111,10 @@ jobs:
 
     - name: Qt install
       if: steps.cache.outputs.cache-hit != 'true'
+      env:
+        TRAVIS_BUILD_DIR: ${{ github.workspace }}
       run: |
-        pip3 install aqtinstall>=2.0.0
-        ./tools/ci_install_qt.sh mac ${QT_VERSION} clang_64 ${HOME}/Cache/Qt
-        echo "export PATH=${HOME}/Cache/Qt/${QT_VERSION}/macos/bin:\$PATH" > "${HOME}/Cache/qt-${QT_VERSION}.env"
+        ./tools/travis_install_osx ${QT_VERSION} aqt
 
     - name: Script
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -104,13 +104,13 @@ jobs:
         key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
 
     - name: Qt install setup
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: jobs.macos_qt6.steps.cache.outputs.cache-hit != 'true'
       uses: actions/setup-python@v2
       with:
         python-version: '3.9'
 
     - name: Qt install
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: jobs.macos_qt6.steps.cache.outputs.cache-hit != 'true'
       run: |
         pip3 install aqtinstall>=2.0.0
         ./tools/ci_install_qt.sh mac ${QT_VERSION} clang_64 ${HOME}/Cache/Qt

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -104,13 +104,13 @@ jobs:
         key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
 
     - name: Qt install setup
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: ${{ (steps.cache.outputs.cache-hit != 'true') }}
       uses: actions/setup-python@v2
       with:
         python-version: '3.9'
 
     - name: Qt install
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: ${{ (steps.cache.outputs.cache-hit != 'true') }}
       run: |
         pip3 install aqtinstall>=2.0.0
         ./tools/ci_install_qt.sh mac ${QT_VERSION} clang_64 ${HOME}/Cache/Qt

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -104,13 +104,13 @@ jobs:
         key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
 
     - name: Qt install setup
-      if: ${{ (steps.cache.outputs.cache-hit != 'true') }}
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/setup-python@v2
       with:
         python-version: '3.9'
 
     - name: Qt install
-      if: ${{ (steps.cache.outputs.cache-hit != 'true') }}
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip3 install aqtinstall>=2.0.0
         ./tools/ci_install_qt.sh mac ${QT_VERSION} clang_64 ${HOME}/Cache/Qt

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -104,13 +104,13 @@ jobs:
         key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
 
     - name: Qt install setup
-      if: jobs.macos_qt6.steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/setup-python@v2
       with:
         python-version: '3.9'
 
     - name: Qt install
-      if: jobs.macos_qt6.steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip3 install aqtinstall>=2.0.0
         ./tools/ci_install_qt.sh mac ${QT_VERSION} clang_64 ${HOME}/Cache/Qt

--- a/tools/make_windows_release.ps1
+++ b/tools/make_windows_release.ps1
@@ -105,7 +105,7 @@ New-Item "$($gui_build_dir)\package" -type directory -Force | Out-Null
 Copy-Item "$($gpsbabel_build_dir)\release\GPSBabel.exe" "$($gui_build_dir)\package\GPSBabel.exe"
 Copy-Item "$($gui_build_dir)\release\GPSBabelFE.exe" "$($gui_build_dir)\package\GPSBabelFE.exe"
 # use --plugindir option to locate the plugins.
-& "$($windeployqt)" --verbose 1 --plugindir package\plugins package\GPSBabelFE.exe
+& "$($windeployqt)" --verbose 1 --plugindir package\plugins package\GPSBabelFE.exe package\GPSBabel.exe
 if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 if ($buildinstaller -eq "true") {
     Set-Location "$($gpsbabel_src_dir)\gui"

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -33,7 +33,11 @@ METHOD=${2:-artifactory}
 
 # our expectation is that install-qt creates $QTDIR, $QTDIR/bin.
 CACHEDIR=${HOME}/Cache
-QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
+if [ "$METHOD" = "aqt" ]; then
+  QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/macos
+else
+  QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
+fi
 
 if [ -d "${QTDIR}/bin" ]; then
   echo "Using cached Qt."
@@ -73,6 +77,11 @@ else
         rm -f "/tmp/${archive}"
       fi
      )
+  elif [ "$METHOD" = "aqt" ]; then
+    pip3 install aqtinstall>=2.0.0
+    "$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"/ci_install_qt.sh mac ${QT_VERSION} clang_64 ${CACHEDIR}/Qt
+    echo "export PATH=${CACHEDIR}/Qt/${QT_VERSION}/macos/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
+
   else
     # install-qt creates the install at $PWD/Qt.
     QT_VERSION_SHORT=${QT_VERSION//./}

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -39,6 +39,8 @@ else
   QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
 fi
 
+TOOLSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)
+
 if [ -d "${QTDIR}/bin" ]; then
   echo "Using cached Qt."
   echo "If you need to clear the cache see"
@@ -79,7 +81,7 @@ else
      )
   elif [ "$METHOD" = "aqt" ]; then
     pip3 install aqtinstall>=2.0.0
-    "$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"/ci_install_qt.sh mac ${QT_VERSION} clang_64 ${CACHEDIR}/Qt
+    "${TOOLSDIR}"/ci_install_qt.sh mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${CACHEDIR}/Qt/${QT_VERSION}/macos/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
 
   else

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -39,8 +39,6 @@ else
   QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
 fi
 
-TOOLSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)
-
 if [ -d "${QTDIR}/bin" ]; then
   echo "Using cached Qt."
   echo "If you need to clear the cache see"
@@ -81,9 +79,8 @@ else
      )
   elif [ "$METHOD" = "aqt" ]; then
     pip3 install aqtinstall>=2.0.0
-    "${TOOLSDIR}"/ci_install_qt.sh mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
+    "${TRAVIS_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${CACHEDIR}/Qt/${QT_VERSION}/macos/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
-
   else
     # install-qt creates the install at $PWD/Qt.
     QT_VERSION_SHORT=${QT_VERSION//./}


### PR DESCRIPTION
windeployqt failed to deploy Qt6Core5Compat.dll because it was
not used by the gui and we didn't tell windeployqt there was
another executable to scan for dependencies.