### PR TITLE
#1062 Fix core dump when merging tracks with disparate IGC extensions

### DIFF
--- a/igc.h
+++ b/igc.h
@@ -298,45 +298,6 @@ struct igc_fsdata : public FormatSpecificData {
   std::optional<double> acz; // Z Acceleration
   std::optional<double> gfo; // G Force?
 
-  bool has_value(KmlFormat::wp_field type) const {
-    bool ret = false;
-    switch (type) {
-      case KmlFormat::wp_field::igc_enl:
-        ret = enl.has_value();
-        break;
-      case KmlFormat::wp_field::igc_tas:
-        ret = tas.has_value();
-        break;
-      case KmlFormat::wp_field::igc_vat:
-        ret = vat.has_value();
-        break;
-      case KmlFormat::wp_field::igc_oat:
-        ret = oat.has_value();
-        break;
-      case KmlFormat::wp_field::igc_trt:
-        ret = trt.has_value();
-        break;
-      case KmlFormat::wp_field::igc_gsp:
-        ret = gsp.has_value();
-        break;
-      case KmlFormat::wp_field::igc_fxa:
-        ret = fxa.has_value();
-        break;
-      case KmlFormat::wp_field::igc_siu:
-        ret = siu.has_value();
-        break;
-      case KmlFormat::wp_field::igc_acz:
-        ret = acz.has_value();
-        break;
-      case KmlFormat::wp_field::igc_gfo:
-        ret = gfo.has_value();
-        break;
-      default:
-        ret = false;
-    }
-  return ret;  
-  }
-
   bool set_value(IgcFormat::igc_ext_type_t type, double value)
   {
     bool success = true;

--- a/igc.h
+++ b/igc.h
@@ -298,6 +298,45 @@ struct igc_fsdata : public FormatSpecificData {
   std::optional<double> acz; // Z Acceleration
   std::optional<double> gfo; // G Force?
 
+  bool has_value(KmlFormat::wp_field type) const {
+    bool ret = false;
+    switch (type) {
+      case KmlFormat::wp_field::igc_enl:
+        ret = enl.has_value();
+        break;
+      case KmlFormat::wp_field::igc_tas:
+        ret = tas.has_value();
+        break;
+      case KmlFormat::wp_field::igc_vat:
+        ret = vat.has_value();
+        break;
+      case KmlFormat::wp_field::igc_oat:
+        ret = oat.has_value();
+        break;
+      case KmlFormat::wp_field::igc_trt:
+        ret = trt.has_value();
+        break;
+      case KmlFormat::wp_field::igc_gsp:
+        ret = gsp.has_value();
+        break;
+      case KmlFormat::wp_field::igc_fxa:
+        ret = fxa.has_value();
+        break;
+      case KmlFormat::wp_field::igc_siu:
+        ret = siu.has_value();
+        break;
+      case KmlFormat::wp_field::igc_acz:
+        ret = acz.has_value();
+        break;
+      case KmlFormat::wp_field::igc_gfo:
+        ret = gfo.has_value();
+        break;
+      default:
+        ret = false;
+    }
+  return ret;  
+  }
+
   bool set_value(IgcFormat::igc_ext_type_t type, double value)
   {
     bool success = true;

--- a/kml.cc
+++ b/kml.cc
@@ -1505,20 +1505,14 @@ void KmlFormat::kml_mt_simple_array(const route_head* header,
     case wp_field::igc_fxa:
     case wp_field::igc_gfo:
     case wp_field::igc_siu:
-    case wp_field::igc_acz: {
-      if (fs_igc) {
-        if (fs_igc->has_value(member)) {
-          double value = fs_igc->get_value(member).value();
-          if (global_opts.debug_level >= 6) {
-            printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
-          }
-          writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
-        } else {
-          if (global_opts.debug_level >= 7) {
-            printf(MYNAME ": Writing empty KML SimpleArray data for %s\n", name);
-          }
-          writer->writeTextElement(QStringLiteral("gx:value"), QString());
+    case wp_field::igc_acz:
+      if (fs_igc && fs_igc->has_value(member)) {
+        double value = fs_igc->get_value(member).value();
+        if (global_opts.debug_level >= 6) {
+          printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
         }
+        writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
+        writer->writeTextElement(QStringLiteral("gx:value"), QString());
       // No igc_fsdata present, but we still need to write out the SimpleArray
       } else {
         if (global_opts.debug_level >= 7) {
@@ -1527,7 +1521,6 @@ void KmlFormat::kml_mt_simple_array(const route_head* header,
         writer->writeTextElement(QStringLiteral("gx:value"), QString());
       }
       break;
-      }
     default:
       fatal("Bad member type");
     }

--- a/kml.cc
+++ b/kml.cc
@@ -1512,7 +1512,6 @@ void KmlFormat::kml_mt_simple_array(const route_head* header,
           printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
         }
         writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
-        writer->writeTextElement(QStringLiteral("gx:value"), QString());
       // No igc_fsdata present, but we still need to write out the SimpleArray
       } else {
         if (global_opts.debug_level >= 7) {

--- a/kml.cc
+++ b/kml.cc
@@ -1506,18 +1506,28 @@ void KmlFormat::kml_mt_simple_array(const route_head* header,
     case wp_field::igc_gfo:
     case wp_field::igc_siu:
     case wp_field::igc_acz: {
-      if (fs_igc->has_value(member)) {
-        double value = fs_igc->get_value(member).value();
-        if (global_opts.debug_level >= 6) {
-          printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
+      if (fs_igc) {
+        if (fs_igc->has_value(member)) {
+          double value = fs_igc->get_value(member).value();
+          if (global_opts.debug_level >= 6) {
+            printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
+          }
+          writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
+        } else {
+          if (global_opts.debug_level >= 7) {
+            printf(MYNAME ": Writing empty KML SimpleArray data for %s\n", name);
+          }
+          writer->writeTextElement(QStringLiteral("gx:value"), QString());
         }
-        writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
-      } else if (global_opts.debug_level >= 7) {
-        printf(MYNAME ": Writing empty KML SimpleArray data for %s\n", name);
+      // No igc_fsdata present, but we still need to write out the SimpleArray
+      } else {
+        if (global_opts.debug_level >= 7) {
+          printf(MYNAME ": Writing empty KML SimpleArray data for %s\n", name);
+        }
         writer->writeTextElement(QStringLiteral("gx:value"), QString());
       }
       break;
-    }
+      }
     default:
       fatal("Bad member type");
     }

--- a/kml.cc
+++ b/kml.cc
@@ -1506,13 +1506,14 @@ void KmlFormat::kml_mt_simple_array(const route_head* header,
     case wp_field::igc_gfo:
     case wp_field::igc_siu:
     case wp_field::igc_acz:
-      if (fs_igc && fs_igc->has_value(member)) {
+      if (fs_igc && fs_igc->get_value(member).has_value()) {
         double value = fs_igc->get_value(member).value();
         if (global_opts.debug_level >= 6) {
           printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
         }
         writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
-      // No igc_fsdata present, but we still need to write out the SimpleArray
+      // No igc_fsdata present, but we still need to write out the SimpleArray.
+      // This can happen when merging tracks with different sets of IGC extensions.
       } else {
         if (global_opts.debug_level >= 7) {
           printf(MYNAME ": Writing empty KML SimpleArray data for %s\n", name);

--- a/kml.cc
+++ b/kml.cc
@@ -1506,9 +1506,8 @@ void KmlFormat::kml_mt_simple_array(const route_head* header,
     case wp_field::igc_gfo:
     case wp_field::igc_siu:
     case wp_field::igc_acz: {
-      double value;
       if (fs_igc->has_value(member)) {
-        value = fs_igc->get_value(member).value();
+        double value = fs_igc->get_value(member).value();
         if (global_opts.debug_level >= 6) {
           printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
         }

--- a/kml.cc
+++ b/kml.cc
@@ -1506,11 +1506,17 @@ void KmlFormat::kml_mt_simple_array(const route_head* header,
     case wp_field::igc_gfo:
     case wp_field::igc_siu:
     case wp_field::igc_acz: {
-      double value = fs_igc->get_value(member).value();
-      if (global_opts.debug_level >= 6) {
-        printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
+      double value;
+      if (fs_igc->has_value(member)) {
+        value = fs_igc->get_value(member).value();
+        if (global_opts.debug_level >= 6) {
+          printf(MYNAME ": Writing KML SimpleArray data: %s of %f\n", name, value);
+        }
+        writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
+      } else if (global_opts.debug_level >= 7) {
+        printf(MYNAME ": Writing empty KML SimpleArray data for %s\n", name);
+        writer->writeTextElement(QStringLiteral("gx:value"), QString());
       }
-      writer->writeTextElement(QStringLiteral("gx:value"), QString::number(value));
       break;
     }
     default:


### PR DESCRIPTION
You're correct, I hadn't considered the case when merging multiple IGC files - I didn't even realize this was possible, so assumed any extension data present will be present for all Waypoints. This issue occurs when merging tracks from recorders using non-identical sets of extensions.

This fix is an igc_fsdata::has_value() function that still allows for IGC extensions to be processed in a single block. I *have* noticed some function templates (not sure what they're called) in [defs.h starting at line 385](https://github.com/GPSBabel/gpsbabel/blob/cad16e14c34f3ee16fde021aa4df82b2461f5bff/defs.h#L385), but that implementation is beyond me currently.

Another `QMap<IgcFormat::ext_rec_type_t, igc_fsdata::std::optional*> igc_opt_fsdata_map` could also work, but I think this way is more readable.

Should we add a test that covers this?

Thanks for bearing with me. At least in this case I think it was my unfamiliarity with GPSBabel and not my out of date C++.

Fixes #1062 