### PR TITLE
string optimizations

### DIFF
--- a/csv_util.cc
+++ b/csv_util.cc
@@ -55,7 +55,7 @@ csv_stringclean(const QString& source, const QString& to_nuke)
     // avoid problematic regular rexpressions, e.g. xmapwpt generated [:\n:],
     // or one can imagine [0-9] when we meant the characters, '0', '-', and '9',
     // or one can imagine [^a] when we meant the characters '^' and 'a'.
-    QRegularExpression regex = QRegularExpression(QString("[%1]").arg(QRegularExpression::escape(to_nuke)));
+    QRegularExpression regex = QRegularExpression(QStringLiteral("[%1]").arg(QRegularExpression::escape(to_nuke)));
     assert(regex.isValid());
     r.remove(regex);
   }

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -203,7 +203,7 @@ Dg100Format::process_gpsfile(uint8_t data[], route_head** track) const
       QDateTime creation_time = bintime2utc(bindate, bintime);
       QString datetime = creation_time.toString("yyyy/MM/dd hh:mm:ss");
       *track = new route_head;
-      (*track)->rte_name = QString("%1 tracklog (%2)").arg(model->name, datetime);
+      (*track)->rte_name = QStringLiteral("%1 tracklog (%2)").arg(model->name, datetime);
       (*track)->rte_desc = "GPS tracklog data";
       track_add_head(*track);
     }

--- a/dg-100.cc
+++ b/dg-100.cc
@@ -201,7 +201,7 @@ Dg100Format::process_gpsfile(uint8_t data[], route_head** track) const
       int bintime = be_read32(data + i +  8) & 0x7FFFFFFF;
       int bindate = be_read32(data + i + 12);
       QDateTime creation_time = bintime2utc(bindate, bintime);
-      QString datetime = creation_time.toString("yyyy/MM/dd hh:mm:ss");
+      QString datetime = creation_time.toString(u"yyyy/MM/dd hh:mm:ss");
       *track = new route_head;
       (*track)->rte_name = QStringLiteral("%1 tracklog (%2)").arg(model->name, datetime);
       (*track)->rte_desc = "GPS tracklog data";

--- a/exif.cc
+++ b/exif.cc
@@ -194,10 +194,10 @@ ExifFormat::exif_type_size(const uint16_t type)
 QString
 ExifFormat::exif_time_str(const QDateTime& time)
 {
-  QString str = time.toString("yyyy/MM/dd hh:mm:ss t");
+  QString str = time.toString(u"yyyy/MM/dd hh:mm:ss t");
   if (time.timeSpec() != Qt::UTC) {
     str.append(" (");
-    str.append(time.toUTC().toString("yyyy/MM/dd hh:mm:ss t"));
+    str.append(time.toUTC().toString(u"yyyy/MM/dd hh:mm:ss t"));
     str.append(")");
   }
   return str;
@@ -1554,7 +1554,7 @@ ExifFormat::write()
       exif_put_double(GPS_IFD, GPS_IFD_TAG_TIMESTAMP, 1, dt.time().minute());
       exif_put_double(GPS_IFD, GPS_IFD_TAG_TIMESTAMP, 2, dt.time().second());
 
-      exif_put_str(GPS_IFD, GPS_IFD_TAG_DATESTAMP, CSTR(dt.toString("yyyy:MM:dd")));
+      exif_put_str(GPS_IFD, GPS_IFD_TAG_DATESTAMP, CSTR(dt.toString(u"yyyy:MM:dd")));
     } else {
       exif_remove_tag(GPS_IFD, GPS_IFD_TAG_TIMESTAMP);
       exif_remove_tag(GPS_IFD, GPS_IFD_TAG_DATESTAMP);

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -239,7 +239,7 @@ GarminFitFormat::fit_parse_definition_message(uint8_t header)
   // second byte is endianness
   def.endian = fit_getuint8();
   if (def.endian > 1) {
-    throw ReaderException(QString("Bad endian field 0x%1 at file position 0x%2.").arg(def.endian, 0, 16).arg(gbftell(fin) - 1, 0, 16).toStdString());
+    throw ReaderException(QStringLiteral("Bad endian field 0x%1 at file position 0x%2.").arg(def.endian, 0, 16).arg(gbftell(fin) - 1, 0, 16).toStdString());
   }
   fit_data.endian = def.endian;
 
@@ -675,7 +675,7 @@ GarminFitFormat::fit_parse_data(const fit_message_def& def, int time_offset)
     auto* lappt = new Waypoint;
     lappt->latitude = GPS_Math_Semi_To_Deg(endlat);
     lappt->longitude = GPS_Math_Semi_To_Deg(endlon);
-    lappt->shortname = QString("LAP%1").arg(++lap_ct, 3, 10, QLatin1Char('0'));
+    lappt->shortname = QStringLiteral("LAP%1").arg(++lap_ct, 3, 10, QLatin1Char('0'));
     waypt_add(lappt);
   }
   break;

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -395,7 +395,7 @@ GarminGPIFormat::read_tag(const char* caller, const int tag, Waypoint* wpt)
           speed = MPS_TO_KPH(speed);
         }
         QString base = wpt->shortname.isEmpty() ? "WPT" : wpt->shortname;
-        wpt->shortname = base + QString("@%1").arg(speed,0,'f',0);
+        wpt->shortname = base + QStringLiteral("@%1").arg(speed,0,'f',0);
       }
     }
 
@@ -1230,7 +1230,7 @@ GarminGPIFormat::rd_init(const QString& fname)
   read_header();
 
   if ((codepage >= 1250) && (codepage <= 1257)) {
-    QString qCodecName = QString("windows-%1").arg(codepage);
+    QString qCodecName = QStringLiteral("windows-%1").arg(codepage);
     cet_convert_init(CSTR(qCodecName), 1);
   } else if (codepage == 65001) {
     cet_convert_init("utf8", 1);
@@ -1273,7 +1273,7 @@ GarminGPIFormat::wr_init(const QString& fname)
   codepage = 0;
 
   for (int i = 1250; i <= 1257; i++) {
-    if (QString("windows-%1").arg(i).compare(QString(opt_writecodec), Qt::CaseInsensitive) == 0) {
+    if (QStringLiteral("windows-%1").arg(i).compare(QString(opt_writecodec), Qt::CaseInsensitive) == 0) {
       codepage = i;
       break;
     }

--- a/garmin_tables.cc
+++ b/garmin_tables.cc
@@ -424,11 +424,11 @@ QString
 gt_find_desc_from_icon_number(const int icon, garmin_formats_e garmin_format)
 {
   if ((garmin_format == GDB) && (icon >= 500) && (icon <= 563)) {
-    return QString("Custom %1").arg(icon - 500);
+    return QStringLiteral("Custom %1").arg(icon - 500);
   }
 
   if ((garmin_format == PCX) && (icon >= 7680) && (icon <= 8191)) {
-    return QString("Custom %1").arg(icon - 7680);
+    return QStringLiteral("Custom %1").arg(icon - 7680);
   }
 
   for (const icon_mapping_t* i = garmin_icon_table; i->icon; i++) {

--- a/gdb.cc
+++ b/gdb.cc
@@ -284,22 +284,22 @@ QString GdbFormat::gdb_to_ISO8601_duration(unsigned int seconds)
   unsigned int days = seconds / 86400u;
   QString out = "P";
   if (days != 0) {
-    out.append(QString("D%1").arg(days));
+    out.append(QStringLiteral("D%1").arg(days));
     seconds -= 86400u * days;
   }
   out.append(QString("T"));
   unsigned int hours = seconds / 3600u;
   if (hours != 0) {
-    out.append(QString("%1H").arg(hours));
+    out.append(QStringLiteral("%1H").arg(hours));
     seconds -= 3600u * hours;
   }
   unsigned int minutes = seconds / 60u;
   if (minutes != 0) {
-    out.append(QString("%1M").arg(minutes));
+    out.append(QStringLiteral("%1M").arg(minutes));
     seconds -= 60u * minutes;
   }
   if (seconds != 0) {
-    out.append(QString("%1S").arg(seconds));
+    out.append(QStringLiteral("%1S").arg(seconds));
   }
   return out;
 }
@@ -578,7 +578,7 @@ GdbFormat::read_waypoint(gt_waypt_classes_e* waypt_class_out)
     res->description = FREAD_CSTR_AS_QSTR;	/* instruction */
     if (wpt_class == gt_waypt_class_map_intersection || wpt_class == gt_waypt_class_map_line) {
       garmin_fs_t::set_duration(gmsd, duration);
-      res->notes = QString("[%1]").arg(gdb_to_ISO8601_duration(duration));
+      res->notes = QStringLiteral("[%1]").arg(gdb_to_ISO8601_duration(duration));
 #if GDB_DEBUG
       DBG(GDB_DBG_WPTe, 1)
       printf(MYNAME "-wpt \"%s\" (%d): duration = %u\n",

--- a/gpssim.cc
+++ b/gpssim.cc
@@ -144,7 +144,7 @@ gpssim_trk_hdr(const route_head* rh)
       fatal(MYNAME ": output file already open.\n");
     }
 
-    QString ofname = QString("%1%2%3.gpssim").arg(fnamestr, doing_tracks ? "-track" : "-route").arg(trk_count++, 4, 10, QChar('0'));
+    QString ofname = QStringLiteral("%1%2%3.gpssim").arg(fnamestr, doing_tracks ? "-track" : "-route").arg(trk_count++, 4, 10, QChar('0'));
     fout = gbfopen(ofname, "wb", MYNAME);
   }
   (void) track_recompute(rh);

--- a/gpssim.cc
+++ b/gpssim.cc
@@ -125,8 +125,8 @@ gpssim_write_pt(const Waypoint* wpt)
   if (wpt->creation_time.isValid()) {
     char tbuf[20];
 
-    QByteArray dmy = wpt->GetCreationTime().toUTC().toString("ddMMyy").toUtf8();
-    QByteArray hms = wpt->GetCreationTime().toUTC().toString("hhmmss").toUtf8();
+    QByteArray dmy = wpt->GetCreationTime().toUTC().toString(u"ddMMyy").toUtf8();
+    QByteArray hms = wpt->GetCreationTime().toUTC().toString(u"hhmmss").toUtf8();
 
     snprintf(tbuf, sizeof(tbuf), ",%s,%s",dmy.constData(), hms.constData());
     strcat(obuf, tbuf);

--- a/gtrnctr.cc
+++ b/gtrnctr.cc
@@ -306,7 +306,7 @@ GtrnctrFormat::gtc_crs_hdr(const route_head* rte)
 
   if (!rte->rte_name.isEmpty()) {
     QString name = rte->rte_name.left(kGtcMaxNameLen);
-    gtc_write_xml(0, QString("<Name>%1</Name>\n").arg(name));
+    gtc_write_xml(0, QStringLiteral("<Name>%1</Name>\n").arg(name));
   } else {
     gtc_write_xml(0, "<Name>New Course</Name>\n");
   }

--- a/kml.cc
+++ b/kml.cc
@@ -391,7 +391,7 @@ void KmlFormat::wr_init(const QString& fname)
 void KmlFormat::wr_position_init(const QString& fname)
 {
   posnfilename = fname;
-  posnfilenametmp = QString("%1-").arg(fname);
+  posnfilenametmp = QStringLiteral("%1-").arg(fname);
   realtime_positioning = 1;
   max_position_points = atoi(opt_max_position_points);
 }
@@ -842,9 +842,9 @@ void KmlFormat::kml_output_point(const Waypoint* waypointp, kml_point_type pt_ty
       if (trackdirection && (pt_type == kmlpt_track)) {
         QString value;
         if (waypointp->speed < 1) {
-          value = QString("%1-none").arg(style);
+          value = QStringLiteral("%1-none").arg(style);
         } else {
-          value = QString("%1-%2").arg(style)
+          value = QStringLiteral("%1-%2").arg(style)
                   .arg((int)(waypointp->course / 22.5 + .5) % 16);
         }
         writer->writeTextElement(QStringLiteral("styleUrl"), value);
@@ -1141,7 +1141,7 @@ QString KmlFormat::kml_lookup_gc_icon(const Waypoint* waypointp)
     break;
   }
 
-  return QString("https://www.geocaching.com/images/kml/%1").arg(icon);
+  return QStringLiteral("https://www.geocaching.com/images/kml/%1").arg(icon);
 }
 
 const char* KmlFormat::kml_lookup_gc_container(const Waypoint* waypointp)
@@ -1184,9 +1184,9 @@ QString KmlFormat::kml_gc_mkstar(int rating)
   }
 
   if (0 == rating % 10) {
-    star_content = QString("stars%1").arg(rating / 10);
+    star_content = QStringLiteral("stars%1").arg(rating / 10);
   } else {
-    star_content = QString("stars%1_%2").arg(rating / 10).arg(rating % 10);
+    star_content = QStringLiteral("stars%1_%2").arg(rating / 10).arg(rating % 10);
   }
 
   return star_content;
@@ -1770,7 +1770,7 @@ void KmlFormat::write()
     if (trackdirection) {
       kml_write_bitmap_style(kmlpt_other, ICON_TRK, "track-none");
       for (int i = 0; i < 16; ++i) {
-        kml_write_bitmap_style(kmlpt_other, QString(ICON_DIR).arg(i), QString("track-%1").arg(i));
+        kml_write_bitmap_style(kmlpt_other, QStringLiteral(ICON_DIR).arg(i), QStringLiteral("track-%1").arg(i));
       }
     } else {
       kml_write_bitmap_style(kmlpt_track, ICON_TRK, nullptr);

--- a/kml.cc
+++ b/kml.cc
@@ -1301,7 +1301,7 @@ void KmlFormat::kml_geocache_pr(const Waypoint* waypointp) const
   kml_output_timestamp(waypointp);
   QString date_placed;
   if (waypointp->GetCreationTime().isValid()) {
-    date_placed = waypointp->GetCreationTime().toString("dd-MMM-yyyy");
+    date_placed = waypointp->GetCreationTime().toString(u"dd-MMM-yyyy");
   }
 
   writer->writeTextElement(QStringLiteral("styleUrl"), QStringLiteral("#geocache"));

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -1549,7 +1549,7 @@ LowranceusrFormat::lowranceusr_trail_hdr(const route_head* trk)
   } else if (!trk->rte_desc.isEmpty()) {
     name = trk->rte_desc;
   } else {
-    name = name + QString("Babel %1").arg(trail_count);
+    name = name + QStringLiteral("Babel %1").arg(trail_count);
   }
 
   int text_len = name.length();

--- a/lowranceusr.cc
+++ b/lowranceusr.cc
@@ -468,10 +468,10 @@ LowranceusrFormat::lowranceusr_parse_waypt(Waypoint* wpt_tmp, int object_num_pre
 
   if (global_opts.debug_level > 2) {
     if (global_opts.debug_level == 99) {
-      printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")));
+      printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString(u"yyyy/MM/dd hh:mm:ss")));
     } else {
       printf(MYNAME " parse_waypt: creation time '%s', waypt_time %" PRId64 "\n",
-             qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")), waypt_time);
+             qPrintable(wpt_tmp->GetCreationTime().toString(u"yyyy/MM/dd hh:mm:ss")), waypt_time);
     }
   }
 
@@ -626,7 +626,7 @@ LowranceusrFormat::lowranceusr4_parse_waypt(Waypoint* wpt_tmp) const
       } else {
         printf(" %6s %16s", QByteArray::number(desc.length()).constData(), qPrintable(desc));
       }
-      printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")));
+      printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString(u"yyyy/MM/dd hh:mm:ss")));
       printf(" %08x %8.3f %08x %08x %08x\n",
              unused_byte, fsdata->depth, loran_GRI, loran_Tda, loran_Tdb);
     } else {
@@ -1064,7 +1064,7 @@ LowranceusrFormat::lowranceusr4_parse_trail(int* trail_num) const
   int create_time = gbfgetint32(file_in);
   if (global_opts.debug_level == 99) {
     QDateTime qdt = lowranceusr4_get_timestamp(create_date, create_time);
-    printf(MYNAME " parse_trails: creation date/time = %s\n", qPrintable(qdt.toString("yyyy-MM-dd hh:mm:ss AP")));
+    printf(MYNAME " parse_trails: creation date/time = %s\n", qPrintable(qdt.toString(u"yyyy-MM-dd hh:mm:ss AP")));
   }
 
   /* Some flag bytes */
@@ -1129,7 +1129,7 @@ LowranceusrFormat::lowranceusr4_parse_trail(int* trail_num) const
     if (global_opts.debug_level >= 2) {
       if (global_opts.debug_level == 99) {
         printf(MYNAME " parse_trails: %+14.9f %+14.9f", wpt_tmp->longitude, wpt_tmp->latitude);
-        printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString("yyyy/MM/dd hh:mm:ss")));
+        printf(" '%s'", qPrintable(wpt_tmp->GetCreationTime().toString(u"yyyy/MM/dd hh:mm:ss")));
       } else {
         printf(MYNAME " parse_trails: added trailpoint %+.9f,%+.9f to trail %s\n",
                wpt_tmp->longitude, wpt_tmp->latitude, qPrintable(trk_head->rte_name));
@@ -1224,7 +1224,7 @@ LowranceusrFormat::read()
     int create_time = gbfgetint32(file_in);
     if (global_opts.debug_level >= 1) {
       QDateTime qdt = lowranceusr4_get_timestamp(create_date, create_time);
-      printf(MYNAME " creation date/time : '%s'\n", qPrintable(qdt.toString("yyyy-MM-dd hh:mm:ss AP")));
+      printf(MYNAME " creation date/time : '%s'\n", qPrintable(qdt.toString(u"yyyy-MM-dd hh:mm:ss AP")));
     }
 
     unsigned char byte = gbfgetc(file_in); /* unused, apparently */
@@ -1334,7 +1334,7 @@ LowranceusrFormat::lowranceusr_waypt_disp(const Waypoint* wpt) const
     /* Lowrance needs it as seconds since Jan 1, 2000 */
     waypt_time -= base_time_secs;
     if (global_opts.debug_level >= 2) {
-      printf("creation_time %" PRId64 ", '%s'", waypt_time, qPrintable(wpt->GetCreationTime().toString("yyyy-MM-dd hh:mm:ss")));
+      printf("creation_time %" PRId64 ", '%s'", waypt_time, qPrintable(wpt->GetCreationTime().toString(u"yyyy-MM-dd hh:mm:ss")));
     }
   } else {
     /* If false, make sure it is an unknown time value */
@@ -1880,7 +1880,7 @@ LowranceusrFormat::write()
 
     /* date string */
     gpsbabel::DateTime now = current_time().toUTC();
-    lowranceusr4_writestr(now.toString("MM/dd/yyyy"), file_out, 1);
+    lowranceusr4_writestr(now.toString(u"MM/dd/yyyy"), file_out, 1);
 
     /* creation date/time */
     auto ts = lowranceusr4_jd_from_timestamp(now);

--- a/lowranceusr.h
+++ b/lowranceusr.h
@@ -484,7 +484,7 @@ private:
     }
 
     // Didn't find it in table, default to leave it as the number found
-    return QString("icon-%1").arg(icon);
+    return QStringLiteral("icon-%1").arg(icon);
   }
 
   template <typename T>

--- a/magproto.cc
+++ b/magproto.cc
@@ -1422,8 +1422,8 @@ void mag_track_disp(const Waypoint* waypointp)
     QDateTime dt = waypointp->GetCreationTime().toUTC();
     dt = dt.addMSecs(10 * lround(dt.time().msec()/10.0) - dt.time().msec());
     assert((dt.time().msec() % 10) == 0);
-    dmy = dt.toString("ddMMyy").toUtf8();
-    hms = dt.toString("hhmmss.zzz").left(9).toUtf8();
+    dmy = dt.toString(u"ddMMyy").toUtf8();
+    hms = dt.toString(u"hhmmss.zzz").left(9).toUtf8();
   }
 
   double lon = fabs(ilon);

--- a/mtk_logger.cc
+++ b/mtk_logger.cc
@@ -803,7 +803,7 @@ static int add_trackpoint(int idx, unsigned long bmask, struct data_item* itm)
   if (global_opts.masked_objective& TRKDATAMASK && (trk_head == nullptr || (mtk_info.track_event & MTK_EVT_START))) {
     char spds[50];
     trk_head = new route_head;
-    trk_head->rte_name = QString("track-%1").arg(1 + track_count());
+    trk_head->rte_name = QStringLiteral("track-%1").arg(1 + track_count());
 
     spds[0] = '\0';
     if (mtk_info.speed > 0) {
@@ -896,7 +896,7 @@ static int add_trackpoint(int idx, unsigned long bmask, struct data_item* itm)
     /* Button press -- create waypoint, start count at 1 */
     auto* w = new Waypoint(*trk);
 
-    w->shortname = QString("WP%1").arg(waypt_count() + 1, 6, 10, QLatin1Char('0'));
+    w->shortname = QStringLiteral("WP%1").arg(waypt_count() + 1, 6, 10, QLatin1Char('0'));
     waypt_add(w);
   }
   // In theory we would not add the waypoint to the list of

--- a/nmea.cc
+++ b/nmea.cc
@@ -359,7 +359,7 @@ QTime NmeaFormat::nmea_parse_hms(const QString& str)
     if (retval.isValid() && parts.size() == 2) {
       bool ok;
       // prepend "0.".  prepending "." won't work if there are no trailing digits.
-      long msec = lround(1000.0 * QString("0.%1").arg(parts.at(1)).toDouble(&ok));
+      long msec = lround(1000.0 * QStringLiteral("0.%1").arg(parts.at(1)).toDouble(&ok));
       if (ok) {
         retval = retval.addMSecs(msec);
       } else {
@@ -631,7 +631,7 @@ NmeaFormat::gpzda_parse(const QString& ibuf)
   const QStringList fields = ibuf.split(',');
   if (fields.size() > 4) {
     QTime time = nmea_parse_hms(fields[1]);
-    QString datestr = QString("%1%2%3").arg(fields[2], fields[3], fields[4]);
+    QString datestr = QStringLiteral("%1%2%3").arg(fields[2], fields[3], fields[4]);
     QDate date = QDate::fromString(datestr, "ddMMyyyy");
 
     // The prev_datetime data member might be used by

--- a/nmea.cc
+++ b/nmea.cc
@@ -1222,8 +1222,8 @@ NmeaFormat::nmea_trackpt_pr(const Waypoint* wpt)
   QByteArray dmy("");
   QByteArray hms("");
   if (wpt->GetCreationTime().isValid()) {
-    dmy = wpt->GetCreationTime().toUTC().toString("ddMMyy").toUtf8();
-    hms = wpt->GetCreationTime().toUTC().toString("hhmmss.zzz").toUtf8();
+    dmy = wpt->GetCreationTime().toUTC().toString(u"ddMMyy").toUtf8();
+    hms = wpt->GetCreationTime().toUTC().toString(u"hhmmss.zzz").toUtf8();
   }
 
   switch (wpt->fix) {

--- a/osm.cc
+++ b/osm.cc
@@ -401,7 +401,7 @@ OsmFormat::osm_feature_symbol(const int ikey, const char* value) const
   if (values.contains(key)) {
     result = values.value(key)->icon;
   } else {
-    result = QString("%1:%2").arg(osm_features[ikey], value);
+    result = QStringLiteral("%1:%2").arg(osm_features[ikey], value);
   }
   return result;
 }

--- a/ozi.cc
+++ b/ozi.cc
@@ -197,7 +197,7 @@ ozi_get_time_str(const Waypoint* waypointp)
 {
   if (waypointp->creation_time.isValid()) {
     double time = (waypt_time(waypointp) / SECONDS_PER_DAY) + DAYS_SINCE_1990;
-    return QString("%1").arg(time, 0, 'f', 7);
+    return QStringLiteral("%1").arg(time, 0, 'f', 7);
   }
   return QString("");
 }
@@ -243,7 +243,7 @@ ozi_openfile(const QString& fname)
 
   QString buff;
   if ((track_out_count) && (ozi_objective == trkdata)) {
-    buff = QString("-%1").arg(track_out_count);
+    buff = QStringLiteral("-%1").arg(track_out_count);
   } else {
     buff = QString("");
   }
@@ -256,7 +256,7 @@ ozi_openfile(const QString& fname)
     sname.chop(suffix_len + 1);
   }
 
-  QString tmpname = QString("%1%2.%3").arg(sname, buff, ozi_extensions[ozi_objective]);
+  QString tmpname = QStringLiteral("%1%2.%3").arg(sname, buff, ozi_extensions[ozi_objective]);
 
   /* re-open file_out with the new filename */
   if (stream != nullptr) {

--- a/qstarz_bl_1000.cc
+++ b/qstarz_bl_1000.cc
@@ -254,7 +254,7 @@ QstarzBL1000Format::qstarz_bl_1000_read_record(QDataStream& stream, route_head* 
 
   if (qstarz_bl_1000_is_waypoint_type(type)) {
     if (global_opts.synthesize_shortnames) {
-      waypoint->shortname = QString("WP%2").arg(waypt_count() + 1, 3, 10, QChar('0'));
+      waypoint->shortname = QStringLiteral("WP%2").arg(waypt_count() + 1, 3, 10, QChar('0'));
       waypoint->wpt_flags.shortname_is_synthetic = 1;
     }
     waypt_add(waypoint);

--- a/route.cc
+++ b/route.cc
@@ -339,7 +339,7 @@ computed_trkdata track_recompute(const route_head* trk)
     }
 
     if (thisw->shortname.isEmpty()) {
-      thisw->shortname = QString("%1-%2").arg(trk->rte_name).arg(tkpt);
+      thisw->shortname = QStringLiteral("%1-%2").arg(trk->rte_name).arg(tkpt);
     }
     tkpt++;
     prev = thisw;

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -606,7 +606,7 @@ SkytraqBase::make_trackpoint(struct read_state* st, double lat, double lon, doub
 {
   auto* wpt = new Waypoint;
 
-  wpt->shortname = QString("TP%1").arg(++st->tpn, 4, 10, QLatin1Char('0'));
+  wpt->shortname = QStringLiteral("TP%1").arg(++st->tpn, 4, 10, QLatin1Char('0'));
 
   wpt->latitude       = lat;
   wpt->longitude      = lon;

--- a/subrip.cc
+++ b/subrip.cc
@@ -180,7 +180,7 @@ SubripFormat::subrip_trkpt_pr(const Waypoint* waypointp)
       qDebug().noquote() << "GPS track start is           "
                          << waypointp->GetCreationTime().toUTC().toString(Qt::ISODateWithMs);
       qDebug().noquote() << "Synchronizing"
-                         << video_time(gps_datetime).toString("HH:mm:ss,zzz")
+                         << video_time(gps_datetime).toString(u"HH:mm:ss,zzz")
                          << "to" << gps_datetime.toString(Qt::ISODateWithMs);
       qDebug().noquote() << "Video start   00:00:00,000 is"
                          << video_datetime.toString(Qt::ISODateWithMs);

--- a/tpo.cc
+++ b/tpo.cc
@@ -279,7 +279,7 @@ static void tpo_read_2_x()
     track_add_head(track_temp);
 
     /* generate a generic track name */
-    track_temp->rte_name = QString("Track %1").arg(i+1);
+    track_temp->rte_name = QStringLiteral("Track %1").arg(i+1);
 
     /* zoom level 1-5 visibility flags */
     gbfread(&buff[0], 1, 10, tpo_file_in);
@@ -566,7 +566,7 @@ static void tpo_process_tracks()
     if (tmp) {
       styles[ii].name = gbfreadbuf(tmp, tpo_file_in);
     } else { // Assign a generic style name
-      styles[ii].name = QString("STYLE %1").arg(ii);
+      styles[ii].name = QStringLiteral("STYLE %1").arg(ii);
     }
 #ifdef Tracks2012
     //TBD: Should this be TRACKNAMELENGTH?
@@ -1219,7 +1219,7 @@ static void tpo_process_map_notes()
     Waypoint* waypoint_temp = tpo_convert_ll(lat, lon);
 
     // Assign a generic waypoint name
-    waypoint_temp->shortname = QString("NOTE %1").arg(ii + 1);
+    waypoint_temp->shortname = QStringLiteral("NOTE %1").arg(ii + 1);
 
 //UNKNOWN DATA LENGTH
     (void)tpo_read_int();
@@ -1320,7 +1320,7 @@ static void tpo_process_symbols()
     Waypoint* waypoint_temp = tpo_convert_ll(lat, lon);
 
     // Assign a generic waypoint name
-    waypoint_temp->shortname = QString("SYM %1").arg(ii + 1);
+    waypoint_temp->shortname = QStringLiteral("SYM %1").arg(ii + 1);
 
     // Add the waypoint to the chain of waypoints
     waypt_add(waypoint_temp);
@@ -1363,7 +1363,7 @@ static void tpo_process_text_labels()
     Waypoint* waypoint_temp = tpo_convert_ll(lat, lon);
 
     // Assign a generic waypoint name
-    waypoint_temp->shortname = QString("TXT %1").arg(ii + 1);
+    waypoint_temp->shortname = QStringLiteral("TXT %1").arg(ii + 1);
 
     for (int jj = 0; jj < 16; jj++) {
 //UNKNOWN DATA LENGTH

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -253,10 +253,10 @@ void TrackFilter::trackfilter_split_init_rte_name(route_head* track, const gpsba
       strftime(buff, sizeof(buff), opt_title, &tm);
       track->rte_name = buff;
     } else {
-      track->rte_name = QString("%1-%2").arg(opt_title, datetimestring);
+      track->rte_name = QStringLiteral("%1-%2").arg(opt_title, datetimestring);
     }
   } else if (!track->rte_name.isEmpty()) {
-    track->rte_name = QString("%1-%2").arg(track->rte_name, datetimestring);
+    track->rte_name = QStringLiteral("%1-%2").arg(track->rte_name, datetimestring);
   } else {
     track->rte_name = datetimestring;
   }
@@ -759,7 +759,7 @@ void TrackFilter::trackfilter_seg2trk()
           dest->rte_num = src->rte_num;
           /* name in the form TRACKNAME #n */
           if (!src->rte_name.isEmpty()) {
-            dest->rte_name = QString("%1 #%2").arg(src->rte_name).arg(++trk_seg_num);
+            dest->rte_name = QStringLiteral("%1 #%2").arg(src->rte_name).arg(++trk_seg_num);
           }
 
           /* Insert after original track or after last newly

--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -238,9 +238,9 @@ void TrackFilter::trackfilter_split_init_rte_name(route_head* track, const gpsba
   QString datetimestring;
 
   if (opt_interval != 0) {
-    datetimestring = dt.toUTC().toString("yyyyMMddhhmmss");
+    datetimestring = dt.toUTC().toString(u"yyyyMMddhhmmss");
   } else {
-    datetimestring = dt.toUTC().toString("yyyyMMdd");
+    datetimestring = dt.toUTC().toString(u"yyyyMMdd");
   }
 
   if ((opt_title != nullptr) && (strlen(opt_title) > 0)) {

--- a/transform.cc
+++ b/transform.cc
@@ -73,7 +73,7 @@ void TransformFilter::transform_rte_disp_hdr_cb(const route_head* rte)
     current_trk = new route_head;
     track_add_head(current_trk);
     if (!rte->rte_name.isEmpty()) {
-      current_trk->rte_desc = QString("Generated from route %1").arg(rte->rte_name);
+      current_trk->rte_desc = QStringLiteral("Generated from route %1").arg(rte->rte_name);
       current_trk->rte_name = rte->rte_name; /* name the new trk */
     }
   }

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -1370,7 +1370,7 @@ UnicsvFormat::unicsv_waypt_disp_cb(const Waypoint* wpt)
                                          &east, &north, &zone, &zonec, unicsv_datum_idx)) {
       unicsv_fatal_outside(wpt);
     }
-    *fout << QString("%1").arg(zone, 2, 10, QLatin1Char('0')) << unicsv_fieldsep
+    *fout << QStringLiteral("%1").arg(zone, 2, 10, QLatin1Char('0')) << unicsv_fieldsep
           << zonec  << unicsv_fieldsep
           << qSetRealNumberPrecision(0) << east << unicsv_fieldsep
           << north;

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -1147,7 +1147,7 @@ UnicsvFormat::unicsv_print_data_time(const QDateTime& idt) const
     dt = dt.toUTC();
   }
 
-  unicsv_print_str(dt.toString("yyyy/MM/dd hh:mm:ss"));
+  unicsv_print_str(dt.toString(u"yyyy/MM/dd hh:mm:ss"));
 }
 
 #define FIELD_USED(a) (gb_getbit(&unicsv_outp_flags, a))
@@ -1547,7 +1547,7 @@ UnicsvFormat::unicsv_waypt_disp_cb(const Waypoint* wpt)
       } else {
         dt = wpt->GetCreationTime().toLocalTime();
       }
-      QString date = dt.toString("yyyy/MM/dd");
+      QString date = dt.toString(u"yyyy/MM/dd");
       *fout << unicsv_fieldsep << date;
     } else {
       *fout << unicsv_fieldsep;
@@ -1564,9 +1564,9 @@ UnicsvFormat::unicsv_waypt_disp_cb(const Waypoint* wpt)
       }
       QString out;
       if (t.msec() > 0) {
-        out = t.toString("hh:mm:ss.zzz");
+        out = t.toString(u"hh:mm:ss.zzz");
       } else {
-        out = t.toString("hh:mm:ss");
+        out = t.toString(u"hh:mm:ss");
       }
       *fout << unicsv_fieldsep << out;
     } else {

--- a/waypt.cc
+++ b/waypt.cc
@@ -617,7 +617,7 @@ WaypointList::waypt_add(Waypoint* wpt)
     } else if (!wpt->notes.isNull()) {
       wpt->shortname = wpt->notes;
     } else {
-      wpt->shortname = QString("WPT%1").arg(waypt_count(), 3, 10, QLatin1Char('0'));
+      wpt->shortname = QStringLiteral("WPT%1").arg(waypt_count(), 3, 10, QLatin1Char('0'));
     }
   }
 
@@ -643,7 +643,7 @@ WaypointList::add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, const QStri
   append(wpt);
 
   if (synth && wpt->shortname.isEmpty()) {
-    wpt->shortname = QString("%1%2").arg(namepart).arg(waypt_ct, number_digits, 10, QChar('0'));
+    wpt->shortname = QStringLiteral("%1%2").arg(namepart).arg(waypt_ct, number_digits, 10, QChar('0'));
     wpt->wpt_flags.shortname_is_synthetic = 1;
   }
 }

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -1590,13 +1590,13 @@ XcsvFormat::xcsv_replace_tokens(const QString& original) const
 
     QDateTime dt = current_time().toUTC();
 
-    QString dts = dt.toString("ddd MMM dd hh:mm:ss yyyy");
+    QString dts = dt.toString(u"ddd MMM dd hh:mm:ss yyyy");
     replacement.replace("__DATE_AND_TIME__", dts);
 
-    QString d = dt.toString("MM/dd/yyyy");
+    QString d = dt.toString(u"MM/dd/yyyy");
     replacement.replace("__DATE__", d);
 
-    QString t = dt.toString("hh:mm:ss");
+    QString t = dt.toString(u"hh:mm:ss");
     replacement.replace("__TIME__", t);
   }
   return replacement;


### PR DESCRIPTION
This PR contains two string optimizations.   The first commit uses QStringLiteral("\*").arg... instead of QString("\*").arg...  The second uses utf-16 strings with QDateTime, QDate, QTime literal string format arguments.