### PR TITLE
miscellaneous minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,9 @@ set(SOURCES
   ${SOURCES} ${ALL_FMTS} ${FILTERS} ${SUPPORT} ${SHAPE} ${ZLIB} ${JEEPS} ${RESOURCES}
 )
 
+list(SORT SOURCES)
+list(SORT HEADERS)
+
 # We don't care about stripping things out of the build.  Full monty, baby.
 add_definitions(-DMAXIMAL_ENABLED)
 add_definitions(-DFILTERS_ENABLED)

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -266,6 +266,9 @@ include(libusb.pri)
 
 SOURCES += $$ALL_FMTS $$FILTERS $$SUPPORT $$JEEPS
 
+SOURCES = $$sorted(SOURCES)
+HEADERS = $$sorted(HEADERS)
+
 # We don't care about stripping things out of the build.  Full monty, baby.
 DEFINES += MAXIMAL_ENABLED
 DEFINES += FILTERS_ENABLED

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -20,7 +20,7 @@
 
  */
 
-#include <assert.h>            // for assert
+#include <cassert>             // for assert
 #include <cctype>              // for isspace
 #include <cmath>               // for fabs
 #include <cstdio>              // for size_t

--- a/discard.h
+++ b/discard.h
@@ -41,7 +41,7 @@ public:
   void process() override;
 
 private:
-  QRegularExpression generateRegExp(const QString& glob_pattern);
+  static QRegularExpression generateRegExp(const QString& glob_pattern);
 
 private:
   char* hdopopt = nullptr;

--- a/dmtlog.cc
+++ b/dmtlog.cc
@@ -699,7 +699,7 @@ write_header(const route_head* trk)
 
   int count = 0;
   if (trk != nullptr) {
-    count = trk->waypoint_list.count();
+    count = trk->rte_waypt_ct();
   }
   if (!trk || trk->rte_name.isEmpty()) {
     write_str("Name", fout);

--- a/jeeps/gpsdevice.cc
+++ b/jeeps/gpsdevice.cc
@@ -25,7 +25,7 @@
 
 extern gps_device_ops gps_serial_ops;
 extern gps_device_ops gps_usb_ops;
-gps_device_ops* ops = nullptr;
+static gps_device_ops* ops = nullptr;
 
 int32  GPS_Device_On(const char* port, gpsdevh** fd)
 {

--- a/mapsend.cc
+++ b/mapsend.cc
@@ -430,7 +430,7 @@ static void mapsend_track_hdr(const route_head* trk)
   gbfputpstr(tname, mapsend_file_out);
 
   /* total nodes (waypoints) this track */
-  int i = trk->waypoint_list.count();
+  int i = trk->rte_waypt_ct();
 
   gbfputint32(i, mapsend_file_out);
 

--- a/testo.d/unitconversion.test
+++ b/testo.d/unitconversion.test
@@ -1,68 +1,68 @@
 # This covers conversions to and from various speed units.
-echo 'DESCRIPTION  Speed Test' > speed.style
-echo 'EXTENSION csv' >> speed.style
-echo 'FIELD_DELIMITER COMMA' >> speed.style
-echo 'RECORD_DELIMITER NEWLINE' >> speed.style
-echo 'DATATYPE TRACK' >> speed.style
-echo 'PROLOGUE Lat,Lon,Speed(m/s),Speed(km/hr),Speed(mile/hr),Speed(knots)' >> speed.style
-echo 'OFIELD LAT_DECIMAL,"","%f"' >> speed.style
-echo 'OFIELD LON_DECIMAL,"","%f"' >> speed.style
-echo 'OFIELD PATH_SPEED,"","%.6e"' >> speed.style
-echo 'OFIELD PATH_SPEED_KPH,"","%.6e"' >> speed.style
-echo 'OFIELD PATH_SPEED_MPH,"","%.6e"' >> speed.style
-echo 'OFIELD PATH_SPEED_KNOTS,"","%.6e"' >> speed.style
+echo 'DESCRIPTION  Speed Test' > ${TMPDIR}/speed.style
+echo 'EXTENSION csv' >> ${TMPDIR}/speed.style
+echo 'FIELD_DELIMITER COMMA' >> ${TMPDIR}/speed.style
+echo 'RECORD_DELIMITER NEWLINE' >> ${TMPDIR}/speed.style
+echo 'DATATYPE TRACK' >> ${TMPDIR}/speed.style
+echo 'PROLOGUE Lat,Lon,Speed(m/s),Speed(km/hr),Speed(mile/hr),Speed(knots)' >> ${TMPDIR}/speed.style
+echo 'OFIELD LAT_DECIMAL,"","%f"' >> ${TMPDIR}/speed.style
+echo 'OFIELD LON_DECIMAL,"","%f"' >> ${TMPDIR}/speed.style
+echo 'OFIELD PATH_SPEED,"","%.6e"' >> ${TMPDIR}/speed.style
+echo 'OFIELD PATH_SPEED_KPH,"","%.6e"' >> ${TMPDIR}/speed.style
+echo 'OFIELD PATH_SPEED_MPH,"","%.6e"' >> ${TMPDIR}/speed.style
+echo 'OFIELD PATH_SPEED_KNOTS,"","%.6e"' >> ${TMPDIR}/speed.style
 
-gpsbabel -t -i unicsv -f ${REFERENCE}/speed.csv -o xcsv,style=speed.style -F ${TMPDIR}/speed~csv.csv
+gpsbabel -t -i unicsv -f ${REFERENCE}/speed.csv -o xcsv,style=${TMPDIR}/speed.style -F ${TMPDIR}/speed~csv.csv
 compare ${REFERENCE}/speed~csv.csv ${TMPDIR}/speed~csv.csv
 
 # This covers distance conversions to meters, but only a couple from meters.
-echo 'DESCRIPTION  Distance Test' > distance.style
-echo 'EXTENSION csv' >> distance.style
-echo 'FIELD_DELIMITER COMMA' >> distance.style
-echo 'RECORD_DELIMITER NEWLINE' >> distance.style
-echo 'DATATYPE TRACK' >> distance.style
-echo 'PROLOGUE Lat,Lon,Alt(m),Alt(ft)' >> distance.style
-echo 'OFIELD LAT_DECIMAL,"","%f"' >> distance.style
-echo 'OFIELD LON_DECIMAL,"","%f"' >> distance.style
-echo 'OFIELD ALT_METERS,"","%.6e"' >> distance.style
-echo 'OFIELD ALT_FEET,"","%.6e"' >> distance.style
+echo 'DESCRIPTION  Distance Test' > ${TMPDIR}/distance.style
+echo 'EXTENSION csv' >> ${TMPDIR}/distance.style
+echo 'FIELD_DELIMITER COMMA' >> ${TMPDIR}/distance.style
+echo 'RECORD_DELIMITER NEWLINE' >> ${TMPDIR}/distance.style
+echo 'DATATYPE TRACK' >> ${TMPDIR}/distance.style
+echo 'PROLOGUE Lat,Lon,Alt(m),Alt(ft)' >> ${TMPDIR}/distance.style
+echo 'OFIELD LAT_DECIMAL,"","%f"' >> ${TMPDIR}/distance.style
+echo 'OFIELD LON_DECIMAL,"","%f"' >> ${TMPDIR}/distance.style
+echo 'OFIELD ALT_METERS,"","%.6e"' >> ${TMPDIR}/distance.style
+echo 'OFIELD ALT_FEET,"","%.6e"' >> ${TMPDIR}/distance.style
 
-gpsbabel -t -i unicsv -f ${REFERENCE}/distance.csv -o xcsv,style=distance.style -F ${TMPDIR}/distance~csv.csv
+gpsbabel -t -i unicsv -f ${REFERENCE}/distance.csv -o xcsv,style=${TMPDIR}/distance.style -F ${TMPDIR}/distance~csv.csv
 compare ${REFERENCE}/distance~csv.csv ${TMPDIR}/distance~csv.csv
 
 # This covers additional distance conversions from meters.
-echo 'DESCRIPTION  Distance 2 Test' > distance2.style
-echo 'EXTENSION csv' >> distance2.style
-echo 'FIELD_DELIMITER COMMA' >> distance2.style
-echo 'RECORD_DELIMITER NEWLINE' >> distance2.style
-echo 'DATATYPE TRACK' >> distance2.style
-echo 'PROLOGUE Lat,Lon,Dist(m),Dist(mile),Dist(nautical miles)' >> distance2.style
-echo 'IFIELD LAT_DECIMAL,"","%f"' >> distance2.style
-echo 'IFIELD LON_DECIMAL,"","%f"' >> distance2.style
-echo 'IFIELD PATH_DISTANCE_METERS,"","%.6e"' >> distance2.style
-echo 'OFIELD LAT_DECIMAL,"","%f"' >> distance2.style
-echo 'OFIELD LON_DECIMAL,"","%f"' >> distance2.style
-echo 'OFIELD PATH_DISTANCE_METERS,"","%.6e"' >> distance2.style
-echo 'OFIELD PATH_DISTANCE_MILES,"","%.6e"' >> distance2.style
-echo 'OFIELD PATH_DISTANCE_NAUTICAL_MILES,"","%.6e"' >> distance2.style
+echo 'DESCRIPTION  Distance 2 Test' > ${TMPDIR}/distance2.style
+echo 'EXTENSION csv' >> ${TMPDIR}/distance2.style
+echo 'FIELD_DELIMITER COMMA' >> ${TMPDIR}/distance2.style
+echo 'RECORD_DELIMITER NEWLINE' >> ${TMPDIR}/distance2.style
+echo 'DATATYPE TRACK' >> ${TMPDIR}/distance2.style
+echo 'PROLOGUE Lat,Lon,Dist(m),Dist(mile),Dist(nautical miles)' >> ${TMPDIR}/distance2.style
+echo 'IFIELD LAT_DECIMAL,"","%f"' >> ${TMPDIR}/distance2.style
+echo 'IFIELD LON_DECIMAL,"","%f"' >> ${TMPDIR}/distance2.style
+echo 'IFIELD PATH_DISTANCE_METERS,"","%.6e"' >> ${TMPDIR}/distance2.style
+echo 'OFIELD LAT_DECIMAL,"","%f"' >> ${TMPDIR}/distance2.style
+echo 'OFIELD LON_DECIMAL,"","%f"' >> ${TMPDIR}/distance2.style
+echo 'OFIELD PATH_DISTANCE_METERS,"","%.6e"' >> ${TMPDIR}/distance2.style
+echo 'OFIELD PATH_DISTANCE_MILES,"","%.6e"' >> ${TMPDIR}/distance2.style
+echo 'OFIELD PATH_DISTANCE_NAUTICAL_MILES,"","%.6e"' >> ${TMPDIR}/distance2.style
 
-gpsbabel -t -i xcsv,style=distance2.style -f ${REFERENCE}/distance2.csv -o xcsv,style=distance2.style -F ${TMPDIR}/distance2~csv.csv
+gpsbabel -t -i xcsv,style=${TMPDIR}/distance2.style -f ${REFERENCE}/distance2.csv -o xcsv,style=${TMPDIR}/distance2.style -F ${TMPDIR}/distance2~csv.csv
 compare ${REFERENCE}/distance2~csv.csv ${TMPDIR}/distance2~csv.csv
 
 # This covers xcsv path distances.
 # Reference has points ~1000m apart.
-echo 'DESCRIPTION  Distance 3 Test' > distance3.style
-echo 'EXTENSION csv' >> distance3.style
-echo 'FIELD_DELIMITER COMMA' >> distance3.style
-echo 'RECORD_DELIMITER NEWLINE' >> distance3.style
-echo 'DATATYPE TRACK' >> distance3.style
-echo 'PROLOGUE Utm,Dist(m),Dist(km),Dist(mile),Dist(nautical miles)' >> distance3.style
-echo 'IFIELD UTM,"","%s"' >> distance3.style
-echo 'OFIELD UTM,"","%s"' >> distance3.style
-echo 'OFIELD PATH_DISTANCE_METERS,"","%.6e"' >> distance3.style
-echo 'OFIELD PATH_DISTANCE_KM,"","%.6e"' >> distance3.style
-echo 'OFIELD PATH_DISTANCE_MILES,"","%.6e"' >> distance3.style
-echo 'OFIELD PATH_DISTANCE_NAUTICAL_MILES,"","%.6e"' >> distance3.style
+echo 'DESCRIPTION  Distance 3 Test' > ${TMPDIR}/distance3.style
+echo 'EXTENSION csv' >> ${TMPDIR}/distance3.style
+echo 'FIELD_DELIMITER COMMA' >> ${TMPDIR}/distance3.style
+echo 'RECORD_DELIMITER NEWLINE' >> ${TMPDIR}/distance3.style
+echo 'DATATYPE TRACK' >> ${TMPDIR}/distance3.style
+echo 'PROLOGUE Utm,Dist(m),Dist(km),Dist(mile),Dist(nautical miles)' >> ${TMPDIR}/distance3.style
+echo 'IFIELD UTM,"","%s"' >> ${TMPDIR}/distance3.style
+echo 'OFIELD UTM,"","%s"' >> ${TMPDIR}/distance3.style
+echo 'OFIELD PATH_DISTANCE_METERS,"","%.6e"' >> ${TMPDIR}/distance3.style
+echo 'OFIELD PATH_DISTANCE_KM,"","%.6e"' >> ${TMPDIR}/distance3.style
+echo 'OFIELD PATH_DISTANCE_MILES,"","%.6e"' >> ${TMPDIR}/distance3.style
+echo 'OFIELD PATH_DISTANCE_NAUTICAL_MILES,"","%.6e"' >> ${TMPDIR}/distance3.style
 
-gpsbabel -t -i xcsv,style=distance3.style -f ${REFERENCE}/distance3.csv -o xcsv,style=distance3.style -F ${TMPDIR}/distance3~csv.csv
+gpsbabel -t -i xcsv,style=${TMPDIR}/distance3.style -f ${REFERENCE}/distance3.csv -o xcsv,style=${TMPDIR}/distance3.style -F ${TMPDIR}/distance3~csv.csv
 compare ${REFERENCE}/distance3~csv.csv ${TMPDIR}/distance3~csv.csv

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -158,7 +158,7 @@ const QHash<QString, XcsvStyle::xcsv_token> XcsvStyle::xcsv_tokens {
 };
 
 /* a table of config file constants mapped to chars */
-const XcsvStyle::char_map_t XcsvStyle::xcsv_char_table[] = {
+const QHash<QString, QString> XcsvStyle::xcsv_char_table {
   { "COMMA",		"," 	},
   { "COMMASPACE",		", " 	},
   { "SINGLEQUOTE",	"'"	},
@@ -172,22 +172,15 @@ const XcsvStyle::char_map_t XcsvStyle::xcsv_char_table[] = {
   { "SPACE",  		" "	},
   { "HASH",  		"#"	},
   { "WHITESPACE",		"\\w"	},
-  { "PIPE",		"|"	},
-  { nullptr, 		nullptr	}
+  { "PIPE",		"|"	}
 };
 
 // Given a keyword of "COMMASPACE", return ", ".
 QString
 XcsvStyle::xcsv_get_char_from_constant_table(const QString& key)
 {
-  static QHash<QString, QString> substitutions;
-  if (substitutions.empty()) {
-    for (const char_map_t* cm = xcsv_char_table; !cm->key.isNull(); cm++) {
-      substitutions.insert(cm->key, cm->chars);
-    }
-  }
-  if (substitutions.contains(key)) {
-    return substitutions[key];
+  if (xcsv_char_table.contains(key)) {
+    return xcsv_char_table[key];
   }
   // No substitution found? Just return original.
   return key;

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -179,11 +179,8 @@ const QHash<QString, QString> XcsvStyle::xcsv_char_table {
 QString
 XcsvStyle::xcsv_get_char_from_constant_table(const QString& key)
 {
-  if (xcsv_char_table.contains(key)) {
-    return xcsv_char_table[key];
-  }
   // No substitution found? Just return original.
-  return key;
+  return xcsv_char_table.value(key, key);
 }
 
 // Remove outer quotes.

--- a/xcsv.h
+++ b/xcsv.h
@@ -244,12 +244,6 @@ public:
 private:
   /* Types */
 
-  /* something to map config file constants to chars */
-  struct char_map_t {
-    const QString key;
-    const QString chars;
-  };
-
   /* Member Functions */
 
   static QString dequote(const QString& in);
@@ -264,7 +258,7 @@ private:
   static const QHash<QString, xcsv_token> xcsv_tokens;
 
   /* a table of config file constants mapped to chars */
-  static const char_map_t xcsv_char_table[];
+  static const QHash<QString, QString> xcsv_char_table;
 };
 
 class XcsvFormat : public Format

--- a/xmldoc/filters/resample.xml
+++ b/xmldoc/filters/resample.xml
@@ -13,7 +13,7 @@ This examples doubles the sample rate.  The data is filtered after interpolation
 <example id="example_resample_filter_decimate">
 <title>Decimation with the resampling filter</title>
 <para>
-This examples reduces the sample rate by a factor of 4.  The data if filtered before decimation regardless of the order of the options.
+This examples reduces the sample rate by a factor of 4.  The data is filtered before decimation regardless of the order of the options.
 </para>
 <para><userinput>gpsbabel -t -i unicsv -f data.csv -x resample,average=4,decimate=2 -o unicsv,utc=0 -F slow.csv</userinput></para>
 </example>


### PR DESCRIPTION
gpsdevice.cc: limit variable scope.  LGTM flags globals with short names.

csv_util.cc: use c++ includes.

discard.h: member function can be static.

xcsv.cc, xcsv.h: use list initialization to construct xcsv char map table.

xmldoc/filters/resample.xml: minor corrections to document.

GPSBabel.pro, CMakeLists.txt: sort SOURCES and HEADERS in build.  this gives a reasonable initial project view in Xcode.  this gives a resaonable order to compilation.

dmtlog.cc, mapsend.cc: prefer rte_waypt_ct() over waypoint_list.count().  this provides some insulation from the underlying WaypointList container.

testo.d/unitconversion.test: sequester temporary style files in TMPDIR

