### PR TITLE
fix various printf related issues.

### DIFF
--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -1119,19 +1119,19 @@ GarminGPIFormat::load_bitmap_from_file(const char* fname, const unsigned char** 
   }
 
   if (GPI_DBG) {
-    printf("data size:             0x%1$x (%1$d)\n", src_h.size);
-    printf("image data offset:     0x%1$x (%1$d)\n", src_h.image_offset);
-    printf("header size:           0x%1$x (%1$d)\n", src_h.header_size);
-    printf("image width:           0x%1$x (%1$d)\n", src_h.width);
-    printf("image height:          0x%1$x (%1$d)\n", src_h.height);
-    printf("number of planes:      0x%1$x (%1$d)\n", src_h.planes);
-    printf("bits per pixel:        0x%1$x (%1$d)\n", src_h.bpp);
-    printf("compression type:      0x%1$x (%1$d)\n", src_h.compression_type);
-    printf("image size:            0x%1$x (%1$d)\n", src_h.image_data_size);
-    printf("horizontal resolution: 0x%1$x (%1$d)\n", src_h.resolution_h);
-    printf("vertical resolution:   0x%1$x (%1$d)\n", src_h.resolution_v);
-    printf("number of colors:      0x%1$x (%1$d)\n", src_h.used_colors);
-    printf("important colors:      0x%1$x (%1$d)\n", src_h.important_colors);
+    printf("data size:             0x%x (%d)\n", src_h.size, src_h.size);
+    printf("image data offset:     0x%x (%d)\n", src_h.image_offset, src_h.image_offset);
+    printf("header size:           0x%x (%d)\n", src_h.header_size, src_h.header_size);
+    printf("image width:           0x%x (%d)\n", src_h.width, src_h.width);
+    printf("image height:          0x%x (%d)\n", src_h.height, src_h.height);
+    printf("number of planes:      0x%x (%d)\n", src_h.planes, src_h.planes);
+    printf("bits per pixel:        0x%x (%d)\n", src_h.bpp, src_h.bpp);
+    printf("compression type:      0x%x (%d)\n", src_h.compression_type, src_h.compression_type);
+    printf("image size:            0x%x (%d)\n", src_h.image_data_size, src_h.image_data_size);
+    printf("horizontal resolution: 0x%x (%d)\n", src_h.resolution_h, src_h.resolution_h);
+    printf("vertical resolution:   0x%x (%d)\n", src_h.resolution_v, src_h.resolution_v);
+    printf("number of colors:      0x%x (%d)\n", src_h.used_colors, src_h.used_colors);
+    printf("important colors:      0x%x (%d)\n", src_h.important_colors, src_h.important_colors);
   }
 
   /* sort out unsupported files */

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -88,9 +88,9 @@
 #include <cinttypes>              // for PRId64
 #include <cmath>                  // for M_PI, round, atan, exp, log, tan
 #include <cstdio>                 // for printf, sprintf, SEEK_CUR
+#include <cstdint>                // for int64_t
 #include <cstdlib>                // for atoi, abs
 #include <cstring>                // for strcmp, strlen
-#include <ctime>                  // for time_t
 
 #include <QByteArray>             // for QByteArray
 #include <QDate>                  // for QDate
@@ -140,8 +140,8 @@ LowranceusrFormat::register_waypt(const Waypoint* wpt) const
   }
 
   if (global_opts.debug_level >= 2) {
-    printf(MYNAME " adding waypt %s (%s) to table at index %d\n",
-           qPrintable(wpt->shortname), qPrintable(wpt->description), waypt_table->size());
+    printf(MYNAME " adding waypt %s (%s) to table at index %s\n",
+           qPrintable(wpt->shortname), qPrintable(wpt->description), QByteArray::number(waypt_table->size()).constData());
   }
 
   waypt_table->append(wpt);
@@ -607,9 +607,9 @@ LowranceusrFormat::lowranceusr4_parse_waypt(Waypoint* wpt_tmp) const
         printf("%08x %08x %08x %08x ",
                fsdata->UUID1, fsdata->UUID2, fsdata->UUID3, fsdata->UUID4);
       }
-      printf(" %10u %8d %8d %8d %6d",
+      printf(" %10u %8d %8d %8d %6s",
              fsdata->uid_unit, fsdata->uid_seq_low, fsdata->uid_seq_high,
-             waypoint_version, name.length());
+             waypoint_version, QByteArray::number(name.length()).constData());
       if (name.length() > 16) {
         printf(" %13.13s...", qPrintable(name));
       } else {
@@ -622,9 +622,9 @@ LowranceusrFormat::lowranceusr4_parse_waypt(Waypoint* wpt_tmp) const
       printf(" %08x %4d %4d %7s", fsdata->flags, fsdata->icon_num, fsdata->color,
              (fsdata->color_desc == nullptr ? "unk" : qPrintable(fsdata->color_desc)));
       if (desc.length() > 16) {
-        printf(" %6d %.13s...", desc.length(), qPrintable(desc));
+        printf(" %6s %.13s...", QByteArray::number(desc.length()).constData(), qPrintable(desc));
       } else {
-        printf(" %6d %16s", desc.length(), qPrintable(desc));
+        printf(" %6s %16s", QByteArray::number(desc.length()).constData(), qPrintable(desc));
       }
       printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")));
       printf(" %08x %8.3f %08x %08x %08x\n",
@@ -1485,7 +1485,7 @@ LowranceusrFormat::lowranceusr4_write_waypoints()
   route_disp_all(nullptr, nullptr, register_waypt_lambda);
 
   if (global_opts.debug_level >= 1) {
-    printf(MYNAME " writing %d waypoints\n", waypt_table->size());
+    printf(MYNAME " writing %s waypoints\n", QByteArray::number(waypt_table->size()).constData());
   }
 
   gbfputint32(waypt_table->size(), file_out);

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -85,6 +85,7 @@
 
 */
 
+#include <cinttypes>              // for PRId64
 #include <cmath>                  // for M_PI, round, atan, exp, log, tan
 #include <cstdio>                 // for printf, sprintf, SEEK_CUR
 #include <cstdlib>                // for atoi, abs
@@ -459,7 +460,7 @@ LowranceusrFormat::lowranceusr_parse_waypt(Waypoint* wpt_tmp, int object_num_pre
   }
 
   /* Input is the number of seconds since Jan. 1, 2000 */
-  time_t waypt_time = gbfgetint32(file_in);
+  int64_t waypt_time = gbfgetint32(file_in);
   if (waypt_time) {
     /* Waypoint needs the number of seconds since UNIX Epoch (Jan 1, 1970) */
     wpt_tmp->SetCreationTime(waypt_time += base_time_secs);
@@ -469,7 +470,7 @@ LowranceusrFormat::lowranceusr_parse_waypt(Waypoint* wpt_tmp, int object_num_pre
     if (global_opts.debug_level == 99) {
       printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")));
     } else {
-      printf(MYNAME " parse_waypt: creation time '%s', waypt_time %ld\n",
+      printf(MYNAME " parse_waypt: creation time '%s', waypt_time %" PRId64 "\n",
              qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")), waypt_time);
     }
   }
@@ -1256,7 +1257,7 @@ LowranceusrFormat::read()
 void
 LowranceusrFormat::lowranceusr_waypt_disp(const Waypoint* wpt) const
 {
-  int Time, SymbolId, alt;
+  int SymbolId, alt;
 
   int Lat = lat_deg_to_mm(wpt->latitude);
   int Lon = lon_deg_to_mm(wpt->longitude);
@@ -1327,22 +1328,23 @@ LowranceusrFormat::lowranceusr_waypt_disp(const Waypoint* wpt) const
   }
 
   /* Waypoint creation time stored as seconds since UNIX Epoch (Jan 1, 1970) */
-  if ((Time = wpt->creation_time.toTime_t()) > base_time_secs) {
+  int64_t waypt_time;
+  if ((waypt_time = wpt->creation_time.toSecsSinceEpoch()) > base_time_secs) {
     /* This should always be true */
     /* Lowrance needs it as seconds since Jan 1, 2000 */
-    Time -= base_time_secs;
+    waypt_time -= base_time_secs;
     if (global_opts.debug_level >= 2) {
-      printf("creation_time %d, '%s'", Time, qPrintable(wpt->GetCreationTime().toString("yyyy-MM-dd hh:mm:ss")));
+      printf("creation_time %" PRId64 ", '%s'", waypt_time, qPrintable(wpt->GetCreationTime().toString("yyyy-MM-dd hh:mm:ss")));
     }
   } else {
     /* If false, make sure it is an unknown time value */
-    Time = 0;
+    waypt_time = 0;
     if (global_opts.debug_level >= 2) {
       printf("creation_time UNKNOWN");
     }
   }
 
-  gbfputint32(Time, file_out);
+  gbfputint32(waypt_time, file_out);
 
   if (get_cache_icon(wpt) && wpt->icon_descr.compare(QLatin1String("Geocache Found")) == 0) {
     SymbolId = lowranceusr_find_icon_number_from_desc(get_cache_icon(wpt));

--- a/lowranceusr.h
+++ b/lowranceusr.h
@@ -390,7 +390,7 @@ private:
   static constexpr double DEGREESTORADIANS = M_PI/180.0;
   static constexpr int MAX_TRAIL_POINTS = 9999;
   static constexpr double UNKNOWN_USR_ALTITUDE = METERS_TO_FEET(-10000); /* -10000ft is how the unit stores unknown */
-  static constexpr time_t base_time_secs = 946706400; /* Jan 1, 2000 00:00:00 */
+  static constexpr int64_t base_time_secs = 946706400; /* Jan 1, 2000 00:00:00 */
 
   /* Member Functions */
 

--- a/lowranceusr.h
+++ b/lowranceusr.h
@@ -87,8 +87,8 @@
 #ifndef LOWRANCEUSR_H_INCLUDED_
 #define LOWRANCEUSR_H_INCLUDED_
 
-#include <cmath>                  // for M_PI, round, atan, exp, log, tan
-#include <ctime>                  // for time_t
+#include <cmath>                // for M_PI, round, atan, exp, log, tan
+#include <cstdint>              // for int64_t
 
 #include <QList>                // for QList
 #include <QString>              // for QString


### PR DESCRIPTION
printf arugment reording is not available on MSVC with printf (it requires_printf_p).  don't use it (garmin_gpi)

lowranceusr has trouble printing time_t.  avoid this by switching to int64_t and using PRId64.  Note QDateTime is using qint64 for SecsSinceEpoch.

lowrancceusr has trouble printing size() related Qt methods.  These changed from int in Qt5 to qsizetype in Qt6.  Qt6 does offfer PRIdQSIZETYPE, but this is available before 6.2.  Punt and just let Qt do the conversion with QByteArray::number().constData() and print the resulting string. 