### PR TITLE
keep gdb route point names and waypoint names aligned.

### DIFF
--- a/reference/route/gdbroutenametest.csv
+++ b/reference/route/gdbroutenametest.csv
@@ -1,0 +1,6 @@
+name,lat,lon
+RoutePoint,40.00,-105.00
+RoutePoint,40.01,-105.00
+RoutePoint,40.01,-105.01
+RoutePoint,40.02,-105.01
+

--- a/reference/route/gdbroutenametest~csv.csv
+++ b/reference/route/gdbroutenametest~csv.csv
@@ -1,0 +1,5 @@
+No,Latitude,Longitude,Name,Symbol
+1,40.000000,-105.000000,"RoutePoint","Waypoint"
+2,40.010000,-105.000000,"RoutePoint.1","Waypoint"
+3,40.010000,-105.010000,"RoutePoint.2","Waypoint"
+4,40.020000,-105.010000,"RoutePoint.3","Waypoint"

--- a/testo.d/gdb.test
+++ b/testo.d/gdb.test
@@ -29,3 +29,13 @@ compare ${REFERENCE}/gdb-sample.gpx ${TMPDIR}/gdb-sample_v3.gpx
 # don't choke if autoroute information is present.
 gpsbabel -i gdb,dropwpt -f ${REFERENCE}/gdb-sample-v3-autoroute.gdb -o gpx -F ${TMPDIR}/gdb-sample-v3-autoroute.gpx
 compare ${REFERENCE}/gdb-sample-v3-autoroute.gpx ${TMPDIR}/gdb-sample-v3-autoroute.gpx
+
+# test that the Route point Point names from the 'R' records match the Waypoint names from the 'W' records.
+# the names in the csv input are all identical which forces the gdb writer to uniquify them.
+gpsbabel -r  -i unicsv -f ${REFERENCE}/route/gdbroutenametest.csv -o gdb -F ${TMPDIR}/gdbroutenametest.gdb
+# if we don't match the names we will get a fatal error:
+# gdb: Route point mismatch!
+#   "RoutePoint" from waypoints differs to "RoutePoint"
+#   from route table by more than 1113.2 meters!
+gpsbabel -r -i gdb -f ${TMPDIR}/gdbroutenametest.gdb -o unicsv -F ${TMPDIR}/gdbroutenametest.csv
+compare ${REFERENCE}/route/gdbroutenametest~csv.csv ${TMPDIR}/gdbroutenametest.csv


### PR DESCRIPTION
This used to work in 1.4.4, but stopped working with the conversion to QString (NEW_STRINGS).

Add a test case to verify the names match.