### PR TITLE
use jfrog docker repo and ninja for codeql.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    container: tsteven4/gpsbabel_build_environment_focal
+    container:
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_focal
+      env:
+        CMAKE_GENERATOR: Ninja
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Using the jfrog docker repo avoids dockerhub download limits.  We use it everywhere else.

Ninja should improve the build time.