### PR TITLE
fix bugs with simplify filter

### DIFF
--- a/reference/simplify_error_length.gpx
+++ b/reference/simplify_error_length.gpx
@@ -516,6 +516,11 @@
         <time>2012-04-12T13:09:52Z</time>
         <speed>5.373000</speed>
       </trkpt>
+      <trkpt lat="48.190376647" lon="11.822674759">
+        <ele>541.600</ele>
+        <time>2012-04-12T13:09:59Z</time>
+        <speed>6.961000</speed>
+      </trkpt>
       <trkpt lat="48.190509081" lon="11.824321132">
         <ele>537.200</ele>
         <time>2012-04-12T13:10:15Z</time>

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -235,13 +235,12 @@ void SimplifyRouteFilter::shuffle_xte(struct xte* xte_rec)
 
 void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
 {
-  int i;
   if (!cur_rte) {
     return;
   }
 
   /* compute all distances */
-  for (i = 0; i < xte_count ; i++) {
+  for (int i = 0; i < xte_count ; i++) {
     compute_xte(xte_recs+i);
   }
 
@@ -257,7 +256,7 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
   }
 
 
-  for (i = 0; i < xte_count; i++) {
+  for (int i = 0; i < xte_count; i++) {
     xte_recs[i].intermed->xte_rec = xte_recs+i;
   }
   // Ensure totalerror starts with the distance between first and second points
@@ -273,23 +272,8 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
   while ((xte_count) &&
          (((limit_basis == limit_basis_t::count) && (count < xte_count)) ||
           ((limit_basis == limit_basis_t::error) && (totalerror < error)))) {
-    i = xte_count - 1;
+    int i = xte_count - 1;
     /* remove the record with the lowest XTE */
-    if (limit_basis == limit_basis_t::error) {
-      switch (metric) {
-      case metric_t::crosstrack:
-      case metric_t::relative:
-        if (i > 1) {
-          totalerror = xte_recs[i-1].distance;
-        } else {
-          totalerror = xte_recs[i].distance;
-        }
-        break;
-      case metric_t::length:
-        totalerror += xte_recs[i].distance;
-        break;
-      }
-    }
     (*waypt_del_fnp)(const_cast<route_head*>(rte),
                      const_cast<Waypoint*>(xte_recs[i].intermed->wpt));
     delete xte_recs[i].intermed->wpt;
@@ -306,8 +290,23 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
     }
     xte_count--;
     free_xte(xte_recs+xte_count);
-    /* end of loop */
-  }
+
+    /* compute impact of deleting next point */
+    if (xte_count) {
+      if (limit_basis == limit_basis_t::error) {
+        i = xte_count - 1;
+        switch (metric) {
+        case metric_t::crosstrack:
+        case metric_t::relative:
+          totalerror = xte_recs[i].distance;
+          break;
+        case metric_t::length:
+          totalerror += xte_recs[i].distance;
+          break;
+        }
+      }
+    }
+  } /* end of loop */
   if (xte_count) {
     do {
       xte_count--;


### PR DESCRIPTION
1. With the length option the last point deleted took the total error over the specified limit.  In the test case with a modified reference file this brought the error to 0.62262 compared to the limit of 0.621371.  This is fixed, resulting in the change of a reference file.

2. When computing the total error (if another point is deleted) it was possible to refer to an xte record that needed to be updated due to the deletion of one of its neighbors.  This is fixed, the impact of another potential deletion is computed after the xte records are  updated.

3. Another issue has not yet been addressed.  The simplify filter ignores track segments and treats each track as if it was continuous.  If a track point that starts a track segment is deleted then that segment is joined with the previous segment.
Should the simplify filter treat each track as a continuous, ignoring track segments?  If so, should it produce a track that only has one segment?
On the other hand, if we choose to filter each segment independently, how would we set the error or count limits for each segment?