### PR TITLE
Mechanically remove QStringRef use for QStringView to help with Qt6.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -39,7 +39,6 @@
 #include <QtCore/QList>           // for QList, QList<>::const_reverse_iterator, QList<>::reverse_iterator
 #include <QtCore/QScopedPointer>  // for QScopedPointer
 #include <QtCore/QString>         // for QString
-#include <QtCore/QStringRef>      // for QStringRef
 #include <QtCore/QTextCodec>      // for QTextCodec
 #include <QtCore/QVector>         // for QVector
 #include <QtCore/Qt>              // for CaseInsensitive

--- a/garmin_tables.cc
+++ b/garmin_tables.cc
@@ -24,7 +24,6 @@
 #include <cstring>               // for strncpy, strchr, strlen, strncmp
 #include <QtCore/QChar>          // for operator==, QChar
 #include <QtCore/QDebug>         // for QDebug
-#include <QtCore/QStringRef>     // for QStringRef
 #include <QtCore/Qt>             // for CaseInsensitive
 #include "defs.h"
 #include "garmin_tables.h"

--- a/geo.cc
+++ b/geo.cc
@@ -48,42 +48,42 @@ static void GeoReadLoc()
   QString current_tag;
 
   while (!reader.atEnd()) {
-    QStringRef tag_name = reader.name();
+    auto tag_name = reader.name();
     if (reader.tokenType()==QXmlStreamReader::StartElement) {
       current_tag.append("/");
       current_tag.append(tag_name);
-      if (current_tag == "/loc/waypoint") {
+      if (current_tag == u"/loc/waypoint") {
         wpt = new Waypoint;
         wpt->AllocGCData();
         // There is no 'unknown' alt value and so many reference files have
         // leaked it that we just paper over that here.
         wpt->altitude = 0;
-      } else if (current_tag == "/loc/waypoint/name") {
+      } else if (current_tag == u"/loc/waypoint/name") {
         QXmlStreamAttributes a = reader.attributes();
         wpt->shortname = a.value("id").toString();
         wpt->description = reader.readElementText();
-      } else if (current_tag == "/loc/waypoint/coord") {
+      } else if (current_tag == u"/loc/waypoint/coord") {
         QXmlStreamAttributes a = reader.attributes();
         wpt->latitude = a.value("lat").toString().toDouble();
         wpt->longitude = a.value("lon").toString().toDouble();
-      } else if (current_tag == "/loc/waypoint/type") {
+      } else if (current_tag == u"/loc/waypoint/type") {
         wpt->icon_descr = reader.readElementText();
-      } else if (current_tag == "/loc/waypoint/link") {
+      } else if (current_tag == u"/loc/waypoint/link") {
         QXmlStreamAttributes a = reader.attributes();
         waypt_add_url(wpt,
                       reader.readElementText(), a.value("text").toString());
-      } else if (current_tag == "/loc/waypoint/difficulty") {
+      } else if (current_tag == u"/loc/waypoint/difficulty") {
         wpt->gc_data->diff = reader.readElementText().toDouble() * 10;
-      } else if (current_tag == "/loc/waypoint/terrain") {
+      } else if (current_tag == u"/loc/waypoint/terrain") {
         wpt->gc_data->terr = reader.readElementText().toDouble() * 10;
-      } else if (current_tag == "/loc/waypoint/container") {
+      } else if (current_tag == u"/loc/waypoint/container") {
         wpt->gc_data->container = wpt_container(reader.readElementText());
       }
     }
 
     // The tokenType may have changed to EndElement as a result of readElementText.
     if (reader.tokenType() == QXmlStreamReader::EndElement) {
-      if (current_tag == "/loc/waypoint") {
+      if (current_tag == u"/loc/waypoint") {
         waypt_add(wpt);
       }
       current_tag.chop(tag_name.length() + 1);

--- a/gpx.cc
+++ b/gpx.cc
@@ -33,7 +33,7 @@
 #include <QtCore/QStaticStringData>                // for QStaticStringData
 #include <QtCore/QString>                          // for QString, QStringLiteral, operator+, operator==
 #include <QtCore/QStringList>                      // for QStringList
-#include <QtCore/QStringRef>                       // for QStringRef
+#include <QtCore/QStringView>                      // for QStringView
 #include <QtCore/QTime>                            // for QTime
 #include <QtCore/QVersionNumber>                   // for QVersionNumber
 #include <QtCore/QXmlStreamAttribute>              // for QXmlStreamAttribute
@@ -213,7 +213,7 @@ GpxFormat::tag_gs_cache(const QXmlStreamAttributes& attr) const
 }
 
 void
-GpxFormat::start_something_else(const QStringRef& el, const QXmlStreamAttributes& attr)
+GpxFormat::start_something_else(const QStringView& el, const QXmlStreamAttributes& attr)
 {
   if (!fs_ptr) {
     return;
@@ -308,7 +308,7 @@ GpxFormat::tag_log_wpt(const QXmlStreamAttributes& attr) const
 }
 
 void
-GpxFormat::gpx_start(const QStringRef& el, const QXmlStreamAttributes& attr)
+GpxFormat::gpx_start(const QStringView& el, const QXmlStreamAttributes& attr)
 {
   /*
    * Reset end-of-string without actually emptying/reallocing cdatastr.
@@ -551,7 +551,7 @@ xml_parse_time(const QString& dateTimeString)
 }
 
 void
-GpxFormat::gpx_end(const QStringRef& /*unused*/)
+GpxFormat::gpx_end(const QStringView& /*unused*/)
 {
   static QDateTime gc_log_date;
 
@@ -891,7 +891,7 @@ GpxFormat::gpx_end(const QStringRef& /*unused*/)
 
 
 void
-GpxFormat::gpx_cdata(const QStringRef& s)
+GpxFormat::gpx_cdata(const QStringView& s)
 {
   QString* cdata;
   cdatastr += s;

--- a/gpx.h
+++ b/gpx.h
@@ -24,7 +24,7 @@
 #include <QtCore/QHash>                 // for QHash
 #include <QtCore/QString>               // for QString
 #include <QtCore/QStringList>           // for QStringList
-#include <QtCore/QStringRef>            // for QStringRef
+#include <QtCore/QStringView>           // for QStringView
 #include <QtCore/QVector>               // for QVector
 #include <QtCore/QVersionNumber>        // for QVersionNumber
 #include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
@@ -197,12 +197,12 @@ private:
   void tag_wpt(const QXmlStreamAttributes& attr);
   void tag_cache_desc(const QXmlStreamAttributes& attr);
   void tag_gs_cache(const QXmlStreamAttributes& attr) const;
-  void start_something_else(const QStringRef& el, const QXmlStreamAttributes& attr);
+  void start_something_else(const QStringView& el, const QXmlStreamAttributes& attr);
   void end_something_else();
   void tag_log_wpt(const QXmlStreamAttributes& attr) const;
-  void gpx_start(const QStringRef& el, const QXmlStreamAttributes& attr);
-  void gpx_end(const QStringRef& unused);
-  void gpx_cdata(const QStringRef& s);
+  void gpx_start(const QStringView& el, const QXmlStreamAttributes& attr);
+  void gpx_end(const QStringView& unused);
+  void gpx_cdata(const QStringView& s);
   void write_attributes(const QXmlStreamAttributes& attributes) const;
   void fprint_xml_chain(xml_tag* tag, const Waypoint* wpt) const;
   void write_gpx_url(const UrlList& urls) const;

--- a/lowranceusr.h
+++ b/lowranceusr.h
@@ -92,7 +92,6 @@
 
 #include <QtCore/QList>         // for QList
 #include <QtCore/QString>       // for QString
-#include <QtCore/QStringRef>    // for QStringRef
 #include <QtCore/QTextCodec>    // for QTextCodec
 #include <QtCore/QVector>       // for QVector
 #include <QtCore/Qt>            // for CaseInsensitive

--- a/maggeo.cc
+++ b/maggeo.cc
@@ -194,7 +194,7 @@ static QDateTime maggeo_parsedate(char* dmy)
   int d = date.midRef(0,2).toInt();
   int m = date.midRef(2,2).toInt();
   int y = date.midRef(4,3).toInt();
-  QDateTime r(QDate(y + 1900, m, d));
+  QDateTime r(QDate(y + 1900, m, d)::startOfDay());
   return r;
 }
 

--- a/mapfactor.cc
+++ b/mapfactor.cc
@@ -44,9 +44,9 @@ static void MapfactorRead()
   Waypoint* wpt = nullptr;
 
   while (!reader.atEnd()) {
-    QStringRef tag_name = reader.name();
+    auto tag_name = reader.name();
     if (reader.tokenType()==QXmlStreamReader::StartElement) {
-      if (tag_name == "item") {
+      if (tag_name == u"item") {
         wpt = new Waypoint;
 
         QXmlStreamAttributes a = reader.attributes();
@@ -57,7 +57,7 @@ static void MapfactorRead()
     }
 
     if (reader.tokenType() == QXmlStreamReader::EndElement) {
-      if (wpt && reader.name() == "item") {
+      if (wpt && reader.name() == u"item") {
         waypt_add(wpt);
       }
     }

--- a/osm.cc
+++ b/osm.cc
@@ -27,7 +27,6 @@
 #include <QtCore/QLatin1String>         // for QLatin1String
 #include <QtCore/QPair>                 // for QPair, operator==
 #include <QtCore/QString>               // for QString, operator==, operator+
-#include <QtCore/QStringRef>            // for QStringRef
 #include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
 #include <QtCore/QtGlobal>              // for qPrintable, QAddConst<>::Type
 

--- a/pcx.cc
+++ b/pcx.cc
@@ -31,7 +31,6 @@
 #include <QtCore/QRegularExpression>  // for QRegularExpression
 #include <QtCore/QString>             // for QString, QString::SectionSkipEmpty
 #include <QtCore/QStringList>         // for QStringList
-#include <QtCore/QStringRef>          // for QStringRef
 #include <QtCore/QTime>               // for QTime
 #include <QtCore/QVector>             // for QVector
 #include <QtCore/Qt>                  // for CaseInsensitive, UTC

--- a/pocketfms_fp.cc
+++ b/pocketfms_fp.cc
@@ -20,7 +20,6 @@
  */
 
 #include <QtCore/QString>               // for QString
-#include <QtCore/QStringRef>            // for QStringRef
 #include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
 
 #include "defs.h"

--- a/tef_xml.cc
+++ b/tef_xml.cc
@@ -25,7 +25,7 @@
 
 #include <QtCore/QLatin1String>         // for QLatin1String
 #include <QtCore/QString>               // for QString
-#include <QtCore/QStringRef>            // for QStringRef
+#include <QtCore/QStringView>           // for QStringView
 #include <QtCore/QVector>               // for QVector
 #include <QtCore/QXmlStreamAttribute>   // for QXmlStreamAttribute
 #include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
@@ -273,7 +273,7 @@ tef_item_start(xg_string, const QXmlStreamAttributes* attrv)
 }
 
 static double
-tef_read_comma_float(const QStringRef& value)
+tef_read_comma_float(const QStringView& value)
 {
   QString svalue = value.toString();
 

--- a/util.cc
+++ b/util.cc
@@ -38,7 +38,6 @@
 #include <QtCore/QList>                 // for QList
 #include <QtCore/QScopedPointer>        // for QScopedPointer
 #include <QtCore/QString>               // for QString
-#include <QtCore/QStringRef>            // for QStringRef
 #include <QtCore/QTextCodec>            // for QTextCodec
 #include <QtCore/QTextStream>           // for operator<<, QTextStream, qSetFieldWidth, endl, QTextStream::AlignLeft
 #include <QtCore/QXmlStreamAttribute>   // for QXmlStreamAttribute

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -258,7 +258,7 @@ QDateTime
 XcsvFormat::yyyymmdd_to_time(const char* s)
 {
   QDate d = QDate::fromString(s, "yyyyMMdd");
-  return QDateTime(d);
+  return QDateTime(d.startOfDay());
 }
 
 
@@ -984,7 +984,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
   latitude = oldlat = wpt->latitude;
 
   QString write_delimiter;
-  if (xcsv_style->field_delimiter == "\\w") {
+  if (xcsv_style->field_delimiter == u"\\w") {
     write_delimiter = " ";
   } else {
     write_delimiter = xcsv_style->field_delimiter;
@@ -1659,7 +1659,7 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
   QString tokenstr = line.mid(sep).trimmed();
   const QStringList tokens = tokenstr.split(',');
 
-  if (op == "FIELD_DELIMITER") {
+  if (op == u"FIELD_DELIMITER") {
     auto cp = xcsv_get_char_from_constant_table(tokens[0]);
     style->field_delimiter = cp;
 
@@ -1674,7 +1674,7 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
 
   } else
 
-    if (op == "FIELD_ENCLOSER") {
+    if (op == u"FIELD_ENCLOSER") {
       auto cp = xcsv_get_char_from_constant_table(tokens[0]);
       style->field_encloser = cp;
 
@@ -1683,7 +1683,7 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
       xfree(p);
     } else
 
-      if (op == "RECORD_DELIMITER") {
+      if (op == u"RECORD_DELIMITER") {
         auto cp = xcsv_get_char_from_constant_table(tokens[0]);
         style->record_delimiter = cp;
 
@@ -1694,33 +1694,33 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
 
       } else
 
-        if (op == "FORMAT_TYPE") {
-          if (tokens[0] == "INTERNAL") {
+        if (op == u"FORMAT_TYPE") {
+          if (tokens[0] == u"INTERNAL") {
             style->type = ff_type_internal;
           }
           // this is almost inconceivable...
-          if (tokens[0] == "SERIAL") {
+          if (tokens[0] == u"SERIAL") {
             style->type = ff_type_serial;
           }
         } else
 
-          if (op == "DESCRIPTION") {
+          if (op == u"DESCRIPTION") {
             style->description = tokens[0];
           } else
 
-            if (op == "EXTENSION") {
+            if (op == u"EXTENSION") {
               style->extension = tokens[0];
             } else
 
-              if (op == "SHORTLEN") {
+              if (op == u"SHORTLEN") {
                 style->shortlen = tokens[0].toInt();
               } else
 
-                if (op == "SHORTWHITE") {
+                if (op == u"SHORTWHITE") {
                   style->whitespace_ok = tokens[0].toInt();
                 } else
 
-                  if (op == "BADCHARS") {
+                  if (op == u"BADCHARS") {
                     char* sp = csv_stringtrim(CSTR(tokenstr), "\"", 1);
                     QString cp = xcsv_get_char_from_constant_table(sp);
                     style->badchars += cp;
@@ -1731,32 +1731,32 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
                       style->prologue.append(tokenstr);
                     } else
 
-                      if (op == "EPILOGUE") {
+                      if (op == u"EPILOGUE") {
                         style->epilogue.append(tokenstr);
                       } else
 
-                        if (op == "ENCODING") {
+                        if (op == u"ENCODING") {
                           style->codecname = tokens[0];
                         } else
 
-                          if (op == "DATUM") {
+                          if (op == u"DATUM") {
                             style->gps_datum_name = tokens[0];
                           } else
 
-                            if (op == "DATATYPE") {
+                            if (op == u"DATATYPE") {
                               QString p = tokens[0].toUpper();
-                              if (p == "TRACK") {
+                              if (p == u"TRACK") {
                                 style->datatype = trkdata;
-                              } else if (p == "ROUTE") {
+                              } else if (p == u"ROUTE") {
                                 style->datatype = rtedata;
-                              } else if (p == "WAYPOINT") {
+                              } else if (p == u"WAYPOINT") {
                                 style->datatype = wptdata;
                               } else {
                                 fatal(FatalMsg() << MYNAME << ": Unknown data type" << p);
                               }
                             } else
 
-                              if (op == "IFIELD") {
+                              if (op == u"IFIELD") {
                                 if (tokens.size() < 3) {
                                   fatal(FatalMsg() << "Invalid IFIELD line: " << tokenstr);
                                 }
@@ -1774,7 +1774,7 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
                                 //  leave this as it's own parsing for now.  We could
                                 //  change the world on ifield vs ofield format later..
                                 //
-                                if (op == "OFIELD") {
+                                if (op == u"OFIELD") {
                                   unsigned options = 0;
                                   // Note: simplified() has to run after split().
                                   if (tokens.size() < 3) {

--- a/xmlgeneric.cc
+++ b/xmlgeneric.cc
@@ -24,7 +24,7 @@
 #include <QtCore/QIODevice>             // for QIODevice, QIODevice::ReadOnly
 #include <QtCore/QLatin1Char>           // for QLatin1Char
 #include <QtCore/QList>
-#include <QtCore/QStringRef>            // for QStringRef
+#include <QtCore/QStringView>           // for QStringView
 #include <QtCore/QTextCodec>            // for QTextCodec
 #include <QtCore/QXmlStreamAttributes>  // for QXmlStreamAttributes
 #include <QtCore/QXmlStreamReader>      // for QXmlStreamReader, QXmlStreamReader::Characters, QXmlStreamReader::EndElement, QXmlStreamReader::IncludeChildElements, QXmlStreamReader::StartDocument, QXmlStreamReader::StartElement
@@ -153,7 +153,7 @@ xml_deinit()
 }
 
 static xg_shortcut
-xml_shortcut(const QStringRef& name)
+xml_shortcut(const QStringView& name)
 {
    QString key = name.toString();
    if (xg_shortcut_taglist->contains(key)) {


### PR DESCRIPTION
* Make more string literals encoded at UTF-16 (bloaty-bytes) to
reduce conversions.
* Favor QStringView(Qt6-ism that mirrors C++ standard std::stringview)
over QStringRef (Qt5 hack).