### PR TITLE
use c++ style attribute syntax with gnu namespace.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -129,15 +129,6 @@ constexpr int kDautmWGS84 = 118; // GPS_Lookup_Datum_Index("WGS 84")
 #  define GB_PATHSEP '/'
 #endif
 
-/*
- *  Toss in some GNU C-specific voodoo for checking.
- */
-#if __GNUC__
-#  define PRINTFLIKE(x,y) __attribute__ ((__format__ (__printf__, (x), (y))))
-#else
-#  define PRINTFLIKE(x,y)
-#endif
-
 
 /*
  * Common definitions.   There should be no protocol or file-specific
@@ -984,8 +975,8 @@ struct ff_vecs_t {
 };
 
 [[noreturn]] void fatal(QDebug& msginstance);
-[[noreturn]] void fatal(const char*, ...) PRINTFLIKE(1, 2);
-void warning(const char*, ...) PRINTFLIKE(1, 2);
+[[noreturn]] [[gnu::format(printf, 1, 2)]] void fatal(const char*, ...);
+[[gnu::format(printf, 1, 2)]] void warning(const char*, ...);
 
 void printposn(double c, bool is_lat);
 
@@ -1018,9 +1009,9 @@ inline int case_ignore_strncmp(const QString& s1, const QString& s2, int n)
 
 int str_match(const char* str, const char* match);
 
-int xasprintf(char** strp, const char* fmt, ...) PRINTFLIKE(2, 3);
-int xasprintf(QString* strp, const char* fmt, ...) PRINTFLIKE(2, 3);
-int xasprintf(QScopedPointer<char, QScopedPointerPodDeleter>& strp, const char* fmt, ...) PRINTFLIKE(2, 3);
+[[gnu::format(printf, 2, 3)]] int xasprintf(char** strp, const char* fmt, ...);
+[[gnu::format(printf, 2, 3)]] int xasprintf(QString* strp, const char* fmt, ...);
+[[gnu::format(printf, 2, 3)]] int xasprintf(QScopedPointer<char, QScopedPointerPodDeleter>& strp, const char* fmt, ...);
 int xvasprintf(char** strp, const char* fmt, va_list ap);
 char* strupper(char* src);
 char* strlower(char* src);

--- a/defs.h
+++ b/defs.h
@@ -975,7 +975,15 @@ struct ff_vecs_t {
 };
 
 [[noreturn]] void fatal(QDebug& msginstance);
-[[noreturn]] [[gnu::format(printf, 1, 2)]] void fatal(const char*, ...);
+// cppcheck 2.10.3 fails to assign noreturn attribute to fatal if
+// the noreturn attribute is listed before the gnu::format attribute.
+// A PR to resolve this is https://github.com/danmar/cppcheck/pull/4971,
+// but cppcheck works if the noreturn attribute follows the gnu::format
+// attribute.
+// This can have a large effect on codacy issues from cppcheck
+// nullPointerRedundantCheck, nullPointerArithmeticRedundantCheck,
+// negativeIndex, arrayIndexOutOfBoundsCond.
+[[gnu::format(printf, 1, 2)]] [[noreturn]] void fatal(const char*, ...);
 [[gnu::format(printf, 1, 2)]] void warning(const char*, ...);
 
 void printposn(double c, bool is_lat);

--- a/garmin_gpi.cc
+++ b/garmin_gpi.cc
@@ -71,10 +71,10 @@
 garmin_fs_t*
 GarminGPIFormat::gpi_gmsd_init(Waypoint* wpt)
 {
-  garmin_fs_t* gmsd = garmin_fs_t::find(wpt);
   if (wpt == nullptr) {
     fatal(MYNAME ": Error in file structure.\n");
   }
+  garmin_fs_t* gmsd = garmin_fs_t::find(wpt);
   if (gmsd == nullptr) {
     gmsd = garmin_fs_alloc(-1);
     wpt->fs.FsChainAdd(gmsd);

--- a/mkshort.cc
+++ b/mkshort.cc
@@ -161,9 +161,13 @@ mkshort_add_to_list(mkshort_handle_imp* h, char* name)
 void
 mkshort_del_handle(short_handle* h)
 {
+  if (!h) {
+    return;
+  }
+
   auto* hdr = (mkshort_handle_imp*) *h;
 
-  if (!h || !hdr) {
+  if (!hdr) {
     return;
   }
 

--- a/util.cc
+++ b/util.cc
@@ -1061,14 +1061,11 @@ pretty_deg_format(double lat, double lon, char fmt, const char* sep, bool html)
 QString
 strip_nastyhtml(const QString& in)
 {
-  char* returnstr;
-  char* lcstr;
+  char* returnstr = xstrdup(in);
+  char* lcstr = strlower(xstrdup(in));
 
-  char* sp = returnstr = xstrdup(in);
-  char* lcp = lcstr = strlower(xstrdup(in));
-
-  while (lcp = strstr(lcstr, "<body>"), nullptr != lcp) {
-    sp = returnstr + (lcp - lcstr) ; /* becomes <!   > */
+  while (char* lcp = strstr(lcstr, "<body>")) {
+    char* sp = returnstr + (lcp - lcstr) ; /* becomes <!   > */
     sp++;
     *sp++ = '!';
     *sp++ = ' ';
@@ -1076,8 +1073,8 @@ strip_nastyhtml(const QString& in)
     *sp++ = ' ';
     *lcp = '*';         /* so we wont find it again */
   }
-  while (lcp = strstr(lcstr, "<body"), lcp != nullptr) {   /* becomes <!--        --> */
-    sp = returnstr + (lcp - lcstr) ;
+  while (char* lcp = strstr(lcstr, "<body")) {   /* becomes <!--        --> */
+    char* sp = returnstr + (lcp - lcstr) ;
     sp++;
     *sp++ = '!';
     *sp++ = '-';
@@ -1089,8 +1086,8 @@ strip_nastyhtml(const QString& in)
     *--sp = '-';
     *lcp = '*';         /* so we wont find it again */
   }
-  while (lcp = strstr(lcstr, "</body>"), nullptr != lcp) {
-    sp = returnstr + (lcp - lcstr) ; /* becomes <!---- */
+  while (char* lcp = strstr(lcstr, "</body>")) {
+    char* sp = returnstr + (lcp - lcstr) ; /* becomes <!---- */
     sp++;
     *sp++ = '!';
     *sp++ = '-';
@@ -1099,8 +1096,8 @@ strip_nastyhtml(const QString& in)
     *sp++ = '-';
     *lcp = '*';         /* so we wont find it again */
   }
-  while (lcp = strstr(lcstr, "</html>"), nullptr != lcp) {
-    sp = returnstr + (lcp - lcstr) ; /* becomes </---- */
+  while (char* lcp = strstr(lcstr, "</html>")) {
+    char* sp = returnstr + (lcp - lcstr) ; /* becomes </---- */
     sp++;
     *sp++ = '!';
     *sp++ = '-';
@@ -1109,8 +1106,8 @@ strip_nastyhtml(const QString& in)
     *sp++ = '-';
     *lcp = '*';         /* so we wont find it again */
   }
-  while (lcp = strstr(lcstr, "<style"), nullptr != lcp) {
-    sp = returnstr + (lcp - lcstr) ; /* becomes <!--   */
+  while (char* lcp = strstr(lcstr, "<style")) {
+    char* sp = returnstr + (lcp - lcstr) ; /* becomes <!--   */
     sp++;
     *sp++ = '!';
     *sp++ = '-';
@@ -1120,8 +1117,8 @@ strip_nastyhtml(const QString& in)
     *sp = ' ';
     *lcp = '*';         /* so we wont find it again */
   }
-  while (lcp = strstr(lcstr, "</style>"), nullptr != lcp) {
-    sp = returnstr + (lcp - lcstr) ; /* becomes    --> */
+  while (char* lcp = strstr(lcstr, "</style>")) {
+    char* sp = returnstr + (lcp - lcstr) ; /* becomes    --> */
     *sp++ = ' ';
     *sp++ = ' ';
     *sp++ = ' ';
@@ -1131,8 +1128,8 @@ strip_nastyhtml(const QString& in)
     *sp++ = '-';
     *lcp = '*';         /* so we wont find it again */
   }
-  while (lcp = strstr(lcstr, "<image"), nullptr != lcp) {
-    sp = returnstr + (lcp - lcstr) ; /* becomes <img */
+  while (char* lcp = strstr(lcstr, "<image")) {
+    char* sp = returnstr + (lcp - lcstr) ; /* becomes <img */
     sp+=3;
     *sp++ = 'g';
     *sp++ = ' ';


### PR DESCRIPTION
cppcheck 2.10.3 seems to have difficulty combining c++ style attributes like [[noreturn]] with gnu `__attribute__` syntax. this leads to lots of false positive [nullPointerRedundantCheck] warnings. https://sourceforge.net/p/cppcheck/discussion/general/thread/02fab2bec8/

I have a feeling I did this before and it failed somewhere.  Perhaps our compilers are all ready for it now.

I did verify the printf mismatched argument detection works as expected with g++ 11.3.0 and clang++ 14.0.0.
