### PR TITLE
restrict osm timestamps.

### DIFF
--- a/osm.cc
+++ b/osm.cc
@@ -718,7 +718,8 @@ OsmFormat::osm_waypt_disp(const Waypoint* waypoint)
   fout->writeAttribute(QStringLiteral("lat"), QString::number(waypoint->latitude, 'f', 7));
   fout->writeAttribute(QStringLiteral("lon"), QString::number(waypoint->longitude, 'f', 7));
   if (waypoint->creation_time.isValid()) {
-    fout->writeAttribute(QStringLiteral("timestamp"), waypoint->CreationTimeXML());
+    // osm readers don't uniformally support fractional seconds, and may only accept time zone designation Z.
+    fout->writeAttribute(QStringLiteral("timestamp"), waypoint->creation_time.toUTC().toString(Qt::ISODate));
   }
 
   if (waypoint->hdop) {


### PR DESCRIPTION
osm consumers may not accept fractional seconds, but all should support whole seconds.
osm consumers may not accept time zone designations other than Z, but all should support time zone designation Z.
See https://github.com/GPSBabel/gpsbabel/issues/1105

This resolves #1105 