### PR TITLE
only support changing gpsbabel.org location at build generation time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,22 +520,8 @@ endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   set(WEB "../babelweb" CACHE PATH "Path where the documentation will be stored for www.gpsbabel.org.")
-  # If using a makefile generator WEB can be overridden on the make
-  # command line, e.g.  make gpsbabel.org WEB=/tmp.  If not overridden on
-  # the make command line, or not using a makefile generator, or if using
-  # "cmake --build dir --target gpsbabel.org", then the cache variable
-  # WEB will be used.  The cache variable can be overridden in the usual
-  # way when configuring, i.e. "cmake dir -DWEB:PATH=/tmp".
-
-  # FIXME: Is overriding WEB on the make command line worth the trouble of
-  # using configure_file to build a wrapper script?
-
-  configure_file(${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_org_wrapper.sh.in
-                 ${CMAKE_BINARY_DIR}/tools/make_gpsbabel_org_wrapper.sh
-                 @ONLY
-                 NEWLINE_STYLE LF)
   add_custom_target(gpsbabel.org
-                    ${CMAKE_BINARY_DIR}/tools/make_gpsbabel_org_wrapper.sh
+                    ${CMAKE_BINARY_DIR}/tools/make_gpsbabel_org.sh ${WEB} ${DOCVERSION}
                     DEPENDS gpsbabel gpsbabel.pdf)
 endif()
 

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -397,10 +397,7 @@ equals(PWD, $${OUT_PWD}) {
   !defined(WEB, var) {
     WEB = ../babelweb
   }
-  # Allow WEB to be overridden when running make.
-  # DOCVERSION must be overridden at qmake time as it also affects the object code.
-  gpsbabel.org.commands += web=\$\${WEB:-$${WEB}};
-  gpsbabel.org.commands += tools/make_gpsbabel_org.sh \"\$\${web}\" $$shell_quote($$DOCVERSION);
+  gpsbabel.org.commands += tools/make_gpsbabel_org.sh $$shell_quote($$WEB) $$shell_quote($$DOCVERSION);
 } else {
   gpsbabel.org.commands += echo "target gpsbabel.org is not supported for out of source builds.";
   gpsbabel.org.commands += exit 1;

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,2 +1,1 @@
 /mkcapabilities
-/make_gpsbabel_org_wrapper.sh

--- a/tools/make_gpsbabel_org_wrapper.sh.in
+++ b/tools/make_gpsbabel_org_wrapper.sh.in
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -e
-
-web=${WEB:-@WEB@}
-"@CMAKE_SOURCE_DIR@/tools/make_gpsbabel_org.sh" "${web}" "@DOCVERSION@"


### PR DESCRIPTION
We still allow the user to change the default location of generated files destined for gpsbabel.org, but only when generating a build system, i.e. when running qmake or cmake.  If using a makefile generator you are no longer able to change the destination at make time.  The default remains ../babelweb.