### PR TITLE
coretool fixes and enhancements

### DIFF
--- a/gui/coretool/coretool.cc
+++ b/gui/coretool/coretool.cc
@@ -1,12 +1,36 @@
-#include <QList>
 #include <QApplication>
+#include <QFile>
+#include <QList>
+#include <QTextStream>
 
 #include "format.h"
 #include "formatload.h"
 
+QTextStream* generate_output_stream;
+
 int main(int argc, char** argv)
 {
   QApplication app(argc, argv);
+  QStringList qargs = QApplication::arguments();
+
   QList<Format> formatList;
-  return FormatLoad().getFormats(formatList) ? 0 : 1;
+
+  if (qargs.size() != 2) {
+    qFatal("Usage: %s output_file_name", qPrintable(qargs.at(0)));
+  }
+
+  QFile generate_output_file(qargs.at(1));
+  bool status = generate_output_file.open(QIODevice::WriteOnly);
+  if (!status) {
+    qFatal("Could not open %s for write!", qPrintable(qargs.at(1)));
+  }
+  generate_output_stream = new QTextStream(&generate_output_file);
+
+  bool fmtstatus = FormatLoad().getFormats(formatList);
+
+  generate_output_stream->flush();
+  generate_output_file.close();
+  delete generate_output_stream;
+
+  return fmtstatus ? 0 : 1;
 }

--- a/gui/coretool/coretool.pro
+++ b/gui/coretool/coretool.pro
@@ -4,6 +4,7 @@
 # these strings.
 #
 CONFIG += console
+CONFIG -= app_bundle
 
 QT -= gui
 QT += core \

--- a/gui/coretool/coretool.pro
+++ b/gui/coretool/coretool.pro
@@ -30,13 +30,18 @@ core_strings.target = core_strings.h
 core_strings.depends = $(TARGET)
 core_strings.depends += ../../gpsbabel
 core_strings.commands = $(COPY_FILE) ../../gpsbabel $(DESTDIR)gpsbabel &&
-core_strings.commands += ./$(TARGET) 2>core_strings.h;
+core_strings.commands += ./$(TARGET) core_strings.h;
 QMAKE_EXTRA_TARGETS += core_strings
 QMAKE_DISTCLEAN += $(DESTDIR)gpsbabel
 
+# The line numbers are almost meaningless the way we generate corestrings.h, and we force everything to the same context.
+# With line numbers and the similartext heuristic enabled translations can be copied from an old message to a new message,
+# and marked as unfinished.  The threshold for similar is low.
+# These will be used by the application, even though they really need to be checked.
+# Disable the similartext heuristic to avoid these mistranslations.
 qtPrepareTool(LUPDATE, lupdate)
 update.depends = core_strings.h
-update.commands = $$LUPDATE -locations absolute core.pro
+update.commands = $$LUPDATE -disable-heuristic similartext core.pro
 QMAKE_EXTRA_TARGETS += update
 
 qtPrepareTool(LRELEASE, lrelease)

--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -40,11 +40,15 @@
 #include "appname.h"                       // for appName
 
 
+#ifdef GENERATE_CORE_STRINGS
+extern QTextStream* generate_output_stream;
+#endif
+
 //------------------------------------------------------------------------
 static QString xlt(const QString& f)
 {
 #ifdef GENERATE_CORE_STRINGS
-  qInfo().nospace() << "QT_TRANSLATE_NOOP(\"core\"," << f << ")";
+  *generate_output_stream << "QT_TRANSLATE_NOOP(\"core\",\"" << f << "\")" << Qt::endl;
 #endif
   return QCoreApplication::translate("core", f.toUtf8().constData());
 }


### PR DESCRIPTION
1. don't generate a bundle on macos.  this fixes a bug where the coretool couldn't find the gpsbabel executable.
2. don't use stderr for coretool output.  this avoids commingling of coretool output and potential error messages.
3. disable the similartext heuristic for coretool.  this heuristic occasionally generated bad translations.  although these were marked as unfinished they get used by the GUI anyway.