### PR TITLE
use static const qregularexpressions where possible

### DIFF
--- a/exif.cc
+++ b/exif.cc
@@ -710,7 +710,7 @@ ExifFormat::exif_get_exif_time(ExifApp* app)
     if (offset_tag) {
       char* time_tag = exif_read_str(offset_tag);
       // string should be +HH:MM or -HH:MM
-      const QRegularExpression re(R"(^([+-])(\d{2}):(\d{2})$)");
+      static const QRegularExpression re(R"(^([+-])(\d{2}):(\d{2})$)");
       assert(re.isValid());
       QRegularExpressionMatch match = re.match(time_tag);
       if (match.hasMatch()) {

--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -52,7 +52,7 @@ static QString xlt(const QString& f)
 //------------------------------------------------------------------------
 bool FormatLoad::skipToValidLine()
 {
-  QRegularExpression regex("^file|serial");
+  static const QRegularExpression regex("^file|serial");
   while ((currentLine_ < lines_.size()) && !regex.match(lines_[currentLine_]).hasMatch()) {
     currentLine_++;
   }
@@ -127,7 +127,8 @@ bool FormatLoad::processFormat(Format& format)
 #ifndef GENERATE_CORE_STRINGS
   if (htmlPage.length() > 0 && Format::getHtmlBase().length() == 0) {
     QString base = htmlPage;
-    base.replace(QRegularExpression("/[^/]+$"), "/");
+    static const QRegularExpression re("/[^/]+$");
+    base.replace(re, "/");
     Format::setHtmlBase(base);
   }
 #endif

--- a/gui/help.cc
+++ b/gui/help.cc
@@ -34,7 +34,8 @@ void ShowHelp(const QString& urlIn)
 
 {
   QString url = urlIn;
-  if (!url.contains(QRegularExpression(R"(^https?://)"))) {
+  static const QRegularExpression re(R"(^https?://)");
+  if (!url.contains(re)) {
     url = Format::getHtmlBase() + url;
   }
   QDesktopServices::openUrl(QUrl(url));

--- a/tools/build_extra_tests.sh
+++ b/tools/build_extra_tests.sh
@@ -28,10 +28,13 @@ make clean
 make -j 3
 make check
 
+# run clazy on both gpsbabel and gpsbabelfe.
+# unlike qmake, cmake uses system includes for Qt which quiets warnings
+# from the Qt headers.
 export CLAZY_CHECKS=level0,level1,no-non-pod-global-static,no-qstring-ref
-qmake -spec linux-clang "CONFIG+=debug" "QMAKE_CXX=clazy"
-make clean
-make -j 3 2>&1 | tee clazy.log
+cmake . -DCMAKE_CXX_COMPILER=clazy -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="Debug"
+cmake --build . --target clean
+cmake --build . 2>&1 | tee clazy.log
 if grep -- '-Wclazy' clazy.log; then
   exit 1
 else

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -75,7 +75,7 @@ qint64 TrackFilter::trackfilter_parse_time_opt(const char* arg)
 {
   qint64 result = 0;
 
-  QRegularExpression re("^([+-]?\\d+)([wdhms])(?:([+-]?\\d+)([wdhms]))?(?:([+-]?\\d+)([wdhms]))?(?:([+-]?\\d+)([wdhms]))?(?:([+-]?\\d+)([wdhms]))?$", QRegularExpression::CaseInsensitiveOption);
+  static const QRegularExpression re("^([+-]?\\d+)([wdhms])(?:([+-]?\\d+)([wdhms]))?(?:([+-]?\\d+)([wdhms]))?(?:([+-]?\\d+)([wdhms]))?(?:([+-]?\\d+)([wdhms]))?$", QRegularExpression::CaseInsensitiveOption);
   assert(re.isValid());
   QRegularExpressionMatch match = re.match(arg);
   if (match.hasMatch()) {
@@ -426,7 +426,7 @@ void TrackFilter::trackfilter_split()
 
     opt_interval = (opt_split && (strlen(opt_split) > 0) && (0 != strcmp(opt_split, TRACKFILTER_SPLIT_OPTION)));
     if (opt_interval != 0) {
-      QRegularExpression re(R"(^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([dhms])$)", QRegularExpression::CaseInsensitiveOption);
+      static const QRegularExpression re(R"(^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([dhms])$)", QRegularExpression::CaseInsensitiveOption);
       assert(re.isValid());
       QRegularExpressionMatch match = re.match(opt_split);
       if (match.hasMatch()) {
@@ -462,7 +462,7 @@ void TrackFilter::trackfilter_split()
 
     opt_distance = (opt_sdistance && (strlen(opt_sdistance) > 0) && (0 != strcmp(opt_sdistance, TRACKFILTER_SDIST_OPTION)));
     if (opt_distance != 0) {
-      QRegularExpression re(R"(^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([km])$)", QRegularExpression::CaseInsensitiveOption);
+      static const QRegularExpression re(R"(^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([km])$)", QRegularExpression::CaseInsensitiveOption);
       assert(re.isValid());
       QRegularExpressionMatch match = re.match(opt_sdistance);
       if (match.hasMatch()) {
@@ -665,7 +665,7 @@ QDateTime TrackFilter::trackfilter_range_check(const char* timestr)
 {
   QDateTime result;
 
-  QRegularExpression re("^(\\d{0,14})$");
+  static const QRegularExpression re("^(\\d{0,14})$");
   assert(re.isValid());
   QRegularExpressionMatch match = re.match(timestr);
   if (match.hasMatch()) {
@@ -826,7 +826,7 @@ TrackFilter::faketime_t TrackFilter::trackfilter_faketime_check(const char* time
 {
   faketime_t result;
 
-  QRegularExpression re(R"(^(f?)(\d{0,14})(?:\+(\d{1,10}))?$)");
+  static const QRegularExpression re(R"(^(f?)(\d{0,14})(?:\+(\d{1,10}))?$)");
   assert(re.isValid());
   QRegularExpressionMatch match = re.match(timestr);
   if (match.hasMatch()) {

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -1659,7 +1659,8 @@ XcsvStyle::xcsv_parse_style_line(XcsvStyle* style, QString line)
   }
 
   // Separate op and tokens.
-  int sep = line.indexOf(QRegularExpression(R"(\s+)"));
+  static const QRegularExpression re(R"(\s+)");
+  int sep = line.indexOf(re);
 
   // the first token is the operation, e.g. "IFIELD"
   QString op = line.mid(0, sep).trimmed().toUpper();


### PR DESCRIPTION
These showed up as 
warning: Don't create temporary QRegularExpression objects. Use a static QRegularExpression object instead [-Wclazy-use-static-qregularexpression]
when testing Qt 6.2.2 on Ubuntu jammy pre-release.

There is also one false positive in csv_util.cc.  I have filed a bug report: https://bugs.kde.org/show_bug.cgi?id=451686