### PR TITLE
fix document generation on fedora

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # version 32, though obsolete, uses Qt 5.14 so we keep it for that.
-        version: ['32', '35']
+        version: ['32', '35', '37']
     container:
       image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_f${{ matrix.version }}
       env:

--- a/tools/Dockerfile_f32
+++ b/tools/Dockerfile_f32
@@ -16,7 +16,7 @@ RUN dnf install --assumeyes libusbx-devel zlib-devel shapelib-devel && \
 RUN dnf install --assumeyes qt5-qtbase-devel qt5-qtserialport-devel qt5-qtwebengine-devel qt5-linguist qt5-qttranslations && \
     dnf clean all
 # tools to build the docs
-RUN dnf install --assumeyes expat desktop-file-utils libxslt docbook-style-xsl fop docbook5-style-xsl jing && \
+RUN dnf install --assumeyes expat desktop-file-utils libxslt docbook-style-xsl fop docbook5-style-xsl docbook5-schemas jing && \
     dnf clean all
 # create a link as fedora uses the name qmake-qt5 for Qt5's qmake.
 RUN alternatives --install /usr/bin/qmake qt /usr/lib64/qt5/bin/qmake 100

--- a/tools/Dockerfile_f35
+++ b/tools/Dockerfile_f35
@@ -16,7 +16,7 @@ RUN dnf install --assumeyes libusb1-devel zlib-devel shapelib-devel && \
 RUN dnf install --assumeyes qt5-qtbase-devel qt5-qtserialport-devel qt5-qtwebengine-devel qt5-linguist qt5-qttranslations && \
     dnf clean all
 # tools to build the docs
-RUN dnf install --assumeyes expat desktop-file-utils libxslt docbook-style-xsl fop docbook5-style-xsl && \
+RUN dnf install --assumeyes expat desktop-file-utils libxslt docbook-style-xsl fop docbook5-style-xsl docbook5-schemas && \
     dnf clean all
 # create a link as fedora uses the name qmake-qt5 for Qt5's qmake.
 RUN alternatives --install /usr/bin/qmake qt /usr/lib64/qt5/bin/qmake 100

--- a/tools/Dockerfile_f37
+++ b/tools/Dockerfile_f37
@@ -1,6 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM fedora:32
+FROM fedora:37
 
 LABEL maintainer="https://github.com/tsteven4"
 
@@ -10,7 +10,7 @@ WORKDIR /app
 RUN dnf install --assumeyes git make valgrind diffutils findutils langpacks-en ninja-build && \
     dnf clean all
 # libraries used by gpsbabel.  zlib and shapelib may or may not be used depending qmake options.
-RUN dnf install --assumeyes libusbx-devel zlib-devel shapelib-devel && \
+RUN dnf install --assumeyes libusb1-devel zlib-devel shapelib-devel && \
     dnf clean all
 # Qt used by gpsbabel, gpsbabelfe
 RUN dnf install --assumeyes qt5-qtbase-devel qt5-qtserialport-devel qt5-qtwebengine-devel qt5-linguist qt5-qttranslations && \

--- a/tools/make_gpsbabel_doc.sh
+++ b/tools/make_gpsbabel_doc.sh
@@ -2,9 +2,9 @@
 set -ex
 
 perl xmldoc/makedoc
-xmllint --noout --relaxng http://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng xmldoc/readme.xml
+xmllint --noout --relaxng http://docbook.org/xml/5.0/rng/docbook.rng xmldoc/readme.xml
 # the following doesn't seem to work.
-#xmllint --noout --schematron http://www.oasis-open.org/docbook/xml/5.0/sch/docbook.sch xmldoc/readme.xml
+#xmllint --noout --schematron http://docbook.org/xml/5.0/sch/docbook.sch xmldoc/readme.xml
 # jing and many depedencies removed from fedora
 if command -v jing >/dev/null 2>&1; then
   jing http://docs.oasis-open.org/docbook/xml/5.0/rng/docbook.rng xmldoc/readme.xml


### PR DESCRIPTION
The xml catalogs on fedora lack http://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng, so we have switched to http://docbook.org/xml/5.0/rng/docbook.rng which seems to be resolved on fedora, ubuntu & homebrew.

jing exists on fedora 32, but is broken.  This is the same classpath bug I just fixed on homebrew (https://github.com/Homebrew/homebrew-core/pull/114567).  This causes jing validation with schematron (http://docs.oasis-open.org/docbook/xml/5.0/sch/docbook.sch) to fail.  To work around this we remove jing from the f32 install.  Note f32 is EOL anyway.

Add f37 build.