### PR TITLE
use efficient methods to delete trkpts in track filter.

### DIFF
--- a/trackfilter.h
+++ b/trackfilter.h
@@ -24,6 +24,7 @@
 
 #include <QDateTime>            // for QDateTime
 #include <QList>                // for QList
+#include <QString>              // for QString
 #include <QVector>              // for QVector
 #include <QtGlobal>             // for qint64
 

--- a/trackfilter.h
+++ b/trackfilter.h
@@ -56,6 +56,7 @@ private:
 
   /* Constants */
 
+  static constexpr double kDistanceLimit = 1.11319; // for points to be considered the same, meters.
   static constexpr char TRACKFILTER_PACK_OPTION[] = "pack";
   static constexpr char TRACKFILTER_SPLIT_OPTION[] = "split";
   static constexpr char TRACKFILTER_SDIST_OPTION[] = "sdistance";


### PR DESCRIPTION
This PR uses track_del_marked_wpts instead of track_del_wpt.  track_del_marked_wpts scales with the number of points in the list, while track_del_wpt scales with the number of points in the list times the number of points deleted.

There are some intentional changes of behavior:

1. previously in option split all existing track segment markers after the first split were removed, but those before the split were conserved.  Now all pre-existing segment markers are removed, leaving only one segment per track.
2. previously in option pack all existing track segment markers after the first track were removed, but those in the first track were conserved.  Now all pre-existing segment markers are removed, leaving only one segment in the packed track.  This is issue #1152. 