### PR TITLE
migrate arcdist, polygon and xcsv style file reading to gpsbabel::TextStream

### DIFF
--- a/bcr.cc
+++ b/bcr.cc
@@ -252,7 +252,7 @@ bcr_data_read()
     route->rte_name = routename;
   }
 
-  for (int index = 1; index > 0; index ++) {
+  for (int index = 1; ; index++) {
     char station[32];
     QString str;
     int mlat, mlon;		/* mercator data */

--- a/polygon.cc
+++ b/polygon.cc
@@ -19,14 +19,14 @@
 
  */
 
-#include <cstdio>           // for sscanf
-#include <cstring>          // for strchr, strlen, strspn
+#include <cstdio>                 // for sscanf
 
-#include <QtGlobal>         // for foreach
+#include <QString>                // for QString
+#include <QtGlobal>               // for foreach
 
 #include "defs.h"
 #include "polygon.h"
-#include "gbfile.h"         // for gbfclose, gbfgetstr, gbfopen, gbfile
+#include "src/core/textstream.h"  // for TextStream
 
 
 #if FILTERS_ENABLED
@@ -225,9 +225,10 @@ void PolygonFilter::process()
   int fileline = 0;
   int first = 1;
   int last = 0;
-  char* line;
+  QString line;
 
-  gbfile* file_in = gbfopen(polyfileopt, "r", MYNAME);
+  gpsbabel::TextStream stream;
+  stream.open(polyfileopt, QIODevice::ReadOnly, MYNAME);
 
   double olat = BADVAL;
   double olon = BADVAL;
@@ -235,18 +236,18 @@ void PolygonFilter::process()
   double lon1 = BADVAL;
   double lat2 = BADVAL;
   double lon2 = BADVAL;
-  while ((line = gbfgetstr(file_in))) {
+  while (stream.readLineInto(&line)) {
     fileline++;
 
-    char* pound = strchr(line, '#');
-    if (pound) {
-      *pound = '\0';
+    auto pound = line.indexOf('#');
+    if (pound >= 0) {
+      line.truncate(pound);
     }
 
     lat2 = lon2 = BADVAL;
-    int argsfound = sscanf(line, "%lf %lf", &lat2, &lon2);
+    int argsfound = sscanf(CSTR(line), "%lf %lf", &lat2, &lon2);
 
-    if (argsfound != 2 && strspn(line, " \t\n") < strlen(line)) {
+    if ((argsfound != 2) && (line.trimmed().size() > 0)) {
       warning(MYNAME
               ": Warning: Polygon file contains unusable vertex on line %d.\n",
               fileline);
@@ -294,7 +295,7 @@ void PolygonFilter::process()
       lon1 = lon2;
     }
   }
-  gbfclose(file_in);
+  stream.close();
 
   foreach (Waypoint* wp, *global_waypoint_list) {
     ed = (extra_data*) wp->extra_data;

--- a/util.cc
+++ b/util.cc
@@ -46,7 +46,6 @@
 #include <QtGlobal>                     // for qAsConst, QAddConst<>::Type, qPrintable
 
 #include "defs.h"
-#include "cet.h"                        // for cet_utf8_to_ucs4
 #include "src/core/datetime.h"          // for DateTime
 #include "src/core/logging.h"           // for Warning
 #include "src/core/xmltag.h"            // for xml_tag, xml_attribute, xml_findfirst, xml_findnext
@@ -1524,16 +1523,13 @@ static
 char*
 entitize(const char* str, bool is_html)
 {
-  int ecount;
-  int nsecount;
   char* p;
   char* tmp;
   char* xstr;
 
-  int bytes = 0;
-  int value = 0;
   entity_types* ep = stdentities;
-  int elen = ecount = nsecount = 0;
+  int elen = 0;
+  int ecount = 0;
 
   /* figure # of entity replacements and additional size. */
   while (ep->text) {
@@ -1546,28 +1542,9 @@ entitize(const char* str, bool is_html)
     ep++;
   }
 
-  /* figure the same for other than standard entities (i.e. anything
-   * that isn't in the range U+0000 to U+007F */
-
-#if 0
-  for (cp = str; *cp; cp++) {
-    if (*cp & 0x80) {
-      cet_utf8_to_ucs4(cp, &bytes, &value);
-      cp += bytes-1;
-      elen += sprintf(tmpsub, "&#x%x;", value) - bytes;
-      nsecount++;
-    }
-  }
-#endif
-
   /* enough space for the whole string plus entity replacements, if any */
   tmp = (char*) xcalloc((strlen(str) + elen + 1), 1);
   strcpy(tmp, str);
-
-  /* no entity replacements */
-  if (ecount == 0 && nsecount == 0) {
-    return (tmp);
-  }
 
   if (ecount != 0) {
     for (ep = stdentities; ep->text; ep++) {
@@ -1590,27 +1567,6 @@ entitize(const char* str, bool is_html)
     }
   }
 
-  if (nsecount != 0) {
-    p = tmp;
-    while (*p) {
-      if (*p & 0x80) {
-        cet_utf8_to_ucs4(p, &bytes, &value);
-        if (p[bytes]) {
-          xstr = xstrdup(p + bytes);
-        } else {
-          xstr = nullptr;
-        }
-        sprintf(p, "&#x%x;", value);
-        p = p+strlen(p);
-        if (xstr) {
-          strcpy(p, xstr);
-          xfree(xstr);
-        }
-      } else {
-        p++;
-      }
-    }
-  }
   return (tmp);
 }
 

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -50,7 +50,6 @@
 #include "csv_util.h"                 // for csv_stringtrim, dec_to_human, csv_stringclean, human_to_dec, ddmmdir_to_degrees, dec_to_intdeg, decdir_to_dec, intdeg_to_dec, csv_linesplit
 #include "formspec.h"                 // for FormatSpecificDataList
 #include "garmin_fs.h"                // for garmin_fs_t, garmin_fs_alloc
-#include "gbfile.h"                   // for gbfgetstr, gbfclose, gbfopen, gbfile
 #include "grtcirc.h"                  // for RAD, gcdist, radtometers
 #include "jeeps/gpsmath.h"            // for GPS_Math_WGS84_To_UTM_EN, GPS_Lookup_Datum_Index, GPS_Math_Known_Datum_To_WGS84_M, GPS_Math_UTM_EN_To_Known_Datum, GPS_Math_WGS84_To_Known_Datum_M, GPS_Math_WGS84_To_UKOSMap_M
 #include "jeeps/gpsport.h"            // for int32
@@ -1832,18 +1831,20 @@ XcsvStyle::xcsv_parse_style_buff(const char* sbuff)
 XcsvStyle
 XcsvStyle::xcsv_read_style(const char* fname)
 {
-  gbfile* fp = gbfopen(fname, "rb", MYNAME);
   XcsvStyle style;
-  for (QString sbuff = gbfgetstr(fp); !sbuff.isNull(); sbuff = gbfgetstr(fp)) {
-    sbuff = sbuff.trimmed();
-    xcsv_parse_style_line(&style, sbuff);
+
+  gpsbabel::TextStream stream;
+  stream.open(fname, QIODevice::ReadOnly, MYNAME);
+  QString sbuff;
+  while (stream.readLineInto(&sbuff)) {
+    xcsv_parse_style_line(&style, sbuff.trimmed());
   }
+  stream.close();
 
   /* if we have no output fields, use input fields as output fields */
   if (style.ofields.isEmpty()) {
     style.ofields = style.ifields;
   }
-  gbfclose(fp);
 
   return style;
 }


### PR DESCRIPTION
fix lgtm detected ill-defined for loop.

remove support for non standard entity replacements, which has been disabled since 2005.