### PR TITLE
use cmake for ubuntu CI, CMakeFileLists tweaks.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,13 +10,37 @@ on:
     - cron: '27 4 * * 2'
 
 jobs:
-  basic:
-    name: basic Build
+  ubuntu:
+    name: ubuntu Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - IMAGE: 'focal'
+            SCRIPT: './tools/build_and_test.sh'
+          - IMAGE: 'focal'
+            SCRIPT: './tools/build_and_test_cmake.sh'
+          - IMAGE: 'jammy'
+            CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt5'
+            SCRIPT: './tools/build_and_test_cmake.sh'
+          - IMAGE: 'jammy'
+            CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt6'
+            SCRIPT: './tools/build_and_test_cmake.sh'
+          - IMAGE: 'jammy'
+            CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt6'
+            SCRIPT: './tools/build_and_test_cmake.sh'
+            TOOLS: 'clang'
+          - IMAGE: 'jammy'
+            CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt5'
+            SCRIPT: './tools/build_extra_tests.sh'
     container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_jammy
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_${{ matrix.IMAGE }}
       env:
         LC_ALL: 'C.UTF-8'
+        JOB_CMAKE_PREFIX_PATH: ${{ matrix.CMAKE_PREFIX_PATH }}
+        JOB_TOOLS: ${{ matrix.TOOLS }}
+        JOB_SCRIPT: ${{ matrix.SCRIPT }}
 
     steps:
     - name: Checkout repository
@@ -26,82 +50,17 @@ jobs:
       run: |
         # when using containers manually whitelist the checkout directory to allow git commands to work
         git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-        ./tools/build_and_test.sh
-
-  cmake:
-    name: cmake Build
-    runs-on: ubuntu-latest
-    container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_jammy
-      env:
-        LC_ALL: 'C.UTF-8'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: build_and_test
-      run: |
-        # when using containers manually whitelist the checkout directory to allow git commands to work
-        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-        ./tools/build_and_test_cmake.sh
-
-  qtio_gcc:
-    name: qtio gcc Build
-    runs-on: ubuntu-latest
-    container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_qtio
-      env:
-        LC_ALL: 'C.UTF-8'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: build_and_test
-      run: |
-        # when using containers manually whitelist the checkout directory to allow git commands to work
-        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-        . /opt/qtio.env
-        ./tools/build_and_test.sh
-
-  qtio_clang:
-    name: qtio clang Build
-    runs-on: ubuntu-latest
-    container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_qtio
-      env:
-        QMAKESPEC: 'linux-clang'
-        LC_ALL: 'C.UTF-8'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: build_and_test
-      run: |
-        # when using containers manually whitelist the checkout directory to allow git commands to work
-        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-        . /opt/qtio.env
-        ./tools/build_and_test.sh
-
-  advanced:
-    name: advanced Build
-    runs-on: ubuntu-latest
-    container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_jammy
-      env:
-        LC_ALL: 'C.UTF-8'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: build_extra_tests
-      run: |
-        # when using containers manually whitelist the checkout directory to allow git commands to work
-        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-        ./tools/build_extra_tests.sh
+        if [ -n "${JOB_CMAKE_PREFIX_PATH}" ]; then
+          CMAKE_PREFIX_PATH="${JOB_CMAKE_PREFIX_PATH}"
+          export CMAKE_PREFIX_PATH
+        fi
+        if [ "${JOB_TOOLS}" = "clang" ]; then
+          CC=clang
+          export CC
+          CXX=clang++
+          export CXX
+        fi
+        "${JOB_SCRIPT}"
 
   coverage:
     name: coverage Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,8 @@ if(UNIX AND NOT APPLE)
                     -l -j ${CMAKE_BINARY_DIR}/testo.d/TESTNAME.vglog -p $<TARGET_FILE:gpsbabel> TESTNAME
                     DEPENDS gpsbabel
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                    VERBATIM)
+                    VERBATIM
+                    USES_TERMINAL)
 endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -169,62 +169,61 @@ message(STATUS "Libs are: \"${LnkLibs}\"")
 get_target_property(IncDirs gpsbabelfe INCLUDE_DIRECTORIES)
 message(STATUS "Include Directores are: \"${IncDirs}\"")
 
+find_package(Qt${QT_VERSION_MAJOR} QUIET COMPONENTS LinguistTools)
+if (NOT Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
+  message(WARNING "Qt${QT_VERSION_MAJOR}LinguistTools not found, gpsbabelfe translations cannot be updated or released, and application cannot be packaged.")
+else()
 # FIXME: remove reliance an app.pro in package_app script.
 # FIXME: translations updated and released in source directory (and under version control).
-list(APPEND TRANSLATIONS gpsbabelfe_de.ts)
-list(APPEND TRANSLATIONS gpsbabelfe_es.ts)
-list(APPEND TRANSLATIONS gpsbabelfe_fr.ts)
-list(APPEND TRANSLATIONS gpsbabelfe_hu.ts)
-list(APPEND TRANSLATIONS gpsbabelfe_it.ts)
-list(APPEND TRANSLATIONS gpsbabelfe_ru.ts)
+  list(APPEND TRANSLATIONS gpsbabelfe_de.ts)
+  list(APPEND TRANSLATIONS gpsbabelfe_es.ts)
+  list(APPEND TRANSLATIONS gpsbabelfe_fr.ts)
+  list(APPEND TRANSLATIONS gpsbabelfe_hu.ts)
+  list(APPEND TRANSLATIONS gpsbabelfe_it.ts)
+  list(APPEND TRANSLATIONS gpsbabelfe_ru.ts)
 
-if(APPLE)
-  get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
-  add_custom_target(package_app
-                    COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_BUNDLE_DIR:gpsbabelfe> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
-                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_BUNDLE_DIR:gpsbabelfe>/../GPSBabelFE.dmg ${CMAKE_CURRENT_BINARY_DIR}
-                    DEPENDS gpsbabelfe gpsbabel coretool_lrelease
+  add_custom_target(gpsbabelfe_lupdate
+                    COMMAND Qt${QT_VERSION_MAJOR}::lupdate ${SOURCES} ${FORMS} -ts ${TRANSLATIONS}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     VERBATIM
                     USES_TERMINAL)
-elseif(UNIX)
-  get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
-  add_custom_target(package_app
-                    COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_FILE_DIR:gpsbabelfe> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
-                    DEPENDS gpsbabelfe gpsbabel coretool_lrelease
+  add_custom_target(gpsbabelfe_lrelease
+                    COMMAND Qt${QT_VERSION_MAJOR}::lrelease ${TRANSLATIONS}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    DEPENDS gpsbabelfe_lupdate
                     VERBATIM
                     USES_TERMINAL)
-elseif(WIN32)
-  find_package(Qt${QT_VERSION_MAJOR} QUIET COMPONENTS LinguistTools)
-  if (NOT Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
-    message(WARNING "Qt${QT_VERSION_MAJOR}LinguistTools not found, gpsbabelfe translations cannot be updated or released, and application cannot be packaged.")
-  endif()
 
-  find_program(INNO_COMPILER NAMES iscc ISCC
-               PATHS "C:/Program Files (x86)/Inno Setup 6" "C:/Program Files/Inno Setup 6")
-  if (INNO_COMPILER STREQUAL "INNO_COMPILER-NOTFOUND")
-    message(WARNING "Inno compiler iscc not found, application cannot be packaged.")
-  endif()
-
-  # in 5.12.12 cmake doesn't know about windeployqt, look in directory that has qmake.
-  get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
-  get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
-  find_program(WINDEPLOYQT NAMES windeployqt PATHS "${_qt_bin_dir}" NO_DEFAULT_PATH)
-  if (WINDEPLOYQT STREQUAL "WINDEPLOYQT-NOTFOUND")
-    message(WARNING "windeployqt not found, application cannot be packaged.")
-  endif()
-
-  if(Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
-    add_custom_target(gpsbabelfe_lupdate
-                      COMMAND Qt${QT_VERSION_MAJOR}::lupdate ${SOURCES} ${FORMS} -ts ${TRANSLATIONS}
-                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  if(APPLE)
+    get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+    add_custom_target(package_app
+                      COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_BUNDLE_DIR:gpsbabelfe> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
+                      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_BUNDLE_DIR:gpsbabelfe>/../GPSBabelFE.dmg ${CMAKE_CURRENT_BINARY_DIR}
+                      DEPENDS gpsbabelfe gpsbabel coretool_lrelease
                       VERBATIM
                       USES_TERMINAL)
-    add_custom_target(gpsbabelfe_lrelease
-                      COMMAND Qt${QT_VERSION_MAJOR}::lrelease ${TRANSLATIONS}
-                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                      DEPENDS gpsbabelfe_lupdate
+  elseif(UNIX)
+    get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+    add_custom_target(package_app
+                      COMMAND QMAKE=${_qmake_executable} ${CMAKE_CURRENT_SOURCE_DIR}/package_app $<TARGET_FILE_DIR:gpsbabelfe> $<TARGET_FILE:gpsbabel> ${CMAKE_CURRENT_SOURCE_DIR}
+                      DEPENDS gpsbabelfe gpsbabel coretool_lrelease
                       VERBATIM
                       USES_TERMINAL)
+  elseif(WIN32)
+    find_program(INNO_COMPILER NAMES iscc ISCC
+                 PATHS "C:/Program Files (x86)/Inno Setup 6" "C:/Program Files/Inno Setup 6")
+    if (INNO_COMPILER STREQUAL "INNO_COMPILER-NOTFOUND")
+      message(WARNING "Inno compiler iscc not found, application cannot be packaged.")
+    endif()
+
+    # in 5.12.12 cmake doesn't know about windeployqt, look in directory that has qmake.
+    get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+    get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
+    find_program(WINDEPLOYQT NAMES windeployqt PATHS "${_qt_bin_dir}" NO_DEFAULT_PATH)
+    if (WINDEPLOYQT STREQUAL "WINDEPLOYQT-NOTFOUND")
+      message(WARNING "windeployqt not found, application cannot be packaged.")
+    endif()
+
     if((NOT WINDEPLOYQT STREQUAL "WINDEPLOYQT-NOTFOUND") AND (NOT INNO_COMPILER STREQUAL "INNO_COMPILER-NOTFOUND"))
       file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" _win_binary_path)
       file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" _win_source_path)

--- a/tools/Dockerfile_focal
+++ b/tools/Dockerfile_focal
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pkgs with qt used by gpsbabel
 RUN apt-get update && apt-get install -y --no-install-recommends \
     qt5-default \
+    qttools5-dev \
     qttools5-dev-tools \
     qttranslations5-l10n \
     qtwebengine5-dev \

--- a/tools/Dockerfile_jammy
+++ b/tools/Dockerfile_jammy
@@ -7,9 +7,15 @@ LABEL maintainer="https://github.com/tsteven4"
 WORKDIR /app
 
 # update environment.
+# software-properties-common, gpg-agent, ppa:tsteven4/qt6-backports
+# are needed because of a build error in qt6-base 6.2.4+dfsg-2ubuntu1
+# https://bugs.launchpad.net/ubuntu/+source/qt6-base/+bug/1970057
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
+    software-properties-common \
+    gpg-agent \
+ && add-apt-repository ppa:tsteven4/qt6-backports \
  && apt-get upgrade -y \
  && rm -rf /var/lib/apt/lists/*
 
@@ -54,10 +60,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pkgs with qt used by gpsbabel
 RUN apt-get update && apt-get install -y --no-install-recommends \
     qtbase5-dev \
+    qttools5-dev \
     qttools5-dev-tools \
     qttranslations5-l10n \
     qtwebengine5-dev \
     libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt6-base-dev \
+    libqt6core5compat6-dev \
+    libqt6opengl6-dev \
+    libqt6serialport6-dev \
+    libqt6webenginecore6-bin \
+    libgl-dev \
+    libopengl-dev \
+    libvulkan-dev \
+    libx11-xcb-dev \
+    libxkbcommon-dev \
+    qt6-l10n-tools \
+    qt6-tools-dev \
+    qt6-tools-dev-tools \
+    qt6-translations-l10n \
+    qt6-webengine-dev \
+    qt6-webengine-dev-tools \
+    qt6-wayland \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs needed to generate coverage report:


### PR DESCRIPTION
- refactor ubuntu workflow using a matrix.
- create gpsbabelfe_lupdate, gpsbabelfe_lrelease targest on all platorms. 
- add USES_TERMINAL to check-vtesto so we can see test progress live. 
- update docker images for focal and jammy for Qt5 cmake issues. 
- update docker image for jammy adding Qt6.  This uses a PPA to work around https://bugs.launchpad.net/ubuntu/+source/qt6-base/+bug/1970057. Note the PPA isn't actually required to build, but it is required to run the GUI, i.e. all users on jammy using Qt6 who want to run the GUI will need the PPA, or need ubuntu to incorporate the upstream debian fix!