### PR TITLE
sync test case list in CMakeLists.txt with testo.d.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ set(TESTS
   track
   transform
   unicsv_grids
+  unicsv_local
   unicsv
   unitconversion
   v900


### PR DESCRIPTION
Yes, manual syncing is suboptimal.