### PR TITLE
eliminate some time_t uses.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -184,7 +184,6 @@ struct global_options {
 
 extern global_options global_opts;
 extern const char gpsbabel_version[];
-extern time_t gpsbabel_now;	/* gpsbabel startup-time; initialized in main.c with time() */
 extern time_t gpsbabel_time;	/* gpsbabel startup-time; initialized in main.c with current_time(), ! ZERO within testo ! */
 
 enum fix_type {

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -39,7 +39,7 @@
 #include <ctime>                   // for time, time_t
 #include <memory>                  // for unique_ptr
 
-#include "defs.h"                  // for Waypoint, fatal, le_write32, le_write16, wp_flags, warning, bounds, KPH_TO_MPS, MPH_TO_MPS, WAYPT_HAS, gpsbabel_testmode, parse_speed, WAYPT_SET, MILES_TO_METERS, MPS_TO_KPH, MPS_TO_MPH, mkgmtime, mkshort, mkshort_del_handle, mkshort_new_...
+#include "defs.h"
 #include "formspec.h"              // for FormatSpecificDataList
 #include "garmin_fs.h"             // for garmin_fs_t, garmin_fs_alloc
 #include "gbfile.h"                // for gbfputint32, gbfgetint32, gbfgetint16, gbfputint16, gbfgetc, gbfputc, gbfread, gbftell, gbfwrite, gbfseek, gbfclose, gbfopen_le, gbfgetuint16, gbsize_t, gbfile

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -24,6 +24,7 @@
 #include "garmin_gpi.h"
 
 #include <QByteArray>              // for QByteArray, operator==
+#include <QDateTime>               // for QDateTime
 #include <QList>                   // for QList
 #include <QString>                 // for QString, operator+, operator<
 #include <QThread>                 // for QThread
@@ -35,7 +36,7 @@
 #include <cstdint>                 // for uint32_t, int32_t
 #include <cstdio>                  // for SEEK_CUR, SEEK_SET
 #include <cstring>                 // for strlen, strncmp
-#include <ctime>                   // for time, gmtime, time_t, tm
+#include <ctime>                   // for time, time_t
 #include <memory>                  // for unique_ptr
 
 #include "defs.h"                  // for Waypoint, fatal, le_write32, le_write16, wp_flags, warning, bounds, KPH_TO_MPS, MPH_TO_MPS, WAYPT_HAS, gpsbabel_testmode, parse_speed, WAYPT_SET, MILES_TO_METERS, MPS_TO_KPH, MPS_TO_MPH, mkgmtime, mkshort, mkshort_del_handle, mkshort_new_...
@@ -174,12 +175,9 @@ GarminGPIFormat::read_header()
   PP;
   rdata->crdate = gbfgetint32(fin);
   if (GPI_DBG) {
-    char stime[32];
-    struct tm tm = *localtime(&rdata->crdate);
-    tm.tm_year += 20; /* !!! */
-    tm.tm_mday -= 1;  /* !!! */
-    strftime(stime, sizeof(stime), "%Y/%m/%d %H:%M:%S", &tm);
-    warning("crdate = %lu (%s)\n", rdata->crdate, stime);
+    time_t crdate = GPS_Math_Gtime_To_Utime(rdata->crdate);
+    warning("crdate = %lu (%s)\n", rdata->crdate,
+            CSTR(QDateTime::fromSecsSinceEpoch(crdate, Qt::UTC).toString(Qt::ISODate)));
   }
 
   (void) gbfgetint16(fin);  /* 0 */
@@ -1007,11 +1005,7 @@ GarminGPIFormat::write_header() const
   time_t time = gpi_timestamp;
 
   if (time != 0) {
-    struct tm tm;
-    tm = *gmtime(&time);
-    tm.tm_year -= 20;
-    time = mkgmtime(&tm);
-    time += SECONDS_PER_DAY;
+    time = GPS_Math_Utime_To_Gtime(gpi_timestamp);
   }
 
   gbfputint32(0, fout);

--- a/gpx.cc
+++ b/gpx.cc
@@ -565,7 +565,7 @@ GpxFormat::gpx_end(QStringView /*unused*/)
    */
   case tt_cache_log_type:
     if ((cdatastr.compare(u"Found it") == 0) &&
-        (0 == wpt_tmp->gc_data->last_found.toTime_t())) {
+        (!wpt_tmp->gc_data->last_found.isValid())) {
       wpt_tmp->AllocGCData()->last_found = gc_log_date;
     }
     gc_log_date = QDateTime();

--- a/gtrnctr.cc
+++ b/gtrnctr.cc
@@ -216,13 +216,13 @@ GtrnctrFormat::gtc_fake_hdr(const computed_trkdata& tdata)
   /* note that the elements must appear in the order required by the schema. */
   /* also note some of the elements are required. */
 
-  long secs = 0;
+  long long secs = 0;
   if (gtc_least_time.isValid() && gtc_most_time.isValid()) {
-    secs = gtc_most_time.toTime_t() - gtc_least_time.toTime_t();
+    secs = gtc_least_time.secsTo(gtc_most_time);
   }
 
   /* write these in either case, course or activity format */
-  gtc_write_xml(0, "<TotalTimeSeconds>%ld</TotalTimeSeconds>\n", secs);
+  gtc_write_xml(0, "<TotalTimeSeconds>%lld</TotalTimeSeconds>\n", secs);
   gtc_write_xml(0, "<DistanceMeters>%.2f</DistanceMeters>\n", tdata.distance_meters);
   if (gtc_course_flag) { /* course format */
     gtc_write_xml(1, "<BeginPosition>\n");

--- a/html.cc
+++ b/html.cc
@@ -28,7 +28,6 @@
 #include <Qt>                      // for CaseInsensitive
 
 #include <cstdint>                 // for int32_t
-#include <ctime>                   // for localtime, time_t
 
 #include "defs.h"
 #include "formspec.h"              // for FormatSpecificDataList, kFsGpx
@@ -151,7 +150,6 @@ HtmlFormat::html_disp(const Waypoint* wpt) const
       XmlTag* root = fs_gpx->tag;
       XmlTag* curlog = root->xml_findfirst(u"groundspeak:log");
       while (curlog) {
-        time_t logtime = 0;
         *file_out << "          <p class=\"gpsbabellog\">\n";
 
         XmlTag* logpart = curlog->xml_findfirst(u"groundspeak:type");
@@ -168,14 +166,9 @@ HtmlFormat::html_disp(const Waypoint* wpt) const
 
         logpart = curlog->xml_findfirst(u"groundspeak:date");
         if (logpart) {
-          logtime = xml_parse_time(logpart->cdata).toTime_t();
-          struct tm* logtm = localtime(&logtime);
-          if (logtm) {
-            *file_out << QStringLiteral("<span class=\"gpsbabellogdate\">%1-%2-%3</span><br>\n")
-                      .arg(logtm->tm_year+1900, 4, 10, QChar('0'))
-                      .arg(logtm->tm_mon+1, 2, 10, QChar('0'))
-                      .arg(logtm->tm_mday, 2, 10, QChar('0'));
-          }
+          gpsbabel::DateTime logtime = xml_parse_time(logpart->cdata).toLocalTime();
+          *file_out << "<span class=\"gpsbabellogdate\">"
+                    << logtime.toString(u"yyyy-MM-dd") << "</span><br>\n";
         }
 
         logpart = curlog->xml_findfirst(u"groundspeak:log_wpt");

--- a/kml.cc
+++ b/kml.cc
@@ -1953,7 +1953,7 @@ void KmlFormat::wr_position(Waypoint* wpt)
     last_valid_fix = wpt->GetCreationTime();
   }
 
-  wpt->icon_descr = kml_get_posn_icon(wpt->GetCreationTime().toTime_t() - last_valid_fix.toTime_t());
+  wpt->icon_descr = kml_get_posn_icon(last_valid_fix.secsTo(wpt->GetCreationTime()));
 
 
   /* In order to avoid clutter while we're sitting still, don't add

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -133,9 +133,12 @@ void SimplifyRouteFilter::compute_xte(struct xte* xte_rec)
       fatal(MYNAME ": relative needs hdop information.\n");
     }
     // if timestamps exist, distance to interpolated point
-    if (wpt1->GetCreationTime() != wpt2->GetCreationTime()) {
-      double frac = (double)(wpt3->GetCreationTime().toTime_t() - wpt1->GetCreationTime().toTime_t()) /
-                    (wpt2->GetCreationTime().toTime_t() - wpt1->GetCreationTime().toTime_t());
+    if (wpt1->GetCreationTime().isValid() && 
+        wpt2->GetCreationTime().isValid() &&
+        wpt3->GetCreationTime().isValid() &&
+        (wpt1->GetCreationTime() != wpt2->GetCreationTime())) {
+      double frac = static_cast<double>(wpt1->GetCreationTime().msecsTo(wpt3->GetCreationTime())) /
+                    static_cast<double>(wpt1->GetCreationTime().msecsTo(wpt2->GetCreationTime()));
       linepart(wpt1->latitude, wpt1->longitude,
                wpt2->latitude, wpt2->longitude,
                frac, &reslat, &reslon);

--- a/text.cc
+++ b/text.cc
@@ -21,14 +21,12 @@
 
 #include "text.h"
 
-#include <QChar>                   // for QChar
 #include <QIODevice>               // for QIODevice, QIODevice::WriteOnly
 #include <QString>                 // for QString, operator!=
 #include <QTextStream>             // for QTextStream
 #include <Qt>                      // for CaseInsensitive
 
 #include <cstdint>                 // for int32_t
-#include <ctime>                   // for localtime, time_t
 
 #include "defs.h"
 #include "formspec.h"              // for FormatSpecificDataList, kFsGpx
@@ -134,7 +132,6 @@ TextFormat::text_disp(const Waypoint* wpt)
       XmlTag* root = fs_gpx->tag;
       XmlTag* curlog = root->xml_findfirst(u"groundspeak:log");
       while (curlog) {
-        time_t logtime = 0;
         *file_out << "\n";
 
         XmlTag* logpart = curlog->xml_findfirst(u"groundspeak:type");
@@ -149,14 +146,8 @@ TextFormat::text_disp(const Waypoint* wpt)
 
         logpart = curlog->xml_findfirst(u"groundspeak:date");
         if (logpart) {
-          logtime = xml_parse_time(logpart->cdata).toTime_t();
-          struct tm* logtm = localtime(&logtime);
-          if (logtm) {
-            *file_out << QStringLiteral("%1-%2-%3\n")
-                      .arg(logtm->tm_year+1900, 4, 10, QChar('0'))
-                      .arg(logtm->tm_mon+1, 2, 10, QChar('0'))
-                      .arg(logtm->tm_mday, 2, 10, QChar('0'));
-          }
+          gpsbabel::DateTime logtime = xml_parse_time(logpart->cdata).toLocalTime();
+          *file_out << logtime.toString(u"yyyy-MM-dd") << "\n";
         }
 
         logpart = curlog->xml_findfirst(u"groundspeak:log_wpt");


### PR DESCRIPTION
This is suppose to be the easy ones.

- text, html: if creation_time is invalid (according to QDateTime, not gpsbabel::DateTime) then the printed string will be empty.
- kml real time position: if the source isn't provided creation times then the icon might be different than before, but I am not sure we care.
- gtrnctr: element is required, continue to use 0 if no data available.
- smplroute: add explicit checks for valid, use msecs instead of secs.  There are subtle differences as (m)secsTo is computed before rounding, while before toTime_t rounds before the difference was computed.
- gpx.cc:  last_found is of class gpsbabel::DateTime.  For default init toTime_T will return 0, and isValid will return false.  There is no need to use toTime_t to see if last_found has been assigned.
