### PR TITLE
Use QStandardPaths to locate data files

### DIFF
--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -54,6 +54,7 @@
 #include <QPushButton>                 // for QPushButton
 #include <QRadioButton>                // for QRadioButton
 #include <QStackedWidget>              // for QStackedWidget
+#include <QStandardPaths>              // for QStandardPaths
 
 #include <cstdlib>                     // for exit
 
@@ -262,17 +263,15 @@ void MainWindow::switchTranslator(QTranslator& translator, const QString& filena
   qApp->removeTranslator(&translator);
 
   // Set a list of locations to search for the translation file.
-  // 1. In the file system in the translations directory relative to the
-  //    location of the executable.
+  // 1. In the file system in the translations subdirectory of any
+  //    QStandardPaths::AppDataLocation directory.
   // 2. In the Qt resource system under the translations path.  This is useful
   //    if the resource was compiled into the executable.
   // 3. In the translations path for Qt.  This is useful to find translations
   //    included with Qt.
-  const QStringList directories = {
-    QApplication::applicationDirPath() + "/translations",
-    ":/translations",
-    QLibraryInfo::location(QLibraryInfo::TranslationsPath)
-  };
+  QStringList directories = QStandardPaths::locateAll(QStandardPaths::AppDataLocation, "translations", QStandardPaths::LocateDirectory);
+  directories.append(":/translations");
+  directories.append(QLibraryInfo::location(QLibraryInfo::TranslationsPath));
 
   // Load the new translator.
   for (const auto& directory : directories) {

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -30,6 +30,7 @@
 #include <QLatin1String>          // for QLatin1String
 #include <QMessageBox>            // for QMessageBox
 #include <QNetworkAccessManager>  // for QNetworkAccessManager
+#include <QStandardPaths>         // for QStandardPaths
 #include <QStringLiteral>         // for QStringLiteral
 #include <QUrl>                   // for QUrl
 #include <QWebChannel>            // for QWebChannel
@@ -89,13 +90,13 @@ Map::Map(QWidget* parent,
   connect(mclicker, &MarkerClicker::logTime, this, &Map::logTime);
 
   // We search the following locations:
-  // 1. In the file system in the same directory as the executable.
+  // 1. In the file system in the QStandardPaths::AppDataLocation directories.
   // 2. In the Qt resource system.  This is useful if the resource was compiled
   //    into the executable.
-  QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
+  QString baseFile = QStandardPaths::locate(QStandardPaths::AppDataLocation, "gmapbase.html");
   QString fileName;
   QUrl baseUrl;
-  if (QFile(baseFile).exists()) {
+  if (!baseFile.isEmpty()) {
     fileName = baseFile;
     baseUrl = QUrl::fromLocalFile(baseFile);
   } else if (QFile(":/gmapbase.html").exists()) {


### PR DESCRIPTION
On Linux where gpsbabel and gpsbabelfe are presumably placed in /usr/bin (and whether or not gmapbase.html and the translations are embedded), the program will still be searching for /usr/bin/gmapbase.html and /usr/bin/translations/*.  No sane Linux package would place those data files in /usr/bin.  A better location is to search for them in a subdirectory of /usr/share, and this change will do just that -- searching in /usr/share/GPSBabel/GPSBabel (taken from the OrganizationName and ApplicationName that are set in gui/main.cc).

Note that I'm unable to test this for Mac/Win; any scripts to create packages for them may need to move the files to an appropriate location.