### PR TITLE
create a snap of the cli

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -98,7 +98,7 @@ jobs:
         sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
         export GBTEMP=$(pwd)/gbtemp
         mkdir -p "$GBTEMP"
-        /snap/bin/gpsbabel -D3
+        /snap/bin/gpsbabel -D3 || true
         ./testo -p /snap/bin/gpsbabel 
 
     - name: Deploy

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -98,6 +98,7 @@ jobs:
         sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
         export GBTEMP=$(pwd)/gbtemp
         mkdir -p "$GBTEMP"
+        /snap/bin/gpsbabel -D3
         ./testo -p /snap/bin/gpsbabel 
 
     - name: Deploy

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -92,3 +92,8 @@ jobs:
     # Make sure the snap is installable
     - run: |
         sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: continuous-linux
+        path: ${{ steps.build-snap.outputs.snap }}
+        retention-days: 7

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -98,7 +98,7 @@ jobs:
         sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
         export GBTEMP=$(pwd)/gbtemp
         mkdir -p "$GBTEMP"
-        /snap/bin/gpsbabel -D3 || true
+        /snap/bin/gpsbabel -D3 | true
         ./testo -p /snap/bin/gpsbabel 
 
     - name: Deploy

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -95,7 +95,7 @@ jobs:
     # Make sure the snap is installable
     - name: Test
       run: |
-        snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
+        sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
         export GBTEMP=$(pwd)/gbtemp
         mkdir -p "$GBTEMP"
         ./testo -p /snap/bin/gpsbabel 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -98,7 +98,7 @@ jobs:
         sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
         export GBTEMP=$(pwd)/gbtemp
         mkdir -p "$GBTEMP"
-        /snap/bin/gpsbabel -D3 | true
+        /snap/bin/gpsbabel -D3 || true
         ./testo -p /snap/bin/gpsbabel 
 
     - name: Deploy

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -78,3 +78,17 @@ jobs:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
       run: |
         ./tools/travis_script_linux_coverage
+
+  snap:
+    name: snap Build
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: snapcore/action-build@v1
+      id: build-snap
+
+    # Make sure the snap is installable
+    - run: |
+        sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -85,15 +85,34 @@ jobs:
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: snapcore/action-build@v1
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Build
+      uses: snapcore/action-build@v1
       id: build-snap
 
     # Make sure the snap is installable
-    - run: |
-        sudo snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
-    - uses: actions/upload-artifact@v3
+    - name: Test
+      run: |
+        snap install --devmode --dangerous ${{ steps.build-snap.outputs.snap }}
+        export GBTEMP=$(pwd)/gbtemp
+        mkdir -p "$GBTEMP"
+        ./testo -p /snap/bin/gpsbabel 
+
+    - name: Deploy
+      # This only handles continous releases now, for other events artifacts may be saved in
+      # the 'Upload Artifacts' step.
+      if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_NAME: Continuous-Linux
+      run: |
+        ./tools/uploadtool/upload_github.sh ${{ steps.build-snap.outputs.snap }}
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
       with:
-        name: continuous-linux
+        name: ${{ steps.build-snap.outputs.snap }}
         path: ${{ steps.build-snap.outputs.snap }}
         retention-days: 7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
 
     override-build: |
-      GITHUB_SHA=$(git rev-parse --short=7 HEAD)
+      GITHUB_SHA=$(git -C ${CRAFT_PART_SRC} rev-parse --short=7 HEAD)
       export GITHUB_SHA
       craftctl default
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ apps:
   gpsbabel:
     command: /usr/bin/gpsbabel
 
+adopt-info: gpsbabel
 parts:
   gpsbabel:
     # See 'snapcraft plugins'
@@ -31,11 +32,7 @@ parts:
     override-pull: |
       craftctl default
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
-
-    override-build: |
-      GITHUB_SHA=$(git -C ${CRAFT_PART_SRC} rev-parse --short=7 HEAD)
-      export GITHUB_SHA
-      craftctl default
+      craftctl set version=$(git show -s --format=continuous-%h-%aI)
 
     build-packages:
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,9 +31,13 @@ parts:
     source: .
     override-pull: |
       craftctl default
+      # add install command to CMakeLists.txt
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
+      # jam repo sha into GITHUB_SHA
+      sed -i -e"s/set(GB.SHA \$ENV{GITHUB_SHA})/set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")/" gbversion.cmake
+      # set snap version
       # ensure version has at most 32 characters
-      craftctl set version=$(git show -s --format=continuous-%as-%h)
+      craftctl set version=$(git log -1 --format='LinuxInstaller-%h-%ad' --date=format:%Y%m%d)
 
     build-packages:
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,10 +29,16 @@ parts:
     cmake-generator: Ninja
     source: https://github.com/GPSBabel/gpsbabel.git
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
 
+    override-build: |
+      GITHUB_SHA=$(git rev-parse --short=7 HEAD)
+      export GITHUB_SHA
+      craftctl default
+
     build-packages:
+      - git
       - vim
       - g++
       - ninja-build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,8 @@ parts:
     override-pull: |
       craftctl default
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
-      craftctl set version=$(git show -s --format=continuous-%h-%aI)
+      # ensure version has at most 32 characters
+      craftctl set version=$(git show -s --format=continuous-%h-%as)
 
     build-packages:
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,66 @@
+name: gpsbabel # you probably want to 'snapcraft register <name>'
+base: core22 # the base snap is the execution environment for this snap
+version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: "Convert, manipulate and transfer GPS data"
+description: |
+  Convert, manipulate and transfer data from GPS programs or GPS
+  recievers.  Open source and supported on macOS, Windows and Linux.
+
+license: GPL-2.0
+title: GPSBabel
+source-code: https://github.com/GPSBabel/gpsbabel.git
+website: https://www.gpsbabel.org
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  gpsbabel:
+    command: /usr/bin/gpsbabel
+
+parts:
+  gpsbabel:
+    # See 'snapcraft plugins'
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DGPSBABEL_WITH_ZLIB=pkgconfig
+      - -DGPSBABEL_WITH_SHAPELIB=pkgconfig
+    cmake-generator: Ninja
+    source: https://github.com/GPSBabel/gpsbabel.git
+    override-pull: |
+      snapcraftctl pull
+      echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
+
+    build-packages:
+      - vim
+      - g++
+      - ninja-build
+      - zlib1g-dev
+      - libshp-dev
+      - libusb-1.0-0-dev
+      - pkg-config
+      - libudev-dev
+      - qt6-base-dev
+      - libqt6core5compat6-dev
+      - libqt6opengl6-dev
+      - libqt6serialport6-dev
+      - libqt6webenginecore6-bin
+      - libgl-dev
+      - libopengl-dev
+      - libvulkan-dev
+      - libx11-xcb-dev
+      - libxkbcommon-dev
+      - qt6-l10n-tools
+      - qt6-tools-dev
+      - qt6-tools-dev-tools
+      - qt6-translations-l10n
+      - qt6-webengine-dev
+      - qt6-webengine-dev-tools
+      - qt6-wayland
+    stage-packages:
+      - zlib1g
+      - libshp2
+      - libusb-1.0-0
+      - libqt6core6
+      - libqt6core5compat6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
       craftctl default
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
       # ensure version has at most 32 characters
-      craftctl set version=$(git show -s --format=continuous-%h-%as)
+      craftctl set version=$(git show -s --format=continuous-%as-%h)
 
     build-packages:
       - git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ parts:
       - -DGPSBABEL_WITH_ZLIB=pkgconfig
       - -DGPSBABEL_WITH_SHAPELIB=pkgconfig
     cmake-generator: Ninja
-    source: https://github.com/GPSBabel/gpsbabel.git
+    source: .
     override-pull: |
       craftctl default
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
       # add install command to CMakeLists.txt
       echo "install(TARGETS gpsbabel CONFIGURATIONS Release RUNTIME DESTINATION /usr/bin)" >> CMakeLists.txt
       # jam repo sha into GITHUB_SHA
-      sed -i -e"s/set(GB.SHA \$ENV{GITHUB_SHA})/set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")/" gbversion.cmake
+      sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake
       # set snap version
       # ensure version has at most 32 characters
       craftctl set version=$(git log -1 --format='LinuxInstaller-%h-%ad' --date=format:%Y%m%d)


### PR DESCRIPTION
This creates a snap of the gpsbabel CLI during CI.  A snap is a "universal Linux package".  It will be uploaded as a continuous release "Continuous-Linux".   It is only built for adm64.  It can be installed with
```
 sudo snap install --devmode --dangerous gpsbabel_0.1_amd64.snap
```