### PR TITLE
use 6 digits after the decimal point for osm_name_from_wpt.

### DIFF
--- a/osm.cc
+++ b/osm.cc
@@ -692,8 +692,8 @@ OsmFormat::osm_name_from_wpt(const Waypoint* waypoint)
 {
   QString name = QString("%1\01%2\01%3")
                  .arg(waypoint->shortname)
-                 .arg(waypoint->latitude)
-                 .arg(waypoint->longitude);
+                 .arg(waypoint->latitude, 0, 'f', 6)
+                 .arg(waypoint->longitude, 0, 'f', 6);
   return name;
 }
 


### PR DESCRIPTION
I beleive this restores the behavior from before commit 4673a25, August 4, 2013.

This should resolve #1047.