### PR TITLE
move CI sanitizier, clazy, coverage builds to cmake

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -110,7 +110,7 @@ jobs:
     - name: install
       run: |
         sudo apt-get update
-        sudo apt-get install gcovr lcov libusb-1.0-0-dev qt5-default ninja-build
+        sudo apt-get install gcovr lcov libusb-1.0-0-dev qt5-default libqt5serialport5-dev ninja-build
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -110,7 +110,7 @@ jobs:
     - name: install
       run: |
         sudo apt-get update
-        sudo apt-get install gcovr lcov libusb-1.0-0-dev qt5-default
+        sudo apt-get install gcovr lcov libusb-1.0-0-dev qt5-default ninja-build
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -110,7 +110,7 @@ jobs:
     - name: install
       run: |
         sudo apt-get update
-        sudo apt-get install gcovr lcov libusb-1.0-0-dev qt5-default libqt5serialport5-dev ninja-build
+        sudo apt-get install gcovr lcov libusb-1.0-0-dev qt5-default  qtwebengine5-dev libqt5serialport5-dev ninja-build
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,20 @@ set(GPSBABEL_EXTRA_LINK_LIBRARIES "" CACHE STRING "extra libraries to link with.
 list(APPEND LIBS ${GPSBABEL_EXTRA_LINK_LIBRARIES})
 set(GPSBABEL_EXTRA_INCLUDE_DIRECTORIES "" CACHE STRING "extra directories to include.")
 target_include_directories(gpsbabel PRIVATE ${GPSBABEL_EXTRA_INCLUDE_DIRECTORIES})
+set(GPSBABEL_EXTRA_COMPILE_OPTIONS "" CACHE STRING "extra compile options.")
+# Qt sanitize.conf used:
+#   -fsanitize=address -fno-omit-frame-pointer
+#   -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-omit-frame-pointer
+# For coverage use --coverage
+separate_arguments(GPSBABEL_EXTRA_COMPILE_OPTIONS)
+target_compile_options(gpsbabel PRIVATE ${GPSBABEL_EXTRA_COMPILE_OPTIONS})
+set(GPSBABEL_EXTRA_LINK_OPTIONS "" CACHE STRING "extra link options.")
+# Qt sanitize.conf used:
+#   -fsanitize=address
+#   -fsanitize=undefined -fsanitize=float-divide-by-zero
+# For coverage use --coverage
+separate_arguments(GPSBABEL_EXTRA_LINK_OPTIONS)
+target_link_options(gpsbabel PRIVATE ${GPSBABEL_EXTRA_LINK_OPTIONS})
 
 set(SOURCES
   ${SOURCES} ${ALL_FMTS} ${FILTERS} ${SUPPORT} ${SHAPE} ${ZLIB} ${JEEPS} ${RESOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,7 +471,8 @@ if(UNIX)
                     ${CMAKE_SOURCE_DIR}/testo -p $<TARGET_FILE:gpsbabel>
                     DEPENDS gpsbabel
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                    VERBATIM)
+                    VERBATIM
+                    USES_TERMINAL)
 endif()
 if(UNIX AND NOT APPLE)
   # This test only works if the pwd is top level source dir due to the

--- a/kml.cc
+++ b/kml.cc
@@ -596,11 +596,13 @@ void KmlFormat::kml_output_trkdescription(const route_head* header, const comput
     kml_td(hwriter, QStringLiteral("Max Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
   }
   if (td->max_spd && td->start.isValid() && td->end.isValid()) {
-    const char* spd_units;
     double elapsed = td->start.msecsTo(td->end)/1000.0;
-    double spd = fmt_speed(td->distance_meters / elapsed, &spd_units);
-    if (spd > 1.0)  {
-      kml_td(hwriter, QStringLiteral("Avg Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
+    if (elapsed > 0.0) {
+      const char* spd_units;
+      double spd = fmt_speed(td->distance_meters / elapsed, &spd_units);
+      if (spd > 1.0)  {
+        kml_td(hwriter, QStringLiteral("Avg Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
+      }
     }
   }
   if (td->avg_hrt) {

--- a/tools/build_extra_tests.sh
+++ b/tools/build_extra_tests.sh
@@ -4,6 +4,8 @@
 # output is conditionally mailed to gpsbabel-code.
 #
 
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
+
 # echo some system info to log
 uname -a
 if [ -e /etc/system-release ]; then
@@ -12,32 +14,42 @@ fi
 if [ -e /etc/os-release ]; then
 	cat /etc/os-release
 fi
-git --no-pager log -n 1
+git -C "${SOURCE_DIR}" --no-pager log -n 1
 
 # build and test keeping output within the pwd.
-export GBTEMP=$(mktemp -d -p $(pwd) GBTEMPXXXX)
+GBTEMP=$(mktemp -d -p "$(pwd)" GBTEMPXXXX)
+export GBTEMP
 
+rm -rf bld-sanitizeaddress
+mkdir bld-sanitizeaddress
+pushd bld-sanitizeaddress
 #note that debug will also enable assertions.
-qmake "CONFIG+=debug sanitizer sanitize_address"
-make clean
-make -j 3
-make check
+cmake -DCMAKE_BUILD_TYPE=Debug -DGPSBABEL_EXTRA_COMPILE_OPTIONS="-fsanitize=address -fno-omit-frame-pointer" -DGPSBABEL_EXTRA_LINK_OPTIONS="-fsanitize=address" -G Ninja "${SOURCE_DIR}"
+cmake --build . --target gpsbabel --verbose
+cmake --build . --target check
+popd
 
-qmake "CONFIG+=debug sanitizer sanitize_undefined"
-make clean
-make -j 3
-make check
+rm -rf bld-sanitizeundefined
+mkdir bld-sanitizeundefined
+pushd bld-sanitizeundefined
+cmake -DCMAKE_BUILD_TYPE=Debug -DGPSBABEL_EXTRA_COMPILE_OPTIONS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-omit-frame-pointer" -DGPSBABEL_EXTRA_LINK_OPTIONS="-fsanitize=undefined -fsanitize=float-divide-by-zero" -G Ninja "${SOURCE_DIR}"
+cmake --build . --target gpsbabel --verbose
+cmake --build . --target check
+popd
+
+rm -rf "${GBTEMP}"
 
 # run clazy on both gpsbabel and gpsbabelfe.
 # unlike qmake, cmake uses system includes for Qt which quiets warnings
 # from the Qt headers.
+rm -rf bld-clazy
+mkdir bld-clazy
+pushd bld-clazy
 export CLAZY_CHECKS=level0,level1,no-non-pod-global-static,no-qstring-ref
-cmake . -DCMAKE_CXX_COMPILER=clazy -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="Debug"
-cmake --build . --target clean
+cmake -DCMAKE_CXX_COMPILER=clazy -DCMAKE_BUILD_TYPE=Debug -G Ninja "${SOURCE_DIR}"
 cmake --build . 2>&1 | tee clazy.log
 if grep -- '-Wclazy' clazy.log; then
   exit 1
 else
   exit 0
 fi
-

--- a/tools/build_extra_tests.sh
+++ b/tools/build_extra_tests.sh
@@ -32,7 +32,7 @@ popd
 rm -rf bld-sanitizeundefined
 mkdir bld-sanitizeundefined
 pushd bld-sanitizeundefined
-cmake -DCMAKE_BUILD_TYPE=Debug -DGPSBABEL_EXTRA_COMPILE_OPTIONS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-omit-frame-pointer" -DGPSBABEL_EXTRA_LINK_OPTIONS="-fsanitize=undefined -fsanitize=float-divide-by-zero" -G Ninja "${SOURCE_DIR}"
+cmake -DCMAKE_BUILD_TYPE=Debug -DGPSBABEL_EXTRA_COMPILE_OPTIONS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-recover=undefined,float-divide-by-zero -fno-omit-frame-pointer" -DGPSBABEL_EXTRA_LINK_OPTIONS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-recover=undefined,float-divide-by-zero" -G Ninja "${SOURCE_DIR}"
 cmake --build . --target gpsbabel --verbose
 cmake --build . --target check
 popd

--- a/tools/travis_script_linux_coverage
+++ b/tools/travis_script_linux_coverage
@@ -6,11 +6,20 @@
 # as of 6/18/2018 you must use java 8, see issue #76, #83 at https://github.com/codacy/codacy-coverage-reporter/issues
 # as of 3/16/2019 with coverage reporter 4.0.3 java 8 is not required.
 
-qmake
-make -j 3 coverage
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
+BUILD_DIR="$(pwd)/bld-coverage"
+
+rm -rf "${BUILD_DIR}"
+mkdir "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake -DCMAKE_BUILD_TYPE=Release -DGPSBABEL_EXTRA_COMPILE_OPTIONS="--coverage" -DGPSBABEL_EXTRA_LINK_OPTIONS="--coverage" -G Ninja "${SOURCE_DIR}"
+cmake --build . --target check
+lcov --capture --directory "${BUILD_DIR}" --base-directory "${SOURCE_DIR}" --no-external --output-file lcov.info
+genhtml lcov.info --demangle-cpp --output-directory coverage_report
 
 # debug tokens
-"$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"/ci_tokens
+"${SOURCE_DIR}"/tools/ci_tokens
 
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # don't leak unhashed tokens!
@@ -20,7 +29,7 @@ set +x
 # by substituting x for the token if the token is set and not null.
 if [ -n "${CODACY_PROJECT_TOKEN:+x}" ] ; then
   # upload coverate report to codacy.
-  bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l CPP -r gpsbabel_coverage.xml
+  bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l CPP -r lcov.info
 else
   echo "Skipping codacy coverage upload as CODACY_PROJECT_TOKEN is not set."
 fi


### PR DESCRIPTION
Additionally this turns undefined sanitizer errors into fatal errors so they result in CI failures, and fixes the detected error in the kml writer.

This PR required installation of qtwebengine5-dev and libqt5serialport5-dev for the coverage run.  These are required by the GUI and not necessary for the CLI.  However, with our current cmake setup build generation fails without them.  If we want to support building the CLI without them we need to enhance gui/CMakeLists.txt.

This also switches the coverage report format to lcov.