### PR TITLE
NMEA: handle date already in ddmmyyyy format

### DIFF
--- a/nmea.cc
+++ b/nmea.cc
@@ -534,7 +534,8 @@ NmeaFormat::gprmc_parse(const QString& ibuf)
   QDate dmy;
   if (fields.size() > 9) {
     QString datestr(fields[9]);
-    datestr.insert(4, "20");
+    if (datestr.length() < 7)
+      datestr.insert(4, "20");
     dmy = QDate::fromString(datestr, "ddMMyyyy");
   }
   if (fix != 'A') {


### PR DESCRIPTION
Trimble CoPilot outputs GPRMC with the full year.  Non-standard and probably unique but this one-liner should fix it.