### PR TITLE
convert html writer to html 5.

### DIFF
--- a/html.h
+++ b/html.h
@@ -65,6 +65,7 @@ public:
 private:
   /* Member Functions */
 
+  static QString create_id(int sequence_number);
   void html_disp(const Waypoint* wpt) const;
   void html_index(const Waypoint* wpt) const;
 
@@ -72,6 +73,8 @@ private:
 
   gpsbabel::TextStream* file_out{nullptr};
   short_handle mkshort_handle{};
+
+  int waypoint_number{};
 
   char* stylesheet = nullptr;
   char* html_encrypt = nullptr;

--- a/reference/gc/GC7FA4.html
+++ b/reference/gc/GC7FA4.html
@@ -1,26 +1,33 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
- <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
- <title>GPSBabel HTML Output</title>
- <style>
-  p.gpsbabelwaypoint { font-size: 120%; font-weight: bold }
- </style>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>GPSBabel HTML Output</title>
+  <style>
+    p.gpsbabelwaypoint { font-size: 120%; font-weight: bold }
+  </style>
 </head>
 <body>
-<p class="index">
-<a href="#GC7FA4">GC7FA4 - Points géodésiques du Québec</a><br>
-</p>
-
-<a name="GC7FA4"><hr></a>
-<table width="100%">
-<tr><td><p class="gpsbabelwaypoint">GC7FA4 - N46&deg;08.000 W73&deg;00.000 (18T 654491 5110806)<br>
-<a href="http://www.geocaching.com/seek/cache_details.aspx?guid=727f9d2c-f080-41f1-a2c9-a326ead462ed">Points géodésiques du Québec</a> by Sverdrup2</p></td>
-<td align="right"><p class="gpsbabelcacheinfo">1 / 1<br>
-Locationless (Reverse) Cache / Virtual</p></td></tr>
-<tr><td colspan="2"><p class="gpsbabeldescshort">LES COORDONÉES PUBLIÉES NE REPRÉSENTENT PAS LA LOCALISATION D'UNE CACHE
-PUBLISHED COORDINATES DO NOT REPRESENT THE LOCALIZATION OF A CACHE</p>
-<p class="gpsbabeldesclong">Le but de cette cache virtuelle est de trouver les points géodésiques du territoire québécois. Les points géodésiques sont faciles à identifier (capuchons de laiton au niveau du sol). Généralement, il y a un panneau de couleur orange sur un poteau à proximité du point. Sur ce panneau, le numéro du point est identifié. Aussi, la distance relative du panneau au point est indiquée. 
+  <p class="index">
+    <a href="#WPT001">GC7FA4 - Points géodésiques du Québec</a><br>
+  </p>
+  <div id="WPT001"><hr>
+    <table style="width:100%">
+      <tr>
+        <td>
+          <p class="gpsbabelwaypoint">GC7FA4 - N46&deg;08.000 W73&deg;00.000 (18T 654491 5110806)<br>
+<a href="http://www.geocaching.com/seek/cache_details.aspx?guid=727f9d2c-f080-41f1-a2c9-a326ead462ed">Points géodésiques du Québec</a> by Sverdrup2</p>
+        </td>
+        <td style="text-align:right">
+          <p class="gpsbabelcacheinfo">1 / 1<br>
+Locationless (Reverse) Cache / Virtual</p>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <div><p class="gpsbabeldescshort">LES COORDONÉES PUBLIÉES NE REPRÉSENTENT PAS LA LOCALISATION D'UNE CACHE
+PUBLISHED COORDINATES DO NOT REPRESENT THE LOCALIZATION OF A CACHE</div>
+          <div><p class="gpsbabeldesclong">Le but de cette cache virtuelle est de trouver les points géodésiques du territoire québécois. Les points géodésiques sont faciles à identifier (capuchons de laiton au niveau du sol). Généralement, il y a un panneau de couleur orange sur un poteau à proximité du point. Sur ce panneau, le numéro du point est identifié. Aussi, la distance relative du panneau au point est indiquée. 
 <P>
 Pour inscrire votre découverte, vous devez prendre en note le NUMÉRO DU POINT(inscrit sur le point même ou au centre du panneau)LA COORDONNÉE(en format HDDD MM.MM WGS84 datum ET UTM NAD83 indiquer la zone SVP)et L'ALTITUDE RELATIVE. Si le points n'est pas visible (il se peut qu'il soit sous quelques centimètres de terre) vous pouvez prendre la coordonnée à l'emplacement du panneau SI LA PRÉCISION DE VOTRE GPS EST SUPÉRIEUR À LA DISTANCE INSCRITE SUR LE PANNEAU (ex : Précison du GPS de 5m et distance au point inscrite sur le panneau de 3m).
 <P>
@@ -54,8 +61,8 @@ And all old names of ministries and/or organization
 <P>
 
 PICTURES of points and of the panels will follow soon. YOU CAN ONLY LOG ONE POINT (ONE POINT PER GEOCACHER)
-Good luck!</p>
-<p class="gpsbabellog">
+Good luck!</div>
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">Christopher R &amp; Pooh B</span> on <span class="gpsbabellogdate">2005-07-12</span><br>
 <span class="gpsbabellogcoords">N48&deg;10.207 W53&deg;58.097</span><br>
 This marker is not in Quebec but it is a Geodesic marker in Clarenville, Newfoundland, Canada!
@@ -69,7 +76,7 @@ Smiles Pooh Bear
 Ce marqueur n'est pas au Québec mais c'est un marqueur géodésique dans Clarenville, Terre-Neuve, Canada!  
 
 A trouvé celui-ci tandis que chasse une cachette traditionnelle et pensé à cette cachette tout de suite!  Elle est située sur la montagne nue dans Clarenville - il y a aactually deux marqueurs à moins de 15 pieds d'un des autres sur la montagne nue...  Ours De Pooh De Sourires</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">TravelBen</span> on <span class="gpsbabellogdate">2005-06-26</span><br>
 <span class="gpsbabellogcoords">N45&deg;26.872 W73&deg;56.410</span><br>
 [:D] 14h22
@@ -83,7 +90,7 @@ UTM: 18T E 582877 N 5033250
 Ce marqueur se trouve dans le ville de Senneville, sur un monument décrivant une page d'histoire du Québec, sur le bas côté avant droit.
 
 Près de la cache:  Exo-07 La Jumelle de Loudiver (GCP3VE)</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">etasse</span> on <span class="gpsbabellogdate">2005-06-03</span><br>
 <span class="gpsbabellogcoords">N45&deg;29.525 W75&deg;43.005</span><br>
 MRN marker 94K4731 in Gatineau, QC. corner of Du Rhone and Gatineau Ave.
@@ -99,18 +106,20 @@ UTM 18T 0443996 5037868
 This pole has everything:  An underground cable warning, a geodesic mark, a bus stop and a garage sale sign.
 
 Judging by the coordinates it looks like the coords should be 45°29'31.5&quot; -75°43'0&quot;  I placed the GPS antenna right against the marker, to no avail.</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">Katou</span> on <span class="gpsbabellogdate">2005-06-03</span><br>
 <span class="gpsbabellogcoords">N46&deg;37.091 W71&deg;55.974</span><br>
 Un bo point géodésique a Lotbinière..en allant faire une nouvelle cache a l'île richelieu ;-)</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">Gps_Gulliver&amp;DauphinBleu</span> on <span class="gpsbabellogdate">2005-05-29</span><br>
 <span class="gpsbabellogcoords">N45&deg;32.449 W73&deg;30.747</span><br>
 Point Geodesique situe near Port de Plaisance de Longueuil
 sur le bord du fleuve st-laurent.
 Il y a des sentiers et une grande piste cyclable
 Enjoy !</p>
-</td></tr>
-</table>
+        </td>
+      </tr>
+    </table>
+  </div>
 </body>
 </html>

--- a/reference/gc/GCGCA8.html
+++ b/reference/gc/GCGCA8.html
@@ -1,25 +1,32 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
- <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
- <title>GPSBabel HTML Output</title>
- <style>
-  p.gpsbabelwaypoint { font-size: 120%; font-weight: bold }
- </style>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>GPSBabel HTML Output</title>
+  <style>
+    p.gpsbabelwaypoint { font-size: 120%; font-weight: bold }
+  </style>
 </head>
 <body>
-<p class="index">
-<a href="#GCGCA8">GCGCA8 - Oozy rat in a sanitary zoo</a><br>
-</p>
-
-<a name="GCGCA8"><hr></a>
-<table width="100%">
-<tr><td><p class="gpsbabelwaypoint">GCGCA8 - N35&deg;55.300 W86&deg;51.700 (16S 512480 3975269)<br>
-<a href="http://www.geocaching.com/seek/cache_details.aspx?guid=cda94cd6-d657-49bd-8e7e-0031ef1b2613">Oozy rat in a sanitary zoo</a> by robertlipe</p></td>
-<td align="right"><p class="gpsbabelcacheinfo">3 / 2<br>
-Unknown Cache / Unknown</p></td></tr>
-<tr><td colspan="2"><p class="gpsbabeldescshort">The cache is not at the coordinates above.   These coords will get you to the correct park and within 1/2 mile of the cache.  The cache is within 35 feet of the trail.   It is not handicapped accessible.   It is a nice walk in the woods that is practical for all ages.  There is no space in the container for trading items.   You should bring a writing stick and bug spray is recommended.</p>
-<p class="gpsbabeldesclong">So if the cache isn't at the above coordinates, where is it?  
+  <p class="index">
+    <a href="#WPT001">GCGCA8 - Oozy rat in a sanitary zoo</a><br>
+  </p>
+  <div id="WPT001"><hr>
+    <table style="width:100%">
+      <tr>
+        <td>
+          <p class="gpsbabelwaypoint">GCGCA8 - N35&deg;55.300 W86&deg;51.700 (16S 512480 3975269)<br>
+<a href="http://www.geocaching.com/seek/cache_details.aspx?guid=cda94cd6-d657-49bd-8e7e-0031ef1b2613">Oozy rat in a sanitary zoo</a> by robertlipe</p>
+        </td>
+        <td style="text-align:right">
+          <p class="gpsbabelcacheinfo">3 / 2<br>
+Unknown Cache / Unknown</p>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <div><p class="gpsbabeldescshort">The cache is not at the coordinates above.   These coords will get you to the correct park and within 1/2 mile of the cache.  The cache is within 35 feet of the trail.   It is not handicapped accessible.   It is a nice walk in the woods that is practical for all ages.  There is no space in the container for trading items.   You should bring a writing stick and bug spray is recommended.</div>
+          <div><p class="gpsbabeldesclong">So if the cache isn't at the above coordinates, where is it?  
 
 <ul>
 
@@ -34,9 +41,11 @@ Unknown Cache / Unknown</p></td></tr>
 
 Now that it's intuitively obvious to even the most casual observer where the cache is, turn on your geo-mojo and go find it.
 <br>
-<img SRC="http://www.mtgc.org/mtgc_member-banner.gif" WIDTH="500" HEIGHT="40" ALT="Member of Middle Tennessee GeoCachers Club [www.mtgc.org]" BORDER="0"></a></p></p>
-<p class="gpsbabelhint"><strong>Hint:</strong> There Is No Hint</p>
-</td></tr>
-</table>
+<img SRC="http://www.mtgc.org/mtgc_member-banner.gif" WIDTH="500" HEIGHT="40" ALT="Member of Middle Tennessee GeoCachers Club [www.mtgc.org]" BORDER="0"></a></p></div>
+          <p class="gpsbabelhint"><strong>Hint:</strong> There Is No Hint</p>
+        </td>
+      </tr>
+    </table>
+  </div>
 </body>
 </html>

--- a/reference/gc/GCGCA8_logs.html
+++ b/reference/gc/GCGCA8_logs.html
@@ -1,25 +1,32 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
- <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
- <title>GPSBabel HTML Output</title>
- <style>
-  p.gpsbabelwaypoint { font-size: 120%; font-weight: bold }
- </style>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>GPSBabel HTML Output</title>
+  <style>
+    p.gpsbabelwaypoint { font-size: 120%; font-weight: bold }
+  </style>
 </head>
 <body>
-<p class="index">
-<a href="#GCGCA8">GCGCA8 - Oozy rat in a sanitary zoo</a><br>
-</p>
-
-<a name="GCGCA8"><hr></a>
-<table width="100%">
-<tr><td><p class="gpsbabelwaypoint">GCGCA8 - N35&deg;55.300 W86&deg;51.700 (16S 512480 3975269)<br>
-<a href="http://www.geocaching.com/seek/cache_details.aspx?guid=cda94cd6-d657-49bd-8e7e-0031ef1b2613">Oozy rat in a sanitary zoo</a> by robertlipe</p></td>
-<td align="right"><p class="gpsbabelcacheinfo">3 / 2<br>
-Unknown Cache / Unknown</p></td></tr>
-<tr><td colspan="2"><p class="gpsbabeldescshort">The cache is not at the coordinates above.   These coords will get you to the correct park and within 1/2 mile of the cache.  The cache is within 35 feet of the trail.   It is not handicapped accessible.   It is a nice walk in the woods that is practical for all ages.  There is no space in the container for trading items.   You should bring a writing stick and bug spray is recommended.</p>
-<p class="gpsbabeldesclong">So if the cache isn't at the above coordinates, where is it?  
+  <p class="index">
+    <a href="#WPT001">GCGCA8 - Oozy rat in a sanitary zoo</a><br>
+  </p>
+  <div id="WPT001"><hr>
+    <table style="width:100%">
+      <tr>
+        <td>
+          <p class="gpsbabelwaypoint">GCGCA8 - N35&deg;55.300 W86&deg;51.700 (16S 512480 3975269)<br>
+<a href="http://www.geocaching.com/seek/cache_details.aspx?guid=cda94cd6-d657-49bd-8e7e-0031ef1b2613">Oozy rat in a sanitary zoo</a> by robertlipe</p>
+        </td>
+        <td style="text-align:right">
+          <p class="gpsbabelcacheinfo">3 / 2<br>
+Unknown Cache / Unknown</p>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <div><p class="gpsbabeldescshort">The cache is not at the coordinates above.   These coords will get you to the correct park and within 1/2 mile of the cache.  The cache is within 35 feet of the trail.   It is not handicapped accessible.   It is a nice walk in the woods that is practical for all ages.  There is no space in the container for trading items.   You should bring a writing stick and bug spray is recommended.</div>
+          <div><p class="gpsbabeldesclong">So if the cache isn't at the above coordinates, where is it?  
 
 <ul>
 
@@ -34,33 +41,35 @@ Unknown Cache / Unknown</p></td></tr>
 
 Now that it's intuitively obvious to even the most casual observer where the cache is, turn on your geo-mojo and go find it.
 <br>
-<img SRC="http://www.mtgc.org/mtgc_member-banner.gif" WIDTH="500" HEIGHT="40" ALT="Member of Middle Tennessee GeoCachers Club [www.mtgc.org]" BORDER="0"></a></p></p>
-<p class="gpsbabelhint"><strong>Hint:</strong> There Is No Hint</p>
-<p class="gpsbabellog">
+<img SRC="http://www.mtgc.org/mtgc_member-banner.gif" WIDTH="500" HEIGHT="40" ALT="Member of Middle Tennessee GeoCachers Club [www.mtgc.org]" BORDER="0"></a></p></div>
+          <p class="gpsbabelhint"><strong>Hint:</strong> There Is No Hint</p>
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">littlepod</span> on <span class="gpsbabellogdate">2005-07-03</span><br>
 Enjoyed the puzzle. We seemed to be about 50ft off though. TFTC.</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Write note</span> by <span class="gpsbabellogfinder">robertlipe</span> on <span class="gpsbabellogdate">2005-04-29</span><br>
 TB Drop to show he's hanging out in Nashville until we blast off for Geowoodstock in a few weeks.</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">Big Bumblebee</span> on <span class="gpsbabellogdate">2005-04-18</span><br>
 Found it a while ago.  Thanks.</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Write note</span> by <span class="gpsbabellogfinder">robertlipe</span> on <span class="gpsbabellogdate">2005-03-27</span><br>
 I had to renew my permit with the CDC and in doing so, I trolled out here verified that the infectious ooze is fully within specification and industry accepted tolerance.   Ooze On!</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Found it</span> by <span class="gpsbabellogfinder">Virtual Babe</span> on <span class="gpsbabellogdate">2004-12-27</span><br>
 This was a great cache, however on this day I considered it a FIFM cache (Fun, Invigorating, Frustrating and Maddening), especially when the cache was not replaced in the proper spot by the previous cacher!  Thanks anyway!!</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Write note</span> by <span class="gpsbabellogfinder">robertlipe</span> on <span class="gpsbabellogdate">2004-01-12</span><br>
 I got a complaint from the CDC about oozy rat this weekend.     I went out tonight in the dark and verified that the infectious ooze is fully within specification and industry accepted tolerance. (Although I realize now I did misstate the cache container to the reporting officer when confronted.   It's, uuuuh, smaller than I said.)</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Write note</span> by <span class="gpsbabellogfinder">robertlipe</span> on <span class="gpsbabellogdate">2003-10-04</span><br>
 In the expectation that this cache will get some traffic in the next 48 hours, Ryan and I checked it earlier today.   The Rat is Oozing just as we planned it.</p>
-<p class="gpsbabellog">
+          <p class="gpsbabellog">
 <span class="gpsbabellogtype">Write note</span> by <span class="gpsbabellogfinder">robertlipe</span> on <span class="gpsbabellogdate">2003-07-03</span><br>
 It won't earn him a smiley face, but I've confirmed that rickrich would have indeed sunk the battleship!      Thanx for playing. You get a copy of the home game and some rice-a-roni...</p>
-</td></tr>
-</table>
+        </td>
+      </tr>
+    </table>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
this also fixes a bug where we could fail to entitize wpt->description.
this also fixes a bug where we could create illegal fragments and id
attributes.

There are some minor changes in rendering with firefox related to margins in p elements.

Every gpx reference file we have was converted to html, and the html was checked with tidy.  There are two files that have warnings, and no errors.
```
reference/tpo-sample3.gpx:
line 250 column 1 - Warning: <a> converting backslash in URI to slash
```
We are interpreting 'w:\photo.jpg' in tpo-sample3.tpo as a link.
```
reference/gc/GCGCA8.gpx:
line 45 column 154 - Warning: discarding unexpected </a>
line 45 column 158 - Warning: inserting implicit <p>
line 45 column 158 - Warning: trimming empty <p>
```
GCGCA8.gpx has two unpaired end tags (entitized) in a groundspeak:long_description element. Also see #895.

The html files produced by text.test were checked with https://validator.w3.org.  Related to GCGCA8.gpx we see these warnings/errors:
```
Warning: Consider adding a lang attribute to the html start tag to declare the language of this document.
Warning: The border attribute is obsolete. Consider specifying img { border: 0; } in CSS instead.
Error: Stray end tag a.
Error: No p element in scope but a p end tag seen.
```
