### PR TITLE
reduce complexity of mkshort from O(n^2) to O(n).

### DIFF
--- a/mkshort.cc
+++ b/mkshort.cc
@@ -49,6 +49,8 @@ class ShortNameKey;
 using ShortNameHash = QHash<ShortNameKey, uniq_shortname*>;
 class ShortNameKey {
 public:
+  ShortNameKey(char* name) : shortname(name) {} /* converting constructor */
+
   using namehash_size_type = ShortNameHash::size_type;
   friend namehash_size_type qHash(const ShortNameKey &key, namehash_size_type seed = 0) noexcept
   {
@@ -110,10 +112,8 @@ static
 uniq_shortname*
 is_unique(mkshort_handle_imp* h, char* name)
 {
-  ShortNameKey key;
-  key.shortname = name;
-  if (h->namelist.contains(key)) {
-    return h->namelist.value(key);
+  if (h->namelist.contains(name)) {
+    return h->namelist.value(name);
   }
   return (uniq_shortname*) nullptr;
 }
@@ -122,9 +122,7 @@ static
 void
 add_to_hashlist(mkshort_handle_imp* h, char* name)
 {
-  ShortNameKey key;
-  key.shortname = name;
-  h->namelist.insert(key, new uniq_shortname);
+  h->namelist.insert(name, new uniq_shortname);
 }
 
 char*


### PR DESCRIPTION
Here is some test data with and without this PR.  time(ref) is without changes to mkshort, time(dut) is with the changes to mkshort in this PR.
The test is 
./gpsbabel -i gpx -f Auckland-numbers.gpx -x validate,debug -o gdb -F Auckland-numbers.gdb
However, in both cases the other O(n^2) issue in the gdb writer is bypassed:
```
@@ -1513,6 +1552,7 @@ GdbFormat::write_waypoint_cb(const Waypoint* refpt)
 // but, but, casting away the const here is wrong...
   (const_cast<Waypoint*>(refpt))->shortname = refpt->shortname.trimmed();
   Waypoint* test = gdb_find_wayptq(&wayptq_out, refpt, 1);
+  //Waypoint* test = nullptr;
```
<img width="454" alt="mkshort_opt" src="https://github.com/GPSBabel/gpsbabel/assets/13596209/ae3cd92d-116a-4a27-bd44-7861d802e0c7">
<img width="454" alt="mkshort_opt_zoom" src="https://github.com/GPSBabel/gpsbabel/assets/13596209/67ae6e11-d980-4739-927d-3a2b6b8e7d81">
