### PR TITLE
Reduce complexity of simplify filter

### DIFF
--- a/arcdist.cc
+++ b/arcdist.cc
@@ -173,7 +173,6 @@ void ArcDistanceFilter::process()
       } else if (projectopt) {
         wp->longitude = ed->prjlongitude;
         wp->latitude = ed->prjlatitude;
-        wp->route_priority = 1;
         if (!arcfileopt &&
             (ed->arcpt2->altitude != unknown_alt) &&
             (ptsopt || (ed->arcpt1->altitude != unknown_alt))) {

--- a/defs.h
+++ b/defs.h
@@ -492,7 +492,6 @@ public:
   void waypt_del(Waypoint* wpt); // a.k.a. erase()
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the element to be deleted, use iterator instead,
   //        and/or implement pop_back() a.k.a. removeLast(), and/or pop_front() a.k.a. removeFirst().
-  iterator waypt_del(iterator it) {return erase(it);}
   void del_rte_waypt(Waypoint* wpt);
   void waypt_compute_bounds(bounds* bounds) const;
   Waypoint* find_waypt_by_name(const QString& name) const;
@@ -525,6 +524,7 @@ public:
   using QList<Waypoint*>::front; // a.k.a. first()
   using QList<Waypoint*>::rbegin;
   using QList<Waypoint*>::rend;
+  using QList<Waypoint*>::size_type;
 };
 
 const global_trait* get_traits();
@@ -674,6 +674,7 @@ public:
   void copy(RouteList** dst) const;
   void restore(RouteList* src);
   void swap(RouteList& other);
+  void swap_wpts(route_head* rte, WaypointList& other);
   template <typename Compare>
   void sort(Compare cmp) {std::sort(begin(), end(), cmp);}
   template <typename T1, typename T2, typename T3>
@@ -728,6 +729,8 @@ void route_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT"
 void track_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT", int number_digits = 3);
 void route_del_wpt(route_head* rte, Waypoint* wpt);
 void track_del_wpt(route_head* rte, Waypoint* wpt);
+void route_swap_wpts(route_head* rte, WaypointList& other);
+void track_swap_wpts(route_head* rte, WaypointList& other);
 //void route_disp(const route_head* rte, waypt_cb); /* template */
 void route_disp(const route_head* rte, std::nullptr_t /* waypt_cb */); /* override to catch nullptr */
 //void route_disp_all(route_hdr, route_trl, waypt_cb); /* template */

--- a/defs.h
+++ b/defs.h
@@ -448,17 +448,6 @@ public:
   gpsbabel::DateTime creation_time;
 
   wp_flags wpt_flags;
-  /*
-   * route priority is for use by the simplify filter.  If we have
-   * some reason to believe that the route point is more important,
-   * we can give it a higher (numerically; 0 is the lowest) priority.
-   * This causes it to be removed last.
-   * This is currently used by the saroute input filter to give named
-   * waypoints (representing turns) a higher priority.
-   * This is also used by the google input filter because they were
-   * nice enough to use exactly the same priority scheme.
-   */
-  int route_priority;
 
   /* Optional dilution of precision:  positional, horizontal, vertical.
    * 1 <= dop <= 50

--- a/reference/simplify_error_length.gpx
+++ b/reference/simplify_error_length.gpx
@@ -516,6 +516,11 @@
         <time>2012-04-12T13:09:52Z</time>
         <speed>5.373000</speed>
       </trkpt>
+      <trkpt lat="48.190376647" lon="11.822674759">
+        <ele>541.600</ele>
+        <time>2012-04-12T13:09:59Z</time>
+        <speed>6.961000</speed>
+      </trkpt>
       <trkpt lat="48.190509081" lon="11.824321132">
         <ele>537.200</ele>
         <time>2012-04-12T13:10:15Z</time>

--- a/route.cc
+++ b/route.cc
@@ -144,6 +144,18 @@ track_del_wpt(route_head* rte, Waypoint* wpt)
 }
 
 void
+route_swap_wpts(route_head* rte, WaypointList& other)
+{
+  global_route_list->swap_wpts(rte, other);
+}
+
+void
+track_swap_wpts(route_head* rte, WaypointList& other)
+{
+  global_track_list->swap_wpts(rte, other);
+}
+
+void
 route_disp(const route_head* /* rh */, std::nullptr_t /* wc */)
 {
 // wc == nullptr
@@ -503,4 +515,11 @@ void RouteList::swap(RouteList& other)
   const RouteList tmp_list = *this;
   *this = other;
   other = tmp_list;
+}
+
+void RouteList::swap_wpts(route_head* rte, WaypointList& other)
+{
+  this->waypt_ct -= rte->rte_waypt_ct();
+  this->waypt_ct += other.count();
+  rte->waypoint_list.swap(other);
 }

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -96,18 +96,18 @@ double SimplifyRouteFilter::compute_track_error(const neighborhood& nb) const
   switch (metric) {
   case metric_t::crosstrack:
     track_error = radtomiles(linedist(
-                         wpt1->latitude, wpt1->longitude,
-                         wpt2->latitude, wpt2->longitude,
-                         wpt3->latitude, wpt3->longitude));
+                               wpt1->latitude, wpt1->longitude,
+                               wpt2->latitude, wpt2->longitude,
+                               wpt3->latitude, wpt3->longitude));
     break;
   case metric_t::length:
     track_error = radtomiles(
-              gcdist(wpt1->latitude, wpt1->longitude,
-                     wpt3->latitude, wpt3->longitude) +
-              gcdist(wpt3->latitude, wpt3->longitude,
-                     wpt2->latitude, wpt2->longitude) -
-              gcdist(wpt1->latitude, wpt1->longitude,
-                     wpt2->latitude, wpt2->longitude));
+                    gcdist(wpt1->latitude, wpt1->longitude,
+                           wpt3->latitude, wpt3->longitude) +
+                    gcdist(wpt3->latitude, wpt3->longitude,
+                           wpt2->latitude, wpt2->longitude) -
+                    gcdist(wpt1->latitude, wpt1->longitude,
+                           wpt2->latitude, wpt2->longitude));
     break;
   case metric_t::relative:
   default: // eliminate false positive warning with g++ 11.3.0: ‘error’ may be used uninitialized in this function [-Wmaybe-uninitialized]
@@ -123,13 +123,13 @@ double SimplifyRouteFilter::compute_track_error(const neighborhood& nb) const
                wpt2->latitude, wpt2->longitude,
                frac, &reslat, &reslon);
       track_error = radtometers(gcdist(
-                            wpt3->latitude, wpt3->longitude,
-                            reslat, reslon));
+                                  wpt3->latitude, wpt3->longitude,
+                                  reslat, reslon));
     } else { // else distance to connecting line
       track_error = radtometers(linedist(
-                            wpt1->latitude, wpt1->longitude,
-                            wpt2->latitude, wpt2->longitude,
-                            wpt3->latitude, wpt3->longitude));
+                                  wpt1->latitude, wpt1->longitude,
+                                  wpt2->latitude, wpt2->longitude,
+                                  wpt3->latitude, wpt3->longitude));
     }
     // error relative to horizontal precision
     track_error /= (6 * wpt3->hdop);

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -77,7 +77,7 @@ inline bool operator<(const SimplifyRouteFilter::trackerror& lhs, const Simplify
   return ((lhs.dist > rhs.dist) || ((lhs.dist == rhs.dist) && (lhs.wptpos < rhs.wptpos)));
 }
 
-double SimplifyRouteFilter::compute_track_error(const neighborhood& nb)
+double SimplifyRouteFilter::compute_track_error(const neighborhood& nb) const
 {
   /* if no previous, this is an endpoint and must be preserved. */
   if (nb.prev == nullptr) {

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -235,13 +235,12 @@ void SimplifyRouteFilter::shuffle_xte(struct xte* xte_rec)
 
 void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
 {
-  int i;
   if (!cur_rte) {
     return;
   }
 
   /* compute all distances */
-  for (i = 0; i < xte_count ; i++) {
+  for (int i = 0; i < xte_count ; i++) {
     compute_xte(xte_recs+i);
   }
 
@@ -257,7 +256,7 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
   }
 
 
-  for (i = 0; i < xte_count; i++) {
+  for (int i = 0; i < xte_count; i++) {
     xte_recs[i].intermed->xte_rec = xte_recs+i;
   }
   // Ensure totalerror starts with the distance between first and second points
@@ -273,23 +272,8 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
   while ((xte_count) &&
          (((limit_basis == limit_basis_t::count) && (count < xte_count)) ||
           ((limit_basis == limit_basis_t::error) && (totalerror < error)))) {
-    i = xte_count - 1;
+    int i = xte_count - 1;
     /* remove the record with the lowest XTE */
-    if (limit_basis == limit_basis_t::error) {
-      switch (metric) {
-      case metric_t::crosstrack:
-      case metric_t::relative:
-        if (i > 1) {
-          totalerror = xte_recs[i-1].distance;
-        } else {
-          totalerror = xte_recs[i].distance;
-        }
-        break;
-      case metric_t::length:
-        totalerror += xte_recs[i].distance;
-        break;
-      }
-    }
     (*waypt_del_fnp)(const_cast<route_head*>(rte),
                      const_cast<Waypoint*>(xte_recs[i].intermed->wpt));
     delete xte_recs[i].intermed->wpt;
@@ -306,8 +290,23 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
     }
     xte_count--;
     free_xte(xte_recs+xte_count);
-    /* end of loop */
-  }
+
+    /* compute impact of deleting next point */
+    if (xte_count) {
+      if (limit_basis == limit_basis_t::error) {
+        i = xte_count - 1;
+        switch (metric) {
+        case metric_t::crosstrack:
+        case metric_t::relative:
+          totalerror = xte_recs[i].distance;
+          break;
+        case metric_t::length:
+          totalerror += xte_recs[i].distance;
+          break;
+        }
+      }
+    }
+  } /* end of loop */
   if (xte_count) {
     do {
       xte_count--;

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -207,8 +207,9 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
     /* remove the record with the lowest XTE */
     neighborhood goner = errormap.last();
     goner.wpt->extra_data = &delete_flag; // mark for deletion
-    errormap.remove(errormap.lastKey());
-    // wpthash.remove(goner.wpt);  removal not necessary
+    // errormap.remove(lastKey());  // with Qt 5.12.12, 5.15.2 results in asan heap-use-after-free errors in build_extra_tests.sh
+    errormap.erase(--errormap.end()); // in Qt6 can use cend().
+    // wpthash.remove(goner.wpt); // removal not necessary
 
     /* recompute neighbors of point marked for deletion. */
     if (goner.prev != nullptr) {

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -256,17 +256,17 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
   (*route_swap_wpts_fnp)(const_cast<route_head*>(rte), oldlist);
 
   // mimic trkseg handling from WaypointList::del_rte_waypt
-  bool inhereit_new_trkseg = false;
+  bool inherit_new_trkseg = false;
   for (Waypoint* wpt : qAsConst(oldlist)) {
     if (wpt->extra_data == nullptr) {
-      if (inhereit_new_trkseg) {
+      if (inherit_new_trkseg) {
         wpt->wpt_flags.new_trkseg = 1;
-        inhereit_new_trkseg = false;
+        inherit_new_trkseg = false;
       }
       (*route_add_wpt_fnp)(const_cast<route_head*>(rte), wpt, u"RPT", 3);
     } else {
       if (wpt->wpt_flags.new_trkseg) {
-        inhereit_new_trkseg = true;
+        inherit_new_trkseg = true;
       }
       delete wpt;
     }

--- a/smplrout.h
+++ b/smplrout.h
@@ -72,6 +72,13 @@ class SimplifyRouteFilter:public Filter
 {
 public:
 
+  /* Types */
+
+  struct trackerror {
+    double dist;
+    WaypointList::size_type wptpos;
+  };
+
   /* Member Functions */
 
   QVector<arglist_t>* get_args() override
@@ -88,26 +95,10 @@ private:
   enum class limit_basis_t {count, error};
   enum class metric_t {crosstrack, length, relative};
 
-  struct xte_intermed;
-
-  struct xte {
-    double distance{0.0};
-    struct xte_intermed* intermed {
-      nullptr
-    };
-  };
-
-  struct xte_intermed {
-    struct xte* xte_rec {
-      nullptr
-    };
-    struct xte_intermed* next {
-      nullptr
-    };
-    struct xte_intermed* prev {
-      nullptr
-    };
-    const Waypoint* wpt{nullptr};
+  struct neighborhood {
+    Waypoint* wpt;
+    Waypoint* prev;
+    Waypoint* next;
   };
 
   /* Constants */
@@ -118,6 +109,7 @@ private:
 
   static void free_xte(struct xte* xte_rec);
   void routesimple_waypt_pr(const Waypoint* wpt);
+  double compute_track_error(const neighborhood& nb);
   void compute_xte(struct xte* xte_rec);
   static int compare_xte(const void* a, const void* b);
   void routesimple_head(const route_head* rte);
@@ -127,7 +119,6 @@ private:
   /* Data Members */
 
   int count = 0;
-  double totalerror = 0;
   double error = 0;
   limit_basis_t limit_basis{limit_basis_t::error};
   metric_t metric{metric_t::crosstrack};
@@ -138,6 +129,8 @@ private:
   char* lenopt = nullptr;
   char* relopt = nullptr;
   void (*waypt_del_fnp)(route_head* rte, Waypoint* wpt) {};
+  void (*route_add_wpt_fnp)(route_head* rte, Waypoint* wpt, QStringView namepart, int number_digits) {};
+  void (*route_swap_wpts_fnp)(route_head* rte, WaypointList& other) {};
 
   QVector<arglist_t> args = {
     {
@@ -162,10 +155,7 @@ private:
     },
   };
 
-  struct xte_intermed* tmpprev = nullptr;
-  int xte_count = 0;
-  const route_head* cur_rte = nullptr;
-  struct xte* xte_recs = nullptr;
+  int delete_flag; // &delete_flag != nullptr
 };
 
 #endif // FILTERS_ENABLED

--- a/smplrout.h
+++ b/smplrout.h
@@ -108,13 +108,7 @@ private:
 
   /* Member Functions */
 
-  static void free_xte(struct xte* xte_rec);
-  void routesimple_waypt_pr(const Waypoint* wpt);
-  double compute_track_error(const neighborhood& nb);
-  void compute_xte(struct xte* xte_rec);
-  static int compare_xte(const void* a, const void* b);
-  void routesimple_head(const route_head* rte);
-  void shuffle_xte(struct xte* xte_rec);
+  double compute_track_error(const neighborhood& nb) const;
   void routesimple_tail(const route_head* rte);
 
   /* Data Members */
@@ -123,6 +117,7 @@ private:
   double error = 0;
   limit_basis_t limit_basis{limit_basis_t::error};
   metric_t metric{metric_t::crosstrack};
+  int delete_flag{}; // &delete_flag != nullptr
 
   char* countopt = nullptr;
   char* erroropt = nullptr;
@@ -155,7 +150,6 @@ private:
     },
   };
 
-  int delete_flag; // &delete_flag != nullptr
 };
 
 #endif // FILTERS_ENABLED

--- a/smplrout.h
+++ b/smplrout.h
@@ -1,7 +1,7 @@
 /*
     Route / track simplification filter
 
-    Copyright (C) 2002-2014 Robert Lipe, robertlipe+source@gpsbabel.org
+    Copyright (C) 2002-2023 Robert Lipe, robertlipe+source@gpsbabel.org
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -59,11 +59,12 @@
 #ifndef SMPLROUT_H_INCLUDED_
 #define SMPLROUT_H_INCLUDED_
 
-#include <QString>   // for QString
-#include <QVector>   // for QVector
+#include <QString>               // for QString
+#include <QStringView>           // for QStringView
+#include <QVector>               // for QVector
 
-#include "defs.h"    // for route_head (ptr only), Waypoint (ptr only), ARGT...
-#include "filter.h"  // for Filter
+#include "defs.h"
+#include "filter.h"              // for Filter
 
 
 #if FILTERS_ENABLED
@@ -128,7 +129,6 @@ private:
   char* xteopt = nullptr;
   char* lenopt = nullptr;
   char* relopt = nullptr;
-  void (*waypt_del_fnp)(route_head* rte, Waypoint* wpt) {};
   void (*route_add_wpt_fnp)(route_head* rte, Waypoint* wpt, QStringView namepart, int number_digits) {};
   void (*route_swap_wpts_fnp)(route_head* rte, WaypointList& other) {};
 

--- a/waypt.cc
+++ b/waypt.cc
@@ -393,7 +393,6 @@ Waypoint::Waypoint() :
   latitude(0),  // These should probably use some invalid data, but
   longitude(0), // it looks like we have code that relies on them being zero.
   altitude(unknown_alt),
-  route_priority(0),
   hdop(0),
   vdop(0),
   pdop(0),
@@ -435,7 +434,6 @@ Waypoint::Waypoint(const Waypoint& other) :
   icon_descr(other.icon_descr),
   creation_time(other.creation_time),
   wpt_flags(other.wpt_flags),
-  route_priority(other.route_priority),
   hdop(other.hdop),
   vdop(other.vdop),
   pdop(other.pdop),
@@ -485,7 +483,6 @@ Waypoint& Waypoint::operator=(const Waypoint& rhs)
     wpt_flags = rhs.wpt_flags;
     icon_descr = rhs.icon_descr;
     creation_time = rhs.creation_time;
-    route_priority = rhs.route_priority;
     hdop = rhs.hdop;
     vdop = rhs.vdop;
     pdop = rhs.pdop;


### PR DESCRIPTION
Reduce the complexity of the simplify filter from O(n^2) to O(nlog(n)) ~= O(n).  The complexity of this filter has been an issue for users in the past.

The test creates random routes of various lengths at uses the simplify filter to reduce the number of points by half:

[test.txt](https://github.com/GPSBabel/gpsbabel/files/12194618/test.txt)

The results are shown in the following plot.  It is difficult to distinguish between O(nlog(n)) and O(n) empirically, but O(nlog(n)) is expected for QMap.  Using the error option instead of count is a bit slower, but the complexity is the same.

![simplify](https://github.com/GPSBabel/gpsbabel/assets/13596209/23b3783b-fdfd-48fc-84b5-34fff058ebc2)

Issues:

1. Unlike the current code route priority is ignored by the simplify filter.  route priority could be implemented if desired.
2. There is a test failure that is resolved by #1148 
3. track segment markers are inherited as done previously.
4. tracks are simplified ignoring any track segments as done previously.