### PR TITLE
fix kml cppcheck warnings.

### DIFF
--- a/kml.cc
+++ b/kml.cc
@@ -78,12 +78,12 @@ void KmlFormat::kml_init_color_sequencer(unsigned int steps_per_rev)
     float color_step = strtod(opt_rotate_colors, nullptr);
     if (color_step > 0.0f) {
       // step around circle by given number of degrees for each track(route)
-      kml_color_sequencer.step = ((float)kml_color_limit) * 6.0f * color_step / 360.0f;
+      kml_color_sequencer.step = static_cast<float>(kml_color_limit) * 6.0f * color_step / 360.0f;
     } else {
       // one cycle around circle for all the tracks(routes)
-      kml_color_sequencer.step = ((float)kml_color_limit) * 6.0f / ((float)steps_per_rev);
+      kml_color_sequencer.step = static_cast<float>(kml_color_limit) * 6.0f / static_cast<float>(steps_per_rev);
     }
-    kml_color_sequencer.color.opacity=255;
+    kml_color_sequencer.color.opacity = 255;
     kml_color_sequencer.seq = 0.0f;
   }
 }
@@ -92,28 +92,28 @@ void KmlFormat::kml_step_color()
 {
   // Map kml_color_sequencer.seq to an integer in the range [0, kml_color_limit*6).
   // Note that color_seq may be outside this range if the cast from float to int fails.
-  int color_seq = ((int) kml_color_sequencer.seq) % (kml_color_limit * 6);
+  int color_seq = static_cast<int>(kml_color_sequencer.seq) % (kml_color_limit * 6);
   if (global_opts.debug_level >= 1) {
-    printf(MYNAME ": kml_color_sequencer seq %f %d, step %f\n",kml_color_sequencer.seq, color_seq, kml_color_sequencer.step);
+    printf(MYNAME ": kml_color_sequencer seq %f %d, step %f\n", kml_color_sequencer.seq, color_seq, kml_color_sequencer.step);
   }
   if ((color_seq >= (0*kml_color_limit)) && (color_seq < (1*kml_color_limit))) {
-    kml_color_sequencer.color.bbggrr = (0)<<16 | (color_seq)<<8 | (kml_color_limit);
+    kml_color_sequencer.color.bbggrr = kml_bgr_to_color(0, color_seq, kml_color_limit);
   } else if ((color_seq >= (1*kml_color_limit)) && (color_seq < (2*kml_color_limit))) {
-    kml_color_sequencer.color.bbggrr = (0)<<16 | (kml_color_limit)<<8 | (2*kml_color_limit-color_seq);
+    kml_color_sequencer.color.bbggrr = kml_bgr_to_color(0, kml_color_limit, 2*kml_color_limit-color_seq);
   } else if ((color_seq >= (2*kml_color_limit)) && (color_seq < (3*kml_color_limit))) {
-    kml_color_sequencer.color.bbggrr = (color_seq-2*kml_color_limit)<<16 | (kml_color_limit)<<8 | (0);
+    kml_color_sequencer.color.bbggrr = kml_bgr_to_color(color_seq-2*kml_color_limit, kml_color_limit, 0);
   } else if ((color_seq >= (3*kml_color_limit)) && (color_seq < (4*kml_color_limit))) {
-    kml_color_sequencer.color.bbggrr = (kml_color_limit)<<16 | (4*kml_color_limit-color_seq)<<8 | (0);
+    kml_color_sequencer.color.bbggrr = kml_bgr_to_color(kml_color_limit, 4*kml_color_limit-color_seq ,0);
   } else if ((color_seq >= (4*kml_color_limit)) && (color_seq < (5*kml_color_limit))) {
-    kml_color_sequencer.color.bbggrr = (kml_color_limit)<<16 | (0)<<8 | (color_seq-4*kml_color_limit);
+    kml_color_sequencer.color.bbggrr = kml_bgr_to_color(kml_color_limit, 0, color_seq-4*kml_color_limit);
   } else if ((color_seq >= (5*kml_color_limit)) && (color_seq < (6*kml_color_limit))) {
-    kml_color_sequencer.color.bbggrr = (6*kml_color_limit-color_seq)<<16 | (0)<<8 | (kml_color_limit);
+    kml_color_sequencer.color.bbggrr = kml_bgr_to_color(6*kml_color_limit-color_seq, 0, kml_color_limit);
   } else { // should not occur, but to be safe generate a legal color.
     warning(MYNAME ": Error in color conversion - using default color.\n");
-    kml_color_sequencer.color.bbggrr = (102)<<16 | (102)<<8 | (102);
+    kml_color_sequencer.color.bbggrr = kml_bgr_to_color(102, 102, 102);
   }
   // compute next color.
-  kml_color_sequencer.seq = kml_color_sequencer.seq + kml_color_sequencer.step;
+  kml_color_sequencer.seq += kml_color_sequencer.step;
 }
 
 void KmlFormat::wpt_s(xg_string /*args*/, const QXmlStreamAttributes* /*attrs*/)

--- a/kml.h
+++ b/kml.h
@@ -138,6 +138,10 @@ private:
   /* Member Functions */
 
   void kml_init_color_sequencer(unsigned int steps_per_rev);
+  static constexpr int kml_bgr_to_color(int blue, int green, int red)
+  {
+    return (blue)<<16 | (green)<<8 | (red);
+  }
   void kml_step_color();
   void wpt_s(const QString& args, const QXmlStreamAttributes* attrs);
   void wpt_e(const QString& args, const QXmlStreamAttributes* attrs);


### PR DESCRIPTION
Operator '|' with one operand equal to zero is redundant.