### PR TITLE
use precompiled headers to speed up compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ CMakeFiles/
 *.swp
 /tmp/
 /mkcapabilities
+/gpsbabel.gch/
 /gpsbabel.rc
 /autogen/
 /makedoc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,25 +39,28 @@ if(${QT_VERSION_MAJOR} EQUAL "6")
   list(APPEND QT_LIBRARIES Qt${QT_VERSION_MAJOR}::Core5Compat)
 endif()
 
-target_precompile_headers(gpsbabel PRIVATE
-  "$<$<COMPILE_LANGUAGE:CXX>:<algorithm$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<cmath$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<cstdarg$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<cstddef$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<cstdint$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<cstdio$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<ctime$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<optional$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<utility$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<QDebug$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<QList$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<QScopedPointer$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<QString$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<QTextCodec$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<QVector$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<Qt$<ANGLE-R>>"
-  "$<$<COMPILE_LANGUAGE:CXX>:<QtGlobal$<ANGLE-R>>"
-)
+option(GPSBABEL_ENABLE_PCH "enable precompiled headers." ON)
+if (GPSBABEL_ENABLE_PCH)
+  target_precompile_headers(gpsbabel PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:<algorithm$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<cmath$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<cstdarg$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<cstddef$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<cstdint$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<cstdio$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<ctime$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<optional$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<utility$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<QDebug$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<QList$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<QScopedPointer$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<QString$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<QTextCodec$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<QVector$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<Qt$<ANGLE-R>>"
+    "$<$<COMPILE_LANGUAGE:CXX>:<QtGlobal$<ANGLE-R>>"
+  )
+endif()
 
 # RESOURCES
 set(RESOURCES gpsbabel.qrc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,26 @@ if(${QT_VERSION_MAJOR} EQUAL "6")
   list(APPEND QT_LIBRARIES Qt${QT_VERSION_MAJOR}::Core5Compat)
 endif()
 
+target_precompile_headers(gpsbabel PRIVATE
+  "$<$<COMPILE_LANGUAGE:CXX>:<algorithm$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<cmath$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<cstdarg$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<cstddef$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<cstdint$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<cstdio$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<ctime$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<optional$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<utility$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QDebug$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QList$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QScopedPointer$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QString$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QTextCodec$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QVector$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<Qt$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGlobal$<ANGLE-R>>"
+)
+
 # RESOURCES
 set(RESOURCES gpsbabel.qrc)
 

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -26,8 +26,11 @@ CONFIG += console
 CONFIG -= app_bundle
 CONFIG += c++17
 CONFIG += link_pkgconfig
+CONFIG += precompile_header
 
 TEMPLATE = app
+
+PRECOMPILED_HEADER = precompiled_headers.h
 
 # RESOURCES
 RESOURCES = gpsbabel.qrc

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -26,11 +26,15 @@ CONFIG += console
 CONFIG -= app_bundle
 CONFIG += c++17
 CONFIG += link_pkgconfig
-CONFIG += precompile_header
+# avoid QTBUG-72404, QTBUG-79694 which were fixed in 5.14.0
+versionAtLeast(QT_VERSION, 5.14.0) | !contains(QMAKE_CXX, .*clang.*) {
+  CONFIG += precompile_header
+  PRECOMPILED_HEADER = precompiled_headers.h
+} else {
+  message("Not using precompiled headers due to QTBUG.")
+}
 
 TEMPLATE = app
-
-PRECOMPILED_HEADER = precompiled_headers.h
 
 # RESOURCES
 RESOURCES = gpsbabel.qrc

--- a/GPSBabel.pro
+++ b/GPSBabel.pro
@@ -26,12 +26,14 @@ CONFIG += console
 CONFIG -= app_bundle
 CONFIG += c++17
 CONFIG += link_pkgconfig
-# avoid QTBUG-72404, QTBUG-79694 which were fixed in 5.14.0
-versionAtLeast(QT_VERSION, 5.14.0) | !contains(QMAKE_CXX, .*clang.*) {
-  CONFIG += precompile_header
-  PRECOMPILED_HEADER = precompiled_headers.h
-} else {
-  message("Not using precompiled headers due to QTBUG.")
+!disable_pch {
+  # avoid QTBUG-72404, QTBUG-79694 which were fixed in 5.14.0
+  versionAtLeast(QT_VERSION, 5.14.0) | !contains(QMAKE_CXX, .*clang.*) {
+    CONFIG += precompile_header
+    PRECOMPILED_HEADER = precompiled_headers.h
+  } else {
+    message("Not using precompiled headers due to QTBUG.")
+  }
 }
 
 TEMPLATE = app

--- a/mynav.cc
+++ b/mynav.cc
@@ -30,7 +30,7 @@
 #include <QStringList>
 #include <QtGlobal>
 
-#include <src/core/textstream.h>
+#include "src/core/textstream.h"
 
 #include "mynav.h"
 

--- a/precompiled_headers.h
+++ b/precompiled_headers.h
@@ -1,0 +1,41 @@
+/*
+    Copyright (C) 2002-2014 Robert Lipe, robertlipe+source@gpsbabel.org
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ */
+
+// This list is from defs.h.  Adding other commonly used headers doesn't help.
+
+#if defined __cplusplus
+#include <algorithm>              // for sort, stable_sort
+#include <cmath>                  // for M_PI
+#include <cstdarg>                // for va_list
+#include <cstddef>                // for NULL, nullptr_t, size_t
+#include <cstdint>                // for int32_t, uint32_t
+#include <cstdio>                 // for NULL, fprintf, FILE, stdout
+#include <ctime>                  // for time_t
+#include <optional>               // for optional
+#include <utility>                // for move
+
+#include <QDebug>                 // for QDebug
+#include <QList>                  // for QList, QList<>::const_reverse_iterator, QList<>::reverse_iterator
+#include <QScopedPointer>         // for QScopedPointer
+#include <QString>                // for QString
+#include <QTextCodec>             // for QTextCodec
+#include <QVector>                // for QVector
+#include <Qt>                     // for CaseInsensitive
+#include <QtGlobal>               // for foreach
+#endif

--- a/src/core/codecdevice.cc
+++ b/src/core/codecdevice.cc
@@ -17,12 +17,12 @@
 
  */
 
+#include <cassert>     // for assert
 #include <cstring>     // for memcpy
 #include <algorithm>   // for min
 
 #include <QByteArray>  // for QByteArray
 #include <QChar>       // for QChar
-#include <QFile>       // for QFile
 #include <QFlags>      // for QFlags
 
 #include "defs.h"      // for list_codecs, warning

--- a/src/core/codecdevice.h
+++ b/src/core/codecdevice.h
@@ -18,11 +18,12 @@
  */
 
 #include <QIODevice>        // for QIODevice
+#include <QIODeviceBase>    // for QIODeviceBase::OpenMode
 #include <QString>          // for QString
 #include <QTextCodec>       // for QTextCodec
 #include <QTextDecoder>     // for QTextDecoder
 #include <QTextEncoder>     // for QTextEncoder
-#include <QtCore>           // for qint64, QIODeviceBase::OpenMode
+#include <QtGlobal>         // for qint64
 
 #include "src/core/file.h"  // for File
 

--- a/src/core/textstream.cc
+++ b/src/core/textstream.cc
@@ -18,7 +18,7 @@
  */
 
 
-#include <QtCore>            // for qint64, QT_VERSION, QT_VERSION_CHECK
+#include <QtGlobal>          // for qint64, QT_VERSION, QT_VERSION_CHECK
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <QByteArrayView>    // for QByteArrayView


### PR DESCRIPTION
In my testing on Linux this reduced the compile time by a factor of 2 to 3.

I did experiment with including other often used Qt headers, but all the combinations I tested didn't improve the situation over just precompiling the Qt and C++ standard library headers used in defs.h.
