### PR TITLE
datetime purity.

### DIFF
--- a/gpx.cc
+++ b/gpx.cc
@@ -437,7 +437,7 @@ xml_parse_time(const QString& dateTimeString)
   }
 
   int year = 0, mon = 0, mday = 0, hour = 0, min = 0, sec = 0;
-  QDateTime dt;
+  gpsbabel::DateTime dt;
   int res = sscanf(timestr, "%d-%d-%dT%d:%d:%d", &year, &mon, &mday, &hour,
                    &min, &sec);
   if (res > 0) {
@@ -452,8 +452,6 @@ xml_parse_time(const QString& dateTimeString)
 
     // Any offsets that were stuck at the end.
     dt = dt.addSecs(-off_sign * off_hr * 3600 - off_sign * off_min * 60);
-  } else {
-    dt = QDateTime();
   }
   return dt;
 }
@@ -461,7 +459,7 @@ xml_parse_time(const QString& dateTimeString)
 void
 GpxFormat::gpx_end(QStringView /*unused*/)
 {
-  static QDateTime gc_log_date;
+  static gpsbabel::DateTime gc_log_date;
 
   // Remove leading, trailing whitespace.
   cdatastr = cdatastr.trimmed();
@@ -568,7 +566,7 @@ GpxFormat::gpx_end(QStringView /*unused*/)
         (!wpt_tmp->gc_data->last_found.isValid())) {
       wpt_tmp->AllocGCData()->last_found = gc_log_date;
     }
-    gc_log_date = QDateTime();
+    gc_log_date = gpsbabel::DateTime();
     break;
   case tt_cache_favorite_points:
     wpt_tmp->AllocGCData()->favorite_points  = cdatastr.toInt();

--- a/interpolate.h
+++ b/interpolate.h
@@ -22,10 +22,8 @@
 #ifndef INTERPOLATE_H_INCLUDED_
 #define INTERPOLATE_H_INCLUDED_
 
-#include <optional>             // for optional
-
+#include <QString>              // for QString
 #include <QVector>              // for QVector
-#include <QtGlobal>             // for qint64
 
 #include "defs.h"               // for ARG_NOMINMAX, arglist_t, ARGTYPE_BEGIN_EXCL, ARG...
 #include "filter.h"             // for Filter

--- a/kml.cc
+++ b/kml.cc
@@ -354,8 +354,8 @@ void KmlFormat::wr_init(const QString& fname)
 {
   char u = 's';
   waypt_init_bounds(&kml_bounds);
-  kml_time_min = QDateTime();
-  kml_time_max = QDateTime();
+  kml_time_min = gpsbabel::DateTime();
+  kml_time_max = gpsbabel::DateTime();
 
   if (opt_units) {
     u = tolower(opt_units[0]);

--- a/position.cc
+++ b/position.cc
@@ -19,15 +19,17 @@
 
  */
 
-#include <cmath>            // for fabs
-#include <cstdlib>          // for strtod
+#include "position.h"
 
-#include <QList>            // for QList
-#include <QtGlobal>         // for qAsConst, QAddConst<>::Type
+#include <cmath>                // for abs
+#include <cstdlib>              // for strtod
+
+#include <QList>                // for QList
+#include <QtGlobal>             // for qAsConst, qRound64, qint64
 
 #include "defs.h"
-#include "grtcirc.h"        // for RAD, gcdist, radtometers
-#include "position.h"
+#include "grtcirc.h"            // for RAD, gcdist, radtometers
+#include "src/core/datetime.h"  // for DateTime
 
 #if FILTERS_ENABLED
 
@@ -64,7 +66,7 @@ void PositionFilter::position_runqueue(WaypointList* waypt_list, int qtype)
 
           if (dist <= pos_dist) {
             if (check_time) {
-              double diff_time = fabs(waypt_time(qlist.at(i).wpt) - waypt_time(qlist.at(j).wpt));
+              qint64 diff_time = std::abs(qlist.at(j).wpt->creation_time.msecsTo(qlist.at(i).wpt->creation_time));
               if (diff_time >= max_diff_time) {
                 continue;
               }
@@ -156,13 +158,13 @@ void PositionFilter::process()
 
 void PositionFilter::init()
 {
-  char* fm;
 
   pos_dist = 0.0;
-  max_diff_time = 0.0;
+  max_diff_time = 0;
   check_time = false;
 
   if (distopt != nullptr) {
+    char* fm;
     pos_dist = strtod(distopt, &fm);
 
     if (!((*fm == 'm') || (*fm == 'M'))) {
@@ -173,7 +175,7 @@ void PositionFilter::init()
 
   if (timeopt != nullptr) {
     check_time = true;
-    max_diff_time = strtod(timeopt, &fm);
+    max_diff_time = qRound64(strtod(timeopt, nullptr) * 1000.0);
   }
 }
 

--- a/position.h
+++ b/position.h
@@ -22,7 +22,9 @@
 #ifndef POSITION_H_INCLUDED_
 #define POSITION_H_INCLUDED_
 
-#include <QVector>         // for QVector
+#include <QString>   // for QString
+#include <QVector>   // for QVector
+#include <QtGlobal>  // for qint64
 
 #include "defs.h"    // for route_head (ptr only), ARG_NOMINMAX, ARGTYPE_FLOAT
 #include "filter.h"  // for Filter
@@ -43,7 +45,7 @@ private:
   route_head* cur_rte = nullptr;
 
   double pos_dist{};
-  double max_diff_time{};
+  qint64 max_diff_time{};
   char* distopt = nullptr;
   char* timeopt = nullptr;
   char* purge_duplicates = nullptr;


### PR DESCRIPTION
eliminate some QDateTime -> gpsbabel:DateTime conversions.  These can also help performance as DateTime defaults to UTC.

eliminate some unecessary involvment of the UNIX epoch when computing time differences.