### PR TITLE
move navilink towards QDateTime

### DIFF
--- a/navilink.cc
+++ b/navilink.cc
@@ -365,15 +365,18 @@ decode_datetime(const unsigned char* buffer)
 }
 
 static void
-encode_datetime(time_t datetime, unsigned char* buffer)
+encode_datetime(const QDateTime& datetime, unsigned char* buffer)
 {
-  if (std::tm* tm = gmtime(&datetime); tm != nullptr) {
-    buffer[0] = tm->tm_year - 100;
-    buffer[1] = tm->tm_mon + 1;
-    buffer[2] = tm->tm_mday;
-    buffer[3] = tm->tm_hour;
-    buffer[4] = tm->tm_min;
-    buffer[5] = tm->tm_sec;
+  if (datetime.isValid()) {
+    QDateTime dt = datetime.toUTC();
+    QDate date = dt.date();
+    QTime time = dt.time();
+    buffer[0] = date.year() - 2000;
+    buffer[1] = date.month();
+    buffer[2] = date.day();
+    buffer[3] = time.hour();
+    buffer[4] = time.minute();
+    buffer[5] = time.second();
   } else {
     memset(buffer, 0, 6);
   }
@@ -430,7 +433,7 @@ encode_waypoint(const Waypoint* waypt, unsigned char* buffer)
   buffer[10] = 0;
   buffer[11] = 0;
   encode_position(waypt, buffer + 12);
-  encode_datetime(waypt->GetCreationTime().toTime_t(), buffer + 22);
+  encode_datetime(waypt->GetCreationTime(), buffer + 22);
   buffer[28] = find_icon_from_descr(waypt->icon_descr);
   buffer[29] = 0;
   buffer[30] = 0x00;
@@ -465,7 +468,7 @@ encode_trackpoint(const Waypoint* waypt, unsigned serial, unsigned char* buffer)
   le_write32(buffer + 4, qRound(x));
   le_write32(buffer + 8, qRound(y));
   encode_position(waypt, buffer + 12);
-  encode_datetime(waypt->GetCreationTime().toTime_t(), buffer + 22);
+  encode_datetime(waypt->GetCreationTime(), buffer + 22);
   buffer[28] = z;
   buffer[29] = qRound(MPS_TO_KPH(waypt->speed_value_or(0) / 2));
   buffer[30] = 0x5a;

--- a/navilink.cc
+++ b/navilink.cc
@@ -23,8 +23,9 @@
 
 /* Based on description at http://wiki.splitbrain.org/navilink */
 
-#include <ctime>                   // for gmtime, time_t
+#include <cstdio>                  // for fprintf, stderr
 #include <cstring>                 // for memcpy, memset, strncpy
+#include <ctime>                   // for gmtime, time_t
 
 #include <QByteArray>              // for QByteArray
 #include <QDate>                   // for QDate
@@ -33,7 +34,7 @@
 #include <QThread>                 // for QThread
 #include <QTime>                   // for QTime
 #include <QVector>                 // for QVector
-#include <QtCore>                  // for qPrintable, UTC
+#include <QtCore>                  // for qRound, qPrintable, UTC
 
 #include "defs.h"
 #include "navilink.h"
@@ -389,9 +390,9 @@ decode_position(const unsigned char* buffer, Waypoint* waypt)
 static void
 encode_position(const Waypoint* waypt, unsigned char* buffer)
 {
-  le_write32(buffer + 0, (int)(waypt->latitude * 10000000));
-  le_write32(buffer + 4, (int)(waypt->longitude * 10000000));
-  le_write16(buffer + 8, METERS_TO_FEET(waypt->altitude));
+  le_write32(buffer + 0, qRound(waypt->latitude * 10000000));
+  le_write32(buffer + 4, qRound(waypt->longitude * 10000000));
+  le_write16(buffer + 8, qRound(METERS_TO_FEET(waypt->altitude)));
 }
 
 static unsigned
@@ -460,13 +461,13 @@ encode_trackpoint(const Waypoint* waypt, unsigned serial, unsigned char* buffer)
   GPS_Math_WGS84_To_UTM_EN(waypt->latitude, waypt->longitude, &x, &y, &z, &zc);
 
   le_write16(buffer + 0, serial);
-  le_write16(buffer + 2, waypt->course_value_or(0));
-  le_write32(buffer + 4, x);
-  le_write32(buffer + 8, y);
+  le_write16(buffer + 2, qRound(waypt->course_value_or(0)));
+  le_write32(buffer + 4, qRound(x));
+  le_write32(buffer + 8, qRound(y));
   encode_position(waypt, buffer + 12);
   encode_datetime(waypt->GetCreationTime().toTime_t(), buffer + 22);
   buffer[28] = z;
-  buffer[29] = MPS_TO_KPH(waypt->speed_value_or(0) / 2);
+  buffer[29] = qRound(MPS_TO_KPH(waypt->speed_value_or(0) / 2));
   buffer[30] = 0x5a;
   buffer[31] = 0x7e;
 }

--- a/navilink.cc
+++ b/navilink.cc
@@ -1089,7 +1089,7 @@ navilink_common_init(const QString& name)
     write_route_point = serial_write_route_point;
     write_route_end = serial_write_route_end;
   } else {
-    const char* mode = operation == READING ? "r" : "w+";
+    const char* mode = operation == READING ? "r" : "wb";
     file_handle = gbfopen(name, mode, MYNAME);
 
     write_waypoint = file_write_waypoint;

--- a/testo.d/navilink.test
+++ b/testo.d/navilink.test
@@ -4,7 +4,8 @@
 gpsbabel -i navilink -f ${REFERENCE}/navilink_waypoints.wpt -o gpx -F ${TMPDIR}/navilink_waypoints.gpx
 compare ${REFERENCE}/navilink_waypoints.gpx ${TMPDIR}/navilink_waypoints.gpx
 gpsbabel -i gpx -f ${TMPDIR}/navilink_waypoints.gpx -o navilink -F ${TMPDIR}/navilink_waypoints_gpx.wpt
-#compare ${TMPDIR}/navilink_waypoints_gpx.wpt ${REFERENCE}/navilink_waypoints_gpx.wpt
+# not quite what we start with.
+compare ${REFERENCE}/navilink_waypoints_gpx.wpt ${TMPDIR}/navilink_waypoints_gpx.wpt
 
 #
 # NaviLink tracks
@@ -12,5 +13,5 @@ gpsbabel -i gpx -f ${TMPDIR}/navilink_waypoints.gpx -o navilink -F ${TMPDIR}/nav
 gpsbabel -t -i navilink -f ${REFERENCE}/navilink_tracks.trk -o gpx -F ${TMPDIR}/navilink_tracks.gpx
 compare ${REFERENCE}/navilink_tracks.gpx ${TMPDIR}/navilink_tracks.gpx
 gpsbabel -t -i gpx -f ${TMPDIR}/navilink_tracks.gpx -o navilink -F ${TMPDIR}/navilink_tracks_gpx.trk
-#compare ${TMPDIR}/navilink_tracks_gpx.trk ${REFERENCE}/navilink_tracks_gpx.trk
+#compare ${REFERENCE}/navilink_tracks_gpx.trk ${TMPDIR}/navilink_tracks_gpx.trk
 


### PR DESCRIPTION
use rounding for round trip fidelity.
enable waypoint write test.
the track test has more serious mismatches.

reading the datalog is untested and still uses the legacy C-style
date and time library.