### PR TITLE
build: Allow building xmldoc in CMake binary dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,22 +489,36 @@ if(UNIX AND NOT APPLE)
                     USES_TERMINAL)
 endif()
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
-  set(WEB "../babelweb" CACHE PATH "Path where the documentation will be stored for www.gpsbabel.org.")
-  add_custom_target(gpsbabel.org
-                    ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_org.sh ${WEB} ${DOCVERSION}
-                    DEPENDS gpsbabel gpsbabel.pdf
-                    VERBATIM)
-endif()
+set(WEB "${CMAKE_SOURCE_DIR}/../babelweb" CACHE PATH "Path where the documentation will be stored for www.gpsbabel.org.")
+add_custom_target(xmldoc
+  COMMAND ${CMAKE_COMMAND} -E make_directory xmldoc
+  COMMAND perl "${CMAKE_SOURCE_DIR}/xmldoc/makedoc"
+  # The generated docs are linking various files from the source dir.
+  # Symlink them to output directory so that they can be resolved by validation and transformation.
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/xmldoc/chapters xmldoc/chapters
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/xmldoc/filters xmldoc/filters
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/xmldoc/formats xmldoc/formats
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/xmldoc/readme.xml xmldoc/readme.xml
+  COMMAND xmlwf xmldoc/readme.xml # Check for well-formedness
+  COMMAND xmllint --noout --valid xmldoc/readme.xml # Validate
+  DEPENDS gpsbabel
+)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
-  add_custom_target(gpsbabel.html
-                    ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_html.sh
-                    DEPENDS gpsbabel)
-endif()
+add_custom_target(gpsbabel.org
+  ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_org.sh ${WEB} ${DOCVERSION}
+  DEPENDS
+    xmldoc
+    gpsbabel # For utils/mkcapabilities
+    gpsbabel.pdf
+  VERBATIM
+)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
-  add_custom_target(gpsbabel.pdf
-                    ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_pdf.sh
-                    DEPENDS gpsbabel)
-endif()
+add_custom_target(gpsbabel.html
+  ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_html.sh
+  DEPENDS xmldoc
+)
+
+add_custom_target(gpsbabel.pdf
+  ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_pdf.sh
+  DEPENDS xmldoc
+)

--- a/tools/make_gpsbabel_html.sh
+++ b/tools/make_gpsbabel_html.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -ex
 
-perl xmldoc/makedoc
 xsltproc \
   --output gpsbabel.html \
   --stringparam toc.section.depth "1" \

--- a/tools/make_gpsbabel_org.sh
+++ b/tools/make_gpsbabel_org.sh
@@ -4,15 +4,14 @@ set -ex
 web=$1
 docversion=$2
 
+sourcedir=$(dirname "$(dirname "$0")")
+
 mkdir -p "${web}/htmldoc-${docversion}"
-perl xmldoc/makedoc
-xmlwf xmldoc/readme.xml #check for well-formedness
-xmllint --noout --valid xmldoc/readme.xml #validate
 xsltproc \
   --stringparam base.dir "${web}/htmldoc-${docversion}/" \
   --stringparam root.filename "index" \
-  xmldoc/babelmain.xsl \
+  "$sourcedir/xmldoc/babelmain.xsl" \
   xmldoc/readme.xml
-tools/fixdoc "${web}/htmldoc-${docversion}" "GPSBabel ${docversion}:"
-tools/mkcapabilities "${web}" "${web}/htmldoc-${docversion}"
+"$sourcedir/tools/fixdoc" "${web}/htmldoc-${docversion}" "GPSBabel ${docversion}:"
+"$sourcedir/tools/mkcapabilities" "${web}" "${web}/htmldoc-${docversion}"
 cp gpsbabel.pdf "${web}/htmldoc-${docversion}/gpsbabel-${docversion}.pdf"

--- a/tools/make_gpsbabel_pdf.sh
+++ b/tools/make_gpsbabel_pdf.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -ex
 
-perl xmldoc/makedoc
-xmlwf xmldoc/readme.xml #check for well-formedness
-xmllint --noout --valid xmldoc/readme.xml #validate
-xsltproc -o gpsbabel.fo xmldoc/babelpdf.xsl xmldoc/readme.xml
+sourcedir=$(dirname "$(dirname "$0")")
+
+xsltproc -o gpsbabel.fo "$sourcedir/xmldoc/babelpdf.xsl" xmldoc/readme.xml
 HOME=. fop -q -fo gpsbabel.fo -pdf gpsbabel.pdf

--- a/xmldoc/makedoc
+++ b/xmldoc/makedoc
@@ -1,8 +1,6 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
-#
-# makedoc.in is used to generate makedoc.   Editing makedoc is a bad idea.
-#
+use Cwd qw(getcwd);
 
 @options;
 
@@ -69,7 +67,7 @@ sub include {
    $d2 = $dir2;
    $d2 =~ s:/.*::;
    $name2 = $d2.'_'.$name2;
-   print PARTS qq(<!ENTITY inc_$name2 SYSTEM "../$dir2/$name.xml">\n);
+   print PARTS qq(<!ENTITY inc_$name2 SYSTEM "$dir2/$name.xml">\n);
    print FILE "\&inc_$name2;\n";
    if (! -e "$dir/$dir2/$name.xml") {
      open TMP, ">$dir/$dir2/$name.xml";
@@ -92,13 +90,15 @@ sub includef {
 $dir = $0;
 $dir =~ s:/.*$::;
 
-@agdir=`mkdir -p $dir/autogen`;
-open PARTS, ">$dir/autogen/_parts.xml";
+# CMake sets the working directory to the build directory.
+$agdir = getcwd;
+$agdir = "$agdir/xmldoc";
+open PARTS, ">$agdir/_parts.xml";
 print PARTS qq(<!-- This document is automatically generated. -->\n);
 print PARTS qq(<!ENTITY formats SYSTEM "_formats.xml">\n);
 print PARTS qq(<!ENTITY filters SYSTEM "_filters.xml">\n);
 
-open FORMATS, ">$dir/autogen/_formats.xml";
+open FORMATS, ">$agdir/_formats.xml";
 print FORMATS qq(<!-- This document is automatically generated. -->\n);
 
 @formats = `./gpsbabel -^3`;
@@ -165,7 +165,7 @@ for (@formats) {
        $fmts{$id} = 1;
      }
      includef( 'fmt_'.$id );
-     open FILE, ">$dir/autogen/fmt_$id.xml";
+     open FILE, ">$agdir/fmt_$id.xml";
      print FILE <<END;
 <!-- This document is automatically generated. -->
 <section id="fmt_$id">
@@ -211,7 +211,7 @@ if ($going) {
 }
 
 
-open FORMATS, ">$dir/autogen/_filters.xml";
+open FORMATS, ">$agdir/_filters.xml";
 print FORMATS qq(<!-- This document is automatically generated. -->\n);
 
 @filters = `./gpsbabel -%1`;
@@ -244,7 +244,7 @@ END
        close FILE;
      }
      includef( 'filter_'.$line[0] );
-     open FILE, ">$dir/autogen/filter_$line[0].xml";
+     open FILE, ">$agdir/filter_$line[0].xml";
      print FILE <<END;
 <!-- This document is automatically generated. -->
 <section id="filter_$line[0]">

--- a/xmldoc/readme.xml
+++ b/xmldoc/readme.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"
 [
-  <!ENTITY % parts SYSTEM "autogen/_parts.xml">
+  <!ENTITY % parts SYSTEM "_parts.xml">
   %parts;
   <!ENTITY % chaps SYSTEM "chapters/_chapters.xml">
   %chaps;


### PR DESCRIPTION
Also factor out generating xmldoc fragments into a separate CMake target. We need to symlink the source files into the build directory for the build to find them and having a single place to do that is cleaner.