### PR TITLE
fix clang diagnostic cast-qual

### DIFF
--- a/exif.cc
+++ b/exif.cc
@@ -1032,7 +1032,7 @@ ExifFormat::exif_put_value(const int ifd_nr, const uint16_t tag_id, const uint16
     if (size_increase > 0) {
       qba.append(size_increase, 0);
     }
-    qba.replace(index, count, (char*) data, count);
+    qba.replace(index, count, static_cast<const char*>(data), count);
     tag->data[0] = qba;
   } else {
     // we haven't coded for insertion of multiple values (except for BYTE_TYPE above).
@@ -1041,17 +1041,17 @@ ExifFormat::exif_put_value(const int ifd_nr, const uint16_t tag_id, const uint16
     case EXIF_TYPE_SHORT:
     case EXIF_TYPE_SSHORT:
       tag->grow<uint16_t>(index + count);
-      tag->data[index] = *(uint16_t*)data;
+      tag->data[index] = *static_cast<const uint16_t*>(data);
       break;
     case EXIF_TYPE_LONG:
     case EXIF_TYPE_SLONG:
     case EXIF_TYPE_IFD:
       tag->grow<uint32_t>(index + count);
-      tag->data[index] = *(uint32_t*)data;
+      tag->data[index] = *static_cast<const uint32_t*>(data);
       break;
     case EXIF_TYPE_RAT:
     case EXIF_TYPE_SRAT: {
-      double val = *(double*)data;
+      double val = *static_cast<const double*>(data);
 
       if ((val < 0.0) && (type == EXIF_TYPE_RAT)) {
         fatal(MYNAME ": A negative value cannot be stored as type RATIONAL.");
@@ -1065,11 +1065,11 @@ ExifFormat::exif_put_value(const int ifd_nr, const uint16_t tag_id, const uint16
     break;
     case EXIF_TYPE_FLOAT:
       tag->grow<float>(index + count);
-      tag->data[index] = *(float*)data;
+      tag->data[index] = *static_cast<const float*>(data);
       break;
     case EXIF_TYPE_DOUBLE:
       tag->grow<double>(index + count);
-      tag->data[index] = *(double*)data;
+      tag->data[index] = *static_cast<const double*>(data);
       break;
     default:
       fatal(MYNAME ": Unknown data type %u!\n", type);

--- a/gui/gpx.h
+++ b/gui/gpx.h
@@ -129,8 +129,7 @@ public:
         prevPt = thisPt;
       }
     }
-    auto* dptr = (double*)(&cachedLength);  // big cheat
-    *dptr = dist;
+    *const_cast<double*>(&cachedLength) = dist;  // big cheat
     return cachedLength;
   }
 
@@ -355,8 +354,7 @@ public:
         }
       }
     }
-    auto* dptr = (double*)(&cachedLength);  // big cheat
-    *dptr = dist;
+    *const_cast<double*>(&cachedLength) = dist;  // big cheat
     return cachedLength;
   }
 

--- a/jeeps/gpsusbcommon.cc
+++ b/jeeps/gpsusbcommon.cc
@@ -153,7 +153,7 @@ top:
 int
 gusb_cmd_send(const garmin_usb_packet* opkt, size_t sz)
 {
-  auto* obuf = reinterpret_cast<const unsigned char*>(&opkt->dbuf);
+  const auto* obuf = opkt->dbuf;
   const char* m2;
 
   unsigned int rv = gusb_llops->llop_send(opkt, sz);

--- a/jeeps/gpsusbcommon.cc
+++ b/jeeps/gpsusbcommon.cc
@@ -153,7 +153,7 @@ top:
 int
 gusb_cmd_send(const garmin_usb_packet* opkt, size_t sz)
 {
-  auto* obuf = (unsigned char*) &opkt->dbuf;
+  auto* obuf = reinterpret_cast<const unsigned char*>(&opkt->dbuf);
   const char* m2;
 
   unsigned int rv = gusb_llops->llop_send(opkt, sz);
@@ -215,7 +215,7 @@ gusb_id_unit(garmin_unit_info_t* gu)
   garmin_usb_packet iresp;
   int i;
 
-  gusb_cmd_send((garmin_usb_packet*)oid, sizeof(oid));
+  gusb_cmd_send(reinterpret_cast<const garmin_usb_packet*>(oid), sizeof(oid));
 
   for (i = 0; i < 25; i++) {
     iresp.gusb_pkt.type = 0;

--- a/jeeps/gpsusbwin.cc
+++ b/jeeps/gpsusbwin.cc
@@ -110,7 +110,7 @@ static int
 gusb_win_send(const garmin_usb_packet* opkt, size_t sz)
 {
   DWORD rsz;
-  auto* obuf = reinterpret_cast<const unsigned char*>(&opkt->dbuf);
+  const auto* obuf = opkt->dbuf;
 
   /* The spec warns us about making writes an exact multiple
    * of the packet size, but isn't clear whether we can issue

--- a/jeeps/gpsusbwin.cc
+++ b/jeeps/gpsusbwin.cc
@@ -110,7 +110,7 @@ static int
 gusb_win_send(const garmin_usb_packet* opkt, size_t sz)
 {
   DWORD rsz;
-  unsigned char* obuf = (unsigned char*) &opkt->dbuf;
+  auto* obuf = reinterpret_cast<const unsigned char*>(&opkt->dbuf);
 
   /* The spec warns us about making writes an exact multiple
    * of the packet size, but isn't clear whether we can issue
@@ -236,7 +236,7 @@ gusb_init(const char* pname, gpsdevh** dh)
     }
   }
 
-  hdevinfo = SetupDiGetClassDevs((GUID*) &GARMIN_GUID, NULL, NULL,
+  hdevinfo = SetupDiGetClassDevs(&GARMIN_GUID, NULL, NULL,
                                  DIGCF_PRESENT | DIGCF_INTERFACEDEVICE);
 
   if (hdevinfo == INVALID_HANDLE_VALUE) {
@@ -249,7 +249,7 @@ gusb_init(const char* pname, gpsdevh** dh)
 
   if (req_unit_number >= 0) {
     if (!SetupDiEnumDeviceInterfaces(hdevinfo, NULL,
-                                     (GUID*) &GARMIN_GUID,
+                                     &GARMIN_GUID,
                                      req_unit_number, &devinterface)) {
       // If there were zero matches, we may be trying to talk to a "GPX Mode" device.
 
@@ -277,7 +277,7 @@ gusb_init(const char* pname, gpsdevh** dh)
    */
   for (match = 0;; match++) {
     if (!SetupDiEnumDeviceInterfaces(hdevinfo, NULL,
-                                     (GUID*) &GARMIN_GUID, match, &devinterface)) {
+                                     &GARMIN_GUID, match, &devinterface)) {
       if (GetLastError() == ERROR_NO_MORE_ITEMS) {
 
         break;

--- a/jeeps/jgpsutil.cc
+++ b/jeeps/jgpsutil.cc
@@ -104,7 +104,7 @@ US GPS_Util_Get_Short(const UC* s)
 
 void GPS_Util_Put_Short(UC* s, const US v)
 {
-  auto* p = reinterpret_cast<const UC*>(&v);
+  const auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little) {
     *s++ = *(p+1);
@@ -163,7 +163,7 @@ void GPS_Util_Put_Double(UC* s, const double v)
 {
   int32 i;
 
-  auto* p = reinterpret_cast<const UC*>(&v);
+  const auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(double)-1; i>-1; --i) {
@@ -224,7 +224,7 @@ void GPS_Util_Put_Int(UC* s, const int32 v)
 {
   int32 i;
 
-  auto* p = reinterpret_cast<const UC*>(&v);
+  const auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(int32)-1; i>-1; --i) {
@@ -284,7 +284,7 @@ void GPS_Util_Put_Uint(UC* s, const uint32 v)
 {
   int32 i;
 
-  auto* p = reinterpret_cast<const UC*>(&v);
+  const auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(uint32)-1; i>-1; --i) {
@@ -344,7 +344,7 @@ void GPS_Util_Put_Float(UC* s, const float v)
 {
   int32 i;
 
-  auto* p = reinterpret_cast<const UC*>(&v);
+  const auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(float)-1; i>-1; --i) {

--- a/jeeps/jgpsutil.cc
+++ b/jeeps/jgpsutil.cc
@@ -104,9 +104,7 @@ US GPS_Util_Get_Short(const UC* s)
 
 void GPS_Util_Put_Short(UC* s, const US v)
 {
-  UC* p;
-
-  p = (UC*)&v;
+  auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little) {
     *s++ = *(p+1);
@@ -163,10 +161,9 @@ double GPS_Util_Get_Double(const UC* s)
 
 void GPS_Util_Put_Double(UC* s, const double v)
 {
-  UC* p;
   int32 i;
 
-  p = (UC*)&v;
+  auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(double)-1; i>-1; --i) {
@@ -225,10 +222,9 @@ int32 GPS_Util_Get_Int(const UC* s)
 
 void GPS_Util_Put_Int(UC* s, const int32 v)
 {
-  UC* p;
   int32 i;
 
-  p = (UC*)&v;
+  auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(int32)-1; i>-1; --i) {
@@ -286,10 +282,9 @@ uint32 GPS_Util_Get_Uint(const UC* s)
 
 void GPS_Util_Put_Uint(UC* s, const uint32 v)
 {
-  UC*    p;
   int32 i;
 
-  p = (UC*)&v;
+  auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(uint32)-1; i>-1; --i) {
@@ -347,10 +342,9 @@ float GPS_Util_Get_Float(const UC* s)
 
 void GPS_Util_Put_Float(UC* s, const float v)
 {
-  UC* p;
   int32 i;
 
-  p = (UC*)&v;
+  auto* p = reinterpret_cast<const UC*>(&v);
 
   if (!GPS_Little)
     for (i=sizeof(float)-1; i>-1; --i) {

--- a/navilink.cc
+++ b/navilink.cc
@@ -418,7 +418,7 @@ decode_waypoint(const unsigned char* buffer)
   auto* waypt = new Waypoint;
 
   decode_position(buffer + 12, waypt);
-  waypt->shortname = (char*) buffer + 4;
+  waypt->shortname = reinterpret_cast<const char*>(buffer) + 4;
   waypt->icon_descr = icon_table[buffer[28]];
   waypt->SetCreationTime(decode_datetime(buffer + 22));
 

--- a/skytraq.cc
+++ b/skytraq.cc
@@ -774,7 +774,7 @@ SkytraqBase::process_data_sector(struct read_state* pst, const uint8_t* buf, int
   int plen, ilen;
 
   for (plen = 0; plen < len  &&  buf[plen] != 0xFF; plen += ilen) {
-    ilen = process_data_item(pst, (item_frame*)&buf[plen], len-plen);
+    ilen = process_data_item(pst, reinterpret_cast<const item_frame*>(&buf[plen]), len-plen);
     if (ilen <= 0) {
       fatal(MYNAME ": Error %i while processing data item #%i (starts at %i)\n",
             ilen, pst->tpn, plen);

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -327,7 +327,7 @@ void SimplifyRouteFilter::init()
     fatal(MYNAME ": You may specify only one of crosstrack, length, or relative.\n");
   }
   if (!xteopt && !lenopt && !relopt) {
-    xteopt = (char*) "";
+    xteopt = (char*) ""; // big cheat
   }
 
   if (countopt) {

--- a/util.cc
+++ b/util.cc
@@ -767,7 +767,7 @@ endian_read_double(const void* ptr, int read_le)
     p = ptr;
   } else {
     for (int i = 0; i < 8; i++) {
-      r[i] = ((char*)ptr)[7-i];
+      r[i] = static_cast<const char*>(ptr)[7-i];
     }
     p = r;
   }
@@ -794,7 +794,7 @@ endian_read_float(const void* ptr, int read_le)
     p = ptr;
   } else {
     for (int i = 0; i < 4; i++) {
-      r[i] = ((char*)ptr)[3-i];
+      r[i] = static_cast<const char*>(ptr)[3-i];
     }
     p = r;
   }

--- a/util_crc.cc
+++ b/util_crc.cc
@@ -69,9 +69,9 @@ unsigned long
 get_crc32(const void* data, int datalen)
 {
   unsigned long crc = 0xFFFFFFFF;
-  const unsigned char* cp = (unsigned char*)data;
+  const unsigned char* cp = static_cast<const unsigned char*>(data);
 
-  while (cp < ((unsigned char*)data + datalen)) {
+  while (cp < (static_cast<const unsigned char*>(data) + datalen)) {
     crc = ((crc >> 8) & 0x00FFFFFF) ^ crc32_table[(crc ^ *cp) &0xFF];
     cp++;
   }

--- a/wbt-200.cc
+++ b/wbt-200.cc
@@ -236,7 +236,7 @@ static void buf_extend(struct buf_head* h, size_t amt)
 
 static void buf_update_checksum(struct buf_head* h, const void* data, size_t len)
 {
-  auto* cp = (unsigned char*) data;
+  auto* cp = static_cast<const unsigned char*>(data);
 
   db(4, "Updating checksum with %p, %zu, before: %02x ",
      data, len, h->checksum);


### PR DESCRIPTION
All but 2 of these didn't need to drop the const qualifier at all.  These two, in gui/gpx.h, now use const_cast to cast away const.

gpsusbcommon.h L156, gpsusbwin L113 didn't need a cast at all.  They also don't need to force array decay, but the implementation in this PR allows the assembly listing of gpsusbcommon, gpsusbwin and jgpsutil to all match the base.
gpsusbwin had a number of (GUID*) casts were unnecessary.


