### PR TITLE
update Qt 5.12 builds on macos and windows to 5.12.11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
     name: macos release Build
     runs-on: macos-latest
     env:
-      QT_VERSION: '5.12.10'
+      QT_VERSION: '5.12.11'
 
     steps:
     - name: Checkout repository
@@ -22,15 +22,23 @@ jobs:
 
     - name: Cache Qt
       uses: actions/cache@v2
+      id: cache
       with:
         path: ~/Cache
         key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
 
+    - name: Qt install setup
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
     - name: Qt install
+      if: steps.cache.outputs.cache-hit != 'true'
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
       run: |
-        ./tools/travis_install_osx ${QT_VERSION} installer
+        ./tools/travis_install_osx ${QT_VERSION} aqt
 
     - name: Script
       run: |
@@ -54,7 +62,7 @@ jobs:
       with:
         name: MacOS_Installer
         path: gui/GPSBabel-*.dmg
-        retention-days: 14
+        retention-days: 7
 
   macos_edge:
     name: macos edge Build
@@ -83,8 +91,15 @@ jobs:
     - name: Script
       run: |
         source ${HOME}/Cache/qt-${QT_VERSION}.env
-        sudo xcode-select --switch /Applications/Xcode_12.1.1.app
+        sudo xcode-select --switch /Applications/Xcode_12.4.app
         ./tools/travis_script_osx
+
+    - name: 'Upload Artifacts'
+      uses: actions/upload-artifact@v2
+      with:
+        name: MacOS_Installer_Edge
+        path: gui/GPSBabel-*.dmg
+        retention-days: 7
 
   macos_qt6:
     name: macos Qt6 Build
@@ -127,4 +142,4 @@ jobs:
       with:
         name: MacOS_Installer_Qt6
         path: gui/GPSBabel-*.dmg
-        retention-days: 14
+        retention-days: 7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,35 +18,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - QT_VERSION: '5.12.10'
+          - QT_VERSION: '5.12.11'
             ARCH: 'amd64'
             HOST_ARCH: 'x86'
             COMPILER: 'msvc2017_64'
+            METHOD: 'aqt'
             FLOW: 'nmake'
             RELEASE: true
-          - QT_VERSION: '5.12.10'
+          - QT_VERSION: '5.12.11'
             ARCH: 'amd64'
             HOST_ARCH: 'x86'
             COMPILER: 'msvc2017_64'
+            METHOD: 'aqt'
             FLOW: 'msbuild'
             RELEASE: false
-          - QT_VERSION: '5.12.10'
+          - QT_VERSION: '5.12.11'
             ARCH: 'amd64'
             HOST_ARCH: 'x86'
             COMPILER: 'msvc2017_64'
+            METHOD: 'aqt'
             FLOW: 'cmake'
             RELEASE: false
-          - QT_VERSION: '5.12.10'
+          - QT_VERSION: '5.12.11'
             ARCH: 'amd64'
             HOST_ARCH: 'x86'
             COMPILER: 'msvc2017_64'
             VCVERSION: '14.16'
+            METHOD: 'aqt'
             FLOW: 'nmake'
             RELEASE: false
-          - QT_VERSION: '5.12.10'
+          - QT_VERSION: '5.12.11'
             ARCH: 'x86'
             HOST_ARCH: 'x86'
             COMPILER: 'msvc2017'
+            METHOD: 'aqt'
             RELEASE: false
             FLOW: 'nmake'
           - QT_VERSION: '6.2.1'

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -3,7 +3,7 @@
 # This script is run on travis for the install stage of mac builds.
 #
 
-function version_ge() { test "$(printf "%s\n%s" $1 $2 | sort -rV | head -n 1)" == "$1"; }
+function version_ge() { test "$(printf "%s\n%s" "$1" "$2" | sort -rV | head -n 1)" == "$1"; }
 
 #debug failed install
 function debug() {
@@ -36,7 +36,7 @@ METHOD=${2:-artifactory}
 # our expectation is that install-qt creates $QTDIR, $QTDIR/bin.
 CACHEDIR=${HOME}/Cache
 if [ "$METHOD" = "aqt" ]; then
-  if version_ge $($QMAKE -query QT_VERSION) 6.1.2; then
+  if version_ge "${QT_VERSION}" 6.1.2; then
     QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/macos
   else
     QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -3,6 +3,8 @@
 # This script is run on travis for the install stage of mac builds.
 #
 
+function version_ge() { test "$(printf "%s\n%s" $1 $2 | sort -rV | head -n 1)" == "$1"; }
+
 #debug failed install
 function debug() {
   cat "${CACHEDIR}/qt-${QT_VERSION}.env"
@@ -34,7 +36,11 @@ METHOD=${2:-artifactory}
 # our expectation is that install-qt creates $QTDIR, $QTDIR/bin.
 CACHEDIR=${HOME}/Cache
 if [ "$METHOD" = "aqt" ]; then
-  QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/macos
+  if version_ge $($QMAKE -query QT_VERSION) 6.1.2; then
+    QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/macos
+  else
+    QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
+  fi
 else
   QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
 fi

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -79,14 +79,14 @@ else
         archive=qt-${QT_VERSION}-release-macos.tar.xz
         curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}" "${ARTIFACTORY_BASE_URL}/${archive}" -o "/tmp/${archive}"
         tar -x -J -f "/tmp/${archive}"
-        echo "export PATH=${CACHEDIR}/Qt/${QT_VERSION}/clang_64/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
+        echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
         rm -f "/tmp/${archive}"
       fi
      )
   elif [ "$METHOD" = "aqt" ]; then
     pip3 install aqtinstall>=2.0.0
     "${TRAVIS_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
-    echo "export PATH=${CACHEDIR}/Qt/${QT_VERSION}/macos/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
+    echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
     # install-qt creates the install at $PWD/Qt.
     QT_VERSION_SHORT=${QT_VERSION//./}


### PR DESCRIPTION
update Qt 5.12 builds on macos and windows to 5.12.11.  
They now use the aqt installer instead of the Qt offline installer.
update macos edge build xcode tools to 12.4.