### PR TITLE
github runner updates

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
       id: cache
       with:
         path: ~/Cache
-        key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ env.XCODE_VERSION }}-${{ secrets.CACHE_VERSION }}
+        key: ${{ runner.os }}-${{ matrix.QT_VERSION }}-${{ matrix.XCODE_VERSION }}-${{ secrets.CACHE_VERSION }}
 
     - name: Qt install setup
       if: steps.cache.outputs.cache-hit != 'true'
@@ -53,8 +53,8 @@ jobs:
 
     - name: Script
       run: |
-        source ${HOME}/Cache/qt-${QT_VERSION}.env
-        sudo xcode-select --switch /Applications/Xcode_${XCODE_VERSION}.app
+        source ${HOME}/Cache/qt-${{ matrix.QT_VERSION }}.env
+        sudo xcode-select --switch /Applications/Xcode_${{ matrix.XCODE_VERSION }}.app
         ./tools/travis_script_osx
 
     - name: Deploy

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
       run: |
-        ./tools/travis_install_osx ${QT_VERSION} aqt
+        ./tools/travis_install_osx $${ matrix.QT_VERSION }} aqt
 
     - name: Script
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
       id: cache
       with:
         path: ~/Cache
-        key: ${{ runner.os }}-${{ matrix.QT_VERSION }}-${{ matrix.XCODE_VERSION }}-${{ secrets.CACHE_VERSION }}
+        key: ${{ runner.os }}-${{ matrix.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
 
     - name: Qt install setup
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,11 +10,22 @@ on:
     - cron: '27 4 * * 2'
 
 jobs:
-  macos_release:
-    name: macos release Build
+  macos:
+    name: macOS Build
     runs-on: macos-latest
-    env:
-      QT_VERSION: '5.12.12'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - QT_VERSION: '5.12.12'
+            XCODE_VERSION: '11.7'
+            RELEASE: false
+          - QT_VERSION: '5.15.2'
+            XCODE_VERSION: '12.4'
+            RELEASE: false
+          - QT_VERSION: '6.2.4'
+            XCODE_VERSION: '12.5.1'
+            RELEASE: true
 
     steps:
     - name: Checkout repository
@@ -25,7 +36,7 @@ jobs:
       id: cache
       with:
         path: ~/Cache
-        key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
+        key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ env.XCODE_VERSION }}-${{ secrets.CACHE_VERSION }}
 
     - name: Qt install setup
       if: steps.cache.outputs.cache-hit != 'true'
@@ -43,103 +54,23 @@ jobs:
     - name: Script
       run: |
         source ${HOME}/Cache/qt-${QT_VERSION}.env
-        sudo xcode-select --switch /Applications/Xcode_11.7.app
+        sudo xcode-select --switch /Applications/Xcode_${XCODE_VERSION}.app
         ./tools/travis_script_osx
-        echo GITHUB_REF: $GITHUB_REF
 
     - name: Deploy
       # This only handles continous releases now, for other events artifacts may be saved in
       # the 'Upload Artifacts' step.
-      if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
+      if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' ) && matrix.RELEASE
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NAME: Continuous-${{ runner.os }}
       run: |
+        echo GITHUB_REF: $GITHUB_REF
         ./tools/uploadtool/upload_github.sh gui/GPSBabel-*.dmg
 
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v2
       with:
-        name: MacOS_Installer
-        path: gui/GPSBabel-*.dmg
-        retention-days: 7
-
-  macos_edge:
-    name: macos edge Build
-    runs-on: macos-latest
-    env:
-      QT_VERSION: '5.15.2'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Cache Qt
-      uses: actions/cache@v2
-      with:
-        path: ~/Cache
-        key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
-
-    - name: Qt install
-      env:
-        ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-        ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
-        ARTIFACTORY_BASE_URL: ${{ secrets.ARTIFACTORY_BASE_URL }}
-      run: |
-        ./tools/travis_install_osx ${QT_VERSION} artifactory
-
-    - name: Script
-      run: |
-        source ${HOME}/Cache/qt-${QT_VERSION}.env
-        sudo xcode-select --switch /Applications/Xcode_12.4.app
-        ./tools/travis_script_osx
-
-    - name: 'Upload Artifacts'
-      uses: actions/upload-artifact@v2
-      with:
-        name: MacOS_Installer_Edge
-        path: gui/GPSBabel-*.dmg
-        retention-days: 7
-
-  macos_qt6:
-    name: macos Qt6 Build
-    runs-on: macos-latest
-    env:
-      QT_VERSION: '6.2.4'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Cache Qt
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: ~/Cache
-        key: ${{ runner.os }}-${{ env.QT_VERSION }}-${{ secrets.CACHE_VERSION }}
-
-    - name: Qt install setup
-      if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-
-    - name: Qt install
-      if: steps.cache.outputs.cache-hit != 'true'
-      env:
-        TRAVIS_BUILD_DIR: ${{ github.workspace }}
-      run: |
-        ./tools/travis_install_osx ${QT_VERSION} aqt
-
-    - name: Script
-      run: |
-        source ${HOME}/Cache/qt-${QT_VERSION}.env
-        sudo xcode-select --switch /Applications/Xcode_12.5.1.app
-        ./tools/travis_script_osx
-
-    - name: 'Upload Artifacts'
-      uses: actions/upload-artifact@v2
-      with:
-        name: MacOS_Installer_Qt6
+        name: MacOS_Installer ${{ join(matrix.*) }}
         path: gui/GPSBabel-*.dmg
         retention-days: 7

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
       run: |
-        ./tools/travis_install_osx $${ matrix.QT_VERSION }} aqt
+        ./tools/travis_install_osx ${{ matrix.QT_VERSION }} aqt
 
     - name: Script
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
             COMPILER: 'msvc2017_64'
             METHOD: 'aqt'
             FLOW: 'nmake'
-            RELEASE: true
+            RELEASE: false
           - QT_VERSION: '5.12.12'
             ARCH: 'amd64'
             HOST_ARCH: 'x86'
@@ -59,7 +59,7 @@ jobs:
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'
             METHOD: 'aqt'
-            RELEASE: false
+            RELEASE: true
             FLOW: 'nmake'
 
     steps:

--- a/tools/travis_install_osx
+++ b/tools/travis_install_osx
@@ -30,8 +30,8 @@ function validate() {
   )
 }
 
-QT_VERSION=${1:-5.12.2}
-METHOD=${2:-artifactory}
+QT_VERSION=${1:-6.2.4}
+METHOD=${2:-aqt}
 
 # our expectation is that install-qt creates $QTDIR, $QTDIR/bin.
 CACHEDIR=${HOME}/Cache


### PR DESCRIPTION
macOS:
  use a matrix for the jobs
  use aqt for all qt installs (no more artifactory)
  flag Qt 6.2.4 as the release build

windows:
  flag Qt 6.2.4 as the release build