### PR TITLE
migrate from directory level cmake commands to target commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,4 @@
-
-# It isn't clear what the minimum required version is.
-# tested against 3.10.2 on ubuntu bionic 2018/07/05
-# tested against 3.5.1 on ubuntu xenial 2018/07/05
-# tested against MSVC 2017 which included 3.11.* 2018/07/05
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.11)
 
 project(gpsbabel LANGUAGES C CXX)
 
@@ -12,6 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+add_executable(gpsbabel)
 
 # Find the QtCore library
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
@@ -323,32 +320,34 @@ set(HEADERS ${HEADERS} ${FILTER_HEADERS})
 
 set(SOURCES ${SOURCES} internal_styles.cc)
 
-include_directories(AFTER zlib)
+target_include_directories(gpsbabel PRIVATE zlib)
 
 include(CheckIncludeFile)
 if(UNIX)
   # this is used by zlib
   check_include_file("unistd.h" HAVE_UNISTD_H)
   if(${HAVE_UNISTD_H})
-    add_definitions(-DHAVE_UNISTD_H)
+    target_compile_definitions(gpsbabel PRIVATE HAVE_UNISTD_H)
   endif()
   # this is used by zlib
   check_include_file("stdarg.h" HAVE_STDARG_H)
   if(${HAVE_STDARG_H})
-    add_definitions(-DHAVE_STDARG_H)
+    target_compile_definitions(gpsbabel PRIVATE HAVE_STDARG_H)
   endif()
-  add_definitions(-DHAVE_LIBUSB_1_0)
+  target_compile_definitions(gpsbabel PRIVATE HAVE_LIBUSB_1_0)
   set(SOURCES ${SOURCES} gbser_posix.cc)
   set(HEADERS ${HEADERS} gbser_posix.h)
   set(JEEPS ${JEEPS} jeeps/gpslibusb.cc)
-  add_compile_options(-O2 -Wall)
+  target_compile_options(gpsbabel PRIVATE -Wall)
 endif()
 
 if(WIN32)
-  add_definitions(-D__WIN32__ -D_CONSOLE)
-  remove_definitions(-DUNICODE -DZLIB_INHIBITED)
+  target_compile_definitions(gpsbabel PRIVATE __WIN32__)
+  if(${QT_VERSION_MAJOR} EQUAL "6")
+    qt_disable_unicode_defines(gpsbabel)
+  endif()
   if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    add_definitions(-D_DEBUG)
+    target_compile_definitions(gpsbabel PRIVATE _DEBUG)
   endif()
   set(SOURCES ${SOURCES} gbser_win.cc)
   set(HEADERS ${HEADERS} gbser_win.h)
@@ -358,8 +357,8 @@ if(WIN32)
 endif()
 
 if(MSVC)
-  add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
-  add_compile_options(/MP -wd4100 -wd4267)
+  target_compile_definitions(gpsbabel PRIVATE _CRT_SECURE_NO_DEPRECATE)
+  target_compile_options(gpsbabel PRIVATE /MP -wd4100 -wd4267)
 endif()
 
 if(UNIX AND NOT APPLE)
@@ -368,7 +367,7 @@ endif()
 
 if(APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lobjc -framework IOKit -framework CoreFoundation")
-  include_directories(AFTER mac/libusb mac/libusb/Xcode)
+  target_include_directories(gpsbabel PRIVATE mac/libusb mac/libusb/Xcode)
   set(SOURCES ${SOURCES}
     mac/libusb/core.c
     mac/libusb/descriptor.c
@@ -390,7 +389,7 @@ if(APPLE)
     mac/libusb/os/events_posix.h
     mac/libusb/os/threads_posix.h
   )
-  add_compile_options(-Wall -Wsign-compare)
+  target_compile_options(gpsbabel PRIVATE -Wall -Wsign-compare)
 endif()
 
 set(SOURCES
@@ -400,22 +399,23 @@ set(SOURCES
 list(SORT SOURCES)
 list(SORT HEADERS)
 
-# We don't care about stripping things out of the build.  Full monty, baby.
-add_definitions(-DMAXIMAL_ENABLED)
-add_definitions(-DFILTERS_ENABLED)
-add_definitions(-DSHAPELIB_ENABLED)
-add_definitions(-DCSVFMTS_ENABLED)
+target_sources(gpsbabel PRIVATE ${SOURCES} ${HEADERS})
 
-add_executable(gpsbabel ${SOURCES} ${HEADERS})
+# We don't care about stripping things out of the build.  Full monty, baby.
+target_compile_definitions(gpsbabel PRIVATE MAXIMAL_ENABLED)
+target_compile_definitions(gpsbabel PRIVATE FILTERS_ENABLED)
+target_compile_definitions(gpsbabel PRIVATE SHAPELIB_ENABLED)
+target_compile_definitions(gpsbabel PRIVATE CSVFMTS_ENABLED)
+
 target_link_libraries(gpsbabel ${QT_LIBRARIES} ${LIBS})
 
-message(STATUS "Sources are: \"${SOURCES}\"")
-message(STATUS "Headers are: \"${HEADERS}\"")
-get_directory_property(DirDefs COMPILE_DEFINITIONS)
+get_target_property(Srcs gpsbabel SOURCES)
+message(STATUS "Sources are: \"${Srcs}\"")
+get_target_property(DirDefs gpsbabel COMPILE_DEFINITIONS)
 message(STATUS "Defines are: \"${DirDefs}\"")
 get_target_property(LnkLibs gpsbabel LINK_LIBRARIES)
 message(STATUS "Libs are: \"${LnkLibs}\"")
-get_directory_property(IncDirs INCLUDE_DIRECTORIES)
+get_target_property(IncDirs gpsbabel INCLUDE_DIRECTORIES)
 message(STATUS "Include Directores are: \"${IncDirs}\"")
 
 if(UNIX)

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -348,8 +348,8 @@ macx|linux|openbsd {
 }
 
 win32 {
-  DEFINES += __WIN32__ _CONSOLE
-  DEFINES -= UNICODE
+  DEFINES += __WIN32__
+  DEFINES -= UNICODE _UNICODE
   CONFIG(debug, debug|release) {
     DEFINES += _DEBUG
   }

--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,4 @@
-The autotools based build system (configure) is no longer suppored and has
+The autotools based build system (configure) is no longer supported and has
 been removed.
 
 The use of cmake is experimental.  The implementation is not complete.  It is

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,9 +1,4 @@
-
-# It isn't clear what the minimum required version is.
-# tested against 3.10.2 on ubuntu bionic 2018/07/05
-# tested against 3.5.1 on ubuntu xenial 2018/07/05
-# tested against MSVC 2017 which included 3.11.* 2018/07/05
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.11)
 
 project(gpsbabelfe LANGUAGES CXX)
 
@@ -19,6 +14,15 @@ set(CMAKE_AUTOUIC ON)
 # Handle the Qt rcc code generator automatically
 set(CMAKE_AUTORCC ON)
 
+if(UNIX AND NOT APPLE)
+  set(TARGET gpsbabelfe)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY GPSBabelFE)
+else()
+  set(TARGET GPSBabelFE)
+endif()
+
+add_executable(${TARGET} WIN32 MACOSX_BUNDLE)
+
 # Find the QtCore library
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Network SerialPort Widgets Xml REQUIRED)
@@ -29,13 +33,18 @@ else()
   message(STATUS "Using Qt${QT_VERSION_MAJOR} version ${Qt${QT_VERSION_MAJOR}Core_VERSION}")
 endif()
 
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS WebEngineWidgets WebChannel REQUIRED)
-list(APPEND QT_LIBRARIES Qt${QT_VERSION_MAJOR}::WebEngineWidgets Qt${QT_VERSION_MAJOR}::WebChannel)
+set(MAPPREVIEW ON CACHE BOOL "enable map preview")
+if (MAPPREVIEW)
+  find_package(Qt${QT_VERSION_MAJOR} COMPONENTS WebEngineWidgets WebChannel REQUIRED)
+  list(APPEND QT_LIBRARIES Qt${QT_VERSION_MAJOR}::WebEngineWidgets Qt${QT_VERSION_MAJOR}::WebChannel)
+else()
+  target_compile_definitions(${TARGET} PRIVATE DISABLE_MAPPREVIEW)
+endif()
 
-set(RESOURCES app.qrc)
+list(APPEND RESOURCES app.qrc)
 
 if(WIN32)
-  set(RESOURCES ${RESOURCES} app.rc)
+  list(APPEND RESOURCES app.rc)
 endif()
 
 if(UNIX AND NOT APPLE)
@@ -45,84 +54,105 @@ else()
   set(TARGET GPSBabelFE)
 endif()
 
-set(FORMS
-  aboutui.ui
-  advui.ui
-  donate.ui
-  filterui.ui
-  gmapui.ui
-  mainwinui.ui
-  miscfltui.ui
-  preferences.ui
-  rttrkui.ui
-  trackui.ui
-  upgrade.ui
-  version_mismatch.ui
-  wayptsui.ui
-)
+# FORMS
+list(APPEND FORMS aboutui.ui)
+list(APPEND FORMS advui.ui)
+list(APPEND FORMS donate.ui)
+list(APPEND FORMS filterui.ui)
+if (MAPPREVIEW)
+  list(APPEND FORMS gmapui.ui)
+endif()
+list(APPEND FORMS mainwinui.ui)
+list(APPEND FORMS miscfltui.ui)
+list(APPEND FORMS preferences.ui)
+list(APPEND FORMS rttrkui.ui)
+list(APPEND FORMS trackui.ui)
+list(APPEND FORMS upgrade.ui)
+list(APPEND FORMS version_mismatch.ui)
+list(APPEND FORMS wayptsui.ui)
 
-set(SOURCES
-  aboutdlg.cc
-  advdlg.cc
-  donate.cc
-  dpencode.cc
-  filterdata.cc
-  filterdlg.cc
-  filterwidgets.cc
-  format.cc
-  formatload.cc
-  gmapdlg.cc
-  gpx.cc
-  help.cc
-  latlng.cc
-  main.cc
-  mainwindow.cc
-  map.cc
-  optionsdlg.cc
-  preferences.cc
-  processwait.cc
-  runmachine.cc
-  upgrade.cc
-  version_mismatch.cc
-)
+# SOURCES
+list(APPEND SOURCES aboutdlg.cc)
+list(APPEND SOURCES advdlg.cc)
+list(APPEND SOURCES donate.cc)
+list(APPEND SOURCES dpencode.cc)
+list(APPEND SOURCES filterdata.cc)
+list(APPEND SOURCES filterdlg.cc)
+list(APPEND SOURCES filterwidgets.cc)
+list(APPEND SOURCES format.cc)
+list(APPEND SOURCES formatload.cc)
+if (MAPPREVIEW)
+  list(APPEND SOURCES gmapdlg.cc)
+  list(APPEND SOURCES gpx.cc)
+endif()
+list(APPEND SOURCES help.cc)
+list(APPEND SOURCES latlng.cc)
+list(APPEND SOURCES main.cc)
+list(APPEND SOURCES mainwindow.cc)
+if (MAPPREVIEW)
+  list(APPEND SOURCES map.cc)
+endif()
+list(APPEND SOURCES optionsdlg.cc)
+list(APPEND SOURCES preferences.cc)
+list(APPEND SOURCES processwait.cc)
+list(APPEND SOURCES runmachine.cc)
+list(APPEND SOURCES upgrade.cc)
+list(APPEND SOURCES version_mismatch.cc)
 
 if(UNIX)
-  set(SOURCES ${SOURCES} serial_unix.cc)
+  list(APPEND SOURCES serial_unix.cc)
 elseif(WIN32)
-  set(SOURCES ${SOURCES} serial_win.cc)
+  list(APPEND SOURCES serial_win.cc)
 endif()
 
-set(HEADERS
-  aboutdlg.h
-  advdlg.h
-  appname.h
-  babeldata.h
-  donate.h
-  filterdata.h
-  filterdlg.h
-  filterwidgets.h
-  format.h
-  formatload.h
-  gmapdlg.h
-  gpx.h
-  help.h
-  mainwindow.h
-  map.h
-  optionsdlg.h
-  preferences.h
-  processwait.h
-  runmachine.h
-  setting.h
-  upgrade.h
-  version_mismatch.h
-)
+# HEADERS
+list(APPEND HEADERS aboutdlg.h)
+list(APPEND HEADERS advdlg.h)
+list(APPEND HEADERS appname.h)
+list(APPEND HEADERS babeldata.h)
+list(APPEND HEADERS donate.h)
+list(APPEND HEADERS filterdata.h)
+list(APPEND HEADERS filterdlg.h)
+list(APPEND HEADERS filterwidgets.h)
+list(APPEND HEADERS format.h)
+list(APPEND HEADERS formatload.h)
+if (MAPPREVIEW)
+  list(APPEND HEADERS gmapdlg.h)
+  list(APPEND HEADERS gpx.h)
+endif()
+list(APPEND HEADERS help.h)
+list(APPEND HEADERS mainwindow.h)
+if (MAPPREVIEW)
+  list(APPEND HEADERS map.h)
+endif()
+list(APPEND HEADERS optionsdlg.h)
+list(APPEND HEADERS preferences.h)
+list(APPEND HEADERS processwait.h)
+list(APPEND HEADERS runmachine.h)
+list(APPEND HEADERS setting.h)
+list(APPEND HEADERS upgrade.h)
+list(APPEND HEADERS version_mismatch.h)
+
+if(UNIX AND NOT APPLE)
+  set(EMBED_TRANSLATIONS ON CACHE BOOL "embed translations")
+  set(EMBED_MAP ON CACHE BOOL "embed map html")
+else()
+  set(EMBED_TRANSLATIONS OFF CACHE BOOL "embed translations")
+  set(EMBED_MAP OFF CACHE BOOL "embed map html")
+endif()
+if (EMBED_TRANSLATIONS)
+  list(APPEND RESOURCES translations.qrc)
+endif()
+if (EMBED_MAP)
+  list(APPEND RESOURCES map.qrc)
+endif()
 
 if(APPLE)
   set(MACOSX_BUNDLE_ICON_FILE appicon.icns)
   set(ICON_FILE images/${MACOSX_BUNDLE_ICON_FILE})
   set_source_files_properties(${ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
-  add_executable(${TARGET} MACOSX_BUNDLE ${SOURCES} ${HEADERS} ${ICON_FILE} ${RESOURCES})
+  target_sources(${TARGET} PRIVATE ${SOURCES} ${HEADERS} ${ICON_FILE} ${RESOURCES})
 
   # Info.plist has not been debugged with the cmake flow, it's a bit different than with the qmake flow.
   set_target_properties(${TARGET} PROPERTIES
@@ -130,20 +160,18 @@ if(APPLE)
     MACOSX_BUNDLE_ICON_FILE ${MACOSX_BUNDLE_ICON_FILE}
   )
 else()
-  add_executable(${TARGET} ${SOURCES} ${HEADERS} ${RESOURCES})
+  target_sources(${TARGET} PRIVATE ${SOURCES} ${HEADERS} ${RESOURCES})
 endif()
 
-set(LIBS ${QT_LIBRARIES})
-list(REMOVE_DUPLICATES LIBS)
-target_link_libraries(${TARGET} ${LIBS})
+target_link_libraries(${TARGET} ${QT_LIBRARIES})
 
-message(STATUS "Sources are: \"${SOURCES}\"")
-message(STATUS "Headers are: \"${HEADERS}\"")
-get_directory_property(DirDefs COMPILE_DEFINITIONS)
+get_target_property(Srcs ${TARGET} SOURCES)
+message(STATUS "Sources are: \"${Srcs}\"")
+get_target_property(DirDefs ${TARGET} COMPILE_DEFINITIONS)
 message(STATUS "Defines are: \"${DirDefs}\"")
 get_target_property(LnkLibs ${TARGET} LINK_LIBRARIES)
 message(STATUS "Libs are: \"${LnkLibs}\"")
-get_directory_property(IncDirs INCLUDE_DIRECTORIES)
+get_target_property(IncDirs ${TARGET} INCLUDE_DIRECTORIES)
 message(STATUS "Include Directores are: \"${IncDirs}\"")
 
 add_custom_target(package_app COMMAND ./package_app DEPENDS ${TARGET})

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -47,13 +47,6 @@ if(WIN32)
   list(APPEND RESOURCES app.rc)
 endif()
 
-if(UNIX AND NOT APPLE)
-  set(TARGET gpsbabelfe)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY GPSBabelFE)
-else()
-  set(TARGET GPSBabelFE)
-endif()
-
 # FORMS
 list(APPEND FORMS aboutui.ui)
 list(APPEND FORMS advui.ui)

--- a/gui/app.pro
+++ b/gui/app.pro
@@ -45,6 +45,7 @@ mac:TARGET=GPSBabelFE
 # Set QMAKE_TARGET_BUNDLE_PREFIX so we get the correct CFBundleIdentifier in Info.plist
 darwin:QMAKE_TARGET_BUNDLE_PREFIX=org.gpsbabel
 
+# FORMS
 FORMS += aboutui.ui
 FORMS += advui.ui
 FORMS += donate.ui
@@ -61,6 +62,7 @@ FORMS += upgrade.ui
 FORMS += version_mismatch.ui
 FORMS += wayptsui.ui
 
+# SOURCES
 SOURCES += aboutdlg.cc
 SOURCES += advdlg.cc
 SOURCES += donate.cc
@@ -93,6 +95,7 @@ unix {
   SOURCES += serial_win.cc
 }
 
+# HEADERS
 HEADERS += aboutdlg.h
 HEADERS += advdlg.h
 HEADERS += appname.h


### PR DESCRIPTION
fix a few bugs with our CMakeLists:

set WIN32 for gui target.  remove _CONSOLE, it's obsolete.

when undefining UNICODE, also undefine _UNICODE.  it's not clear to
me we have a sensitivity to UNICODE/_UNICODE.

take optimization flags out of CMakeLists, rely on CMAKE_BUILD_TYPE
to select appropriate flags.

don't force ZLIB_INHIBITED to be undefined on windows.

add cmake support for some of our configuration options:
disable-mappreview, embed_map, embed_translations.