### PR TITLE
archive docs in CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,19 +20,24 @@ jobs:
         include:
           - IMAGE: 'focal'
             SCRIPT: './tools/build_and_test_cmake.sh'
+            RELEASE: false
           - IMAGE: 'jammy'
             CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt5'
             SCRIPT: './tools/build_and_test_cmake.sh'
+            RELEASE: false
           - IMAGE: 'jammy'
             CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt6'
             SCRIPT: './tools/build_and_test_cmake.sh'
+            RELEASE: true
           - IMAGE: 'jammy'
             CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt6'
             SCRIPT: './tools/build_and_test_cmake.sh'
             TOOLS: 'clang'
+            RELEASE: false
           - IMAGE: 'jammy'
             CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt5'
             SCRIPT: './tools/build_extra_tests.sh'
+            RELEASE: false
     container:
       image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_${{ matrix.IMAGE }}
       env:
@@ -60,6 +65,18 @@ jobs:
           export CXX
         fi
         "${JOB_SCRIPT}"
+
+    - name: 'Upload Artifacts'
+      if: matrix.RELEASE
+      uses: actions/upload-artifact@v3
+      with:
+        name: Documents ${{ join(matrix.*) }}
+        path: |
+          ${{ github.workspace }}/gpsbabel.org/
+          ${{ github.workspace }}/gpsbabel.pdf
+          ${{ github.workspace }}/gpsbabel.html
+          ${{ github.workspace }}/docbook.css
+        retention-days: 7
 
   coverage:
     name: coverage Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -72,10 +72,10 @@ jobs:
       with:
         name: Documents
         path: |
-          ${{ github.workspace }}/gpsbabel.org/
-          ${{ github.workspace }}/gpsbabel.pdf
-          ${{ github.workspace }}/gpsbabel.html
-          ${{ github.workspace }}/docbook.css
+          gpsbabel.org/
+          gpsbabel.pdf
+          gpsbabel.html
+          docbook.css
         retention-days: 7
 
   coverage:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -70,7 +70,7 @@ jobs:
       if: matrix.RELEASE
       uses: actions/upload-artifact@v3
       with:
-        name: Documents ${{ join(matrix.*) }}
+        name: Documents
         path: |
           ${{ github.workspace }}/gpsbabel.org/
           ${{ github.workspace }}/gpsbabel.pdf


### PR DESCRIPTION
This creates an archive of our document targets in CI: gpsbabel.pdf, gpsbabel.org, gpsbabel.html.  The archive is available for 7 days to committers.  If this is merged the action will be available to run on demand on any branch.