### PR TITLE
use QStringView with namepart parameter in add wpt functions.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -533,7 +533,7 @@ class WaypointList : private QList<Waypoint*>
 {
 public:
   void waypt_add(Waypoint* wpt); // a.k.a. append(), push_back()
-  void add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, const QString& namepart, int number_digits);
+  void add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, QStringView namepart, int number_digits);
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the element to be deleted, use iterator instead,
   //        and/or implement pop_back() a.k.a. removeLast(), and/or pop_front() a.k.a. removeFirst().
   void waypt_del(Waypoint* wpt); // a.k.a. erase()
@@ -709,7 +709,7 @@ public:
   void del_head(route_head* rte); // a.k.a. erase()
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the insertion point, use iterator instead.
   void insert_head(route_head* rte, route_head* predecessor); // a.k.a. insert
-  void add_wpt(route_head* rte, Waypoint* wpt, bool synth, const QString& namepart, int number_digits);
+  void add_wpt(route_head* rte, Waypoint* wpt, bool synth, QStringView namepart, int number_digits);
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the insertion point, use iterator instead.
   void del_wpt(route_head* rte, Waypoint* wpt);
   void common_disp_session(const session_t* se, route_hdr rh, route_trl rt, waypt_cb wc);
@@ -767,8 +767,8 @@ void route_del_head(route_head* rte);
 void track_add_head(route_head* rte);
 void track_del_head(route_head* rte);
 void track_insert_head(route_head* rte, route_head* predecessor);
-void route_add_wpt(route_head* rte, Waypoint* wpt, const QString& namepart = "RPT", int number_digits = 3);
-void track_add_wpt(route_head* rte, Waypoint* wpt, const QString& namepart = "RPT", int number_digits = 3);
+void route_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT", int number_digits = 3);
+void track_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT", int number_digits = 3);
 void route_del_wpt(route_head* rte, Waypoint* wpt);
 void track_del_wpt(route_head* rte, Waypoint* wpt);
 //void route_disp(const route_head* rte, waypt_cb); /* template */

--- a/defs.h
+++ b/defs.h
@@ -19,36 +19,39 @@
 #ifndef DEFS_H_INCLUDED_
 #define DEFS_H_INCLUDED_
 
-#include <algorithm>              // for sort, stable_sort
-#include <cmath>                  // for M_PI
-#include <cstdarg>                // for va_list
-#include <cstddef>                // for NULL, nullptr_t, size_t
-#include <cstdint>                // for int32_t, uint32_t
-#include <cstdio>                 // for NULL, fprintf, FILE, stdout
-#include <ctime>                  // for time_t
-#include <optional>               // for optional
-#include <utility>                // for move
+#include <algorithm>                 // for sort, stable_sort
+#include <cmath>                     // for M_PI
+#include <cstdarg>                   // for va_list
+#include <cstddef>                   // for NULL, nullptr_t, size_t
+#include <cstdint>                   // for int32_t, uint32_t
+#include <cstdio>                    // for NULL, fprintf, FILE, stdout
+#include <ctime>                     // for time_t
+#include <optional>                  // for optional
+#include <utility>                   // for move
 
 #if HAVE_LIBZ
-#include <zlib.h>                 // doesn't really belong here, but is missing elsewhere.
+#include <zlib.h>                    // doesn't really belong here, but is missing elsewhere.
 #elif !ZLIB_INHIBITED
-#include "zlib.h"                 // doesn't really belong here, but is missing elsewhere.
+#include "zlib.h"                    // doesn't really belong here, but is missing elsewhere.
 #endif
 
-#include <QDebug>                 // for QDebug
-#include <QList>                  // for QList, QList<>::const_reverse_iterator, QList<>::reverse_iterator
-#include <QScopedPointer>         // for QScopedPointer
-#include <QString>                // for QString
-#include <QTextCodec>             // for QTextCodec
-#include <QVector>                // for QVector
-#include <Qt>                     // for CaseInsensitive
-#include <QtGlobal>               // for foreach
+#include <QDateTime>                 // for QDateTime
+#include <QDebug>                    // for QDebug
+#include <QList>                     // for QList, QList<>::const_iterator, QList<>::const_reverse_iterator, QList<>::count, QList<>::reverse_iterator
+#include <QScopedPointer>            // for QScopedPointer
+#include <QScopedPointerPodDeleter>  // for QScopedPointerPodDeleter
+#include <QString>                   // for QString
+#include <QStringView>               // for QStringView
+#include <QTextCodec>                // for QTextCodec
+#include <QVector>                   // for QVector
+#include <Qt>                        // for CaseInsensitive
+#include <QtGlobal>                  // for QForeachContainer, qMakeForeachContainer, foreach, qint64
 
-#include "formspec.h"             // for FormatSpecificData
-#include "inifile.h"              // for inifile_t
-#include "gbfile.h"               // doesn't really belong here, but is missing elsewhere.
-#include "session.h"              // for session_t
-#include "src/core/datetime.h"    // for DateTime
+#include "formspec.h"                // for FormatSpecificData
+#include "inifile.h"                 // for inifile_t
+#include "gbfile.h"                  // doesn't really belong here, but is missing elsewhere.
+#include "session.h"                 // for session_t
+#include "src/core/datetime.h"       // for DateTime
 
 
 #define CSTR(qstr) ((qstr).toUtf8().constData())

--- a/qstarz_bl_1000.cc
+++ b/qstarz_bl_1000.cc
@@ -259,7 +259,7 @@ QstarzBL1000Format::qstarz_bl_1000_read_record(QDataStream& stream, route_head* 
     }
     waypt_add(waypoint);
   } else if (qstarz_bl_1000_is_trackpoint_type(type)) {
-    track_add_wpt(track_route, waypoint, "TP", 3);
+    track_add_wpt(track_route, waypoint, u"TP", 3);
   } else {
     delete waypoint;
   }

--- a/route.cc
+++ b/route.cc
@@ -103,7 +103,7 @@ track_insert_head(route_head* rte, route_head* predecessor)
 }
 
 void
-route_add_wpt(route_head* rte, Waypoint* wpt, const QString& namepart, int number_digits)
+route_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart, int number_digits)
 {
   // First point in a route is always a new segment.
   // This improves compatibility when reading from
@@ -116,7 +116,7 @@ route_add_wpt(route_head* rte, Waypoint* wpt, const QString& namepart, int numbe
 }
 
 void
-track_add_wpt(route_head* rte, Waypoint* wpt, const QString& namepart, int number_digits)
+track_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart, int number_digits)
 {
   // First point in a track is always a new segment.
   // This improves compatibility when reading from
@@ -408,7 +408,7 @@ RouteList::insert_head(route_head* rte, route_head* predecessor)
 // in the RouteList AND any routes that have had waypoints added but haven't been
 // added themselves yet.
 void
-RouteList::add_wpt(route_head* rte, Waypoint* wpt, bool synth, const QString& namepart, int number_digits)
+RouteList::add_wpt(route_head* rte, Waypoint* wpt, bool synth, QStringView namepart, int number_digits)
 {
   ++waypt_ct;
   rte->waypoint_list.add_rte_waypt(waypt_ct, wpt, synth, namepart, number_digits);
@@ -456,7 +456,6 @@ RouteList::copy(RouteList** dst) const
     *dst = new RouteList;
   }
 
-  const char RPT[] = "RPT";
   for (const auto& rte_old : *this) {
     auto* rte_new = new route_head;
     // waypoint_list created below with add_wpt.
@@ -471,7 +470,7 @@ RouteList::copy(RouteList** dst) const
     (*dst)->add_head(rte_new);
     const auto& old_list = rte_old->waypoint_list;
     for (const auto& old_wpt : old_list) {
-      (*dst)->add_wpt(rte_new, new Waypoint(*old_wpt), false, RPT, 3);
+      (*dst)->add_wpt(rte_new, new Waypoint(*old_wpt), false, u"RPT", 3);
     }
   }
 }

--- a/route.cc
+++ b/route.cc
@@ -19,16 +19,17 @@
 
 #include <cassert>              // for assert
 #include <cstddef>              // for nullptr_t
-#include <algorithm>            // for sort
-#include <iterator>
 #include <optional>             // for optional, operator>, operator<
 
-#include <QDateTime>            // for QDateTime
-#include <QList>                // for QList<>::iterator
+#include <QDateTime>            // for operator>, QDateTime, operator<
+#include <QList>                // for QList<>::const_iterator
 #include <QString>              // for QString
-#include <QtGlobal>             // for foreach
+#include <QStringLiteral>       // for qMakeStringPrivate, QStringLiteral
+#include <QStringView>          // for QStringView
+#include <QtGlobal>             // for QForeachContainer, qMakeForeachContainer, foreach
 
 #include "defs.h"
+#include "formspec.h"           // for FormatSpecificDataList
 #include "grtcirc.h"            // for RAD, gcdist, heading_true_degrees, radtometers
 #include "session.h"            // for curr_session, session_t (ptr only)
 #include "src/core/datetime.h"  // for DateTime

--- a/waypt.cc
+++ b/waypt.cc
@@ -21,22 +21,27 @@
 
 #include <cassert>              // for assert
 #include <cmath>                // for fabs
-#include <cstdio>               // for printf, fflush, fprintf, stdout
-#include <algorithm>            // for stable_sort
+#include <cstdio>               // for fflush, fprintf, stdout
 
 #include <QChar>                // for QChar
 #include <QDateTime>            // for QDateTime
-#include <QList>                // for QList
+#include <QDebug>               // for QDebug
+#include <QLatin1Char>          // for QLatin1Char
+#include <QList>                // for QList<>::const_iterator
 #include <QString>              // for QString, operator==
+#include <QStringLiteral>       // for qMakeStringPrivate, QStringLiteral
+#include <QStringView>          // for QStringView
 #include <QTime>                // for QTime
-#include <QtGlobal>             // for qPrintable
+#include <QtGlobal>             // for QForeachContainer, qMakeForeachContainer, foreach, qint64
 
 #include "defs.h"
-#include "garmin_fs.h"          // for garmin_ilink_t, garmin_fs_t, GMSD_FIND
+#include "formspec.h"           // for FormatSpecificDataList
+#include "garmin_fs.h"          // for garmin_ilink_t, garmin_fs_t
 #include "grtcirc.h"            // for RAD, gcdist, heading_true_degrees, radtometers
 #include "session.h"            // for curr_session, session_t
 #include "src/core/datetime.h"  // for DateTime
-#include "src/core/logging.h"   // for Warning, Fatal
+#include "src/core/logging.h"   // for FatalMsg
+
 
 WaypointList* global_waypoint_list;
 

--- a/waypt.cc
+++ b/waypt.cc
@@ -638,7 +638,7 @@ WaypointList::waypt_add(Waypoint* wpt)
 }
 
 void
-WaypointList::add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, const QString& namepart, int number_digits)
+WaypointList::add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, QStringView namepart, int number_digits)
 {
   append(wpt);
 


### PR DESCRIPTION
In a specially constructed test case this showed a 1.5% speed improvement.

This does not resolve the long standing disconnect in synthetic name generation for track points.  transform and qstarz_bl_1000 both attempt to use synthetic name generation with tracks.

>   // FIXME: It is misleading to accept namepart and number_digits parameters which
// are ignored because synth is set to false.

