### PR TITLE
add "build" date from CI.

### DIFF
--- a/gbversion.cmake
+++ b/gbversion.cmake
@@ -24,6 +24,14 @@ list(GET VERSION_COMPONENTS 2 GB.MICRO)
 set(GB.BUILD 32 CACHE STRING "Fourth component of Windows VERSIONINFO resource FILEVERSION and PRODUCTVERSION parameters.")
 set(GB.PACKAGE_RELEASE "" CACHE STRING "String to append to VERSION tuple.") # .e.g. "-beta20190413"
 set(GB.SHA $ENV{GITHUB_SHA})
+if(DEFINED ENV{GITHUB_SHA})
+  find_program(GIT_EXECUTABLE NAMES git)
+  if(NOT GIT_EXECUTABLE STREQUAL "GIT-NOTFOUND")
+    execute_process(COMMAND ${GIT_EXECUTABLE} show -s --format=%aI
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE GB.DATE OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+endif()
 string(TIMESTAMP GB.COPYRIGHT_YEAR "%Y" UTC)
 
 # may be overridden on cmake command line

--- a/gbversion.h.in
+++ b/gbversion.h.in
@@ -15,5 +15,6 @@
 #else
 #define VERSION "@GB.MAJOR@.@GB.MINOR@.@GB.MICRO@@GB.PACKAGE_RELEASE@"
 constexpr char kVersionSHA[] = "@GB.SHA@";
+constexpr char kVersionDate[] = "@GB.DATE@";
 #define WEB_DOC_DIR "https://www.gpsbabel.org/htmldoc-@DOCVERSION@"
 #endif

--- a/gui/aboutdlg.cc
+++ b/gui/aboutdlg.cc
@@ -30,6 +30,7 @@
 
 AboutDlg::AboutDlg(QWidget* parent, const QString& ver1,
                    const QString& ver2, const QString& ver3,
+                   const QString& date,
                    const QString& installationId): QDialog(parent)
 {
   ui_.setupUi(this);
@@ -43,6 +44,11 @@ AboutDlg::AboutDlg(QWidget* parent, const QString& ver1,
     tt.replace("$hash$", "");
   } else {
     tt.replace("$hash$", "Hash: " + ver3);
+  }
+  if (date.isEmpty()) {
+    tt.replace("$date$", "");
+  } else {
+    tt.replace("$date$", "Date: " + date);
   }
   tt.replace("$installationId$", installationId);
 

--- a/gui/aboutdlg.h
+++ b/gui/aboutdlg.h
@@ -33,6 +33,7 @@ class AboutDlg: public QDialog
 public:
   AboutDlg(QWidget* parent,  const QString& ver1,
            const QString& ver2, const QString& ver3,
+           const QString& date,
            const QString& installationId);
 
 private:

--- a/gui/aboutui.ui
+++ b/gui/aboutui.ui
@@ -89,6 +89,7 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;(Using backend $babelversion$)&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;$hash$&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;$date$&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;$upgradetestmode$&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Installation ID: $installationId$&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -1148,7 +1148,12 @@ void MainWindow::moreOptionButtonClicked()
 //------------------------------------------------------------------------
 void MainWindow::aboutActionX()
 {
-  AboutDlg aboutDlg(nullptr, babelVersion_, QString(appName) + QString(" " VERSION), kVersionSHA, babelData_.installationUuid_);
+  QDateTime date = QDateTime::fromString(kVersionDate, Qt::ISODate);
+  QString utcdate;
+  if (date.isValid()) {
+    utcdate = date.toUTC().toString(Qt::ISODate);
+  }
+  AboutDlg aboutDlg(nullptr, babelVersion_, QString(appName) + QString(" " VERSION), kVersionSHA, utcdate, babelData_.installationUuid_);
   aboutDlg.setWindowTitle(tr("About %1").arg(appName));
   aboutDlg.exec();
 }

--- a/main.cc
+++ b/main.cc
@@ -492,6 +492,12 @@ run(const char* prog_name)
         if(sizeof(kVersionSHA) > 1) {
           warning(MYNAME ": Repository SHA: %s\n", kVersionSHA);
         }
+        if(sizeof(kVersionDate) > 1) {
+          QDateTime date = QDateTime::fromString(kVersionDate, Qt::ISODate);
+          if (date.isValid()) {
+            warning(MYNAME ": Date: %s\n", qPrintable(date.toUTC().toString(Qt::ISODate)));
+          }
+        }
         warning(MYNAME ": Compiled with Qt %s for architecture %s\n",
                 QT_VERSION_STR,
                 qPrintable(QSysInfo::buildAbi()));


### PR DESCRIPTION
Actually we add the git author date.  This provides a common date between the CI builds on macos and windows.  The date is only added if GITHUB_SHA exists which implies the repository doesn't have uncommitted changes.