### PR TITLE
convert googletakeout format to dynamic.

### DIFF
--- a/googletakeout.cc
+++ b/googletakeout.cc
@@ -217,16 +217,13 @@ GoogleTakeoutFormat::title_case(QString& title)
 }
 
 void
-GoogleTakeoutFormat::rd_init(const QString& fname) {
+GoogleTakeoutFormat::read()
+{
   if (global_opts.debug_level >= 4) {
     Debug(4) << "rd_init(" << fname << ")";
   }
-  inputStream = GoogleTakeoutInputStream(fname);
-}
+  GoogleTakeoutInputStream inputStream(fname);
 
-void
-GoogleTakeoutFormat::read()
-{
   int items = 0;
   int points = 0;
   int place_visits = 0;

--- a/googletakeout.h
+++ b/googletakeout.h
@@ -65,6 +65,8 @@ private:
 class GoogleTakeoutFormat : public Format
 {
 public:
+  using Format::Format;
+
   /* Member functions */
   QVector<arglist_t>* get_args() override
   {
@@ -81,7 +83,8 @@ public:
     return { ff_cap_read, ff_cap_read, ff_cap_none };
   }
 
-  void rd_init(const QString& fname) override;
+  void rd_init(const QString& fname) override
+  {}
   void read() override;
  
 private:
@@ -119,7 +122,6 @@ private:
 
   /* Data Members */
 
-  GoogleTakeoutInputStream inputStream;
   QVector<arglist_t> googletakeout_args;
 };
 

--- a/vecs.cc
+++ b/vecs.cc
@@ -163,7 +163,6 @@ struct Vecs::Impl {
   GeoJsonFormat geojson_fmt;
   GlobalsatSportFormat globalsat_sport_fmt;
   QstarzBL1000Format qstarz_bl_1000_fmt;
-  GoogleTakeoutFormat google_timeline_fmt;
 #endif // MAXIMAL_ENABLED
 
   const QVector<vecs_t> vec_list {
@@ -495,11 +494,12 @@ struct Vecs::Impl {
       nullptr,
     },
     {
-      &google_timeline_fmt,
+      nullptr,
       "googletakeout",
       "Google Takeout Location History",
       "json",
       nullptr,
+      &fmtfactory<GoogleTakeoutFormat>
     }
 #endif // MAXIMAL_ENABLED
   };


### PR DESCRIPTION
Dynamic formats are constructed for each use, and destroyed afterwards.  This allows:
1) format class resources to be initialized by the format constructor, e.g. with default member initializers or member initializer lists.
2) eliminate the burden of returning resources held by a format class data member.  The destructor of the class data member will be called when the class is destroyed.
3) In some cases this can eliminate the need for a member variable that stores something set by rd(wr)_init and is used by read(write).  This alone can simplify the return of resources as any variables of automatic storage duration will be destroyed at the end of the enclosing block.
4) unintended communication between successive invocations of the format to be prevented.

In this case, the data member inputStream can become variable with automatic storage duration of the member function read().  Note that previously the inputStream was not cleaned up until program exit.