### PR TITLE
Fix ODR violations discovered when using -flto.

### DIFF
--- a/brauniger_iq.cc
+++ b/brauniger_iq.cc
@@ -27,25 +27,27 @@ static void* serial_handle;
 #define MYNAME "BRAUNIGER-IQ"
 #define PRESTRKNAME "PRESALTTRK"
 
-enum state_t {
-  st_sync,
-  st_fl_num,
-  st_data_len,
-  st_ser_num,
-  st_pilot_name,
-  st_start_date,
-  st_start_year,
-  st_max_alt_1,
-  st_max_alt_2,
-  st_max_climb,
-  st_flight_dur,
-  st_log_ival,
-  st_start_time,
-  st_end_time,
-  st_sample_alt,
-  st_sample_spd,
-  num_states
-};
+namespace { // fix ODR violation with igc
+  enum state_t {
+    st_sync,
+    st_fl_num,
+    st_data_len,
+    st_ser_num,
+    st_pilot_name,
+    st_start_date,
+    st_start_year,
+    st_max_alt_1,
+    st_max_alt_2,
+    st_max_climb,
+    st_flight_dur,
+    st_log_ival,
+    st_start_time,
+    st_end_time,
+    st_sample_alt,
+    st_sample_spd,
+    num_states
+  };
+}
 static state_t state;
 inline state_t& operator++(state_t& s) // prefix
 {

--- a/igc.cc
+++ b/igc.cc
@@ -147,7 +147,9 @@ static void rd_deinit()
   gbfclose(file_in);
 }
 
-enum state_t { id, takeoff, start, turnpoint, finish, landing };
+namespace { // fix ODR violation with brauniger_iq
+  enum state_t { id, takeoff, start, turnpoint, finish, landing };
+}
 inline state_t& operator++(state_t& s) // prefix
 {
   return s = static_cast<state_t>(s + 1);

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -663,14 +663,16 @@ ECEF_to_LLA(double x, double y, long z, double* lat, double* lon, double* alt)
   *lon = *lon /M_PI*180;
 }
 
-struct read_state {
-  route_head*          route_head_;
-  unsigned            wpn, tpn;
-
-  unsigned gps_week;
-  unsigned gps_sec;
-  long x, y, z;
-};
+namespace { // fix ODR violation with wbt-200
+  struct read_state {
+    route_head*          route_head_;
+    unsigned            wpn, tpn;
+  
+    unsigned gps_week;
+    unsigned gps_sec;
+    long x, y, z;
+  };
+}
 
 static void
 state_init(struct read_state* pst)

--- a/wbt-200.cc
+++ b/wbt-200.cc
@@ -124,12 +124,14 @@ struct buf_head {
   unsigned            checksum;
 };
 
-struct read_state {
-  route_head*          route_head_;
-  unsigned            wpn, tpn;
-
-  struct buf_head     data;
-};
+namespace { // fix ODR violation with skytraq
+  struct read_state {
+    route_head*          route_head_;
+    unsigned            wpn, tpn;
+  
+    struct buf_head     data;
+  };
+}
 
 static void db(int l, const char* msg, ...)
 {


### PR DESCRIPTION
The fedora build shows these:
skytraq.cc:666:8: warning: type 'struct read_state' violates the C++ One Definition Rule [-Wodr]
wbt-200.cc:127:8: note: a different type is defined in another translation unit
brauniger_iq.cc:30:6: warning: type 'state_t' violates the C++ One Definition Rule [-Wodr]
igc.cc:150:6: note: an enum with different value name is defined in another translation unit

However, even with link time optimization I was unable to observe a problem, i.e. testo passes.

There is a relevant note in https://en.cppreference.com/w/cpp/language/definition, see the note
about using unnamed namespaces to resolve this issue.

Also note the use of unnamed namespaces is not recommended in header files,
https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL59-CPP.+Do+not+define+an+unnamed+namespace+in+a+header+file