### PR TITLE
odds and ends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,11 @@ message(STATUS "Libs are: \"${LnkLibs}\"")
 get_target_property(IncDirs gpsbabel INCLUDE_DIRECTORIES)
 message(STATUS "Include Directores are: \"${IncDirs}\"")
 
+# In case we ever update the garmin_icons mkicondoc helps 
+# update the related document table.
+add_executable(mkicondoc EXCLUDE_FROM_ALL mkicondoc.cc)
+target_link_libraries(mkicondoc PRIVATE ${QT_LIBRARIES})
+
 set(TESTS
   arc-project
   arc

--- a/discard.h
+++ b/discard.h
@@ -66,7 +66,7 @@ private:
   int satpf{};
   int eleminpf{};
   int elemaxpf{};
-  gpsdata_type what;
+  gpsdata_type what{};
   route_head* head{};
 
   QVector<arglist_t> args = {

--- a/exif.cc
+++ b/exif.cc
@@ -254,7 +254,7 @@ ExifFormat::exif_read_timestamp(const ExifTag* tag)
   double min = exif_read_double(tag, 1);
   double sec = exif_read_double(tag, 2);
 
-  return QTime(int(hour), int(min), int(sec));
+  return QTime(0, 0).addMSecs(lround((((hour * 60.0) + min) * 60.0 + sec) * 1000.0));
 }
 
 QDate

--- a/garmin_device_xml.h
+++ b/garmin_device_xml.h
@@ -19,6 +19,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
+#ifndef GARMIN_DEVICE_XML_H_
+#define GARMIN_DEVICE_XML_H_
 
 /*
  * Describes a file on the unit.
@@ -54,3 +56,4 @@ const gdx_info* gdx_find_file(char** dirlist);
 #include <csetjmp>
 extern jmp_buf gdx_jmp_buf;
 
+#endif // GARMIN_DEVICE_XML_H_

--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -229,7 +229,7 @@ enum_waypt_cb(const Waypoint* wpt)
     }
     for (int i = 0; i < wpt_a_ct; i++) {		/* check for duplicates */
       const Waypoint* tmp = wpt_a[i];
-      if (case_ignore_strcmp(tmp->shortname, wpt->shortname) == 0) {
+      if (tmp->shortname.compare(wpt->shortname, Qt::CaseInsensitive) == 0) {
         wpt_a[i] = wpt;
         waypoints--;
         return;

--- a/gbser_private.h
+++ b/gbser_private.h
@@ -18,6 +18,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
+#ifndef GBSER_PRIVATE_H_
+#define GBSER_PRIVATE_H_
 
 #define MYMAGIC 0x91827364
 #define BUFSIZE 512
@@ -25,3 +27,4 @@
 void gbser_db(int l, const char* msg, ...);
 int gbser_fill_buffer(void* h, unsigned want, unsigned* ms);
 unsigned gbser_read_buffer(void* handle, void** buf, unsigned* len);
+#endif // GBSER_PRIVATE_H_

--- a/gui/latlng.h
+++ b/gui/latlng.h
@@ -28,8 +28,8 @@
 class LatLng
 {
 public:
-  LatLng(): _lat(0), _lng(0) {};
-  LatLng(double lat, double lng): _lat(lat), _lng(lng) {};
+  LatLng(): _lat(0), _lng(0) {}
+  LatLng(double lat, double lng): _lat(lat), _lng(lng) {}
   double lat() const
   {
     return _lat;

--- a/mkicondoc.cc
+++ b/mkicondoc.cc
@@ -1,6 +1,5 @@
 // Display all the Garmin icons that we know about so we can copy/paste
 // into our doc, xmldoc/chapters/garmin_icons.xml.
-// cd mkicondoc && qmake && make
 
 #include <algorithm>             // for sort
 #include <cstdio>                // for printf

--- a/mkicondoc/mkicondoc.pro
+++ b/mkicondoc/mkicondoc.pro
@@ -1,9 +1,0 @@
-QT -= gui
-
-CONFIG += console
-CONFIG -= app_bundle
-CONFIG += c++17
-
-TEMPLATE = app
-
-SOURCES += ../mkicondoc.cc

--- a/nmea.h
+++ b/nmea.h
@@ -94,11 +94,11 @@ private:
     gprmc
   };
 
-  enum {
+  enum read_mode_type {
     rm_unknown = 0,
     rm_serial,
     rm_file
-  } read_mode;
+  };
 
   /* Member Functions */
 
@@ -132,7 +132,8 @@ private:
   gbfile* file_in{}, *file_out{};
   route_head* trk_head{};
   short_handle mkshort_handle{};
-  preferred_posn_type posn_type;
+  preferred_posn_type posn_type{};
+  read_mode_type read_mode{};
   QDateTime prev_datetime;
   Waypoint* curr_waypt{};
   Waypoint* last_waypt{};

--- a/src/core/codecdevice.h
+++ b/src/core/codecdevice.h
@@ -16,6 +16,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
+#ifndef SRC_CORE_CODECDEVICE_H_
+#define SRC_CORE_CODECDEVICE_H_
 
 #include <QIODevice>        // for QIODevice
 #include <QIODeviceBase>    // for QIODeviceBase::OpenMode
@@ -61,3 +63,4 @@ private:
 };
 
 } // namespace
+#endif // SRC_CORE_CODECDEVICE_H_

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  */
-#ifndef gpsbabel_logging_h_included
-#define gpsbabel_logging_h_included
+#ifndef SRC_CORE_LOGGING_H_
+#define SRC_CORE_LOGGING_H_
 
 // A wrapper for QDebug that provides a sensible Warning() and FatalMsg()
 // with convenient functions, stream operators and manipulators.
@@ -79,4 +79,4 @@ namespace Qt
   inline QTextStream& uppercasedigits(QTextStream &s) { return ::uppercasedigits(s); }
 }
 #endif
-#endif //  gpsbabel_logging_h_included
+#endif //  SRC_CORE_LOGGING_H_


### PR DESCRIPTION
support subseconds in exif GPSTimeStamp. While rare, some devices provide subsecond information.

add missing include guards.

use cmake for mkicondoc, retiring the last qmake build.

provide default initializers for a couple of data members.

kill some empty statements.