### PR TITLE
Fix warnings on Mac related to printing qint64s

### DIFF
--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -25,6 +25,7 @@
 #include <cstdint>             // for uint8_t, uint16_t, uint32_t, int32_t, int8_t, uint64_t
 #include <cstdio>              // for EOF, SEEK_SET, snprintf
 #include <deque>               // for deque, _Deque_iterator, operator!=
+#include <inttypes.h>          // for PRItNN
 #include <memory>              // for allocator_traits<>::value_type
 #include <string>              // for operator+, to_string, char_traits
 #include <utility>             // for pair
@@ -409,7 +410,7 @@ GarminFitFormat::fit_parse_data(const fit_message_def& def, int time_offset)
   QString description;
 
   if (global_opts.debug_level >= 7) {
-    debug_print(7,"%s: parsing fit data ID %d with num_fields=%d\n", MYNAME, def.global_id, def.fields.size());
+    debug_print(7,"%s: parsing fit data ID %d with num_fields=%" PRId64 "\n", MYNAME, def.global_id, def.fields.size());
   }
   for (int i = 0; i < def.fields.size(); ++i) {
     if (global_opts.debug_level >= 7) {
@@ -659,7 +660,7 @@ GarminFitFormat::fit_parse_data(const fit_message_def& def, int time_offset)
   }
 
   if (global_opts.debug_level >= 7) {
-    debug_print(7,"%s: storing fit data with num_fields=%d\n", MYNAME, def.fields.size());
+    debug_print(7,"%s: storing fit data with num_fields=%" PRId64 "\n", MYNAME, def.fields.size());
   }
   switch (def.global_id) {
   case kIdLap: { // lap message

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -90,6 +90,7 @@
 #include <cstdlib>                // for atoi, abs
 #include <cstring>                // for strcmp, strlen
 #include <ctime>                  // for time_t
+#include <inttypes.h>             // for PRIxNN
 
 #include <QByteArray>             // for QByteArray
 #include <QDate>                  // for QDate
@@ -139,7 +140,7 @@ LowranceusrFormat::register_waypt(const Waypoint* wpt) const
   }
 
   if (global_opts.debug_level >= 2) {
-    printf(MYNAME " adding waypt %s (%s) to table at index %d\n",
+    printf(MYNAME " adding waypt %s (%s) to table at index %" PRId64 "\n",
            qPrintable(wpt->shortname), qPrintable(wpt->description), waypt_table->size());
   }
 
@@ -606,7 +607,7 @@ LowranceusrFormat::lowranceusr4_parse_waypt(Waypoint* wpt_tmp) const
         printf("%08x %08x %08x %08x ",
                fsdata->UUID1, fsdata->UUID2, fsdata->UUID3, fsdata->UUID4);
       }
-      printf(" %10u %8d %8d %8d %6d",
+      printf(" %10u %8d %8d %8d %6" PRId64,
              fsdata->uid_unit, fsdata->uid_seq_low, fsdata->uid_seq_high,
              waypoint_version, name.length());
       if (name.length() > 16) {
@@ -621,9 +622,9 @@ LowranceusrFormat::lowranceusr4_parse_waypt(Waypoint* wpt_tmp) const
       printf(" %08x %4d %4d %7s", fsdata->flags, fsdata->icon_num, fsdata->color,
              (fsdata->color_desc == nullptr ? "unk" : qPrintable(fsdata->color_desc)));
       if (desc.length() > 16) {
-        printf(" %6d %.13s...", desc.length(), qPrintable(desc));
+        printf(" %6" PRId64 " %.13s...", desc.length(), qPrintable(desc));
       } else {
-        printf(" %6d %16s", desc.length(), qPrintable(desc));
+        printf(" %6" PRId64 " %16s", desc.length(), qPrintable(desc));
       }
       printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")));
       printf(" %08x %8.3f %08x %08x %08x\n",
@@ -1483,7 +1484,7 @@ LowranceusrFormat::lowranceusr4_write_waypoints()
   route_disp_all(nullptr, nullptr, register_waypt_lambda);
 
   if (global_opts.debug_level >= 1) {
-    printf(MYNAME " writing %d waypoints\n", waypt_table->size());
+    printf(MYNAME " writing %" PRId64 " waypoints\n", waypt_table->size());
   }
 
   gbfputint32(waypt_table->size(), file_out);


### PR DESCRIPTION
Fix default warnings on Mac by printing qint64s as %lld, but portably.