### PR TITLE
modernize units

### DIFF
--- a/kml.cc
+++ b/kml.cc
@@ -404,6 +404,8 @@ void KmlFormat::wr_deinit()
   oqfile->close();
   delete oqfile;
   oqfile = nullptr;
+  delete unitsformatter;
+  unitsformatter = nullptr;
 
   if (!posnfilenametmp.isEmpty()) {
     // QFile::rename() can't replace an existing file, so do a QFile::remove()

--- a/kml.cc
+++ b/kml.cc
@@ -37,6 +37,7 @@
 #include <QList>                        // for QList
 #include <QString>                      // for QString, QStringLiteral, operator+, operator!=
 #include <QStringList>                  // for QStringList
+#include <QStringLiteral>               // for qMakeStringPrivate, QStringLit...
 #include <QVector>                      // for QVector
 #include <QXmlStreamAttributes>         // for QXmlStreamAttributes
 #include <Qt>                           // for ISODate
@@ -357,16 +358,16 @@ void KmlFormat::wr_init(const QString& fname)
 
   switch (u) {
   case 's':
-    fmt_setunits(units_statute);
+    fmt_setunits(fmt_units::statute);
     break;
   case 'm':
-    fmt_setunits(units_metric);
+    fmt_setunits(fmt_units::metric);
     break;
   case 'n':
-    fmt_setunits(units_nautical);
+    fmt_setunits(fmt_units::nautical);
     break;
   case 'a':
-    fmt_setunits(units_aviation);
+    fmt_setunits(fmt_units::aviation);
     break;
   default:
     fatal("Units argument '%s' should be 's' for statute units, 'm' for metric, 'n' for nautical or 'a' for aviation.\n", opt_units);
@@ -570,34 +571,28 @@ void KmlFormat::kml_output_trkdescription(const route_head* header, const comput
   if (!header->rte_desc.isEmpty()) {
     kml_td(hwriter, QStringLiteral("Description"), QStringLiteral(" %1 ").arg(header->rte_desc));
   }
-  const char* distance_units;
-  double distance = fmt_distance(td->distance_meters, &distance_units);
+  auto [distance, distance_units] = fmt_distance(td->distance_meters);
   kml_td(hwriter, QStringLiteral("Distance"), QStringLiteral(" %1 %2 ").arg(QString::number(distance, 'f', 1), distance_units));
   if (td->min_alt) {
-    const char* min_alt_units;
-    double min_alt = fmt_altitude(*td->min_alt, &min_alt_units);
+    auto [min_alt, min_alt_units] = fmt_altitude(*td->min_alt);
     kml_td(hwriter, QStringLiteral("Min Alt"), QStringLiteral(" %1 %2 ").arg(QString::number(min_alt, 'f', 3), min_alt_units));
   }
   if (td->max_alt) {
-    const char* max_alt_units;
-    double max_alt = fmt_altitude(*td->max_alt, &max_alt_units);
+    auto [max_alt, max_alt_units] = fmt_altitude(*td->max_alt);
     kml_td(hwriter, QStringLiteral("Max Alt"), QStringLiteral(" %1 %2 ").arg(QString::number(max_alt, 'f', 3), max_alt_units));
   }
   if (td->min_spd) {
-    const char* spd_units;
-    double spd = fmt_speed(*td->min_spd, &spd_units);
+    auto [spd, spd_units] = fmt_speed(*td->min_spd);
     kml_td(hwriter, QStringLiteral("Min Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
   }
   if (td->max_spd) {
-    const char* spd_units;
-    double spd = fmt_speed(*td->max_spd, &spd_units);
+    auto [spd, spd_units] = fmt_speed(*td->max_spd);
     kml_td(hwriter, QStringLiteral("Max Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
   }
   if (td->max_spd && td->start.isValid() && td->end.isValid()) {
     double elapsed = td->start.msecsTo(td->end)/1000.0;
     if (elapsed > 0.0) {
-      const char* spd_units;
-      double spd = fmt_speed(td->distance_meters / elapsed, &spd_units);
+      auto [spd, spd_units] = fmt_speed(td->distance_meters / elapsed);
       if (spd > 1.0)  {
         kml_td(hwriter, QStringLiteral("Avg Speed"), QStringLiteral(" %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
       }
@@ -721,16 +716,12 @@ void KmlFormat::kml_output_positioning(bool tessellate) const
 /* Output something interesting when we can for route and trackpoints */
 void KmlFormat::kml_output_description(const Waypoint* pt) const
 {
-  const char* alt_units;
-
   if (!trackdata) {
     return;
   }
 
   QString hstring;
   gpsbabel::XmlStreamWriter hwriter(&hstring);
-
-  double alt = fmt_altitude(pt->altitude, &alt_units);
 
   writer->writeStartElement(QStringLiteral("description"));
   hwriter.writeCharacters(QStringLiteral("\n"));
@@ -740,6 +731,7 @@ void KmlFormat::kml_output_description(const Waypoint* pt) const
   kml_td(hwriter, QStringLiteral("Latitude: %1 ").arg(QString::number(pt->latitude, 'f', precision)));
 
   if (kml_altitude_known(pt)) {
+    auto [alt, alt_units] = fmt_altitude(pt->altitude);
     kml_td(hwriter, QStringLiteral("Altitude: %1 %2 ").arg(QString::number(alt, 'f', 3), alt_units));
   }
 
@@ -761,14 +753,12 @@ void KmlFormat::kml_output_description(const Waypoint* pt) const
   }
 
   if WAYPT_HAS(pt, depth) {
-    const char* depth_units;
-    double depth = fmt_distance(pt->depth, &depth_units);
+    auto [depth, depth_units] = fmt_distance(pt->depth);
     kml_td(hwriter, QStringLiteral("Depth: %1 %2 ").arg(QString::number(depth, 'f', 1), depth_units));
   }
 
   if WAYPT_HAS(pt, speed) {
-    const char* spd_units;
-    double spd = fmt_speed(pt->speed, &spd_units);
+    auto [spd, spd_units] = fmt_speed(pt->speed);
     kml_td(hwriter, QStringLiteral("Speed: %1 %2 ").arg(QString::number(spd, 'f', 1), spd_units));
   }
 

--- a/kml.h
+++ b/kml.h
@@ -34,6 +34,7 @@
 #include "src/core/datetime.h"          // for DateTime
 #include "src/core/file.h"              // for File
 #include "src/core/xmlstreamwriter.h"   // for XmlStreamWriter
+#include "units.h"                      // for UnitsFormatter
 #include "xmlgeneric.h"                 // for cb_cdata, cb_end, cb_start, xg_callback, xg_string, xg_cb_type, xml_deinit, xml_ignore_tags, xml_init, xml_read, xg_tag_mapping
 
 
@@ -226,6 +227,7 @@ private:
   QList<gpsbabel::DateTime>* gx_trk_times{nullptr};
   QList<std::tuple<int, double, double, double>>* gx_trk_coords{nullptr};
 
+  UnitsFormatter* unitsformatter{nullptr};
   gpsbabel::File* oqfile{nullptr};
   gpsbabel::XmlStreamWriter* writer{nullptr};
 

--- a/units.cc
+++ b/units.cc
@@ -22,16 +22,15 @@
 #include "defs.h"
 #include "units.h"
 
-static fmt_units units = fmt_units::statute;
 
 void
-fmt_setunits(fmt_units u)
+UnitsFormatter::setunits(units_t u)
 {
   switch (u) {
-  case fmt_units::statute:
-  case fmt_units::metric:
-  case fmt_units::nautical:
-  case fmt_units::aviation:
+  case units_t::statute:
+  case units_t::metric:
+  case units_t::nautical:
+  case units_t::aviation:
     units = u;
     break;
   default:
@@ -41,13 +40,13 @@ fmt_setunits(fmt_units u)
 }
 
 std::pair<double, QString>
-fmt_distance(const double distance_meters)
+UnitsFormatter::fmt_distance(const double distance_meters) const
 {
   double d;
   const char* tag;
 
   switch (units) {
-  case fmt_units::statute:
+  case units_t::statute:
     d = METERS_TO_FEET(distance_meters);
     if (d < 5280) {
       tag = "ft";
@@ -56,12 +55,12 @@ fmt_distance(const double distance_meters)
       tag = "mi";
     }
     break;
-  case fmt_units::nautical:
-  case fmt_units::aviation:
+  case units_t::nautical:
+  case units_t::aviation:
     d = METERS_TO_NMILES(distance_meters);
     tag = "NM";
     break;
-  case fmt_units::metric:
+  case units_t::metric:
     d = distance_meters;
     if (d < 1000) {
       tag = "meters";
@@ -80,22 +79,22 @@ fmt_distance(const double distance_meters)
 }
 
 std::pair<double, QString>
-fmt_altitude(const double distance_meters)
+UnitsFormatter::fmt_altitude(const double distance_meters) const
 {
   double d;
   const char* tag;
 
   switch (units) {
-  case fmt_units::statute:
-  case fmt_units::aviation:
+  case units_t::statute:
+  case units_t::aviation:
     d = METERS_TO_FEET(distance_meters);
     tag = "ft";
     break;
-  case fmt_units::nautical:
+  case units_t::nautical:
     d = METERS_TO_NMILES(distance_meters);
     tag = "NM";
     break;
-  case fmt_units::metric:
+  case units_t::metric:
     d = distance_meters;
     tag = "meters";
     break;
@@ -109,23 +108,23 @@ fmt_altitude(const double distance_meters)
 }
 
 std::pair<double, QString>
-fmt_speed(const double distance_meters_sec)
+UnitsFormatter::fmt_speed(const double speed_meters_per_sec) const
 {
   double d;
   const char* tag;
 
   switch (units) {
-  case fmt_units::statute:
-    d = METERS_TO_MILES(distance_meters_sec) * SECONDS_PER_HOUR ;
+  case units_t::statute:
+    d = METERS_TO_MILES(speed_meters_per_sec) * SECONDS_PER_HOUR ;
     tag = "mph";
     break;
-  case fmt_units::nautical:
-  case fmt_units::aviation:
-    d = METERS_TO_NMILES(distance_meters_sec) * SECONDS_PER_HOUR ;
+  case units_t::nautical:
+  case units_t::aviation:
+    d = METERS_TO_NMILES(speed_meters_per_sec) * SECONDS_PER_HOUR ;
     tag = "knts";
     break;
-  case fmt_units::metric:
-    d = distance_meters_sec * SECONDS_PER_HOUR;
+  case units_t::metric:
+    d = speed_meters_per_sec * SECONDS_PER_HOUR;
     tag = "meters/hour";
     if (d > 1000.0) {
       d /= 1000.0;

--- a/units.cc
+++ b/units.cc
@@ -22,50 +22,52 @@
 #include "defs.h"
 #include "units.h"
 
-static int units = units_statute;
+static fmt_units units = fmt_units::statute;
 
-int
+void
 fmt_setunits(fmt_units u)
 {
   switch (u) {
-  case units_statute:
-  case units_metric:
-  case units_nautical:
-  case units_aviation:
+  case fmt_units::statute:
+  case fmt_units::metric:
+  case fmt_units::nautical:
+  case fmt_units::aviation:
     units = u;
-    return 0;
+    break;
   default:
-    return 1;
+    fatal("not done yet");
+    break;
   }
 }
 
-double
-fmt_distance(const double distance_meters, const char** tag)
+std::pair<double, QString>
+fmt_distance(const double distance_meters)
 {
   double d;
+  const char* tag;
 
   switch (units) {
-  case units_statute:
+  case fmt_units::statute:
     d = METERS_TO_FEET(distance_meters);
     if (d < 5280) {
-      *tag = "ft";
+      tag = "ft";
     } else  {
       d = METERS_TO_MILES(distance_meters);
-      *tag = "mi";
+      tag = "mi";
     }
     break;
-  case units_nautical:
-  case units_aviation:
+  case fmt_units::nautical:
+  case fmt_units::aviation:
     d = METERS_TO_NMILES(distance_meters);
-    *tag = "NM";
+    tag = "NM";
     break;
-  case units_metric:
+  case fmt_units::metric:
     d = distance_meters;
     if (d < 1000) {
-      *tag = "meters";
+      tag = "meters";
     } else {
       d = d / 1000.0;
-      *tag = "km";
+      tag = "km";
     }
     break;
 
@@ -74,27 +76,28 @@ fmt_distance(const double distance_meters, const char** tag)
     break;
   }
 
-  return d;
+  return {d, tag};
 }
 
-double
-fmt_altitude(const double distance_meters, const char** tag)
+std::pair<double, QString>
+fmt_altitude(const double distance_meters)
 {
   double d;
+  const char* tag;
 
   switch (units) {
-  case units_statute:
-  case units_aviation:
+  case fmt_units::statute:
+  case fmt_units::aviation:
     d = METERS_TO_FEET(distance_meters);
-    *tag = "ft";
+    tag = "ft";
     break;
-  case units_nautical:
+  case fmt_units::nautical:
     d = METERS_TO_NMILES(distance_meters);
-    *tag = "NM";
+    tag = "NM";
     break;
-  case units_metric:
+  case fmt_units::metric:
     d = distance_meters;
-    *tag = "meters";
+    tag = "meters";
     break;
 
   default:
@@ -102,35 +105,36 @@ fmt_altitude(const double distance_meters, const char** tag)
     break;
   }
 
-  return d;
+  return {d, tag};
 }
 
-double
-fmt_speed(const double distance_meters_sec, const char** tag)
+std::pair<double, QString>
+fmt_speed(const double distance_meters_sec)
 {
   double d;
+  const char* tag;
 
   switch (units) {
-  case units_statute:
+  case fmt_units::statute:
     d = METERS_TO_MILES(distance_meters_sec) * SECONDS_PER_HOUR ;
-    *tag = "mph";
+    tag = "mph";
     break;
-  case units_nautical:
-  case units_aviation:
+  case fmt_units::nautical:
+  case fmt_units::aviation:
     d = METERS_TO_NMILES(distance_meters_sec) * SECONDS_PER_HOUR ;
-    *tag = "knts";
+    tag = "knts";
     break;
-  case units_metric:
+  case fmt_units::metric:
     d = distance_meters_sec * SECONDS_PER_HOUR;
-    *tag = "meters/hour";
+    tag = "meters/hour";
     if (d > 1000.0) {
       d /= 1000.0;
-      *tag = "km/hour";
+      tag = "km/hour";
     }
     break;
   default:
     fatal("not done yet");
 
   }
-  return d;
+  return {d, tag};
 }

--- a/units.h
+++ b/units.h
@@ -23,25 +23,21 @@
 #ifndef GPSBABEL_UNITS_H
 #define GPSBABEL_UNITS_H
 
-/*
- *  From units.c
- */
-enum fmt_units {
-  units_unknown = 0,
-  units_statute = 1,
-  units_metric = 2,
-  units_nautical =3,
-  units_aviation =4
+#include <utility>  // for pair
+
+#include <QString>  // for QString
+
+
+enum class fmt_units {
+  statute,
+  metric,
+  nautical,
+  aviation
 };
 
-int    fmt_setunits(fmt_units);
-
-double fmt_distance(double, const char** tag);
-
-double fmt_altitude(double, const char** tag);
-
-double fmt_speed(double, const char** tag);
-
-#include "defs.h"
+void fmt_setunits(fmt_units);
+std::pair<double, QString> fmt_distance(double);
+std::pair<double, QString> fmt_altitude(double);
+std::pair<double, QString> fmt_speed(double);
 
 #endif //GPSBABEL_UNITS_H

--- a/units.h
+++ b/units.h
@@ -28,16 +28,29 @@
 #include <QString>  // for QString
 
 
-enum class fmt_units {
-  statute,
-  metric,
-  nautical,
-  aviation
+class UnitsFormatter
+{
+public:
+
+  /* Types */
+
+  enum class units_t {
+    statute,
+    metric,
+    nautical,
+    aviation
+  };
+
+  /* Member Functions */
+
+  void setunits(units_t u);
+  std::pair<double, QString> fmt_distance(double distance_meters) const;
+  std::pair<double, QString> fmt_altitude(double distance_meters) const;
+  std::pair<double, QString> fmt_speed(double speed_meters_per_sec) const;
+
+  /* Data Members */
+
+  units_t units{units_t::statute};
+
 };
-
-void fmt_setunits(fmt_units);
-std::pair<double, QString> fmt_distance(double);
-std::pair<double, QString> fmt_altitude(double);
-std::pair<double, QString> fmt_speed(double);
-
 #endif //GPSBABEL_UNITS_H


### PR DESCRIPTION
fmt_* returns a std::pair of the value and the units. 
use structured binding to unpack the pair.
use scoped enumeration for the units system.

When the Qt floor raises to 5.14 we can return a QStringView instead.