### PR TITLE
de-duplicate format setup in find_vec

### DIFF
--- a/format.h
+++ b/format.h
@@ -169,29 +169,6 @@ public:
   virtual ff_type get_type() const = 0;
   virtual QVector<ff_cap> get_cap() const = 0;
 
-  QString get_name() const
-  {
-    return name;
-  }
-
-  void set_name(const QString& nm)
-  {
-    name = nm;
-  }
-
-  QString get_argstring() const
-  {
-    return argstring;
-  }
-
-  void set_argstring(const QString& string)
-  {
-    argstring = string;
-  }
-private:
-  QString name;
-  QString argstring;
-
 protected:
   template <class MyFormat>
   class RteHdFunctor

--- a/garmin.cc
+++ b/garmin.cc
@@ -355,7 +355,7 @@ rd_init(const QString& fname)
 {
   if (setjmp(gdx_jmp_buf)) {
     const gdx_info* gi = gdx_get_info();
-    gpx_vec = Vecs::Instance().find_vec("gpx");
+    gpx_vec = Vecs::Instance().find_vec("gpx").fmt;
     gpx_vec->rd_init(gi->from_device.canon);
   } else {
     gpx_vec = nullptr;

--- a/vecs.cc
+++ b/vecs.cc
@@ -876,8 +876,7 @@ Vecs::fmtinfo_t Vecs::find_vec(const QString& fmtargstring)
   /*
    * Not found.
    */
-  fmtinfo_t fmtinfo;
-  return  fmtinfo;
+  return {};
 }
 
 /*

--- a/vecs.h
+++ b/vecs.h
@@ -35,6 +35,25 @@ class Vecs
 {
 // Meyers Singleton
 public:
+
+  /* Types */
+
+  class fmtinfo_t {
+  public:
+
+    explicit operator bool() const {
+      return fmt != nullptr;
+    }
+    Format* operator->() const {
+      return fmt;
+    }
+
+    Format* fmt{};
+    QString fmtname;
+    QString style_filename;
+    QStringList options;
+  };
+
   /* Special Member Functions */
 
   static Vecs& Instance();
@@ -51,7 +70,8 @@ public:
   static void disp_vec_options(const QString& vecname, const QVector<arglist_t>* args);
   static void validate_options(const QStringList& options, const QVector<arglist_t>* args, const QString& name);
   static QString get_option(const QStringList& options, const QString& argname);
-  Format* find_vec(const QString& fmtargstring);
+  void prepare_format(const fmtinfo_t& data) const;
+  fmtinfo_t find_vec(const QString& fmtargstring);
   void disp_vecs() const;
   void disp_vec(const QString& vecname) const;
   static const char* name_option(uint32_t type);
@@ -116,7 +136,6 @@ private:
   static bool is_integer(const QString& val);
   static bool is_float(const QString& val);
   static bool is_bool(const QString& val);
-  void prepare_format(Format* fmt, const QString& fmtname, const QString& stylefilename, const QStringList& options, const QString& fmtargstring) const;
   static QVector<style_vec_t> create_style_vec();
   QVector<vecinfo_t> sort_and_unify_vecs() const;
   static void disp_v1(ff_type t);

--- a/vecs.h
+++ b/vecs.h
@@ -51,7 +51,7 @@ public:
   static void disp_vec_options(const QString& vecname, const QVector<arglist_t>* args);
   static void validate_options(const QStringList& options, const QVector<arglist_t>* args, const QString& name);
   static QString get_option(const QStringList& options, const QString& argname);
-  Format* find_vec(const QString& vecname);
+  Format* find_vec(const QString& fmtargstring);
   void disp_vecs() const;
   void disp_vec(const QString& vecname) const;
   static const char* name_option(uint32_t type);
@@ -116,6 +116,7 @@ private:
   static bool is_integer(const QString& val);
   static bool is_float(const QString& val);
   static bool is_bool(const QString& val);
+  void prepare_format(Format* fmt, const QString& fmtname, const QString& stylefilename, const QStringList& options, const QString& fmtargstring) const;
   static QVector<style_vec_t> create_style_vec();
   QVector<vecinfo_t> sort_and_unify_vecs() const;
   static void disp_v1(ff_type t);


### PR DESCRIPTION
This de-duplication isolates the code that prepares a format for execution.  Previously it was duplicated once for normal formats and once for style based formats.  In the future it is anticipated this will be used with dynamic formats, likely with a modified set of parameters.