### PR TITLE
remove misleading, dangerous and unneeded redefinitions for snprintf, vsnprintf

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -126,25 +126,14 @@ constexpr double KNOTS_TO_MPS(double a)  {return a * kMPSPerKnot;}
 #define CENTI_TO_MICRO(t) ((t) * 10000) /* Centiseconds to Microseconds */
 #define MICRO_TO_CENTI(t) ((t) / 10000) /* Centiseconds to Microseconds */
 
-/*
- * Snprintf is in SUS (so it's in most UNIX-like substance) and it's in
- * C99 (albeit with slightly different semantics) but it isn't in C89.
- * This tweaks allows us to use snprintf on the holdout.
- */
 #if __WIN32__
-#  define snprintf _snprintf
-#  define vsnprintf _vsnprintf
 #  ifndef fileno
 #    define fileno _fileno
 #  endif
 #  define strdup _strdup
 #endif
 
-/* Turn off numeric conversion warning */
 #if __WIN32__
-#  if _MSC_VER
-#    pragma warning(disable:4244)
-#  endif
 #if !defined _CRT_SECURE_NO_DEPRECATE
 #  define _CRT_SECURE_NO_DEPRECATE 1
 #endif


### PR DESCRIPTION
> Beginning with the UCRT in Visual Studio 2015 and Windows 10, snprintf is no longer identical to _snprintf. The snprintf function behavior is now C99 standard conformant.

> Beginning with the UCRT in Visual Studio 2015 and Windows 10, vsnprintf is no longer identical to _vsnprintf. The vsnprintf function conforms to the C99 standard; _vnsprintf is kept for backward compatibility with older Visual Studio code.

delete an unneeded MSVC compiler pragma.