### PR TITLE
update makedoc perl code

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   macos:
     name: macOS Build
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:

--- a/xmldoc/makedoc
+++ b/xmldoc/makedoc
@@ -7,92 +7,92 @@
 @options;
 
 sub expandrw {
-   my $read = shift;
-   my $write = shift;
-   my $type = shift;
+    my $read  = shift;
+    my $write = shift;
+    my $type  = shift;
 
-   my $res = "";
-   if ( ($read eq 'r') || ($write eq 'w')) {
-     $res .= "      <listitem>\n        <para role=\"fmtcapsitem\">\n          ";
-     if ( ($read eq 'r') && ($write eq 'w')) {
-       $res .= "read and write $type";
-     }
-     elsif ( $read eq 'r' ) {
-       $res .= "read $type";
-     }
-     elsif ( $write eq 'w' ) {
-       $res .= "write $type";
-     }
-     $res .= "\n        </para>\n      </listitem>\n";
-   }
-   $res;
+    my $res = "";
+    if ( ( $read eq 'r' ) || ( $write eq 'w' ) ) {
+        $res .=
+          "      <listitem>\n        <para role=\"fmtcapsitem\">\n          ";
+        if ( ( $read eq 'r' ) && ( $write eq 'w' ) ) {
+            $res .= "read and write $type";
+        }
+        elsif ( $read eq 'r' ) {
+            $res .= "read $type";
+        }
+        elsif ( $write eq 'w' ) {
+            $res .= "write $type";
+        }
+        $res .= "\n        </para>\n      </listitem>\n";
+    }
+    $res;
 }
 
 sub expandoptions {
-   my $opts = shift;
-   my $res = "  <para role=\"fmtcapshdr\">\n    This format can...\n    <itemizedlist>\n";
+    my $opts = shift;
+    my $res =
+"  <para role=\"fmtcapshdr\">\n    This format can...\n    <itemizedlist>\n";
 
-   $res .= expandrw( substr($opts,0,1), substr($opts,1,1), 'waypoints' );
-   $res .= expandrw( substr($opts,2,1), substr($opts,3,1), 'tracks' );
-   $res .= expandrw( substr($opts,4,1), substr($opts,5,1), 'routes' );
+    $res .=
+      expandrw( substr( $opts, 0, 1 ), substr( $opts, 1, 1 ), 'waypoints' );
+    $res .= expandrw( substr( $opts, 2, 1 ), substr( $opts, 3, 1 ), 'tracks' );
+    $res .= expandrw( substr( $opts, 4, 1 ), substr( $opts, 5, 1 ), 'routes' );
 
-   $res .= "    </itemizedlist></para>\n";
+    $res .= "    </itemizedlist></para>\n";
 
-   $res;
+    $res;
 }
 
 sub expandsuboptions {
-  my $f = shift;
-  my $res;
-  $olist = $options{$f};
+    my $f = shift;
+    my $res;
+    $olist = $options{$f};
 
-  # If no options, don't clutter things.
-  if ($olist eq "") { return; }
+    # If no options, don't clutter things.
+    if ( $olist eq "" ) { return; }
 
-  # Comma separate the human-readable variation.
-  $olist =~ s/> </>, </g;
+    # Comma separate the human-readable variation.
+    $olist =~ s/> </>, </g;
 
-  $res .= "<para>This format has the following options: ";
-  $res .= $olist;
-  $res .= ".</para>";
+    $res .= "<para>This format has the following options: ";
+    $res .= $olist;
+    $res .= ".</para>";
 
-  $res;
+    $res;
 }
 
-
 sub include {
-   my $name=shift;
-   my $dir2=shift;
+    my $name = shift;
+    my $dir2 = shift;
 
-   $name2 = $name;
-   $name2 =~ s/-/_/g;
-   $d2 = $dir2;
-   $d2 =~ s:/.*::;
-   $name2 = $d2.'_'.$name2;
-   print PARTS qq(<!ENTITY inc_$name2 SYSTEM "../$dir2/$name.xml">\n);
-   print FILE "\&inc_$name2;\n";
-   if (! -e "$dir/$dir2/$name.xml") {
-     open TMP, ">$dir/$dir2/$name.xml";
-     print TMP "\n";
-     close TMP;
-   }
+    $name2 = $name;
+    $name2 =~ s/-/_/g;
+    $d2 = $dir2;
+    $d2 =~ s:/.*::;
+    $name2 = $d2 . '_' . $name2;
+    print PARTS qq(<!ENTITY inc_$name2 SYSTEM "../$dir2/$name.xml">\n);
+    print FILE "\&inc_$name2;\n";
+    if ( !-e "$dir/$dir2/$name.xml" ) {
+        open TMP, ">$dir/$dir2/$name.xml";
+        print TMP "\n";
+        close TMP;
+    }
 }
 
 sub includef {
-   my $name=shift;
+    my $name = shift;
 
-   $name2 = $name;
-   $name2 =~ s/-/_/g;
-   print PARTS qq(<!ENTITY inc_$name2 SYSTEM "$name.xml">\n);
-   print FORMATS "\&inc_$name2;\n";
+    $name2 = $name;
+    $name2 =~ s/-/_/g;
+    print PARTS qq(<!ENTITY inc_$name2 SYSTEM "$name.xml">\n);
+    print FORMATS "\&inc_$name2;\n";
 }
-
-
 
 $dir = $0;
 $dir =~ s:/.*$::;
 
-@agdir=`mkdir -p $dir/autogen`;
+@agdir = `mkdir -p $dir/autogen`;
 open PARTS, ">$dir/autogen/_parts.xml";
 print PARTS qq(<!-- This document is automatically generated. -->\n);
 print PARTS qq(<!ENTITY formats SYSTEM "_formats.xml">\n);
@@ -103,113 +103,114 @@ print FORMATS qq(<!-- This document is automatically generated. -->\n);
 
 @formats = `./gpsbabel -^3`;
 
-$going = 0;
+$going     = 0;
 $dooptions = 0;
 
 # Prescan the argument list for options.
 
 for (@formats) {
-   chomp;
-   s/\&/\&amp;/g;
-   s/</\&lt;/g;
-   s/>/\&gt;/g;
-   @line = split "\t";
+    chomp;
+    s/\&/\&amp;/g;
+    s/</\&lt;/g;
+    s/>/\&gt;/g;
+    @line = split "\t";
 
-   if (($line[0] eq 'file') || ($line[0] eq 'serial')) {
-	$fmt = $line[2];
-	# Pennance for earlier sins.  Rename magellan -> magellan1 here.
-	if ($line[4] eq "Magellan serial protocol") {
-	 $fmt = "magellan1";
-	}
-	$skipping = 0;
-   }
-   if ( $line[0] eq 'internal' || $line[5] eq 'xcsv') {
-	$skipping = 1;
-   }
-   if ($line[0] eq 'option' && $skipping == 0) {
-     $optname = $line[2];
+    if ( ( $line[0] eq 'file' ) || ( $line[0] eq 'serial' ) ) {
+        $fmt = $line[2];
 
-     $options{$fmt} .= "<link linkend=\"fmt_${fmt}_o_${optname}\">$optname</link> ";
-   }
+        # Pennance for earlier sins.  Rename magellan -> magellan1 here.
+        if ( $line[4] eq "Magellan serial protocol" ) {
+            $fmt = "magellan1";
+        }
+        $skipping = 0;
+    }
+    if ( $line[0] eq 'internal' || $line[5] eq 'xcsv' ) {
+        $skipping = 1;
+    }
+    if ( $line[0] eq 'option' && $skipping == 0 ) {
+        $optname = $line[2];
+
+        $options{$fmt} .=
+          "<link linkend=\"fmt_${fmt}_o_${optname}\">$optname</link> ";
+    }
 }
 
-
 for (@formats) {
-   chomp;
-   s/\&/\&amp;/g;
-   s/</\&lt;/g;
-   s/>/\&gt;/g;
-   @line = split "\t";
+    chomp;
+    s/\&/\&amp;/g;
+    s/</\&lt;/g;
+    s/>/\&gt;/g;
+    @line = split "\t";
 
-   if ( $line[0] eq 'internal') {
-     if ($going) {
-       print FILE "</section>\n";
-       close FILE;
-       $going = 0;
-     }
-     if ( $line[5] eq 'xcsv' ) {
-       $line[0] = 'file';
-     }
-   }
+    if ( $line[0] eq 'internal' ) {
+        if ($going) {
+            print FILE "</section>\n";
+            close FILE;
+            $going = 0;
+        }
+        if ( $line[5] eq 'xcsv' ) {
+            $line[0] = 'file';
+        }
+    }
 
-   if (($line[0] eq 'file') || ($line[0] eq 'serial')) {
-     if ($going) {
-       print FILE "</section>\n";
-       close FILE;
-     }
-     $id = $line[2];
-     if ( $fmts{$id} ) {
-       $id .= $fmts{$id}++;
-     }
-     else {
-       $fmts{$id} = 1;
-     }
-     includef( 'fmt_'.$id );
-     open FILE, ">$dir/autogen/fmt_$id.xml";
-     print FILE <<END;
+    if ( ( $line[0] eq 'file' ) || ( $line[0] eq 'serial' ) ) {
+        if ($going) {
+            print FILE "</section>\n";
+            close FILE;
+        }
+        $id = $line[2];
+        if ( $fmts{$id} ) {
+            $id .= $fmts{$id}++;
+        }
+        else {
+            $fmts{$id} = 1;
+        }
+        includef( 'fmt_' . $id );
+        open FILE, ">$dir/autogen/fmt_$id.xml";
+        print FILE <<END;
 <!-- This document is automatically generated. -->
 <section id="fmt_$id">
   <title>$line[4] ($line[2])</title>
 END
-     print FILE expandoptions($line[1]);
-     print FILE expandsuboptions($id);
-     $going = 1;
-     $dooptions = 1;
-     if ( defined($line[5]) && ($line[5] ne $line[2]) ) {
-       print FILE <<END;
+        print FILE expandoptions( $line[1] );
+        print FILE expandsuboptions($id);
+        $going     = 1;
+        $dooptions = 1;
+
+        if ( defined( $line[5] ) && ( $line[5] ne $line[2] ) ) {
+            print FILE <<END;
 <para>
 This format is derived from the <link linkend="fmt_$line[5]">$line[5]</link>
 format, so it has all of the same options as that format.
 </para>
 END
-       if ($line[5] eq 'xcsv' ) {
-         $dooptions=0;
-       }
-     }
-     include($id,"formats");
-   }
-   elsif ($going && $dooptions && ($line[0] eq 'option')) {
-     $nid = 'fmt_'.$id.'_o_'.$line[2];
-     print FILE <<END;
+            if ( $line[5] eq 'xcsv' ) {
+                $dooptions = 0;
+            }
+        }
+        include( $id, "formats" );
+    }
+    elsif ( $going && $dooptions && ( $line[0] eq 'option' ) ) {
+        $nid = 'fmt_' . $id . '_o_' . $line[2];
+        print FILE <<END;
   <section id="$nid">
     <title><option>$line[2]</option> option</title>
     <para>
       $line[3].
     </para>
 END
-     include($id.'-'.$line[2],"formats/options");
-     print FILE <<END;
+        include( $id . '-' . $line[2], "formats/options" );
+        print FILE <<END;
   </section>
 END
-   }
+    }
 }
 
 if ($going) {
-  print FILE "</section>\n";
-  close FILE;
-  $going = 0;
+    print FILE "</section>\n";
+    close FILE;
+    $going = 0;
 }
-
 
 open FORMATS, ">$dir/autogen/_filters.xml";
 print FORMATS qq(<!-- This document is automatically generated. -->\n);
@@ -219,47 +220,46 @@ print FORMATS qq(<!-- This document is automatically generated. -->\n);
 $going = 0;
 
 for (@filters) {
-   chomp;
-   s/\&/\&amp;/g;
-   s/</\&lt;/g;
-   s/>/\&gt;/g;
-   @line = split "\t";
+    chomp;
+    s/\&/\&amp;/g;
+    s/</\&lt;/g;
+    s/>/\&gt;/g;
+    @line = split "\t";
 
-   if ($going && ($line[0] eq 'option')) {
-     print FILE <<END;
+    if ( $going && ( $line[0] eq 'option' ) ) {
+        print FILE <<END;
   <section id="fmt_$line[1]_o_$line[2]">
     <title>$line[2] option</title>
     <para>
       $line[3].
     </para>
 END
-     include($line[1].'-'.$line[2],"filters/options");
-     print FILE <<END;
+        include( $line[1] . '-' . $line[2], "filters/options" );
+        print FILE <<END;
   </section>
 END
-   }
-   else {
-     if ($going) {
-       print FILE "</section>\n";
-       close FILE;
-     }
-     includef( 'filter_'.$line[0] );
-     open FILE, ">$dir/autogen/filter_$line[0].xml";
-     print FILE <<END;
+    }
+    else {
+        if ($going) {
+            print FILE "</section>\n";
+            close FILE;
+        }
+        includef( 'filter_' . $line[0] );
+        open FILE, ">$dir/autogen/filter_$line[0].xml";
+        print FILE <<END;
 <!-- This document is automatically generated. -->
 <section id="filter_$line[0]">
   <title>$line[1] ($line[0])</title>
 END
-     include($line[0],"filters");
-     $going = $line[0];
-   }
+        include( $line[0], "filters" );
+        $going = $line[0];
+    }
 }
 
-
 if ($going) {
-  print FILE "</section>\n";
-  close FILE;
-  $going = 0;
+    print FILE "</section>\n";
+    close FILE;
+    $going = 0;
 }
 close FORMATS;
 close PARTS;

--- a/xmldoc/makedoc
+++ b/xmldoc/makedoc
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 
+use strict;
 use warnings;
 
 use File::Basename;
@@ -9,6 +10,7 @@ use File::Basename;
 #
 
 my %options;
+my $dir;
 
 sub expandrw {
     my $read  = shift;
@@ -51,7 +53,7 @@ sub expandoptions {
 sub expandsuboptions {
     my $f = shift;
     my $res;
-    $olist = $options{$f};
+    my $olist = $options{$f};
 
     # If no options, don't clutter things.
     if ( not defined($olist) ) { return; }
@@ -70,15 +72,15 @@ sub include {
     my $name = shift;
     my $dir2 = shift;
 
-    $name2 = $name;
+    my $name2 = $name;
     $name2 =~ s/-/_/g;
-    $d2 = $dir2;
+    my $d2 = $dir2;
     $d2 =~ s:/.*::;
     $name2 = $d2 . '_' . $name2;
     print PARTS qq(<!ENTITY inc_$name2 SYSTEM "../$dir2/$name.xml">\n);
     print FILE "\&inc_$name2;\n";
     if ( !-e "$dir/$dir2/$name.xml" ) {
-        open $tmp, '>', "$dir/$dir2/$name.xml" or die $!;
+        open my $tmp, '>', "$dir/$dir2/$name.xml" or die $!;
         print $tmp "\n";
         close $tmp;
     }
@@ -87,7 +89,7 @@ sub include {
 sub includef {
     my $name = shift;
 
-    $name2 = $name;
+    my $name2 = $name;
     $name2 =~ s/-/_/g;
     print PARTS qq(<!ENTITY inc_$name2 SYSTEM "$name.xml">\n);
     print FORMATS "\&inc_$name2;\n";
@@ -107,22 +109,25 @@ print PARTS qq(<!ENTITY filters SYSTEM "_filters.xml">\n);
 open FORMATS, ">$dir/autogen/_formats.xml";
 print FORMATS qq(<!-- This document is automatically generated. -->\n);
 
-@formats = qx(./gpsbabel -^3);
+my @formats = qx(./gpsbabel -^3);
 if ( $? != 0 ) {
     die "error running gpsbabel: $?";
 }
 
-$going     = 0;
-$dooptions = 0;
+my $going     = 0;
+my $dooptions = 0;
 
 # Prescan the argument list for options.
+
+my $fmt;
+my $skipping;
 
 for (@formats) {
     chomp;
     s/\&/\&amp;/g;
     s/</\&lt;/g;
     s/>/\&gt;/g;
-    @line = split "\t";
+    my @line = split "\t";
     next if ( scalar(@line) < 1 );
 
     if ( ( $line[0] eq 'file' ) || ( $line[0] eq 'serial' ) ) {
@@ -140,19 +145,22 @@ for (@formats) {
         $skipping = 1;
     }
     if ( $line[0] eq 'option' && $skipping == 0 ) {
-        $optname = $line[2];
+        my $optname = $line[2];
 
         $options{$fmt} .=
           "<link linkend=\"fmt_${fmt}_o_${optname}\">$optname</link> ";
     }
 }
 
+my $id;
+my %fmts;
+
 for (@formats) {
     chomp;
     s/\&/\&amp;/g;
     s/</\&lt;/g;
     s/>/\&gt;/g;
-    @line = split "\t";
+    my @line = split "\t";
     next if ( scalar(@line) < 1 );
 
     if ( $line[0] eq 'internal' ) {
@@ -204,7 +212,7 @@ END
         include( $id, "formats" );
     }
     elsif ( $going && $dooptions && ( $line[0] eq 'option' ) ) {
-        $nid = 'fmt_' . $id . '_o_' . $line[2];
+        my $nid = 'fmt_' . $id . '_o_' . $line[2];
         print FILE <<END;
   <section id="$nid">
     <title><option>$line[2]</option> option</title>
@@ -228,7 +236,7 @@ if ($going) {
 open FORMATS, ">$dir/autogen/_filters.xml";
 print FORMATS qq(<!-- This document is automatically generated. -->\n);
 
-@filters = qx(./gpsbabel -%1);
+my @filters = qx(./gpsbabel -%1);
 if ( $? != 0 ) {
     die "error running gpsbabel: $?";
 }
@@ -240,7 +248,7 @@ for (@filters) {
     s/\&/\&amp;/g;
     s/</\&lt;/g;
     s/>/\&gt;/g;
-    @line = split "\t";
+    my @line = split "\t";
 
     if ( $going && ( $line[0] eq 'option' ) ) {
         print FILE <<END;

--- a/xmldoc/makedoc
+++ b/xmldoc/makedoc
@@ -1,10 +1,14 @@
 #!/usr/bin/perl
 
+use warnings;
+
+use File::Basename;
+
 #
 # makedoc.in is used to generate makedoc.   Editing makedoc is a bad idea.
 #
 
-@options;
+my %options;
 
 sub expandrw {
     my $read  = shift;
@@ -50,7 +54,7 @@ sub expandsuboptions {
     $olist = $options{$f};
 
     # If no options, don't clutter things.
-    if ( $olist eq "" ) { return; }
+    if ( not defined($olist) ) { return; }
 
     # Comma separate the human-readable variation.
     $olist =~ s/> </>, </g;
@@ -74,9 +78,9 @@ sub include {
     print PARTS qq(<!ENTITY inc_$name2 SYSTEM "../$dir2/$name.xml">\n);
     print FILE "\&inc_$name2;\n";
     if ( !-e "$dir/$dir2/$name.xml" ) {
-        open TMP, ">$dir/$dir2/$name.xml";
-        print TMP "\n";
-        close TMP;
+        open $tmp, '>', "$dir/$dir2/$name.xml" or die $!;
+        print $tmp "\n";
+        close $tmp;
     }
 }
 
@@ -89,10 +93,12 @@ sub includef {
     print FORMATS "\&inc_$name2;\n";
 }
 
-$dir = $0;
-$dir =~ s:/.*$::;
+$dir = dirname($0);
 
-@agdir = `mkdir -p $dir/autogen`;
+qx(mkdir -p $dir/autogen);
+if ( $? != 0 ) {
+    die "error creating autogen directory: $?";
+}
 open PARTS, ">$dir/autogen/_parts.xml";
 print PARTS qq(<!-- This document is automatically generated. -->\n);
 print PARTS qq(<!ENTITY formats SYSTEM "_formats.xml">\n);
@@ -101,7 +107,10 @@ print PARTS qq(<!ENTITY filters SYSTEM "_filters.xml">\n);
 open FORMATS, ">$dir/autogen/_formats.xml";
 print FORMATS qq(<!-- This document is automatically generated. -->\n);
 
-@formats = `./gpsbabel -^3`;
+@formats = qx(./gpsbabel -^3);
+if ( $? != 0 ) {
+    die "error running gpsbabel: $?";
+}
 
 $going     = 0;
 $dooptions = 0;
@@ -114,6 +123,7 @@ for (@formats) {
     s/</\&lt;/g;
     s/>/\&gt;/g;
     @line = split "\t";
+    next if ( scalar(@line) < 1 );
 
     if ( ( $line[0] eq 'file' ) || ( $line[0] eq 'serial' ) ) {
         $fmt = $line[2];
@@ -124,7 +134,9 @@ for (@formats) {
         }
         $skipping = 0;
     }
-    if ( $line[0] eq 'internal' || $line[5] eq 'xcsv' ) {
+    if (   ( $line[0] eq 'internal' )
+        || ( defined( $line[5] ) && ( $line[5] eq 'xcsv' ) ) )
+    {
         $skipping = 1;
     }
     if ( $line[0] eq 'option' && $skipping == 0 ) {
@@ -141,6 +153,7 @@ for (@formats) {
     s/</\&lt;/g;
     s/>/\&gt;/g;
     @line = split "\t";
+    next if ( scalar(@line) < 1 );
 
     if ( $line[0] eq 'internal' ) {
         if ($going) {
@@ -215,7 +228,10 @@ if ($going) {
 open FORMATS, ">$dir/autogen/_filters.xml";
 print FORMATS qq(<!-- This document is automatically generated. -->\n);
 
-@filters = `./gpsbabel -%1`;
+@filters = qx(./gpsbabel -%1);
+if ( $? != 0 ) {
+    die "error running gpsbabel: $?";
+}
 
 $going = 0;
 

--- a/xmldoc/makedoc
+++ b/xmldoc/makedoc
@@ -5,12 +5,11 @@ use warnings;
 
 use File::Basename;
 
-#
-# makedoc.in is used to generate makedoc.   Editing makedoc is a bad idea.
-#
-
 my %options;
 my $dir;
+my $parts;
+my $formats;
+my $file;
 
 sub expandrw {
     my $read  = shift;
@@ -77,8 +76,8 @@ sub include {
     my $d2 = $dir2;
     $d2 =~ s:/.*::;
     $name2 = $d2 . '_' . $name2;
-    print PARTS qq(<!ENTITY inc_$name2 SYSTEM "../$dir2/$name.xml">\n);
-    print FILE "\&inc_$name2;\n";
+    print $parts qq(<!ENTITY inc_$name2 SYSTEM "../$dir2/$name.xml">\n);
+    print $file "\&inc_$name2;\n";
     if ( !-e "$dir/$dir2/$name.xml" ) {
         open my $tmp, '>', "$dir/$dir2/$name.xml" or die $!;
         print $tmp "\n";
@@ -91,8 +90,8 @@ sub includef {
 
     my $name2 = $name;
     $name2 =~ s/-/_/g;
-    print PARTS qq(<!ENTITY inc_$name2 SYSTEM "$name.xml">\n);
-    print FORMATS "\&inc_$name2;\n";
+    print $parts qq(<!ENTITY inc_$name2 SYSTEM "$name.xml">\n);
+    print $formats "\&inc_$name2;\n";
 }
 
 $dir = dirname($0);
@@ -101,13 +100,13 @@ qx(mkdir -p $dir/autogen);
 if ( $? != 0 ) {
     die "error creating autogen directory: $?";
 }
-open PARTS, ">$dir/autogen/_parts.xml";
-print PARTS qq(<!-- This document is automatically generated. -->\n);
-print PARTS qq(<!ENTITY formats SYSTEM "_formats.xml">\n);
-print PARTS qq(<!ENTITY filters SYSTEM "_filters.xml">\n);
+open $parts, '>', "$dir/autogen/_parts.xml" or die $!;
+print $parts qq(<!-- This document is automatically generated. -->\n);
+print $parts qq(<!ENTITY formats SYSTEM "_formats.xml">\n);
+print $parts qq(<!ENTITY filters SYSTEM "_filters.xml">\n);
 
-open FORMATS, ">$dir/autogen/_formats.xml";
-print FORMATS qq(<!-- This document is automatically generated. -->\n);
+open $formats, '>', "$dir/autogen/_formats.xml" or die $!;
+print $formats qq(<!-- This document is automatically generated. -->\n);
 
 my @formats = qx(./gpsbabel -^3);
 if ( $? != 0 ) {
@@ -165,8 +164,8 @@ for (@formats) {
 
     if ( $line[0] eq 'internal' ) {
         if ($going) {
-            print FILE "</section>\n";
-            close FILE;
+            print $file "</section>\n";
+            close $file;
             $going = 0;
         }
         if ( $line[5] eq 'xcsv' ) {
@@ -176,8 +175,8 @@ for (@formats) {
 
     if ( ( $line[0] eq 'file' ) || ( $line[0] eq 'serial' ) ) {
         if ($going) {
-            print FILE "</section>\n";
-            close FILE;
+            print $file "</section>\n";
+            close $file;
         }
         $id = $line[2];
         if ( $fmts{$id} ) {
@@ -187,19 +186,19 @@ for (@formats) {
             $fmts{$id} = 1;
         }
         includef( 'fmt_' . $id );
-        open FILE, ">$dir/autogen/fmt_$id.xml";
-        print FILE <<END;
+        open $file, '>', "$dir/autogen/fmt_$id.xml" or die $!;
+        print $file <<END;
 <!-- This document is automatically generated. -->
 <section id="fmt_$id">
   <title>$line[4] ($line[2])</title>
 END
-        print FILE expandoptions( $line[1] );
-        print FILE expandsuboptions($id);
+        print $file expandoptions( $line[1] );
+        print $file expandsuboptions($id);
         $going     = 1;
         $dooptions = 1;
 
         if ( defined( $line[5] ) && ( $line[5] ne $line[2] ) ) {
-            print FILE <<END;
+            print $file <<END;
 <para>
 This format is derived from the <link linkend="fmt_$line[5]">$line[5]</link>
 format, so it has all of the same options as that format.
@@ -213,7 +212,7 @@ END
     }
     elsif ( $going && $dooptions && ( $line[0] eq 'option' ) ) {
         my $nid = 'fmt_' . $id . '_o_' . $line[2];
-        print FILE <<END;
+        print $file <<END;
   <section id="$nid">
     <title><option>$line[2]</option> option</title>
     <para>
@@ -221,20 +220,21 @@ END
     </para>
 END
         include( $id . '-' . $line[2], "formats/options" );
-        print FILE <<END;
+        print $file <<END;
   </section>
 END
     }
 }
 
 if ($going) {
-    print FILE "</section>\n";
-    close FILE;
+    print $file "</section>\n";
+    close $file;
     $going = 0;
 }
 
-open FORMATS, ">$dir/autogen/_filters.xml";
-print FORMATS qq(<!-- This document is automatically generated. -->\n);
+close $formats;
+open $formats, '>', "$dir/autogen/_filters.xml" or die $!;
+print $formats qq(<!-- This document is automatically generated. -->\n);
 
 my @filters = qx(./gpsbabel -%1);
 if ( $? != 0 ) {
@@ -251,7 +251,7 @@ for (@filters) {
     my @line = split "\t";
 
     if ( $going && ( $line[0] eq 'option' ) ) {
-        print FILE <<END;
+        print $file <<END;
   <section id="fmt_$line[1]_o_$line[2]">
     <title>$line[2] option</title>
     <para>
@@ -259,18 +259,18 @@ for (@filters) {
     </para>
 END
         include( $line[1] . '-' . $line[2], "filters/options" );
-        print FILE <<END;
+        print $file <<END;
   </section>
 END
     }
     else {
         if ($going) {
-            print FILE "</section>\n";
-            close FILE;
+            print $file "</section>\n";
+            close $file;
         }
         includef( 'filter_' . $line[0] );
-        open FILE, ">$dir/autogen/filter_$line[0].xml";
-        print FILE <<END;
+        open $file, '>', "$dir/autogen/filter_$line[0].xml" or die $!;
+        print $file <<END;
 <!-- This document is automatically generated. -->
 <section id="filter_$line[0]">
   <title>$line[1] ($line[0])</title>
@@ -281,9 +281,9 @@ END
 }
 
 if ($going) {
-    print FILE "</section>\n";
-    close FILE;
+    print $file "</section>\n";
+    close $file;
     $going = 0;
 }
-close FORMATS;
-close PARTS;
+close $formats;
+close $parts;


### PR DESCRIPTION
clean up formatting with perltidy.
cleanup warnings, and use warnings.
cleanup strict issues, and use strict.
cleanup perlcritic issues.

use dirname to get directory of $0.  This allows "./xmldoc/perldoc" to work, not just "perl xmdoc/makedoc".
die on file open errors or errors from backtick commands (mkdir, gpsbabel).

the created autogen directory is identical to that before this PR.