### PR TITLE
fix GUI handling of track filter start/stop times.

### DIFF
--- a/gui/filterdata.cc
+++ b/gui/filterdata.cc
@@ -55,14 +55,9 @@ QStringList WayPtsFilterData::makeOptionString()
 }
 
 //------------------------------------------------------------------------
-static QString optionDate(const QDateTime& dt, bool useLocal)
+static QString optionDate(const QDateTime& dt)
 {
-  QDateTime d;
-  if (useLocal) {
-    d = dt.toLocalTime();
-  } else {
-    d = dt.toUTC();
-  }
+  QDateTime d = dt.toUTC();
 
   QDate date = d.date();
   QTime time = d.time();
@@ -130,10 +125,10 @@ QStringList TrackFilterData::makeOptionString()
   }
 
   if (start) {
-    s += QString(",start=%1").arg(optionDate(startTime, TZ));
+    s += QString(",start=%1").arg(optionDate(startTime));
   }
   if (stop) {
-    s += QString(",stop=%1").arg(optionDate(stopTime, TZ));
+    s += QString(",stop=%1").arg(optionDate(stopTime));
   }
   if (move) {
     s += QString(",move=%1w%2d%3h%4m%5s").arg(weeks).arg(days).arg(hours).arg(mins).arg(secs);

--- a/gui/filterdata.h
+++ b/gui/filterdata.h
@@ -61,7 +61,7 @@ class TrackFilterData: public FilterData
 public:
   TrackFilterData():  title(false), titleString(QString()),
     move(false),  weeks(0), days(0), hours(0), mins(0), secs(0),
-    TZ(true),
+    localTime(true), utc(false),
     start(false),
     stop(false),
     pack(false), merge(false), split(false),
@@ -96,7 +96,8 @@ public:
     sg.addVarSetting(new DateTimeSetting("trks.startTime", startTime));
     sg.addVarSetting(new BoolSetting("trks.stop", stop));
     sg.addVarSetting(new DateTimeSetting("trks.stopTime", stopTime));
-    sg.addVarSetting(new BoolSetting("trks.TZ", TZ));
+    sg.addVarSetting(new BoolSetting("trks.localTime", localTime));
+    sg.addVarSetting(new BoolSetting("trks.utc", utc));
     sg.addVarSetting(new BoolSetting("trks.move", move));
     sg.addVarSetting(new IntSetting("trks.weeks", weeks));
     sg.addVarSetting(new IntSetting("trks.days", days));
@@ -117,7 +118,7 @@ public:
   QString titleString;
   bool move;
   int  weeks, days, hours, mins, secs;
-  bool TZ;
+  bool localTime, utc;
 
   bool start;
   QDateTime startTime;

--- a/gui/filterdata.h
+++ b/gui/filterdata.h
@@ -61,7 +61,7 @@ class TrackFilterData: public FilterData
 public:
   TrackFilterData():  title(false), titleString(QString()),
     move(false),  weeks(0), days(0), hours(0), mins(0), secs(0),
-    TZ(false),
+    TZ(true),
     start(false),
     stop(false),
     pack(false), merge(false), split(false),

--- a/gui/filterwidgets.cc
+++ b/gui/filterwidgets.cc
@@ -69,7 +69,8 @@ TrackWidget::TrackWidget(QWidget* parent, TrackFilterData& tfd): FilterWidget(pa
   connect(ui.splitTimeCheck,   &QAbstractButton::clicked, this, &TrackWidget::splitTimeX);
   connect(ui.splitDistanceCheck,   &QAbstractButton::clicked, this, &TrackWidget::splitDistanceX);
 
-  connect(ui.TZCheck, &QAbstractButton::clicked, this, &TrackWidget::TZX);
+  connect(ui.localTime, &QAbstractButton::clicked, this, &TrackWidget::TZX);
+  connect(ui.utc, &QAbstractButton::clicked, this, &TrackWidget::TZX);
 
   ui.startEdit->setDisplayFormat("dd MMM yyyy hh:mm:ss AP");
   ui.stopEdit->setDisplayFormat("dd MMM yyyy hh:mm:ss AP");
@@ -82,15 +83,16 @@ TrackWidget::TrackWidget(QWidget* parent, TrackFilterData& tfd): FilterWidget(pa
   // If the two timeSpecs match Qt5 and Qt6 behave the same.
   ui.startEdit->setTimeSpec(tfd.startTime.timeSpec());
   ui.stopEdit->setTimeSpec(tfd.stopTime.timeSpec());
-  // Force TZ data to be in sync with startTime & stopTime time spec.
-  // This makes sure the initial state of the TZCheck box is in agreement
-  // with the startTime::timeSpec and stopTime::timeSpec.
-  tfd.TZ = tfd.startTime.timeSpec() == Qt::LocalTime;
+  // Make sure the initial state of the localTime and utc radio buttons
+  // is in agreement with the startTime::timeSpec and stopTime::timeSpec.
+  tfd.localTime = tfd.startTime.timeSpec() == Qt::LocalTime;
+  tfd.utc = !tfd.localTime;
 
   // Collect the data fields.
   fopts << new BoolFilterOption(tfd.title,  ui.titleCheck);
   fopts << new BoolFilterOption(tfd.move,   ui.moveCheck);
-  fopts << new BoolFilterOption(tfd.TZ,     ui.TZCheck);
+  fopts << new BoolFilterOption(tfd.localTime,     ui.localTime);
+  fopts << new BoolFilterOption(tfd.utc,     ui.utc);
   fopts << new BoolFilterOption(tfd.start,  ui.startCheck);
   fopts << new BoolFilterOption(tfd.stop,   ui.stopCheck);
   fopts << new BoolFilterOption(tfd.pack,   ui.packCheck);
@@ -124,7 +126,8 @@ TrackWidget::TrackWidget(QWidget* parent, TrackFilterData& tfd): FilterWidget(pa
 //------------------------------------------------------------------------
 void TrackWidget::otherCheckX()
 {
-  ui.TZCheck->setEnabled(ui.stopCheck->isChecked() || ui.startCheck->isChecked());
+  ui.localTime->setEnabled(ui.stopCheck->isChecked() || ui.startCheck->isChecked());
+  ui.utc->setEnabled(ui.stopCheck->isChecked() || ui.startCheck->isChecked());
 
   ui.splitTimeSpin->setEnabled(ui.splitTimeCheck->isChecked());
   ui.splitTimeCombo->setEnabled(ui.splitTimeCheck->isChecked());
@@ -184,7 +187,7 @@ void TrackWidget::splitDistanceX()
 //------------------------------------------------------------------------
 void TrackWidget::TZX()
 {
-  if (ui.TZCheck->isChecked()) {
+  if (ui.localTime->isChecked()) {
     ui.startEdit->setTimeSpec(Qt::LocalTime);
     ui.stopEdit->setTimeSpec(Qt::LocalTime);
   } else {

--- a/gui/filterwidgets.h
+++ b/gui/filterwidgets.h
@@ -23,15 +23,26 @@
 #ifndef FILTERWIDGETS_H
 #define FILTERWIDGETS_H
 
+#include <QAbstractButton>   // for QAbstractButton
+#include <QComboBox>         // for QComboBox
+#include <QDateTime>         // for QDateTime
+#include <QDateTimeEdit>     // for QDateTimeEdit
+#include <QDoubleValidator>  // for QDoubleValidator
+#include <QFunctionPointer>  // for qMax, qMin
+#include <QLineEdit>         // for QLineEdit
+#include <QList>             // for QList
+#include <QObject>           // for QObject, Q_OBJECT, slots
+#include <QSpinBox>          // for QSpinBox
+#include <QString>           // for QString
+#include <QWidget>           // for QWidget
 
-#include "ui_trackui.h"
-#include "ui_wayptsui.h"
-#include "ui_rttrkui.h"
-#include "ui_miscfltui.h"
-#include "filterdata.h"
+#include "filterdata.h"      // for MiscFltFilterData, RtTrkFilterData, TrackFilterData, WayPtsFilterData
+#include "ui_miscfltui.h"    // for Ui_MiscFltWidget
+#include "ui_rttrkui.h"      // for Ui_RtTrkWidget
+#include "ui_trackui.h"      // for Ui_TrackWidget
+#include "ui_wayptsui.h"     // for Ui_WayPtsWidget
 
-class CheckEnabler;
-class FilterOption;
+
 //------------------------------------------------------------------------
 class CheckEnabler: public QObject
 {
@@ -307,6 +318,7 @@ private slots:
   void splitDateX();
   void splitTimeX();
   void splitDistanceX();
+  void TZX();
   void packCheckX();
 };
 

--- a/gui/trackui.ui
+++ b/gui/trackui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>663</width>
+    <width>675</width>
     <height>270</height>
    </rect>
   </property>
@@ -217,19 +217,6 @@ This option is used along with the stop to discard trackpoints that were recorde
       <widget class="QDateTimeEdit" name="startEdit">
        <property name="toolTip">
         <string>Use track pts. after this time. </string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="3" rowspan="2">
-      <widget class="QCheckBox" name="TZCheck">
-       <property name="toolTip">
-        <string>If checked, time specified here is based on this computer's current time zone. </string>
-       </property>
-       <property name="whatsThis">
-        <string>If checked, the times specified here are based on the local computer's time zone.  Otherwise it is UTC.</string>
-       </property>
-       <property name="text">
-        <string>Local Time</string>
        </property>
       </widget>
      </item>
@@ -480,6 +467,38 @@ This option computes (or recomputes) a value for the GPS heading at each trackpo
        </property>
       </widget>
      </item>
+     <item row="3" column="3" rowspan="2">
+      <widget class="QRadioButton" name="localTime">
+       <property name="toolTip">
+        <string>If checked, times specified here are based on this computer's current time zone.</string>
+       </property>
+       <property name="whatsThis">
+        <string>If checked, times specified here are based on this computer's current time zone.</string>
+       </property>
+       <property name="text">
+        <string>Local Time</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item row="3" column="4" rowspan="2">
+      <widget class="QRadioButton" name="utc">
+       <property name="toolTip">
+        <string>If checked, times specified here are UTC.</string>
+       </property>
+       <property name="whatsThis">
+        <string>If checked, times specified here are UTC.</string>
+       </property>
+       <property name="text">
+        <string>UTC</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="0" column="1">
@@ -512,4 +531,7 @@ This option computes (or recomputes) a value for the GPS heading at each trackpo
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
This resolves #915

The timeSpec of the QDateTimeEdit objects is maintained in
accordance with the TZCheck QCheckBox.  This solves additional
issues with DST transitions and edits.

As an aside, when the TZCheck box check status changes, the times shown in the start and stop edits will be converted between the two time zones.  This behavior is part of QDateTimeEdit.

There is an ambiguity in the fall with local times, we don't have a way to distinguish 1:30AM daylight time from 1:30AM standard time.
