### PR TITLE
At Qt6 build to Fedora CI

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -14,11 +14,20 @@ jobs:
       fail-fast: false
       matrix:
         # version 32, though obsolete, uses Qt 5.14 so we keep it for that.
-        version: ['32', '35', '37']
+        include:
+          - IMAGE: '32'
+            CMAKE_PREFIX_PATH: '/usr/lib64/cmake/Qt5'
+          - IMAGE: '35'
+            CMAKE_PREFIX_PATH: '/usr/lib64/cmake/Qt5'
+          - IMAGE: '37'
+            CMAKE_PREFIX_PATH: '/usr/lib64/cmake/Qt5'
+          - IMAGE: '37'
+            CMAKE_PREFIX_PATH: '/usr/lib64/cmake/Qt6'
     container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_f${{ matrix.version }}
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_f${{ matrix.IMAGE }}
       env:
-        LC_ALL: C.UTF-8
+        LC_ALL: 'C.UTF-8'
+        JOB_CMAKE_PREFIX_PATH: ${{ matrix.CMAKE_PREFIX_PATH }}
 
     steps:
     - name: Checkout repository
@@ -28,4 +37,8 @@ jobs:
       run: |
         # when using containers manually whitelist the checkout directory to allow git commands to work
         git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+        if [ -n "${JOB_CMAKE_PREFIX_PATH}" ]; then
+          CMAKE_PREFIX_PATH="${JOB_CMAKE_PREFIX_PATH}"
+          export CMAKE_PREFIX_PATH
+        fi
         ./tools/build_and_test_cmake.sh

--- a/tools/Dockerfile_f37
+++ b/tools/Dockerfile_f37
@@ -15,8 +15,8 @@ RUN dnf install --assumeyes libusb1-devel zlib-devel shapelib-devel && \
 # Qt used by gpsbabel, gpsbabelfe
 RUN dnf install --assumeyes qt5-qtbase-devel qt5-qtserialport-devel qt5-qtwebengine-devel qt5-linguist qt5-qttranslations && \
     dnf clean all
+RUN dnf install --assumeyes qt6-qtbase-devel qt6-qtserialport-devel qt6-qtwebengine-devel qt6-linguist qt6-qttranslations qt6-qt5compat-devel qt6-qttools-devel && \
+    dnf clean all
 # tools to build the docs
 RUN dnf install --assumeyes expat desktop-file-utils libxslt docbook-style-xsl fop docbook5-style-xsl docbook5-schemas && \
     dnf clean all
-# create a link as fedora uses the name qmake-qt5 for Qt5's qmake.
-RUN alternatives --install /usr/bin/qmake qt /usr/lib64/qt5/bin/qmake 100

--- a/tools/Dockerfile_f37
+++ b/tools/Dockerfile_f37
@@ -15,7 +15,7 @@ RUN dnf install --assumeyes libusb1-devel zlib-devel shapelib-devel && \
 # Qt used by gpsbabel, gpsbabelfe
 RUN dnf install --assumeyes qt5-qtbase-devel qt5-qtserialport-devel qt5-qtwebengine-devel qt5-linguist qt5-qttranslations && \
     dnf clean all
-RUN dnf install --assumeyes qt6-qtbase-devel qt6-qtserialport-devel qt6-qtwebengine-devel qt6-linguist qt6-qttranslations qt6-qt5compat-devel qt6-qttools-devel && \
+RUN dnf install --assumeyes qt6-qtbase-devel qt6-qtserialport-devel qt6-qtwebengine-devel qt6-linguist qt6-qttranslations qt6-qt5compat-devel qt6-qttools-devel libxkbcommon-devel && \
     dnf clean all
 # tools to build the docs
 RUN dnf install --assumeyes expat desktop-file-utils libxslt docbook-style-xsl fop docbook5-style-xsl docbook5-schemas && \


### PR DESCRIPTION
Fedora has finally provided Qt6 WebEngine.  This adds a CI job that builds with Qt6 in addition to the existing jobs that build with Qt5.