### PR TITLE
QStringize vecs a bit more.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -960,13 +960,13 @@ void setshort_defname(short_handle, const char* s);
 #define ARG_NOMINMAX nullptr, nullptr
 
 struct arglist_t {
-  const char* argstring{nullptr};
-  char** argval{nullptr};
-  const char* helpstring{nullptr};
-  const char* defaultvalue{nullptr};
+  const QString argstring;
+  char** const argval{nullptr};
+  const QString helpstring;
+  const QString defaultvalue;
   const uint32_t argtype{ARGTYPE_UNKNOWN};
-  const char* minvalue{nullptr};    /* minimum value for numeric options */
-  const char* maxvalue{nullptr};    /* maximum value for numeric options */
+  const QString minvalue;    /* minimum value for numeric options */
+  const QString maxvalue;    /* maximum value for numeric options */
   char* argvalptr{nullptr};         /* !!! internal helper. Not used in definitions !!! */
 };
 

--- a/filter_vecs.cc
+++ b/filter_vecs.cc
@@ -221,7 +221,7 @@ Filter* FilterVecs::find_filter_vec(const QString& vecname)
         if (qtemp.isNull()) {
           Vecs::assign_option(vec.name, &arg, arg.defaultvalue);
         } else {
-          Vecs::assign_option(vec.name, &arg, CSTR(qtemp));
+          Vecs::assign_option(vec.name, &arg, qtemp);
         }
       }
     }
@@ -233,7 +233,7 @@ Filter* FilterVecs::find_filter_vec(const QString& vecname)
         for (auto& arg : *args) {
           const QString opt = Vecs::get_option(options, arg.argstring);
           if (!opt.isNull()) {
-            Vecs::assign_option(vec.name, &arg, CSTR(opt));
+            Vecs::assign_option(vec.name, &arg, opt);
           }
         }
       }
@@ -308,7 +308,7 @@ void FilterVecs::disp_filter_vecs() const
       for (const auto& arg : *args) {
         if (!(arg.argtype & ARGTYPE_HIDDEN)) {
           printf("	  %-18.18s    %-.50s %s\n",
-                 arg.argstring, arg.helpstring,
+                 qPrintable(arg.argstring), qPrintable(arg.helpstring),
                  (arg.argtype & ARGTYPE_REQUIRED) ? "(required)" : "");
         }
       }
@@ -329,7 +329,7 @@ void FilterVecs::disp_filter_vec(const QString& vecname) const
       for (const auto& arg : *args) {
         if (!(arg.argtype & ARGTYPE_HIDDEN)) {
           printf("	  %-18.18s    %-.50s %s\n",
-                 arg.argstring, arg.helpstring,
+                 qPrintable(arg.argstring), qPrintable(arg.helpstring),
                  (arg.argtype & ARGTYPE_REQUIRED) ? "(required)" : "");
         }
       }
@@ -341,7 +341,7 @@ void FilterVecs::disp_help_url(const fl_vecs_t& vec, const arglist_t* arg)
 {
   printf("\t" WEB_DOC_DIR "/filter_%s.html", CSTR(vec.name));
   if (arg) {
-    printf("#fmt_%s_o_%s", CSTR(vec.name), arg->argstring);
+    printf("#fmt_%s_o_%s", CSTR(vec.name), CSTR(arg->argstring));
   }
 }
 
@@ -355,12 +355,12 @@ void FilterVecs::disp_v1(const fl_vecs_t& vec)
       if (!(arg.argtype & ARGTYPE_HIDDEN)) {
         printf("option\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
                CSTR(vec.name),
-               arg.argstring,
-               arg.helpstring,
+               CSTR(arg.argstring),
+               CSTR(arg.helpstring),
                Vecs::name_option(arg.argtype),
-               arg.defaultvalue ? arg.defaultvalue : "",
-               arg.minvalue ? arg.minvalue : "",
-               arg.maxvalue ? arg.maxvalue : "");
+               CSTR(arg.defaultvalue),
+               CSTR(arg.minvalue),
+               CSTR(arg.maxvalue));
         disp_help_url(vec, &arg);
         printf("\n");
       }

--- a/reference/filter1.txt
+++ b/reference/filter1.txt
@@ -34,8 +34,8 @@ option	track	split	Split by date or time interval (see README)	string				https:/
 option	track	sdistance	Split by distance	string				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_sdistance
 option	track	merge	Merge multiple tracks for the same way	string				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_merge
 option	track	name	Use only track(s) where title matches given name	string				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_name
-option	track	start	Use only track points after this timestamp	integer				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_start
-option	track	stop	Use only track points before this timestamp	integer				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_stop
+option	track	start	Use only track points after this timestamp	string				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_start
+option	track	stop	Use only track points before this timestamp	string				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_stop
 option	track	title	Basic title for new track(s)	string				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_title
 option	track	fix	Synthesize GPS fixes (PPS, DGPS, 3D, 2D, NONE)	string				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_fix
 option	track	course	Synthesize course	boolean				https://www.gpsbabel.org/WEB_DOC_DIR/filter_track.html#fmt_track_o_course

--- a/trackfilter.h
+++ b/trackfilter.h
@@ -116,12 +116,12 @@ private:
     },
     {
       TRACKFILTER_START_OPTION, &opt_start,
-      "Use only track points after this timestamp", nullptr, ARGTYPE_INT,
+      "Use only track points after this timestamp", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
     {
       TRACKFILTER_STOP_OPTION, &opt_stop,
-      "Use only track points before this timestamp", nullptr, ARGTYPE_INT,
+      "Use only track points before this timestamp", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
     {

--- a/vecs.h
+++ b/vecs.h
@@ -47,10 +47,10 @@ public:
 
   void init_vecs();
   void exit_vecs();
-  static void assign_option(const QString& module, arglist_t* arg, const char* val);
+  static void assign_option(const QString& module, arglist_t* arg, const QString& val);
   static void disp_vec_options(const QString& vecname, const QVector<arglist_t>* args);
   static void validate_options(const QStringList& options, const QVector<arglist_t>* args, const QString& name);
-  static QString get_option(const QStringList& options, const char* argname);
+  static QString get_option(const QStringList& options, const QString& argname);
   Format* find_vec(const QString& vecname);
   void disp_vecs() const;
   void disp_vec(const QString& vecname) const;
@@ -113,7 +113,9 @@ private:
 
   /* Member Functions */
 
-  static int is_integer(const char* c);
+  static bool is_integer(const QString& val);
+  static bool is_float(const QString& val);
+  static bool is_bool(const QString& val);
   static QVector<style_vec_t> create_style_vec();
   QVector<vecinfo_t> sort_and_unify_vecs() const;
   static void disp_v1(ff_type t);


### PR DESCRIPTION
This fixes an ancient FIXME regarding the use of the option name
to indicate a option was given without a value.  This practice was unnecessary as we can (and could before) distinguish between an option not being given (nullptr or isNull), an option be given without a value(pointer valid and points to \0 or !isNull && isEmpty), and option being given with a value.

This was tested with a custom format and filter that echoed the received argument values.  However, this test apparatus was not included in this PR. 

This enhances the validity checking of default, minimum and maximum argument
values.

More rigorous input validation was attempted with std::stoi & std::stod.  This revealed that two trackfilter options had range errors.  Although the values of these options are a series of decimal digits they are interpreted as a string by the filter.  The GUI handles creates these values from dates and times.  This PR changes these argtypes from ARGTYPE_INT to ARGTYPE_STRING.