### PR TITLE
prepare for deprecation of qmake.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,15 +17,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - QT_VERSION: '5.12.12'
-            XCODE_VERSION: '11.7'
-            RELEASE: false
           - QT_VERSION: '5.15.2'
             XCODE_VERSION: '12.4'
+            GENERATOR: qmake
             RELEASE: false
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '12.5.1'
+            GENERATOR: qmake
             RELEASE: true
+          - QT_VERSION: '6.2.4'
+            XCODE_VERSION: '12.5.1'
+            GENERATOR: 'Ninja'
+            RELEASE: false
 
     steps:
     - name: Checkout repository
@@ -51,11 +54,21 @@ jobs:
       run: |
         ./tools/travis_install_osx ${{ matrix.QT_VERSION }} aqt
 
+    - name: Brew install
+      if: matrix.GENERATOR == 'Ninja'
+      run: |
+        brew update
+        brew install ninja
+
     - name: Script
       run: |
         source ${HOME}/Cache/qt-${{ matrix.QT_VERSION }}.env
         sudo xcode-select --switch /Applications/Xcode_${{ matrix.XCODE_VERSION }}.app
-        ./tools/travis_script_osx
+        if [ "${{ matrix.GENERATOR }}" == qmake ]; then
+          ./tools/travis_script_osx
+        else
+          ./tools/ci_script_osx.sh . ${{ matrix.QT_VERSION }} ${{ matrix.GENERATOR }}
+        fi
 
     - name: Deploy
       # This only handles continous releases now, for other events artifacts may be saved in

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,32 +14,36 @@ jobs:
     name: basic Build
     runs-on: ubuntu-latest
     container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_focal
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_jammy
       env:
         LC_ALL: 'C.UTF-8'
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: build_and_test
       run: |
+        # when using containers manually whitelist the checkout directory to allow git commands to work
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         ./tools/build_and_test.sh
 
   cmake:
     name: cmake Build
     runs-on: ubuntu-latest
     container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_focal
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_jammy
       env:
         LC_ALL: 'C.UTF-8'
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: build_and_test
       run: |
+        # when using containers manually whitelist the checkout directory to allow git commands to work
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         ./tools/build_and_test_cmake.sh
 
   qtio_gcc:
@@ -52,10 +56,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: build_and_test
       run: |
+        # when using containers manually whitelist the checkout directory to allow git commands to work
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         . /opt/qtio.env
         ./tools/build_and_test.sh
 
@@ -70,10 +76,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: build_and_test
       run: |
+        # when using containers manually whitelist the checkout directory to allow git commands to work
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         . /opt/qtio.env
         ./tools/build_and_test.sh
 
@@ -81,16 +89,18 @@ jobs:
     name: advanced Build
     runs-on: ubuntu-latest
     container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_focal
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_jammy
       env:
         LC_ALL: 'C.UTF-8'
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: build_extra_tests
       run: |
+        # when using containers manually whitelist the checkout directory to allow git commands to work
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         ./tools/build_extra_tests.sh
 
   coverage:
@@ -103,7 +113,7 @@ jobs:
         sudo apt-get install gcovr lcov libusb-1.0-0-dev qt5-default
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: script
       env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,13 +36,6 @@ jobs:
             ARCH: 'amd64'
             HOST_ARCH: 'x86'
             COMPILER: 'msvc2017_64'
-            METHOD: 'aqt'
-            FLOW: 'cmake'
-            RELEASE: false
-          - QT_VERSION: '5.12.12'
-            ARCH: 'amd64'
-            HOST_ARCH: 'x86'
-            COMPILER: 'msvc2017_64'
             VCVERSION: '14.16'
             METHOD: 'aqt'
             FLOW: 'nmake'
@@ -61,6 +54,13 @@ jobs:
             METHOD: 'aqt'
             RELEASE: true
             FLOW: 'nmake'
+          - QT_VERSION: '6.2.4'
+            ARCH: 'amd64'
+            HOST_ARCH: 'amd64'
+            COMPILER: 'msvc2019_64'
+            METHOD: 'aqt'
+            RELEASE: false
+            FLOW: 'cmake'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/windows_ondemand.yml
+++ b/.github/workflows/windows_ondemand.yml
@@ -1,66 +1,55 @@
-name: "windows"
+name: "windows ondemand"
 
 on:
-  push:
-    branches: [ '**']
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
   schedule:
     - cron: '27 4 * * 2'
+  workflow_dispatch: ~
 
 jobs:
 
   windows:
-    name: windows Build
-    runs-on: windows-latest
+    name: windows ondemand Build
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - QT_VERSION: '5.12.12'
             ARCH: 'amd64'
-            HOST_ARCH: 'x86'
+            HOST_ARCH: 'amd64'
             COMPILER: 'msvc2017_64'
             METHOD: 'aqt'
-            FLOW: 'nmake'
-            RELEASE: false
+            GENERATOR: 'Visual Studio 16 2019'
+            os: windows-2019
           - QT_VERSION: '5.12.12'
             ARCH: 'amd64'
-            HOST_ARCH: 'x86'
+            HOST_ARCH: 'amd64'
             COMPILER: 'msvc2017_64'
+            TOOLSET: 'v141,version=14.16.27023'
             METHOD: 'aqt'
-            FLOW: 'msbuild'
-            RELEASE: false
-          - QT_VERSION: '5.12.12'
-            ARCH: 'amd64'
-            HOST_ARCH: 'x86'
-            COMPILER: 'msvc2017_64'
-            VCVERSION: '14.16'
-            METHOD: 'aqt'
-            FLOW: 'nmake'
-            RELEASE: false
+            GENERATOR: 'Visual Studio 16 2019'
+            os: windows-2019
           - QT_VERSION: '5.12.12'
             ARCH: 'x86'
-            HOST_ARCH: 'x86'
+            HOST_ARCH: 'amd64'
             COMPILER: 'msvc2017'
             METHOD: 'aqt'
-            RELEASE: false
-            FLOW: 'nmake'
+            GENERATOR: 'Visual Studio 16 2019'
+            os: windows-2019
           - QT_VERSION: '6.2.4'
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'
             METHOD: 'aqt'
-            RELEASE: true
-            FLOW: 'nmake'
+            GENERATOR: 'Visual Studio 16 2019'
+            os: windows-2019
           - QT_VERSION: '6.2.4'
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'
             METHOD: 'aqt'
-            RELEASE: false
-            GENERATOR: 'Ninja'
+            GENERATOR: 'Visual Studio 17 2022'
+            os: windows-latest
 
     steps:
     - name: Checkout repository
@@ -92,7 +81,7 @@ jobs:
       run: |
         .\tools\ci_setup_windows.ps1 -qtdir "$Home\Cache\Qt\${{ matrix.QT_VERSION }}\${{ matrix.COMPILER }}" -arch "${{ matrix.ARCH }}" -host_arch "${{ matrix.HOST_ARCH }}" -vcversion "${{ matrix.VCVERSION }}"
         if ( "${{ matrix.generator }}" ) {
-          .\tools\ci_script_windows.ps1 -generator "${{ matrix.GENERATOR }}" -arch "${{ matrix.ARCH }}"
+          .\tools\ci_script_windows.ps1 -generator "${{ matrix.GENERATOR }}" -arch "${{ matrix.ARCH }}" -toolset "${{ matrix.TOOLSET }}"
         } else {
           .\tools\make_windows_release.ps1 -iscc "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" -buildinstaller true -flow "${{ matrix.FLOW }}" -arch "${{ matrix.ARCH }}"
         }
@@ -110,17 +99,6 @@ jobs:
         # PATH="${HOME}/Cache/Qt/${{ matrix.QT_VERSION }}/${{ matrix.COMPILER }}/bin:${PATH}"
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
-
-    - name: Deploy
-      # This only handles continous releases now, for other events artifacts may be saved in
-      # the 'Upload Artifacts' step.
-      if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' ) && matrix.RELEASE
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_NAME: Continuous-${{ runner.os }}
-      run: |
-        ./tools/uploadtool/upload_github.sh bld/gui/GPSBabel-*-Setup.exe
 
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v2

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -2,6 +2,8 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   message(FATAL_ERROR "Please use CMakeLists.txt in the project root directory to generate a build system.")
 endif()
 
+add_subdirectory(coretool)
+
 configure_file(${CMAKE_SOURCE_DIR}/gbversion.h.in gbversion.h @ONLY NEWLINE_STYLE LF)
 configure_file(setup.iss.in setup.iss @ONLY NEWLINE_STYLE CRLF)
 
@@ -170,36 +172,78 @@ message(STATUS "Libs are: \"${LnkLibs}\"")
 get_target_property(IncDirs ${TARGET} INCLUDE_DIRECTORIES)
 message(STATUS "Include Directores are: \"${IncDirs}\"")
 
+# FIXME: remove reliance an app.pro in package_app script.
+# FIXME: translations updated and released in source directory (and under version control).
+list(APPEND TRANSLATIONS gpsbabelfe_de.ts)
+list(APPEND TRANSLATIONS gpsbabelfe_es.ts)
+list(APPEND TRANSLATIONS gpsbabelfe_fr.ts)
+list(APPEND TRANSLATIONS gpsbabelfe_hu.ts)
+list(APPEND TRANSLATIONS gpsbabelfe_it.ts)
+list(APPEND TRANSLATIONS gpsbabelfe_ru.ts)
+
 if(APPLE)
+  get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
   add_custom_target(package_app
-                    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_BUNDLE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
+                    COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_BUNDLE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
                     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_BUNDLE_DIR:${TARGET}>/../GPSBabelFE.dmg ${CMAKE_CURRENT_BINARY_DIR}
-                    DEPENDS ${TARGET}
-                    VERBATIM)
-elseif(UNIX)
-  add_custom_target(package_app
-                    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_FILE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
-                    DEPENDS ${TARGET}
-                    VERBATIM)
-elseif(WIN32)
-  find_program(INNO_COMPILER NAMES iscc ISCC
-               PATHS "C:/Program Files (x86)/Inno Setup 6" "C:/Program Files/Inno Setup 6")
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" win_binary_path)
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" win_source_path)
-  add_custom_target(package_app
-                    COMMAND lupdate ${CMAKE_CURRENT_SOURCE_DIR}/app.pro
-                    COMMAND lrelease ${CMAKE_CURRENT_SOURCE_DIR}/app.pro
-                    # deploy to a clean directory as different build systems create differently named debris in release.
-                    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/package
-                    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/package
-                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET}> ${CMAKE_CURRENT_BINARY_DIR}/package
-                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_BINARY_DIR}/package
-                    # use --plugindir option to locate the plugins.
-                    COMMAND windeployqt --verbose 1 --plugindir ${CMAKE_CURRENT_BINARY_DIR}/package/plugins ${CMAKE_CURRENT_BINARY_DIR}/package/GPSBabelFE.exe ${CMAKE_CURRENT_BINARY_DIR}/package/GPSBabel.exe
-                    # set location to location of generated setup.iss file.
-                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} ${INNO_COMPILER} /Doutput_dir=${win_binary_path} /Dsource_dir=${win_source_path} setup.iss
                     DEPENDS ${TARGET}
                     VERBATIM
                     USES_TERMINAL)
+elseif(UNIX)
+  get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+  add_custom_target(package_app
+                    COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_FILE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
+                    DEPENDS ${TARGET}
+                    VERBATIM
+                    USES_TERMINAL)
+elseif(WIN32)
+  find_package(Qt${QT_VERSION_MAJOR} QUIET COMPONENTS LinguistTools)
+  if (NOT Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
+    message(WARNING "Qt${QT_VERSION_MAJOR}LinguistTools not found, ${TARGET} translations cannot be updated or released, and application cannot be packaged.")
+  endif()
 
+  find_program(INNO_COMPILER NAMES iscc ISCC
+               PATHS "C:/Program Files (x86)/Inno Setup 6" "C:/Program Files/Inno Setup 6")
+  if (INNO_COMPILER STREQUAL "INNO_COMPILER-NOTFOUND")
+    message(WARNING "Inno compiler iscc not found, application cannot be packaged.")
+  endif()
+
+  # in 5.12.12 cmake doesn't know about windeployqt, look in directory that has qmake.
+  get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+  get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
+  find_program(WINDEPLOYQT NAMES windeployqt PATHS "${_qt_bin_dir}" NO_DEFAULT_PATH)
+  if (WINDEPLOYQT STREQUAL "WINDEPLOYQT-NOTFOUND")
+    message(WARNING "windeployqt not found, application cannot be packaged.")
+  endif()
+
+  if(Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
+    add_custom_target(${TARGET}_lupdate
+                      COMMAND Qt${QT_VERSION_MAJOR}::lupdate ${SOURCES} ${FORMS} -ts ${TRANSLATIONS}
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                      VERBATIM
+                      USES_TERMINAL)
+    add_custom_target(${TARGET}_lrelease
+                      COMMAND Qt${QT_VERSION_MAJOR}::lrelease ${TRANSLATIONS}
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                      DEPENDS ${TARGET}_lupdate
+                      VERBATIM
+                      USES_TERMINAL)
+    if((NOT WINDEPLOYQT STREQUAL "WINDEPLOYQT-NOTFOUND") AND (NOT INNO_COMPILER STREQUAL "INNO_COMPILER-NOTFOUND"))
+      file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" _win_binary_path)
+      file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" _win_source_path)
+      add_custom_target(package_app
+                        # deploy to a clean directory as different build systems create differently named debris in release.
+                        COMMAND ${CMAKE_COMMAND} -E remove_directory package
+                        COMMAND ${CMAKE_COMMAND} -E make_directory package
+                        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET}> package
+                        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gpsbabel> package
+                        # use --plugindir option to locate the plugins.
+                        COMMAND ${WINDEPLOYQT} --verbose 1 --plugindir package\\plugins package\\GPSBabelFE.exe package\\GPSBabel.exe
+                        # set location to location of generated setup.iss file.
+                        COMMAND ${INNO_COMPILER} /Doutput_dir=${_win_binary_path} /Dsource_dir=${_win_source_path} setup.iss
+                        DEPENDS ${TARGET} ${TARGET}_lrelease
+                        VERBATIM
+                        USES_TERMINAL)
+    endif()
+  endif()
 endif()

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -181,4 +181,25 @@ elseif(UNIX)
                     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_FILE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
                     DEPENDS ${TARGET}
                     VERBATIM)
+elseif(WIN32)
+  find_program(INNO_COMPILER NAMES iscc ISCC
+               PATHS "C:/Program Files (x86)/Inno Setup 6" "C:/Program Files/Inno Setup 6")
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" win_binary_path)
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" win_source_path)
+  add_custom_target(package_app
+                    COMMAND lupdate ${CMAKE_CURRENT_SOURCE_DIR}/app.pro
+                    COMMAND lrelease ${CMAKE_CURRENT_SOURCE_DIR}/app.pro
+                    # deploy to a clean directory as different build systems create differently named debris in release.
+                    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/package
+                    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/package
+                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET}> ${CMAKE_CURRENT_BINARY_DIR}/package
+                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_BINARY_DIR}/package
+                    # use --plugindir option to locate the plugins.
+                    COMMAND windeployqt --verbose 1 --plugindir ${CMAKE_CURRENT_BINARY_DIR}/package/plugins ${CMAKE_CURRENT_BINARY_DIR}/package/GPSBabelFE.exe ${CMAKE_CURRENT_BINARY_DIR}/package/GPSBabel.exe
+                    # set location to location of generated setup.iss file.
+                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} ${INNO_COMPILER} /Doutput_dir=${win_binary_path} /Dsource_dir=${win_source_path} setup.iss
+                    DEPENDS ${TARGET}
+                    VERBATIM
+                    USES_TERMINAL)
+
 endif()

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -186,14 +186,14 @@ if(APPLE)
   add_custom_target(package_app
                     COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_BUNDLE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
                     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_BUNDLE_DIR:${TARGET}>/../GPSBabelFE.dmg ${CMAKE_CURRENT_BINARY_DIR}
-                    DEPENDS ${TARGET}
+                    DEPENDS ${TARGET} gpsbabel coretool_lrelease
                     VERBATIM
                     USES_TERMINAL)
 elseif(UNIX)
   get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
   add_custom_target(package_app
                     COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_FILE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
-                    DEPENDS ${TARGET}
+                    DEPENDS ${TARGET} gpsbabel coretool_lrelease
                     VERBATIM
                     USES_TERMINAL)
 elseif(WIN32)
@@ -241,7 +241,7 @@ elseif(WIN32)
                         COMMAND ${WINDEPLOYQT} --verbose 1 --plugindir package\\plugins package\\GPSBabelFE.exe package\\GPSBabel.exe
                         # set location to location of generated setup.iss file.
                         COMMAND ${INNO_COMPILER} /Doutput_dir=${_win_binary_path} /Dsource_dir=${_win_source_path} setup.iss
-                        DEPENDS ${TARGET} ${TARGET}_lrelease
+                        DEPENDS ${TARGET} gpsbabel ${TARGET}_lrelease coretool_lrelease
                         VERBATIM
                         USES_TERMINAL)
     endif()

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -170,4 +170,15 @@ message(STATUS "Libs are: \"${LnkLibs}\"")
 get_target_property(IncDirs ${TARGET} INCLUDE_DIRECTORIES)
 message(STATUS "Include Directores are: \"${IncDirs}\"")
 
-add_custom_target(package_app COMMAND ./package_app DEPENDS ${TARGET})
+if(APPLE)
+  add_custom_target(package_app
+                    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_BUNDLE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
+                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_BUNDLE_DIR:${TARGET}>/../GPSBabelFE.dmg ${CMAKE_CURRENT_BINARY_DIR}
+                    DEPENDS ${TARGET}
+                    VERBATIM)
+elseif(UNIX)
+  add_custom_target(package_app
+                    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_FILE_DIR:${TARGET}> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
+                    DEPENDS ${TARGET}
+                    VERBATIM)
+endif()

--- a/gui/app.pro
+++ b/gui/app.pro
@@ -35,6 +35,7 @@ unix:DESTDIR = objects
 unix:MOC_DIR = objects
 unix:OBJECTS_DIR = objects
 unix:RCC_DIR = objects
+unix:!mac:DESTDIR = GPSBabelFE
 mac:DESTDIR = .
 
 UI_DIR = tmp

--- a/gui/coretool/CMakeLists.txt
+++ b/gui/coretool/CMakeLists.txt
@@ -24,9 +24,11 @@ target_link_libraries(${TARGET} ${QT_LIBRARIES})
 # FIXME: core_strings.h generated in source directory (and under version control).
 # FIXME: translations updated and released in source directory (and under version control).
 
+get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
 add_custom_target(core_strings
                   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_BINARY_DIR}
-                  COMMAND ${TARGET} 2> core_strings.h;
+                  COMMAND ${CMAKE_COMMAND} -DQTBINDIR=${_qt_bin_dir} -DCURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/coretool.cmake
                   DEPENDS ${TARGET}
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   VERBATIM

--- a/gui/coretool/CMakeLists.txt
+++ b/gui/coretool/CMakeLists.txt
@@ -1,0 +1,59 @@
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  message(FATAL_ERROR "Please use CMakeLists.txt in the project root directory to generate a build system.")
+endif()
+
+set(TARGET coretool)
+
+add_executable(${TARGET} EXCLUDE_FROM_ALL)
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Widgets REQUIRED)
+list(APPEND QT_LIBRARIES Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)
+
+list(APPEND SOURCES ../formatload.cc)
+list(APPEND SOURCES coretool.cc)
+
+list(APPEND HEADERS ../format.h)
+list(APPEND HEADERS ../formatload.h)
+
+target_compile_definitions(${TARGET} PRIVATE GENERATE_CORE_STRINGS)
+target_include_directories(${TARGET} PRIVATE ..)
+target_sources(${TARGET} PRIVATE ${SOURCES} ${HEADERS})
+target_link_libraries(${TARGET} ${QT_LIBRARIES})
+
+# FIXME: core_strings.h generated in source directory (and under version control).
+# FIXME: translations updated and released in source directory (and under version control).
+
+add_custom_target(core_strings
+                  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMAND ${TARGET} 2> core_strings.h;
+                  DEPENDS ${TARGET}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  VERBATIM
+                  USES_TERMINAL)
+
+list(APPEND TRANSLATIONS gpsbabel_de.ts)
+list(APPEND TRANSLATIONS gpsbabel_es.ts)
+list(APPEND TRANSLATIONS gpsbabel_fr.ts)
+list(APPEND TRANSLATIONS gpsbabel_hu.ts)
+list(APPEND TRANSLATIONS gpsbabel_it.ts)
+list(APPEND TRANSLATIONS gpsbabel_ru.ts)
+
+find_package(Qt${QT_VERSION_MAJOR} QUIET COMPONENTS LinguistTools)
+if(Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
+  add_custom_target(coretool_lupdate
+                    COMMAND Qt${QT_VERSION_MAJOR}::lupdate -locations absolute core_strings.h -ts ${TRANSLATIONS}
+                    DEPENDS core_strings
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    VERBATIM
+                    USES_TERMINAL)
+  
+  add_custom_target(coretool_lrelease
+                    COMMAND Qt${QT_VERSION_MAJOR}::lrelease ${TRANSLATIONS}
+                    DEPENDS coretool_lupdate
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    VERBATIM
+                    USES_TERMINAL)
+else()
+  message(WARNING "Qt${QT_VERSION_MAJOR}LinguistTools not found, coretool translations cannot be updated or released.")
+endif()

--- a/gui/coretool/CMakeLists.txt
+++ b/gui/coretool/CMakeLists.txt
@@ -43,8 +43,13 @@ list(APPEND TRANSLATIONS gpsbabel_ru.ts)
 
 find_package(Qt${QT_VERSION_MAJOR} QUIET COMPONENTS LinguistTools)
 if(Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
+  # The line numbers are almost meaningless the way we generate corestrings.h, and we force everything to the same context.
+  # With line numbers and the similartext heuristic enabled translations can be copied from an old message to a new message,
+  # and marked as unfinished.  The threshold for similar is low.
+  # These will be used by the application, even though they really need to be checked.
+  # Disable the similartext heuristic to avoid these mistranslations.
   add_custom_target(coretool_lupdate
-                    COMMAND Qt${QT_VERSION_MAJOR}::lupdate -locations absolute core_strings.h -ts ${TRANSLATIONS}
+                    COMMAND Qt${QT_VERSION_MAJOR}::lupdate -disable-heuristic similartext core_strings.h -ts ${TRANSLATIONS}
                     DEPENDS core_strings
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     VERBATIM

--- a/gui/coretool/CMakeLists.txt
+++ b/gui/coretool/CMakeLists.txt
@@ -26,10 +26,10 @@ target_link_libraries(${TARGET} ${QT_LIBRARIES})
 
 get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
 get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
-add_custom_target(core_strings
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/core_strings.h
                   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_BINARY_DIR}
                   COMMAND ${CMAKE_COMMAND} -DQTBINDIR=${_qt_bin_dir} -DCURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/coretool.cmake
-                  DEPENDS ${TARGET}
+                  DEPENDS ${TARGET} gpsbabel
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   VERBATIM
                   USES_TERMINAL)
@@ -50,7 +50,7 @@ if(Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
   # Disable the similartext heuristic to avoid these mistranslations.
   add_custom_target(coretool_lupdate
                     COMMAND Qt${QT_VERSION_MAJOR}::lupdate -disable-heuristic similartext core_strings.h -ts ${TRANSLATIONS}
-                    DEPENDS core_strings
+                    DEPENDS core_strings.h
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     VERBATIM
                     USES_TERMINAL)

--- a/gui/coretool/coretool.cmake
+++ b/gui/coretool/coretool.cmake
@@ -10,5 +10,4 @@ if(WIN32)
   set(ENV{PATH} "${_qt_win_path};$ENV{PATH}")
 endif()
 execute_process(
-  COMMAND ${CURRENT_BINARY_DIR}/coretool
-  ERROR_FILE core_strings.h)
+  COMMAND ${CURRENT_BINARY_DIR}/coretool core_strings.h)

--- a/gui/coretool/coretool.cmake
+++ b/gui/coretool/coretool.cmake
@@ -1,0 +1,14 @@
+foreach(var QTBINDIR CURRENT_BINARY_DIR)
+  if(NOT DEFINED ${var})
+    message(FATAL_ERROR "${var} must be passed on the command line")
+  endif()
+endforeach()
+
+if(WIN32)
+  # windows needs the Qt Binary directory in the path to find the DLLs.
+  file(TO_NATIVE_PATH "${QTBINDIR}" _qt_win_path)
+  set(ENV{PATH} "${_qt_win_path};$ENV{PATH}")
+endif()
+execute_process(
+  COMMAND ${CURRENT_BINARY_DIR}/coretool
+  ERROR_FILE core_strings.h)

--- a/gui/package_app
+++ b/gui/package_app
@@ -74,6 +74,9 @@ LRELEASE="$(${QMAKE} -query QT_INSTALL_BINS)/lrelease"
 LCONVERT="$(${QMAKE} -query QT_INSTALL_BINS)/lconvert"
 MACDEPLOYQT="$(${QMAKE} -query QT_INSTALL_BINS)/macdeployqt"
 
+GPSBABEL=${2:-../gpsbabel}
+SOURCEDIR=${3:-.}
+
 case "$(uname -s)" in
   Linux*)     machine=Linux;;
   Darwin*)    machine=Mac;;
@@ -81,41 +84,42 @@ case "$(uname -s)" in
 esac
 
 # update our translations and compile them.
-"${LUPDATE}" app.pro
-"${LRELEASE}" app.pro
+"${LUPDATE}" "${SOURCEDIR}/app.pro"
+"${LRELEASE}" "${SOURCEDIR}/app.pro"
 
 if [ "${machine}" = "Linux" ]; then
   # need absolute paths for convert_qt_translations()
-  APPDIR="$(pwd)/GPSBabelFE"
+  APPDIR="$( cd "${1:-GPSBabelFE}" && pwd )"
   LANGDIR="${APPDIR}/translations"
 else
-  APPBUNDLE=GPSBabelFE.app
   # need absolute paths for convert_qt_translations()
-  APPDIR="$(pwd)/${APPBUNDLE}"
+  APPDIR="$( cd "${1:-GPSBabelFE.app}" && pwd )"
   LANGDIR="${APPDIR}/Contents/MacOS/translations"
+  APPBUNDLE=$(basename "$APPDIR")
 fi
 
 rm -fr "${LANGDIR}"
 mkdir -p "${LANGDIR}"
 
 # copy our compiled translations.
-cp gpsbabelfe_??.qm "${LANGDIR}"
-cp coretool/gpsbabel_??.qm "${LANGDIR}"
+cp "${SOURCEDIR}"/gpsbabelfe_??.qm "${LANGDIR}"
+cp "${SOURCEDIR}"/coretool/gpsbabel_??.qm "${LANGDIR}"
 
 # bundle Qt .qm files, deploy them with our .qm files,
 # and, for macos, make & deploy locversion.plist files.
 (convert_qt_translations)
 
 if [ "${machine}" = "Linux" ]; then
-  cp objects/gpsbabelfe "${APPDIR}"
-  cp ../gpsbabel "${APPDIR}"
-  cp gmapbase.html "${APPDIR}"
-  cp COPYING.txt "${APPDIR}"
+  cp "${GPSBABEL}" "${APPDIR}"
+  cp "${SOURCEDIR}/gmapbase.html" "${APPDIR}"
+  cp "${SOURCEDIR}/COPYING.txt" "${APPDIR}"
 else # Mac
-  cp ../gpsbabel "${APPDIR}/Contents/MacOS/gpsbabel"
-  cp gmapbase.html "${APPDIR}/Contents/MacOS"
-  cp COPYING.txt "${APPDIR}/Contents/MacOS"
+  cp "${GPSBABEL}" "${APPDIR}/Contents/MacOS/gpsbabel"
+  cp "${SOURCEDIR}/gmapbase.html" "${APPDIR}/Contents/MacOS"
+  cp "${SOURCEDIR}/COPYING.txt" "${APPDIR}/Contents/MacOS"
+  pushd "${APPDIR}/.."
   rm -f GPSBabelFE.dmg
   # macdeploytqt likes relative paths or else the dmg mount points get funky.
   "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -dmg -verbose=2
+  popd
 fi

--- a/gui/setup.iss.in
+++ b/gui/setup.iss.in
@@ -7,8 +7,8 @@
 ; Uses the Inno setup compiler.
 ; windeployqt should be run to prepare the necessary Qt files before
 ; running Inno Setup.
-#ifndef package_dir
-  #define package_dir "..\build-app-Desktop-Release\package"
+#ifndef output_dir
+  #define output_dir "."
 #endif
 #ifndef source_dir
   #define source_dir "."
@@ -29,7 +29,7 @@ ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 DefaultDirName={pf}\GPSBabel
 DefaultGroupName=GPSBabel
-OutputDir=release
+OutputDir="{#output_dir}"
 OutputBaseFilename=GPSBabel-@GB.VERSION@@GB.PACKAGE_RELEASE@-Setup
 OutputManifestFile=GPSBabel-@GB.VERSION@@GB.PACKAGE_RELEASE@-Manifest.txt
 SetupIconFile=images\babel2.ico
@@ -48,10 +48,10 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: gmapbase.html; 			DestDir: "{app}"; Flags: ignoreversion
 Source: qt.conf;       			DestDir: "{app}"; Flags: ignoreversion
 
-Source: "{#package_dir}\*"; Excludes: "vc_redist.*.exe"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{#package_dir}\vc_redist.x86.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
-Source: "{#package_dir}\vc_redist.x64.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
-Source: "{#package_dir}\gpsbabel.exe";   	DestDir: "{app}"; Flags: ignoreversion
+Source: "{#output_dir}\package\*"; Excludes: "vc_redist.*.exe"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#output_dir}\package\vc_redist.x86.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: "{#output_dir}\package\vc_redist.x64.exe"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: "{#output_dir}\package\gpsbabel.exe";   	DestDir: "{app}"; Flags: ignoreversion
 ; Source: release\help\*;           	DestDir: "{app}\help"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 ; Translation strings extracted from source code.  Include it in the dist

--- a/gui/setup.iss.qmake.in
+++ b/gui/setup.iss.qmake.in
@@ -7,11 +7,11 @@
 ; Uses the Inno setup compiler.
 ; windeployqt should be run to prepare the necessary Qt files before
 ; running Inno Setup.
-#ifndef package_dir
-  #define package_dir \"..\\build-app-Desktop-Release\\package\"
+#ifndef output_dir
+  #define output_dir \".\"
 #endif
 #ifndef source_dir
-  #define source_dir "."
+  #define source_dir \".\"
 #endif
 
 [Setup]
@@ -29,7 +29,7 @@ ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 DefaultDirName={pf}\\GPSBabel
 DefaultGroupName=GPSBabel
-OutputDir=release
+OutputDir=\"{#output_dir}\"
 OutputBaseFilename=GPSBabel-$${GB.VERSION}$${GB.PACKAGE_RELEASE}-Setup
 OutputManifestFile=GPSBabel-$${GB.VERSION}$${GB.PACKAGE_RELEASE}-Manifest.txt
 SetupIconFile=images\\babel2.ico
@@ -48,10 +48,10 @@ Name: \"desktopicon\"; Description: \"{cm:CreateDesktopIcon}\"; GroupDescription
 Source: gmapbase.html; 			DestDir: \"{app}\"; Flags: ignoreversion
 Source: qt.conf;       			DestDir: \"{app}\"; Flags: ignoreversion
 
-Source: \"{#package_dir}\\*\"; Excludes: \"vc_redist.*.exe\"; DestDir: \"{app}\"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: \"{#package_dir}\\vc_redist.x86.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
-Source: \"{#package_dir}\\vc_redist.x64.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
-Source: \"{#package_dir}\\gpsbabel.exe\";   	DestDir: \"{app}\"; Flags: ignoreversion
+Source: \"{#output_dir}\\package\\*\"; Excludes: \"vc_redist.*.exe\"; DestDir: \"{app}\"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: \"{#output_dir}\\package\\vc_redist.x86.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: \"{#output_dir}\\package\\vc_redist.x64.exe\"; DestDir: \"{app}\"; Flags: ignoreversion skipifsourcedoesntexist deleteafterinstall
+Source: \"{#output_dir}\\package\\gpsbabel.exe\";   	DestDir: \"{app}\"; Flags: ignoreversion
 ; Source: release\\help\\*;           	DestDir: \"{app}\\help\"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 ; Translation strings extracted from source code.  Include it in the dist

--- a/tools/Dockerfile_jammy
+++ b/tools/Dockerfile_jammy
@@ -1,0 +1,74 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:jammy
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    valgrind \
+    expat \
+    libxml2-utils \
+    bear \
+    cmake \
+    ninja-build \
+    clazy \
+ && rm -rf /var/lib/apt/lists/*
+
+# alternative compiler
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs needed to build document
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fop \
+    xsltproc \
+    docbook-xml \
+    docbook-xsl \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-1.0-0-dev \
+    pkg-config \
+    libudev-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qtbase5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    qtwebengine5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs needed to generate coverage report:
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcovr \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a

--- a/tools/ci_script_osx.sh
+++ b/tools/ci_script_osx.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -ex
+#
+# this script is run on ci for the script stage of mac builds
+#
+ 
+function version_ge() { test "$(printf "%s\n%s" $1 $2 | sort -rV | head -n 1)" == "$1"; }
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 source_directory qt_version [Generator]"
+  exit 1
+fi
+SOURCE_DIR=$1
+QTVER=$2
+if [ $# -ge 3 ]; then
+  if [ -n "$3" ]; then
+    GENERATOR[0]=-G
+    GENERATOR[1]=$3
+  fi
+fi
+if version_ge "${QTVER}" 6.0.0; then
+  DEPLOY_TARGET="10.14"
+  ARCHS="x86_64;arm64"
+elif version_ge "${QTVER}" 5.14.0; then
+  DEPLOY_TARGET="10.13"
+  ARCHS="x86_64"
+else
+  DEPLOY_TARGET="10.12"
+  ARCHS="x86_64"
+fi
+  
+# we assume we are on macOS, so date is not gnu date.
+VERSIONID=${VERSIONID:-$(date -ju -f %Y-%m-%dT%H:%M:%S%z $(git show -s --format="%aI" HEAD | sed 's/:\(..\)$/\1/') +%Y%m%dT%H%MZ)-$(git rev-parse --short=7 HEAD)}
+
+# debug tokens
+"$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"/ci_tokens
+
+case "${GENERATOR[1]}" in
+Xcode | "Ninja Multi-Config")
+  cmake "${SOURCE_DIR}" -DCMAKE_OSX_ARCHITECTURES=${ARCHS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${DEPLOY_TARGET} "${GENERATOR[@]}"
+  cmake --build . --config Release
+  ctest -C Release
+  cmake --build . --config Release --target package_app
+  ;;
+*)
+  cmake "${SOURCE_DIR}" -DCMAKE_OSX_ARCHITECTURES=${ARCHS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${DEPLOY_TARGET} -DCMAKE_BUILD_TYPE=Release "${GENERATOR[@]}"
+  cmake --build .
+  ctest
+  cmake --build . --target package_app
+  ;;
+esac
+
+# what is in there?
+hdiutil attach -noverify gui/GPSBabelFE.dmg
+find /Volumes/GPSBabelFE -ls
+hdiutil detach /Volumes/GPSBabelFE
+
+mv gui/GPSBabelFE.dmg "gui/GPSBabel-${VERSIONID}.dmg"

--- a/tools/ci_script_windows.ps1
+++ b/tools/ci_script_windows.ps1
@@ -1,0 +1,63 @@
+# Script to build and create windows installer.
+#
+# Run this from a Qt Desktop command window that has the Qt and mingw compiler paths set up,
+# such as the one Qt Creator will put on the start menu, or
+# from a power shell prompt after settings up the paths with tools\ci_setup_windows.ps1.
+# For example
+# powershell.exe -ExecutionPolicy Unrestricted -File tools\make_windows_release.ps1
+#
+# The defaults should be compatible with github action builds.
+Param(
+    $build_dir_name = "bld",
+    $generator = "Ninja",
+    $toolset = "",
+    [ValidateSet("x86", "amd64", "amd64_x86", "x86_amd64")] $arch = "amd64"
+)
+# the arch parameter values correspond to:
+# vcvarsall arch parameter x86 => host x86, target x86.
+# vcvarsall arch paramter amd64 => host amd64, target amd64.
+# vcvarsall arch parameter amd64_x86 => host amd64, target x86
+# vcvarsall arch parameter x86_amd64 => host x86, target amd64
+# vsdevcmd arch parameter x86 => target x86.
+# vsdevcmd arch parameter amd64 => target amd64.
+
+$ErrorActionPreference = "Stop"
+# verify we are in the top of the gpsbabel clone
+Get-Item tools/ci_script_windows.ps1 -ErrorAction Stop | Out-Null
+$src_dir = $Pwd
+$build_dir = Join-Path $src_dir $build_dir_name
+$CMAKE_PREFIX_PATH = Split-Path $((Get-Command qmake) | Split-Path) -Parent
+# translate target architecture to Platform property value.
+switch ($arch) {
+    "x86" { $platform = "Win32" }
+    "amd64" { $platform = "x64" }
+    "amd64_x86" { $platform = "Win32" }
+    "x86_amd64" { $platform = "x64" }
+}
+# make sure we are staring with a clean build directory
+Remove-Item $build_dir -Recurse -ErrorAction Ignore
+New-Item $build_dir -type directory -Force | Out-Null
+Set-Location $build_dir
+$hashargs = "-G", $generator
+if ( $toolset ) {
+  $hashargs += "-T", $toolset
+}
+if ( $generator -like "Visual Studio*") {
+  $hashargs += "-A", $platform
+} else {
+  $hashargs += "-DCMAKE_BUILD_TYPE:STRING=Release"
+}
+$hashargs += "-DCMAKE_PREFIX_PATH:PATH=$CMAKE_PREFIX_PATH"
+Write-Output cmake $hashargs $src_dir
+cmake $hashargs $src_dir
+if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+switch -wildcard ($generator) {
+    "Visual Studio*" { cmake --build $build_dir --config Release }
+    default { cmake --build $build_dir }
+}
+if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+switch -wildcard ($generator) {
+    "Visual Studio*" { cmake --build $build_dir --config Release --target package_app }
+    default { cmake --build $build_dir --target package_app}
+}
+if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }


### PR DESCRIPTION
build a release level package in CI with cmake on windows & macOS.
this can be compared with the release package build in CI with qmake.

support cmake multi-config generators on macOS (e.g. Xcode) as well
as well as single-config generators (.e.g Unix Makefiles, Ninja).

support packaging of out of source builds on macOS when using cmake.
note that Qt6 support for packaging still has many features in
preview, thus we still use our script based packaging.

move some Ubuntu CI jobs to jammy.  Unfortunately Qt6WebEngine is
unusable on jammy due to a bug in qt6-base.  So we are still using
Qt5 :(
https://bugs.launchpad.net/ubuntu/+source/qt6-base/+bug/1970057