### PR TITLE
retire some csv char based routines.

### DIFF
--- a/csv_util.cc
+++ b/csv_util.cc
@@ -52,80 +52,15 @@ QString
 csv_stringclean(const QString& source, const QString& to_nuke)
 {
   QString r = source;
-  // avoid problematic regular rexpressions, e.g. xmapwpt generated [:\n:],
-  // or one can imagine [0-9] when we meant the characters, '0', '-', and '9',
-  // or one can imagine [^a] when we meant the characters '^' and 'a'.
-  QRegularExpression regex = QRegularExpression(QString("[%1]").arg(QRegularExpression::escape(to_nuke)));
-  assert(regex.isValid());
-  return r.remove(regex);
-}
-
-// csv_stringtrim() - trim whitespace and leading and trailing
-//                    enclosures (quotes)
-//                    returns a copy of the modified string
-//    usage: p = csv_stringtrim(string, "\"", 0)
-char*
-csv_stringtrim(const char* string, const char* enclosure, int strip_max)
-{
-  static const char* p1 = nullptr;
-  char* tmp = xstrdup(string);
-  size_t elen;
-
-  if (!strlen(string)) {
-    return (tmp);
+  if (!to_nuke.isEmpty()) {
+    // avoid problematic regular rexpressions, e.g. xmapwpt generated [:\n:],
+    // or one can imagine [0-9] when we meant the characters, '0', '-', and '9',
+    // or one can imagine [^a] when we meant the characters '^' and 'a'.
+    QRegularExpression regex = QRegularExpression(QString("[%1]").arg(QRegularExpression::escape(to_nuke)));
+    assert(regex.isValid());
+    r.remove(regex);
   }
-
-  if (!enclosure) {
-    elen = 0;
-  } else {
-    elen = strlen(enclosure);
-  }
-
-  char* p2 = tmp + strlen(tmp) - 1;
-  p1 = tmp;
-
-  /* trim off trailing whitespace */
-  while ((p2 > p1) && isspace(*p2)) {
-    p2--;
-  }
-
-  /* advance p1 past any leading whitespace */
-  while ((p1 < p2) && (isspace(*p1))) {
-    p1++;
-  }
-
-  /* if no maximum strippage, assign a reasonable value to max */
-  strip_max = strip_max ? strip_max : 9999;
-
-  /* if we have enclosures, skip past them in pairs */
-  if (elen) {
-    int stripped = 0;
-    while (
-      (stripped < strip_max) &&
-      ((size_t)(p2 - p1 + 1) >= (elen * 2)) &&
-      (strncmp(p1, enclosure, elen) == 0) &&
-      (strncmp((p2 - elen + 1), enclosure, elen) == 0)) {
-      p2 -= elen;
-      p1 += elen;
-      stripped++;
-    }
-  }
-
-  /* copy what's left over back into tmp. */
-  memmove(tmp, p1, (p2 - p1) + 1);
-
-  tmp[(p2 - p1) + 1] = '\0';
-
-  return (tmp);
-}
-
-// Is this really the replacement for the above? No.
-QString
-csv_stringtrim(const QString& source, const QString& enclosure)
-{
-  QString r = source;
-  r.replace(enclosure, "");
-  return r.trimmed();
+  return r;
 }
 
 // csv_stringtrim() - trim whitespace and leading and trailing
@@ -211,121 +146,6 @@ csv_dequote(const QString& string, const QString& enclosure)
   }
 
   return retval;
-}
-/*****************************************************************************/
-/* csv_lineparse() - extract data fields from a delimited string. designed   */
-/*                   to handle quoted and delimited data within quotes.      */
-/*                   returns temporary COPY of delimited data field (use it  */
-/*                   or lose it on the next call).                           */
-/*    usage: p = csv_lineparse(string, ",", "\"", line)  [initial call]      */
-/*           p = csv_lineparse(NULL, ",", "\"", line)    [subsequent calls]  */
-/*****************************************************************************/
-char*
-csv_lineparse(const char* stringstart, const char* delimited_by,
-              const char* enclosed_in, const int line_no)
-{
-  static const char* p = nullptr;
-  static char* tmp = nullptr;
-  size_t dlen = 0, elen = 0, efound = 0;
-  int enclosedepth = 0;
-  short int hyper_whitespace_delimiter = 0;
-
-  if (tmp) {
-    xfree(tmp);
-    tmp = nullptr;
-  }
-
-  if (strcmp(delimited_by, "\\w") == 0) {
-    hyper_whitespace_delimiter = 1;
-  }
-
-  /*
-   * This is tacky.  Our "csv" format is actually "commaspace" format.
-   * Changing that causes unwanted churn, but it also makes "real"
-   * comma separated data (such as likely to be produced by Excel, etc.)
-   * unreadable.   So we silently change it here on a read and let the
-   * whitespace eater consume the space.
-   */
-  if (strcmp(delimited_by, ", ") == 0) {
-    delimited_by = ",";
-  }
-
-  if (!p) {
-    /* first pass thru */
-    p =  stringstart;
-
-    if (!p) {
-      /* last pass out */
-      return (nullptr);
-    }
-  }
-
-  /* the beginning of the string we start with (this pass) */
-  const char* sp = p;
-
-  /* length of delimiters and enclosures */
-  if ((delimited_by) && (!hyper_whitespace_delimiter)) {
-    dlen = strlen(delimited_by);
-  }
-  if (enclosed_in) {
-    elen = strlen(enclosed_in);
-  }
-  short int dfound = 0;
-
-  while ((*p) && (!dfound)) {
-    if ((elen) && (strncmp(p, enclosed_in, elen) == 0)) {
-      efound = 1;
-      p+=elen;
-      if (enclosedepth) {
-        enclosedepth--;
-      } else {
-        enclosedepth++;
-      }
-      continue;
-    }
-
-    if (!enclosedepth) {
-      if ((dlen) && (strncmp(p, delimited_by, dlen) == 0)) {
-        dfound = 1;
-      } else if ((hyper_whitespace_delimiter) && (ISWHITESPACE(*p))) {
-        dfound = 1;
-        while (ISWHITESPACE(*p)) {
-          p++;
-        }
-      } else {
-        p++;
-      }
-    } else {
-      p++;
-    }
-  }
-
-  /* allocate enough space for this data field */
-  tmp = (char*) xcalloc((p - sp) + 1, sizeof(char));
-
-  strncpy(tmp, sp, (p - sp));
-  tmp[p - sp] = '\0';
-
-  if (elen && efound) {
-    char* c = csv_stringtrim(tmp, enclosed_in, 0);
-    xfree(tmp);
-    tmp = c;
-  }
-
-  if (dfound) {
-    /* skip over the delimited_by */
-    p += dlen;
-  } else {
-    /* end of the line */
-    p = nullptr;
-  }
-
-  if (enclosedepth != 0) {
-    warning(MYNAME
-            ": Warning- Unbalanced Field Enclosures (%s) on line %d\n",
-            enclosed_in, line_no);
-  }
-  return (tmp);
 }
 
 /*****************************************************************************/

--- a/csv_util.h
+++ b/csv_util.h
@@ -32,10 +32,6 @@
 QString
 csv_stringclean(const QString& source, const QString& to_nuke);
 
-char*
-csv_stringtrim(const char* string, const char* enclosure, int strip_max);
-QString
-csv_stringtrim(const QString& source, const QString& enclosure);
 QString
 csv_stringtrim(const QString& string, const QString& enclosure, int strip_max);
 QString
@@ -45,8 +41,6 @@ csv_dequote(const QString& string, const QString& enclosure);
 
 enum class CsvQuoteMethod {historic, rfc4180};
 
-char*
-csv_lineparse(const char* stringstart, const char* delimited_by, const char* enclosed_in, int line_no);
 QStringList
 csv_linesplit(const QString& string, const QString& delimited_by,
               const QString& enclosed_in, const int line_no, CsvQuoteMethod method = CsvQuoteMethod::historic);

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -663,10 +663,10 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     break;
   case XcsvStyle::XT_GEOCACHE_TYPE:
     /* Geocache Type */
-    wpt->AllocGCData()->type = gs_mktype(s);
+    wpt->AllocGCData()->type = gs_mktype(value);
     break;
   case XcsvStyle::XT_GEOCACHE_CONTAINER:
-    wpt->AllocGCData()->container = gs_mkcont(s);
+    wpt->AllocGCData()->container = gs_mkcont(value);
     break;
   case XcsvStyle::XT_GEOCACHE_HINT:
     wpt->AllocGCData()->hint = value.trimmed();
@@ -711,11 +711,11 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   case XcsvStyle::XT_GPS_FIX:
     wpt->fix = (fix_type)(atoi(s)-(fix_type)1);
     if (wpt->fix < fix_2d) {
-      if (!case_ignore_strcmp(s, "none")) {
+      if (!case_ignore_strcmp(value, "none")) {
         wpt->fix = fix_none;
-      } else if (!case_ignore_strcmp(s, "dgps")) {
+      } else if (!case_ignore_strcmp(value, "dgps")) {
         wpt->fix = fix_dgps;
-      } else if (!case_ignore_strcmp(s, "pps")) {
+      } else if (!case_ignore_strcmp(value, "pps")) {
         wpt->fix = fix_pps;
       } else {
         wpt->fix = fix_unknown;

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -1673,7 +1673,7 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
 
     /* field delimiters are always bad characters */
     if (cp == u"\\w") {
-      style->badchars = " \n\r";
+      style->badchars += " \n\r";
     } else {
       style->badchars += cp;
     }

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -245,7 +245,7 @@ XcsvStyle::xcsv_ofield_add(XcsvStyle* style, const QString& qkey, const QString&
 }
 
 QDateTime
-XcsvFormat::yyyymmdd_to_time(const char* s)
+XcsvFormat::yyyymmdd_to_time(const QString& s)
 {
   QDate d = QDate::fromString(s, "yyyyMMdd");
 #if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
@@ -387,7 +387,7 @@ void
 XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle::field_map& fmp,
                            xcsv_parse_data* parse_data, const int line_no)
 {
-  const char* enclosure = "";
+  QString enclosure = "";
   geocache_data* gc_data = nullptr;
 
   if (fmp.printfc.isNull()) {
@@ -617,7 +617,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   }
   break;
   case XcsvStyle::XT_YYYYMMDD_TIME:
-    wpt->SetCreationTime(yyyymmdd_to_time(s));
+    wpt->SetCreationTime(yyyymmdd_to_time(value));
     break;
   case XcsvStyle::XT_GMT_TIME:
     wpt->SetCreationTime(sscanftime(s, fmp.printfc.constData(), 1));
@@ -649,7 +649,7 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
   }
   break;
   case XcsvStyle::XT_GEOCACHE_LAST_FOUND:
-    wpt->AllocGCData()->last_found = yyyymmdd_to_time(s);
+    wpt->AllocGCData()->last_found = yyyymmdd_to_time(value);
     break;
 
   /* GEOCACHING STUFF ***************************************************/

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -416,13 +416,13 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     /* IGNORE -- Calculated Sequence # For Output*/
     break;
   case XcsvStyle::XT_SHORTNAME:
-    wpt->shortname = csv_stringtrim(s, enclosure);
+    wpt->shortname = csv_stringtrim(value, enclosure, 0);
     break;
   case XcsvStyle::XT_DESCRIPTION:
-    wpt->description = csv_stringtrim(s, enclosure);
+    wpt->description = csv_stringtrim(value, enclosure, 0);
     break;
   case XcsvStyle::XT_NOTES:
-    wpt->notes = csv_stringtrim(s, "");
+    wpt->notes = value.trimmed();
     break;
   case XcsvStyle::XT_URL:
     if (!parse_data->link_) {
@@ -676,9 +676,9 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     break;
   case XcsvStyle::XT_GEOCACHE_ISAVAILABLE:
     gc_data = wpt->AllocGCData();
-    if (case_ignore_strcmp(csv_stringtrim(s, ""), "False") == 0) {
+    if (case_ignore_strcmp(value.trimmed(), "False") == 0) {
       gc_data->is_available = status_false;
-    } else if (case_ignore_strcmp(csv_stringtrim(s, ""), "True") == 0) {
+    } else if (case_ignore_strcmp(value.trimmed(), "True") == 0) {
       gc_data->is_available = status_true;
     } else {
       gc_data->is_available = status_unknown;
@@ -686,9 +686,9 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     break;
   case XcsvStyle::XT_GEOCACHE_ISARCHIVED:
     gc_data = wpt->AllocGCData();
-    if (case_ignore_strcmp(csv_stringtrim(s, ""), "False") == 0) {
+    if (case_ignore_strcmp(value.trimmed(), "False") == 0) {
       gc_data->is_archived = status_false;
-    } else if (case_ignore_strcmp(csv_stringtrim(s, ""), "True") == 0) {
+    } else if (case_ignore_strcmp(value.trimmed(), "True") == 0) {
       gc_data->is_archived = status_true;
     } else {
       gc_data->is_archived = status_unknown;
@@ -724,13 +724,13 @@ XcsvFormat::xcsv_parse_val(const QString& value, Waypoint* wpt, const XcsvStyle:
     break;
   /* Tracks and routes *********************************************/
   case XcsvStyle::XT_ROUTE_NAME:
-    parse_data->rte_name = csv_stringtrim(s, enclosure);
+    parse_data->rte_name = csv_stringtrim(value, enclosure, 0);
     break;
   case XcsvStyle::XT_TRACK_NEW:
     parse_data->new_track = atoi(s);
     break;
   case XcsvStyle::XT_TRACK_NAME:
-    parse_data->trk_name = csv_stringtrim(s, enclosure);
+    parse_data->trk_name = csv_stringtrim(value, enclosure, 0);
     break;
 
   /* OTHER STUFF ***************************************************/
@@ -1667,34 +1667,31 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
   const QStringList tokens = tokenstr.split(',');
 
   if (op == u"FIELD_DELIMITER") {
-    auto cp = xcsv_get_char_from_constant_table(tokens[0]);
+    auto sp = csv_stringtrim(tokenstr, "\"", 1);
+    auto cp = xcsv_get_char_from_constant_table(sp);
     style->field_delimiter = cp;
 
-    char* p = csv_stringtrim(CSTR(style->field_delimiter), " ", 0);
     /* field delimiters are always bad characters */
-    if (0 == strcmp(p, "\\w")) {
+    if (cp == u"\\w") {
       style->badchars = " \n\r";
     } else {
-      style->badchars += p;
+      style->badchars += cp;
     }
-    xfree(p);
 
   } else if (op == u"FIELD_ENCLOSER") {
-    auto cp = xcsv_get_char_from_constant_table(tokens[0]);
+    auto sp = csv_stringtrim(tokenstr, "\"", 1);
+    auto cp = xcsv_get_char_from_constant_table(sp);
     style->field_encloser = cp;
 
-    char* p = csv_stringtrim(CSTR(style->field_encloser), " ", 0);
-    style->badchars += p;
-    xfree(p);
+    style->badchars += cp;
 
   } else if (op == u"RECORD_DELIMITER") {
-    auto cp = xcsv_get_char_from_constant_table(tokens[0]);
+    auto sp = csv_stringtrim(tokenstr, "\"", 1);
+    auto cp = xcsv_get_char_from_constant_table(sp);
     style->record_delimiter = cp;
 
     // Record delimiters are always bad characters.
-    auto* p = csv_stringtrim(CSTR(style->record_delimiter), " ", 0);
-    style->badchars += p;
-    xfree(p);
+    style->badchars += cp;
 
   } else if (op == u"FORMAT_TYPE") {
     if (tokens[0] == u"INTERNAL") {
@@ -1718,10 +1715,9 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
     style->whitespace_ok = tokens[0].toInt();
 
   } else if (op == u"BADCHARS") {
-    char* sp = csv_stringtrim(CSTR(tokenstr), "\"", 1);
-    QString cp = xcsv_get_char_from_constant_table(sp);
+    auto sp = csv_stringtrim(tokenstr, "\"", 1);
+    auto cp = xcsv_get_char_from_constant_table(sp);
     style->badchars += cp;
-    xfree(sp);
 
   } else if (op =="PROLOGUE") {
     style->prologue.append(tokenstr);

--- a/xcsv.h
+++ b/xcsv.h
@@ -370,7 +370,7 @@ private:
 
   /* Member Functions */
 
-  static QDateTime yyyymmdd_to_time(const char* s);
+  static QDateTime yyyymmdd_to_time(const QString& s);
   static time_t sscanftime(const char* s, const char* format, int gmt);
   static time_t addhms(const char* s, const char* format);
   static QString writetime(const char* format, time_t t, bool gmt);


### PR DESCRIPTION
The last csv_lineparse user, garmin_txt, is converted to csv_linesplit.

xcsv_parse_val converted to use csv_stringtrim(QString,QString,int),
eliminating the other overloads.

xcsv_parse_style_line parsing of FIELD_DELIMITER, FIELD_ENCLOSER,
RECORD_DELIMITER and BADCHARS updated to use the above overload of
csv_stringtrim.  FIELD_DELIMITER, FIELD_ENCLOSER and RECORD_DELIMITER
changed to trim, with a double quote enclosure,  before character substitution.
There was a subtle bug in csvs_stringtrim(char, char, int).  When trimming
a source that was all white space the first white space character would
be retained, while others would be trimmed.  This did occur with CRNEWLINE,
but the bug allowed other substitutions to work, e.g. SPACE, NEWLINE, TAB, CR.

A small bug in csv_stringclean was fixed.  If the to_nuke was empty an invalid
regular expression was created.