### PR TITLE
add option to transform filter to delete creation times

### DIFF
--- a/reference/filter1.txt
+++ b/reference/filter1.txt
@@ -111,6 +111,7 @@ option	transform	trk	Transform waypoint(s) or route(s) into tracks(s) [W/R]	stri
 option	transform	rptdigits	Number of digits in generated names	integer		2		https://www.gpsbabel.org/WEB_DOC_DIR/filter_transform.html#fmt_transform_o_rptdigits
 option	transform	rptname	Use source name for route point names	boolean	N			https://www.gpsbabel.org/WEB_DOC_DIR/filter_transform.html#fmt_transform_o_rptname
 option	transform	del	Delete source data after transformation	boolean	N			https://www.gpsbabel.org/WEB_DOC_DIR/filter_transform.html#fmt_transform_o_del
+option	transform	timeless	Create transformed points without times	boolean	N			https://www.gpsbabel.org/WEB_DOC_DIR/filter_transform.html#fmt_transform_o_timeless
 validate	Validate internal data structures	https://www.gpsbabel.org/WEB_DOC_DIR/filter_validate.html
 option	validate	checkempty	Check for empty input	boolean	0			https://www.gpsbabel.org/WEB_DOC_DIR/filter_validate.html#fmt_validate_o_checkempty
 option	validate	debug	Output debug messages instead of possibly issuing a fatal error	boolean	0			https://www.gpsbabel.org/WEB_DOC_DIR/filter_validate.html#fmt_validate_o_debug

--- a/reference/help.txt
+++ b/reference/help.txt
@@ -584,6 +584,7 @@ Supported data filters:
 	  rptdigits             Number of digits in generated names 
 	  rptname               Use source name for route point names 
 	  del                   Delete source data after transformation 
+	  timeless              Create transformed points without times 
 	height                Manipulate altitudes                              
 	  add                   Adds a constant value to every altitude (meter, ap 
 	  wgs84tomsl            Converts WGS84 ellipsoidal height to orthometric h 

--- a/transform.cc
+++ b/transform.cc
@@ -49,6 +49,9 @@ void TransformFilter::transform_waypoints()
   foreach (Waypoint* wpt, *global_waypoint_list) {
 
     wpt = new Waypoint(*wpt);
+    if (timeless) {
+      wpt->SetCreationTime(gpsbabel::DateTime());
+    }
     switch (current_target) {
     case 'R':
       route_add_wpt(rte, wpt, RPT, name_digits);
@@ -96,6 +99,9 @@ void TransformFilter::transform_trk_disp_hdr_cb(const route_head* trk)
 void TransformFilter::transform_any_disp_wpt_cb(const Waypoint* wpt)
 {
   auto* temp = new Waypoint(*wpt);
+  if (timeless) {
+    temp->SetCreationTime(gpsbabel::DateTime());
+  }
   if (current_target == 'R') {
     route_add_wpt(current_rte, temp, current_namepart, name_digits);
   } else if (current_target == 'T') {
@@ -127,9 +133,11 @@ void TransformFilter::transform_tracks()
 
 void TransformFilter::process()
 {
-  int delete_after = (opt_delete && (*opt_delete == '1')) ? 1 : 0;
+  timeless = opt_timeless && (*opt_timeless == '1');
 
-  use_src_name = (opt_rpt_name && (*opt_rpt_name == '1')) ? 1 : 0;
+  bool delete_after = opt_delete && (*opt_delete == '1');
+
+  use_src_name = opt_rpt_name && (*opt_rpt_name == '1');
 
   name_digits = 3;
   if (rpt_name_digits && *rpt_name_digits) {

--- a/transform.h
+++ b/transform.h
@@ -46,9 +46,12 @@ private:
   route_head* current_rte{};
 
   char* opt_routes{}, *opt_tracks{}, *opt_waypts{}, *opt_delete{}, *rpt_name_digits{}, *opt_rpt_name{};
+  char* opt_timeless{};
+  bool timeless{};
+  bool use_src_name{};
   QString current_namepart;
 
-  int name_digits{}, use_src_name{};
+  int name_digits{};
 
   const QString RPT = "RPT";
 
@@ -77,6 +80,10 @@ private:
       "del", &opt_delete, "Delete source data after transformation", "N",
       ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
+    {
+      "timeless", &opt_timeless, "Create transformed points without times", "N",
+      ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
+    }
   };
 
   void transform_waypoints();

--- a/xmldoc/filters/options/transform-timeless.xml
+++ b/xmldoc/filters/options/transform-timeless.xml
@@ -1,4 +1,4 @@
 <para>
 This option tells
-GPSBabel to creating points without creation times instead of copying the creation time from the source point.
+GPSBabel to create points without creation times instead of copying the creation time from the source points.
 </para>

--- a/xmldoc/filters/options/transform-timeless.xml
+++ b/xmldoc/filters/options/transform-timeless.xml
@@ -1,0 +1,4 @@
+<para>
+This option tells
+GPSBabel to creating points without creation times instead of copying the creation time from the source point.
+</para>


### PR DESCRIPTION
This can be useful when one has recorded a track, e.g. with strava, and wants to create a route, e.g with ridewithgps.

./gpsbabel -i gpx -f track.gpx -x transform,rte=trk,del,timeless -x simplify,error=2m -o gpx -F route.gpx