### PR TITLE
fix maps javascript api deprecation warning.

### DIFF
--- a/gui/gmapbase.html
+++ b/gui/gmapbase.html
@@ -155,7 +155,7 @@ function setupWebChannel() {
     }
 }
 
-google.maps.event.addDomListener(window, "load", initialize);
+window.addEventListener("load", initialize);
 
     </script>
 


### PR DESCRIPTION
js: google.maps.event.addDomListener() is deprecated, use the standard addEventListener() method instead: https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener