### PR TITLE
Introduce efficient member functions for deleting waypoints

### DIFF
--- a/arcdist.cc
+++ b/arcdist.cc
@@ -19,6 +19,8 @@
 
  */
 
+#include "arcdist.h"
+
 #include <cmath>                  // for round
 #include <cstdio>                 // for printf, sscanf
 #include <cstdlib>                // for strtod
@@ -28,7 +30,6 @@
 #include <QtGlobal>               // for foreach, qPrintable, qint64
 
 #include "defs.h"
-#include "arcdist.h"
 #include "grtcirc.h"              // for RAD, gcdist, linedistprj, radtomi
 #include "src/core/datetime.h"    // for DateTime
 #include "src/core/logging.h"     // for Fatal
@@ -163,12 +164,11 @@ void ArcDistanceFilter::process()
 
   unsigned removed = 0;
   foreach (Waypoint* wp, *global_waypoint_list) {
-    auto* ed = (extra_data*) wp->extra_data;
-    wp->extra_data = nullptr;
-    if (ed) {
+    if (wp->extra_data) {
+      auto* ed = (extra_data*) wp->extra_data;
+      wp->extra_data = nullptr;
       if ((ed->distance >= pos_dist) == (exclopt == nullptr)) {
-        waypt_del(wp);
-        delete wp;
+        wp->extra_data = &delete_flag; // mark for deletion
         removed++;
       } else if (projectopt) {
         wp->longitude = ed->prjlongitude;
@@ -208,6 +208,7 @@ void ArcDistanceFilter::process()
       delete ed;
     }
   }
+  del_wpts(wpt_extra_data_evaluator); // delete marked wpts
   if (global_opts.verbose_status > 0) {
     printf(MYNAME "-arc: %u waypoint(s) removed.\n", removed);
   }

--- a/arcdist.cc
+++ b/arcdist.cc
@@ -162,14 +162,13 @@ void ArcDistanceFilter::process()
     track_disp_all(arcdist_arc_disp_hdr_cb_f, nullptr, arcdist_arc_disp_wpt_cb_f);
   }
 
-  int delete_flag; // &delete_flag != nullptr
   unsigned removed = 0;
   foreach (Waypoint* wp, *global_waypoint_list) {
     if (wp->extra_data) {
       auto* ed = (extra_data*) wp->extra_data;
       wp->extra_data = nullptr;
       if ((ed->distance >= pos_dist) == (exclopt == nullptr)) {
-        wp->extra_data = &delete_flag; // mark for deletion
+        wp->wpt_flags.marked_for_deletion = 1;
         removed++;
       } else if (projectopt) {
         wp->longitude = ed->prjlongitude;
@@ -209,7 +208,7 @@ void ArcDistanceFilter::process()
       delete ed;
     }
   }
-  del_wpts(wpt_extra_data_evaluator); // delete marked wpts
+  del_marked_wpts();
   if (global_opts.verbose_status > 0) {
     printf(MYNAME "-arc: %u waypoint(s) removed.\n", removed);
   }

--- a/arcdist.cc
+++ b/arcdist.cc
@@ -162,6 +162,7 @@ void ArcDistanceFilter::process()
     track_disp_all(arcdist_arc_disp_hdr_cb_f, nullptr, arcdist_arc_disp_wpt_cb_f);
   }
 
+  int delete_flag; // &delete_flag != nullptr
   unsigned removed = 0;
   foreach (Waypoint* wp, *global_waypoint_list) {
     if (wp->extra_data) {

--- a/arcdist.h
+++ b/arcdist.h
@@ -58,7 +58,6 @@ private:
 
   /* Data Members */
 
-  int delete_flag{}; // &delete_flag != nullptr
   double pos_dist{};
   char* distopt = nullptr;
   char* arcfileopt = nullptr;

--- a/arcdist.h
+++ b/arcdist.h
@@ -40,14 +40,7 @@ public:
   void process() override;
 
 private:
-  double pos_dist{};
-  char* distopt = nullptr;
-  char* arcfileopt = nullptr;
-  char* rteopt = nullptr;
-  char* trkopt = nullptr;
-  char* exclopt = nullptr;
-  char* ptsopt = nullptr;
-  char* projectopt = nullptr;
+  /* Types */
 
   struct extra_data {
     double distance;
@@ -57,6 +50,23 @@ private:
     const Waypoint* arcpt1;
     const Waypoint* arcpt2;
   };
+
+  /* Member Functions */
+
+  void arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2);
+  void arcdist_arc_disp_hdr_cb(const route_head*);
+
+  /* Data Members */
+
+  int delete_flag{}; // &delete_flag != nullptr
+  double pos_dist{};
+  char* distopt = nullptr;
+  char* arcfileopt = nullptr;
+  char* rteopt = nullptr;
+  char* trkopt = nullptr;
+  char* exclopt = nullptr;
+  char* ptsopt = nullptr;
+  char* projectopt = nullptr;
 
   QVector<arglist_t> args = {
     {
@@ -88,9 +98,6 @@ private:
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
   };
-
-  void arcdist_arc_disp_wpt_cb(const Waypoint* arcpt2);
-  void arcdist_arc_disp_hdr_cb(const route_head*);
 
 };
 #endif // FILTERS_ENABLED

--- a/defs.h
+++ b/defs.h
@@ -251,11 +251,13 @@ public:
     shortname_is_synthetic(0),
     fmt_use(0),
     is_split(0),
-    new_trkseg(0) {}
+    new_trkseg(0),
+    marked_for_deletion(0) {}
   unsigned int shortname_is_synthetic:1;
   unsigned int fmt_use:2;			/* lightweight "extra data" */
   unsigned int is_split:1;		/* the waypoint represents a split */
   unsigned int new_trkseg:1;		/* True if first in new trkseg. */
+  unsigned int marked_for_deletion:1;		/* True if schedulded for deletion. */
 };
 
 // These are dicey as they're collected on read. Subsequent filters may change
@@ -469,9 +471,6 @@ public:
 };
 
 using waypt_cb = void (*)(const Waypoint*);
-using wpt_evaluator_t = bool (*)(const Waypoint*);
-inline bool wpt_extra_data_evaluator(const Waypoint* wpt) {return wpt->extra_data != nullptr;}
-
 
 // TODO: Consider using composition instead of private inheritance.
 class WaypointList : private QList<Waypoint*>
@@ -482,7 +481,7 @@ public:
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the element to be deleted, use iterator instead,
   //        and/or implement pop_back() a.k.a. removeLast(), and/or pop_front() a.k.a. removeFirst().
   void waypt_del(Waypoint* wpt); // a.k.a. erase()
-  void del_wpts(wpt_evaluator_t ev);
+  void del_marked_wpts();
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the element to be deleted, use iterator instead,
   //        and/or implement pop_back() a.k.a. removeLast(), and/or pop_front() a.k.a. removeFirst().
   void del_rte_waypt(Waypoint* wpt);
@@ -525,7 +524,7 @@ void waypt_init();
 //void update_common_traits(const Waypoint* wpt);
 void waypt_add(Waypoint* wpt);
 void waypt_del(Waypoint* wpt);
-void del_wpts(wpt_evaluator_t ev);
+void del_marked_wpts();
 unsigned int waypt_count();
 void waypt_status_disp(int total_ct, int myct);
 //void waypt_disp_all(waypt_cb); /* template */
@@ -663,7 +662,7 @@ public:
   void add_wpt(route_head* rte, Waypoint* wpt, bool synth, QStringView namepart, int number_digits);
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the insertion point, use iterator instead.
   void del_wpt(route_head* rte, Waypoint* wpt);
-  void del_wpts(route_head* rte, wpt_evaluator_t ev);
+  void del_marked_wpts(route_head* rte);
   void common_disp_session(const session_t* se, route_hdr rh, route_trl rt, waypt_cb wc);
   void flush(); // a.k.a. clear()
   void copy(RouteList** dst) const;
@@ -724,8 +723,8 @@ void route_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT"
 void track_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT", int number_digits = 3);
 void route_del_wpt(route_head* rte, Waypoint* wpt);
 void track_del_wpt(route_head* rte, Waypoint* wpt);
-void route_del_wpts(route_head* rte, wpt_evaluator_t ev);
-void track_del_wpts(route_head* rte, wpt_evaluator_t ev);
+void route_del_marked_wpts(route_head* rte);
+void track_del_marked_wpts(route_head* rte);
 void route_swap_wpts(route_head* rte, WaypointList& other);
 void track_swap_wpts(route_head* rte, WaypointList& other);
 //void route_disp(const route_head* rte, waypt_cb); /* template */

--- a/defs.h
+++ b/defs.h
@@ -469,6 +469,9 @@ public:
 };
 
 using waypt_cb = void (*)(const Waypoint*);
+using wpt_evaluator_t = bool (*)(const Waypoint*);
+inline bool wpt_extra_data_evaluator(const Waypoint* wpt) {return wpt->extra_data != nullptr;}
+
 
 // TODO: Consider using composition instead of private inheritance.
 class WaypointList : private QList<Waypoint*>
@@ -479,6 +482,7 @@ public:
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the element to be deleted, use iterator instead,
   //        and/or implement pop_back() a.k.a. removeLast(), and/or pop_front() a.k.a. removeFirst().
   void waypt_del(Waypoint* wpt); // a.k.a. erase()
+  void del_wpts(wpt_evaluator_t ev);
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the element to be deleted, use iterator instead,
   //        and/or implement pop_back() a.k.a. removeLast(), and/or pop_front() a.k.a. removeFirst().
   void del_rte_waypt(Waypoint* wpt);
@@ -521,6 +525,7 @@ void waypt_init();
 //void update_common_traits(const Waypoint* wpt);
 void waypt_add(Waypoint* wpt);
 void waypt_del(Waypoint* wpt);
+void del_wpts(wpt_evaluator_t ev);
 unsigned int waypt_count();
 void waypt_status_disp(int total_ct, int myct);
 //void waypt_disp_all(waypt_cb); /* template */
@@ -658,6 +663,7 @@ public:
   void add_wpt(route_head* rte, Waypoint* wpt, bool synth, QStringView namepart, int number_digits);
   // FIXME: Generally it is inefficient to use an element pointer or reference to define the insertion point, use iterator instead.
   void del_wpt(route_head* rte, Waypoint* wpt);
+  void del_wpts(route_head* rte, wpt_evaluator_t ev);
   void common_disp_session(const session_t* se, route_hdr rh, route_trl rt, waypt_cb wc);
   void flush(); // a.k.a. clear()
   void copy(RouteList** dst) const;
@@ -718,8 +724,8 @@ void route_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT"
 void track_add_wpt(route_head* rte, Waypoint* wpt, QStringView namepart = u"RPT", int number_digits = 3);
 void route_del_wpt(route_head* rte, Waypoint* wpt);
 void track_del_wpt(route_head* rte, Waypoint* wpt);
-void route_swap_wpts(route_head* rte, WaypointList& other);
-void track_swap_wpts(route_head* rte, WaypointList& other);
+void route_del_wpts(route_head* rte, wpt_evaluator_t ev);
+void track_del_wpts(route_head* rte, wpt_evaluator_t ev);
 //void route_disp(const route_head* rte, waypt_cb); /* template */
 void route_disp(const route_head* rte, std::nullptr_t /* waypt_cb */); /* override to catch nullptr */
 //void route_disp_all(route_hdr, route_trl, waypt_cb); /* template */

--- a/defs.h
+++ b/defs.h
@@ -726,6 +726,8 @@ void route_del_wpt(route_head* rte, Waypoint* wpt);
 void track_del_wpt(route_head* rte, Waypoint* wpt);
 void route_del_wpts(route_head* rte, wpt_evaluator_t ev);
 void track_del_wpts(route_head* rte, wpt_evaluator_t ev);
+void route_swap_wpts(route_head* rte, WaypointList& other);
+void track_swap_wpts(route_head* rte, WaypointList& other);
 //void route_disp(const route_head* rte, waypt_cb); /* template */
 void route_disp(const route_head* rte, std::nullptr_t /* waypt_cb */); /* override to catch nullptr */
 //void route_disp_all(route_hdr, route_trl, waypt_cb); /* template */

--- a/discard.cc
+++ b/discard.cc
@@ -26,7 +26,7 @@
 
 #include <cstdlib>             // for strtod
 
-#include "defs.h"              // for Waypoint, fatal, route_del_wpt, route_disp_all, track_del_wpt, track_disp_all, waypt_del, waypt_disp_all, route_head, rtedata, trkdata, wptdata, fix_none, fix_unknown
+#include "defs.h"              // for Waypoint, fatal, route_head (ptr only), xstrtoi, wpt_extra_data_evaluator, del_wpts, route_del_wpts, route_disp_all, track_del_wpts, track_disp_all, waypt_disp_all, fix_none, fix_unknown
 #include "src/core/logging.h"  // for FatalMsg
 
 
@@ -41,12 +41,10 @@ void DiscardFilter::fix_process_wpt(const Waypoint* wpt)
   bool delh = false;
   bool delv = false;
 
-  auto* waypointp = const_cast<Waypoint*>(wpt);
-
-  if ((hdopf >= 0.0) && (waypointp->hdop > hdopf)) {
+  if ((hdopf >= 0.0) && (wpt->hdop > hdopf)) {
     delh = true;
   }
-  if ((vdopf >= 0.0) && (waypointp->vdop > vdopf)) {
+  if ((vdopf >= 0.0) && (wpt->vdop > vdopf)) {
     delv = true;
   }
 
@@ -56,81 +54,63 @@ void DiscardFilter::fix_process_wpt(const Waypoint* wpt)
     del = delh || delv;
   }
 
-  if ((satpf >= 0) && (waypointp->sat < satpf)) {
+  if ((satpf >= 0) && (wpt->sat < satpf)) {
     del = true;
   }
 
-  if ((fixnoneopt) && (waypointp->fix == fix_none)) {
+  if ((fixnoneopt) && (wpt->fix == fix_none)) {
     del = true;
   }
 
-  if ((fixunknownopt) && (waypointp->fix == fix_unknown)) {
+  if ((fixunknownopt) && (wpt->fix == fix_unknown)) {
     del = true;
   }
 
-  if ((eleminopt) && (waypointp->altitude < eleminpf)) {
+  if ((eleminopt) && (wpt->altitude < eleminpf)) {
     del = true;
   }
 
-  if ((elemaxopt) && (waypointp->altitude > elemaxpf)) {
+  if ((elemaxopt) && (wpt->altitude > elemaxpf)) {
     del = true;
   }
 
-  if (nameopt && name_regex.match(waypointp->shortname).hasMatch()) {
+  if (nameopt && name_regex.match(wpt->shortname).hasMatch()) {
     del = true;
   }
-  if (descopt && desc_regex.match(waypointp->description).hasMatch()) {
+  if (descopt && desc_regex.match(wpt->description).hasMatch()) {
     del = true;
   }
-  if (cmtopt && cmt_regex.match(waypointp->notes).hasMatch()) {
+  if (cmtopt && cmt_regex.match(wpt->notes).hasMatch()) {
     del = true;
   }
-  if (iconopt && icon_regex.match(waypointp->icon_descr).hasMatch()) {
+  if (iconopt && icon_regex.match(wpt->icon_descr).hasMatch()) {
     del = true;
   }
 
-  if (del) {
-    switch (what) {
-    case wptdata:
-      waypt_del(waypointp);
-      delete waypointp;
-      break;
-    case trkdata:
-      track_del_wpt(head, waypointp);
-      delete waypointp;
-      break;
-    case rtedata:
-      route_del_wpt(head, waypointp);
-      delete waypointp;
-      break;
-    default:
-      return;
-    }
-  }
-}
-
-void DiscardFilter::fix_process_head(const route_head* trk)
-{
-  head = const_cast<route_head*>(trk);
+  const_cast<Waypoint*>(wpt)->extra_data = del? &delete_flag : nullptr;
 }
 
 void DiscardFilter::process()
 {
-  WayptFunctor<DiscardFilter> fix_process_wpt_f(this, &DiscardFilter::fix_process_wpt);
-  RteHdFunctor<DiscardFilter> fix_process_head_f(this, &DiscardFilter::fix_process_head);
+  auto waypoint_cb_lambda = [this](const Waypoint* wpt) -> void {
+    fix_process_wpt(wpt);
+  };
 
   // Filter waypoints.
-  what = wptdata;
-  waypt_disp_all(fix_process_wpt_f);
+  waypt_disp_all(waypoint_cb_lambda);
+  del_wpts(wpt_extra_data_evaluator);
 
   // Filter tracks
-  what = trkdata;
-  track_disp_all(fix_process_head_f, nullptr, fix_process_wpt_f);
+  auto track_tlr_lambda = [](const route_head* rte)->void {
+    track_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+  };
+  track_disp_all(nullptr, track_tlr_lambda, waypoint_cb_lambda);
 
   // And routes
-  what = rtedata;
-  route_disp_all(fix_process_head_f, nullptr, fix_process_wpt_f);
-
+  auto route_tlr_lambda = [](const route_head* rte)->void {
+    route_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+  };
+  route_disp_all(nullptr, route_tlr_lambda, waypoint_cb_lambda);
 }
 
 QRegularExpression DiscardFilter::generateRegExp(const QString& glob_pattern)

--- a/discard.h
+++ b/discard.h
@@ -41,9 +41,14 @@ public:
   void process() override;
 
 private:
+  /* Member Functions */
+
+  void fix_process_wpt(const Waypoint* wpt);
   static QRegularExpression generateRegExp(const QString& glob_pattern);
 
-private:
+  /* Data Members */
+
+  int delete_flag{}; // delete_flag != nullptr
   char* hdopopt = nullptr;
   char* vdopopt = nullptr;
   char* andopt = nullptr;
@@ -66,8 +71,6 @@ private:
   int satpf{};
   int eleminpf{};
   int elemaxpf{};
-  gpsdata_type what{};
-  route_head* head{};
 
   QVector<arglist_t> args = {
     {
@@ -123,9 +126,6 @@ private:
       ARG_NOMINMAX, nullptr
     },
   };
-
-  void fix_process_wpt(const Waypoint* wpt);
-  void fix_process_head(const route_head* trk);
 
 };
 

--- a/discard.h
+++ b/discard.h
@@ -48,7 +48,6 @@ private:
 
   /* Data Members */
 
-  int delete_flag{}; // delete_flag != nullptr
   char* hdopopt = nullptr;
   char* vdopopt = nullptr;
   char* andopt = nullptr;

--- a/duplicate.cc
+++ b/duplicate.cc
@@ -77,8 +77,6 @@ void DuplicateFilter::init()
 
 void DuplicateFilter::process()
 {
-  int delete_flag; // &delete_flag != nullptr
-
   auto wptlist = *global_waypoint_list;
 
   auto compare_lambda = [](const Waypoint* wa, const Waypoint* wb)->bool {
@@ -88,7 +86,6 @@ void DuplicateFilter::process()
 
   QMultiHash<QString, Waypoint*> wpthash;
   for (Waypoint* waypointp : wptlist) {
-    waypointp->extra_data = nullptr;
 
     QString key;
     if (lcopt) {
@@ -121,12 +118,12 @@ void DuplicateFilter::process()
       for (auto it = values.cbegin(); it != values.cend(); ++it) {
         Waypoint* wpt = *it;
         if (purge_duplicates || (wpt != wptfirst)) {
-          wpt->extra_data = &delete_flag;
+          wpt->wpt_flags.marked_for_deletion = 1;;
         }
       }
     }
   }
-  del_wpts(wpt_extra_data_evaluator);
+  del_marked_wpts();
 }
 
 #endif

--- a/duplicate.cc
+++ b/duplicate.cc
@@ -126,18 +126,7 @@ void DuplicateFilter::process()
       }
     }
   }
-
-  // For lineary complexity build a new list from the points we keep.
-  WaypointList oldlist;
-  waypt_swap(oldlist);
-  
-  for (Waypoint* wpt : qAsConst(oldlist)) {
-    if (wpt->extra_data == nullptr) {
-      waypt_add(wpt);
-    } else {
-      delete wpt;
-    }
-  }
+  del_wpts(wpt_extra_data_evaluator);
 }
 
 #endif

--- a/polygon.cc
+++ b/polygon.cc
@@ -298,7 +298,6 @@ void PolygonFilter::process()
   }
   stream.close();
 
-  int delete_flag{}; // &delete_flag != nullptr
   foreach (Waypoint* wp, *global_waypoint_list) {
     if (wp->extra_data) {
       ed = (extra_data*) wp->extra_data;
@@ -307,12 +306,12 @@ void PolygonFilter::process()
         ed->state = INSIDE;
       }
       if (((ed->state & INSIDE) == OUTSIDE) == (exclopt == nullptr)) {
-        wp->extra_data = &delete_flag; // mark for deletion
+        wp->wpt_flags.marked_for_deletion = 1;
       }
       delete ed;
     }
   }
-  del_wpts(wpt_extra_data_evaluator); // delete marked wpts
+  del_marked_wpts();
 }
 
 #endif // FILTERS_ENABLED

--- a/polygon.cc
+++ b/polygon.cc
@@ -298,6 +298,7 @@ void PolygonFilter::process()
   }
   stream.close();
 
+  int delete_flag{}; // &delete_flag != nullptr
   foreach (Waypoint* wp, *global_waypoint_list) {
     if (wp->extra_data) {
       ed = (extra_data*) wp->extra_data;

--- a/polygon.cc
+++ b/polygon.cc
@@ -301,13 +301,12 @@ void PolygonFilter::process()
   foreach (Waypoint* wp, *global_waypoint_list) {
     if (wp->extra_data) {
       ed = (extra_data*) wp->extra_data;
+      wp->extra_data = nullptr;
       if (ed->override) {
         ed->state = INSIDE;
       }
       if (((ed->state & INSIDE) == OUTSIDE) == (exclopt == nullptr)) {
         wp->extra_data = &delete_flag; // mark for deletion
-      } else {
-        wp->extra_data = nullptr;
       }
       delete ed;
     }

--- a/polygon.cc
+++ b/polygon.cc
@@ -19,13 +19,14 @@
 
  */
 
+#include "polygon.h"
+
 #include <cstdio>                 // for sscanf
 
 #include <QString>                // for QString
 #include <QtGlobal>               // for foreach
 
 #include "defs.h"
-#include "polygon.h"
 #include "src/core/textstream.h"  // for TextStream
 
 
@@ -257,7 +258,7 @@ void PolygonFilter::process()
         if (waypointp->extra_data) {
           ed = (extra_data*) waypointp->extra_data;
         } else {
-          ed = (extra_data*) xcalloc(1, sizeof(*ed));
+          ed = new extra_data;
           ed->state = OUTSIDE;
           ed->override = 0;
           waypointp->extra_data = ed;
@@ -298,19 +299,20 @@ void PolygonFilter::process()
   stream.close();
 
   foreach (Waypoint* wp, *global_waypoint_list) {
-    ed = (extra_data*) wp->extra_data;
-    wp->extra_data = nullptr;
-    if (ed) {
+    if (wp->extra_data) {
+      ed = (extra_data*) wp->extra_data;
       if (ed->override) {
         ed->state = INSIDE;
       }
       if (((ed->state & INSIDE) == OUTSIDE) == (exclopt == nullptr)) {
-        waypt_del(wp);
-        delete wp;
+        wp->extra_data = &delete_flag; // mark for deletion
+      } else {
+        wp->extra_data = nullptr;
       }
-      xfree(ed);
+      delete ed;
     }
   }
+  del_wpts(wpt_extra_data_evaluator); // delete marked wpts
 }
 
 #endif // FILTERS_ENABLED

--- a/polygon.h
+++ b/polygon.h
@@ -55,7 +55,6 @@ private:
 
   /* Data Members */
 
-  int delete_flag{}; // &delete_flag != nullptr
   char* polyfileopt = nullptr;
   char* exclopt = nullptr;
 

--- a/polygon.h
+++ b/polygon.h
@@ -39,13 +39,25 @@ public:
   void process() override;
 
 private:
-  char* polyfileopt = nullptr;
-  char* exclopt = nullptr;
+  /* Types */
 
   struct extra_data {
     unsigned short state;
     unsigned short override;
   };
+
+  /* Member Functions */
+
+  static void polytest(double lat1, double lon1,
+                double lat2, double lon2,
+                double wlat, double wlon,
+                unsigned short* state, int first, int last);
+
+  /* Data Members */
+
+  int delete_flag{}; // &delete_flag != nullptr
+  char* polyfileopt = nullptr;
+  char* exclopt = nullptr;
 
   QVector<arglist_t> args = {
     {
@@ -57,11 +69,6 @@ private:
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
   };
-
-  static void polytest(double lat1, double lon1,
-                double lat2, double lon2,
-                double wlat, double wlon,
-                unsigned short* state, int first, int last);
 
 };
 #endif // FILTERS_ENABLED

--- a/position.cc
+++ b/position.cc
@@ -36,8 +36,6 @@
 void PositionFilter::position_runqueue(const WaypointList& waypt_list, int qtype)
 {
   if (!waypt_list.empty()) {
-    // We really don't need to copy the waypt_list, but the nested for loops
-    // are O(n^2) and the copy is O(n) so the impact on performance is minimal.
     QList<WptRecord> qlist;
   
     for (auto* const waypointp : waypt_list) {

--- a/position.cc
+++ b/position.cc
@@ -64,7 +64,7 @@ void PositionFilter::position_runqueue(const WaypointList& waypt_list, int qtype
               }
   
               qlist[j].deleted = true;
-              qlist.at(j).wpt->extra_data = &delete_flag;
+              qlist.at(j).wpt->wpt_flags.marked_for_deletion = 1;
               something_deleted = true;
             } else {
               // Unlike waypoints, routes and tracks are ordered paths.
@@ -78,7 +78,7 @@ void PositionFilter::position_runqueue(const WaypointList& waypt_list, int qtype
         }
   
         if (something_deleted && (purge_duplicates != nullptr)) {
-          qlist.at(i).wpt->extra_data = &delete_flag;
+          qlist.at(i).wpt->wpt_flags.marked_for_deletion = 1;
         }
       }
     }
@@ -88,13 +88,13 @@ void PositionFilter::position_runqueue(const WaypointList& waypt_list, int qtype
 void PositionFilter::process()
 {
   position_runqueue(*global_waypoint_list, wptdata);
-  del_wpts(wpt_extra_data_evaluator);
+  del_marked_wpts();
 
   auto position_process_rte_lambda = [this](const route_head* rte) ->void {
     position_runqueue(rte->waypoint_list, rtedata);
   };
   auto rte_trl_lambda = [](const route_head* rte) -> void {
-    route_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+    route_del_marked_wpts(const_cast<route_head*>(rte));
   };
   route_disp_all(position_process_rte_lambda, rte_trl_lambda, nullptr);
 
@@ -102,7 +102,7 @@ void PositionFilter::process()
     position_runqueue(rte->waypoint_list, trkdata);
   };
   auto trk_trl_lambda = [](const route_head* rte) -> void {
-    track_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+    track_del_marked_wpts(const_cast<route_head*>(rte));
   };
   track_disp_all(position_process_trk_lambda, trk_trl_lambda, nullptr);
 }

--- a/position.h
+++ b/position.h
@@ -65,7 +65,6 @@ private:
 
   /* Data Members */
 
-  int delete_flag{}; // &delete_flag != nullptr
   double pos_dist{};
   qint64 max_diff_time{};
   char* distopt = nullptr;

--- a/position.h
+++ b/position.h
@@ -22,12 +22,14 @@
 #ifndef POSITION_H_INCLUDED_
 #define POSITION_H_INCLUDED_
 
-#include <QString>   // for QString
-#include <QVector>   // for QVector
-#include <QtGlobal>  // for qint64
+#include <QString>    // for QString
+#include <QVector>    // for QVector
+#include <QtGlobal>   // for qint64
 
-#include "defs.h"    // for route_head (ptr only), ARG_NOMINMAX, ARGTYPE_FLOAT
-#include "filter.h"  // for Filter
+#include "defs.h"     // for arglist_t, route_head (ptr only), ARG_NOMINMAX, ARGTYPE_FLOAT, ARGTYPE_REQUIRED, ARGTYPE_BOOL, Waypoint, WaypointList (ptr only)
+#include "filter.h"   // for Filter
+#include "grtcirc.h"  // for RAD, gcdist, radtometers
+
 
 #if FILTERS_ENABLED
 
@@ -42,8 +44,28 @@ public:
   void process() override;
 
 private:
-  route_head* cur_rte = nullptr;
+  /* Types */
 
+  class WptRecord
+  {
+  public:
+    explicit WptRecord(Waypoint* w) : wpt(w) {}
+
+    Waypoint* wpt{nullptr};
+    bool deleted{false};
+  };
+
+  /* Member Functions */
+
+  static double gc_distance(double lat1, double lon1, double lat2, double lon2)
+  {
+    return radtometers(gcdist(RAD(lat1), RAD(lon1), RAD(lat2), RAD(lon2)));
+  }
+  void position_runqueue(const WaypointList& waypt_list, int qtype);
+
+  /* Data Members */
+
+  int delete_flag{}; // &delete_flag != nullptr
   double pos_dist{};
   qint64 max_diff_time{};
   char* distopt = nullptr;
@@ -66,21 +88,6 @@ private:
       nullptr, ARGTYPE_FLOAT | ARGTYPE_REQUIRED, ARG_NOMINMAX, nullptr
     },
   };
-
-  class WptRecord
-  {
-  public:
-    Waypoint* wpt{nullptr};
-    bool deleted{false};
-
-    explicit WptRecord(Waypoint* w) : wpt(w) {}
-  };
-
-  static double gc_distance(double lat1, double lon1, double lat2, double lon2);
-  void position_runqueue(WaypointList* waypt_list, int qtype);
-  void position_process_any_route(const route_head* rh, int type);
-  void position_process_rte(const route_head* rh);
-  void position_process_trk(const route_head* rh);
 
 };
 #endif // FILTERS_ENABLED

--- a/radius.cc
+++ b/radius.cc
@@ -19,40 +19,35 @@
 
  */
 
+#include "radius.h"
+
 #include <cstdlib>          // for strtod
 
 #include <QString>          // for QString
 #include <QtGlobal>         // for qAsConst, QAddConst<>::Type, foreach
 
-#include "defs.h"           // for Waypoint, waypt_del, route_add_head, route_add_wpt, route_head, waypt_add, waypt_count, xcalloc, xfree, kMilesPerKilometer
-#include "radius.h"
-#include "grtcirc.h"        // for RAD, gcdist, radtomiles
+#include "defs.h"           // for Waypoint, del_wpts, route_add_head, route_add_wpt, waypt_add, waypt_sort, waypt_swap, xstrtoi, route_head, WaypointList, kMilesPerKilometer
 
 
 #if FILTERS_ENABLED
 
-double RadiusFilter::gc_distance(double lat1, double lon1, double lat2, double lon2)
-{
-  return radtomiles(gcdist(RAD(lat1), RAD(lon1), RAD(lat2), RAD(lon2)));
-}
+int RadiusFilter::delete_flag{}; // ODR-use
 
 void RadiusFilter::process()
 {
-  // waypt_del may modify container.
   foreach (Waypoint* waypointp, *global_waypoint_list) {
     double dist = gc_distance(waypointp->latitude, waypointp->longitude,
                               home_pos->latitude, home_pos->longitude);
 
     if ((dist >= pos_dist) == (exclopt == nullptr)) {
-      waypt_del(waypointp);
-      delete waypointp;
-      continue;
+      waypointp->extra_data = &delete_flag; // mark for deletion
+    } else {
+      auto* ed = new extra_data;
+      ed->distance = dist;
+      waypointp->extra_data = ed;
     }
-
-    auto* ed = new extra_data;
-    ed->distance = dist;
-    waypointp->extra_data = ed;
   }
+  del_wpts(wpt_deletion_evaluator); // delete marked wpts
 
   if (nosort == nullptr) {
     auto dist_comp_lambda = [](const Waypoint* a, const Waypoint* b)->bool {

--- a/radius.cc
+++ b/radius.cc
@@ -26,12 +26,10 @@
 #include <QString>          // for QString
 #include <QtGlobal>         // for qAsConst, QAddConst<>::Type, foreach
 
-#include "defs.h"           // for Waypoint, del_wpts, route_add_head, route_add_wpt, waypt_add, waypt_sort, waypt_swap, xstrtoi, route_head, WaypointList, kMilesPerKilometer
+#include "defs.h"           // for Waypoint, del_marked_wpts, route_add_head, route_add_wpt, waypt_add, waypt_sort, waypt_swap, xstrtoi, route_head, WaypointList, kMilesPerKilometer
 
 
 #if FILTERS_ENABLED
-
-int RadiusFilter::delete_flag{}; // ODR-use
 
 void RadiusFilter::process()
 {
@@ -40,14 +38,14 @@ void RadiusFilter::process()
                               home_pos->latitude, home_pos->longitude);
 
     if ((dist >= pos_dist) == (exclopt == nullptr)) {
-      waypointp->extra_data = &delete_flag; // mark for deletion
+      waypointp->wpt_flags.marked_for_deletion = 1;
     } else {
       auto* ed = new extra_data;
       ed->distance = dist;
       waypointp->extra_data = ed;
     }
   }
-  del_wpts(wpt_deletion_evaluator); // delete marked wpts
+  del_marked_wpts();
 
   if (nosort == nullptr) {
     auto dist_comp_lambda = [](const Waypoint* a, const Waypoint* b)->bool {

--- a/radius.h
+++ b/radius.h
@@ -22,10 +22,12 @@
 #ifndef RADIUS_H_INCLUDED_
 #define RADIUS_H_INCLUDED_
 
-#include <QVector>         // for QVector
+#include <QString>    // for QString
+#include <QVector>    // for QVector
 
-#include "defs.h"    // for ARG_NOMINMAX, ARGTYPE_FLOAT, ARGTYPE_REQUIRED
-#include "filter.h"  // for Filter
+#include "defs.h"     // for arglist_t, ARG_NOMINMAX, ARGTYPE_FLOAT, ARGTYPE_REQUIRED, ARGTYPE_BOOL, ARGTYPE_INT, ARGTYPE_STRING, Waypoint
+#include "filter.h"   // for Filter
+#include "grtcirc.h"  // for RAD, gcdist, radtomiles
 
 #if FILTERS_ENABLED
 
@@ -41,6 +43,23 @@ public:
   void deinit() override;
 
 private:
+  /* Types */
+
+  struct extra_data {
+    double distance;
+  };
+
+  /* Member Functions */
+
+  static bool wpt_deletion_evaluator(const Waypoint* wpt) {return wpt->extra_data == &delete_flag;}
+  static double gc_distance(double lat1, double lon1, double lat2, double lon2)
+  {
+    return radtomiles(gcdist(RAD(lat1), RAD(lon1), RAD(lat2), RAD(lon2)));
+  }
+
+  /* Data Members */
+
+  static int delete_flag;
   double pos_dist{};
   char* distopt = nullptr;
   char* latopt = nullptr;
@@ -52,10 +71,6 @@ private:
   int maxct{};
 
   Waypoint* home_pos{};
-
-  struct extra_data {
-    double distance;
-  };
 
   QVector<arglist_t> args = {
     {
@@ -87,8 +102,6 @@ private:
       nullptr, ARGTYPE_STRING, nullptr, nullptr, nullptr
     },
   };
-
-  static double gc_distance(double lat1, double lon1, double lat2, double lon2);
 
 };
 #endif // FILTERS_ENABLED

--- a/radius.h
+++ b/radius.h
@@ -51,7 +51,6 @@ private:
 
   /* Member Functions */
 
-  static bool wpt_deletion_evaluator(const Waypoint* wpt) {return wpt->extra_data == &delete_flag;}
   static double gc_distance(double lat1, double lon1, double lat2, double lon2)
   {
     return radtomiles(gcdist(RAD(lat1), RAD(lon1), RAD(lat2), RAD(lon2)));
@@ -59,7 +58,6 @@ private:
 
   /* Data Members */
 
-  static int delete_flag;
   double pos_dist{};
   char* distopt = nullptr;
   char* latopt = nullptr;

--- a/route.cc
+++ b/route.cc
@@ -144,15 +144,15 @@ track_del_wpt(route_head* rte, Waypoint* wpt)
 }
 
 void
-route_del_wpts(route_head* rte, wpt_evaluator_t ev)
+route_del_marked_wpts(route_head* rte)
 {
-  global_route_list->del_wpts(rte, ev);
+  global_route_list->del_marked_wpts(rte);
 }
 
 void
-track_del_wpts(route_head* rte, wpt_evaluator_t ev)
+track_del_marked_wpts(route_head* rte)
 {
-  global_track_list->del_wpts(rte, ev);
+  global_track_list->del_marked_wpts(rte);
 }
 
 void
@@ -459,9 +459,8 @@ RouteList::del_wpt(route_head* rte, Waypoint* wpt)
 }
 
 void
-RouteList::del_wpts(route_head* rte, wpt_evaluator_t evaluator)
+RouteList::del_marked_wpts(route_head* rte)
 {
-  /* delete marked points */
   // For lineary complexity build a new list from the points we keep.
   WaypointList oldlist;
   swap_wpts(rte, oldlist);
@@ -469,17 +468,17 @@ RouteList::del_wpts(route_head* rte, wpt_evaluator_t evaluator)
   // mimic trkseg handling from WaypointList::del_rte_waypt
   bool inherit_new_trkseg = false;
   for (Waypoint* wpt : qAsConst(oldlist)) {
-    if (!evaluator(wpt)) {
+    if (wpt->wpt_flags.marked_for_deletion) {
+      if (wpt->wpt_flags.new_trkseg) {
+        inherit_new_trkseg = true;
+      }
+      delete wpt;
+    } else {
       if (inherit_new_trkseg) {
         wpt->wpt_flags.new_trkseg = 1;
         inherit_new_trkseg = false;
       }
       add_wpt(rte, wpt, false, u"RPT", 3);
-    } else {
-      if (wpt->wpt_flags.new_trkseg) {
-        inherit_new_trkseg = true;
-      }
-      delete wpt;
     }
   }
 }

--- a/route.cc
+++ b/route.cc
@@ -156,6 +156,18 @@ track_del_wpts(route_head* rte, wpt_evaluator_t ev)
 }
 
 void
+route_swap_wpts(route_head* rte, WaypointList& other)
+{
+  global_route_list->swap_wpts(rte, other);
+}
+
+void
+track_swap_wpts(route_head* rte, WaypointList& other)
+{
+  global_track_list->swap_wpts(rte, other);
+}
+
+void
 route_disp(const route_head* /* rh */, std::nullptr_t /* wc */)
 {
 // wc == nullptr

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -139,7 +139,7 @@ double SimplifyRouteFilter::compute_track_error(const neighborhood& nb) const
   return track_error;
 }
 
-void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
+void SimplifyRouteFilter::routesimple_head(const route_head* rte)
 {
   /* short-circuit if we already have fewer than the max points */
   if ((limit_basis == limit_basis_t::count) && count >= rte->rte_waypt_ct()) {
@@ -249,41 +249,23 @@ void SimplifyRouteFilter::routesimple_tail(const route_head* rte)
     }
 
   } /* end of too many records loop */
-
-  /* delete marked points */
-  // For lineary complexity build a new list from the points we keep.
-  WaypointList oldlist;
-  (*route_swap_wpts_fnp)(const_cast<route_head*>(rte), oldlist);
-
-  // mimic trkseg handling from WaypointList::del_rte_waypt
-  bool inherit_new_trkseg = false;
-  for (Waypoint* wpt : qAsConst(oldlist)) {
-    if (wpt->extra_data == nullptr) {
-      if (inherit_new_trkseg) {
-        wpt->wpt_flags.new_trkseg = 1;
-        inherit_new_trkseg = false;
-      }
-      (*route_add_wpt_fnp)(const_cast<route_head*>(rte), wpt, u"RPT", 3);
-    } else {
-      if (wpt->wpt_flags.new_trkseg) {
-        inherit_new_trkseg = true;
-      }
-      delete wpt;
-    }
-  }
 }
 
 void SimplifyRouteFilter::process()
 {
-  RteHdFunctor<SimplifyRouteFilter> routesimple_tail_f(this, &SimplifyRouteFilter::routesimple_tail);
+  auto common_head_lambda = [this](const route_head* rte)->void {
+    routesimple_head(rte);
+  };
 
-  route_add_wpt_fnp = route_add_wpt;
-  route_swap_wpts_fnp = route_swap_wpts;
-  route_disp_all(nullptr, routesimple_tail_f, nullptr);
+  auto route_tail_lambda = [](const route_head* rte)->void {
+    route_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+  };
+  route_disp_all(common_head_lambda, route_tail_lambda, nullptr);
 
-  route_add_wpt_fnp = track_add_wpt;
-  route_swap_wpts_fnp = track_swap_wpts;
-  track_disp_all(nullptr, routesimple_tail_f, nullptr);
+  auto track_tail_lambda = [](const route_head* rte)->void {
+    track_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+  };
+  track_disp_all(common_head_lambda, track_tail_lambda, nullptr);
 }
 
 void SimplifyRouteFilter::init()

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -206,7 +206,7 @@ void SimplifyRouteFilter::routesimple_head(const route_head* rte)
 
     /* remove the record with the lowest XTE */
     neighborhood goner = errormap.last();
-    goner.wpt->extra_data = &delete_flag; // mark for deletion
+    goner.wpt->wpt_flags.marked_for_deletion = 1;
     // errormap.remove(lastKey());  // with Qt 5.12.12, 5.15.2 results in asan heap-use-after-free errors in build_extra_tests.sh
     errormap.erase(--errormap.end()); // in Qt6 can use cend().
     // wpthash.remove(goner.wpt); // removal not necessary
@@ -258,12 +258,12 @@ void SimplifyRouteFilter::process()
   };
 
   auto route_tail_lambda = [](const route_head* rte)->void {
-    route_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+    route_del_marked_wpts(const_cast<route_head*>(rte));
   };
   route_disp_all(common_head_lambda, route_tail_lambda, nullptr);
 
   auto track_tail_lambda = [](const route_head* rte)->void {
-    track_del_wpts(const_cast<route_head*>(rte), wpt_extra_data_evaluator);
+    track_del_marked_wpts(const_cast<route_head*>(rte));
   };
   track_disp_all(common_head_lambda, track_tail_lambda, nullptr);
 }

--- a/smplrout.h
+++ b/smplrout.h
@@ -109,7 +109,7 @@ private:
   /* Member Functions */
 
   double compute_track_error(const neighborhood& nb) const;
-  void routesimple_tail(const route_head* rte);
+  void routesimple_head(const route_head* rte);
 
   /* Data Members */
 
@@ -124,8 +124,6 @@ private:
   char* xteopt = nullptr;
   char* lenopt = nullptr;
   char* relopt = nullptr;
-  void (*route_add_wpt_fnp)(route_head* rte, Waypoint* wpt, QStringView namepart, int number_digits) {};
-  void (*route_swap_wpts_fnp)(route_head* rte, WaypointList& other) {};
 
   QVector<arglist_t> args = {
     {

--- a/smplrout.h
+++ b/smplrout.h
@@ -117,7 +117,6 @@ private:
   double error = 0;
   limit_basis_t limit_basis{limit_basis_t::error};
   metric_t metric{metric_t::crosstrack};
-  int delete_flag{}; // &delete_flag != nullptr
 
   char* countopt = nullptr;
   char* erroropt = nullptr;

--- a/waypt.cc
+++ b/waypt.cc
@@ -88,6 +88,12 @@ waypt_del(Waypoint* wpt)
   global_waypoint_list->waypt_del(wpt);
 }
 
+void
+del_wpts(wpt_evaluator_t ev)
+{
+  global_waypoint_list->del_wpts(ev);
+}
+
 unsigned int
 waypt_count()
 {
@@ -658,6 +664,23 @@ WaypointList::waypt_del(Waypoint* wpt)
   const int idx = this->indexOf(wpt);
   assert(idx >= 0);
   removeAt(idx);
+}
+
+void
+WaypointList::del_wpts(wpt_evaluator_t evaluator)
+{
+  /* delete marked points */
+  // For lineary complexity build a new list from the points we keep.
+  WaypointList oldlist;
+  swap(oldlist);
+
+  for (Waypoint* wpt : qAsConst(oldlist)) {
+    if (!evaluator(wpt)) {
+      waypt_add(wpt);
+    } else {
+      delete wpt;
+    }
+  }
 }
 
 void

--- a/waypt.cc
+++ b/waypt.cc
@@ -89,9 +89,9 @@ waypt_del(Waypoint* wpt)
 }
 
 void
-del_wpts(wpt_evaluator_t ev)
+del_marked_wpts()
 {
-  global_waypoint_list->del_wpts(ev);
+  global_waypoint_list->del_marked_wpts();
 }
 
 unsigned int
@@ -667,18 +667,17 @@ WaypointList::waypt_del(Waypoint* wpt)
 }
 
 void
-WaypointList::del_wpts(wpt_evaluator_t evaluator)
+WaypointList::del_marked_wpts()
 {
-  /* delete marked points */
   // For lineary complexity build a new list from the points we keep.
   WaypointList oldlist;
   swap(oldlist);
 
   for (Waypoint* wpt : qAsConst(oldlist)) {
-    if (!evaluator(wpt)) {
-      waypt_add(wpt);
-    } else {
+    if (wpt->wpt_flags.marked_for_deletion) {
       delete wpt;
+    } else {
+      waypt_add(wpt);
     }
   }
 }


### PR DESCRIPTION
New functions with complexity O(n) for deleting pre-marked waypoints are:
  WaypointList::del_wpts
  RouteList::del_wpts
  del_wpts
  route_del_wpts
  track_del_wpts

Use those functions instead of the inefficient versions:
WaypointList::waypt_del
RouteList::del_wpt
waypt_del
route_del_wpt
track_del_wpt.
When these functions are used while looping over a waypoint list the overall complexity is O(n^2).  This is because these functions themselves amortize to O(n).

Optimization of the track filter will be done separately.