### PR TITLE
tidy fixes

### DIFF
--- a/duplicate.cc
+++ b/duplicate.cc
@@ -97,7 +97,7 @@ void DuplicateFilter::process()
         .arg(degrees2ddmm(waypointp->latitude), 11, 'f', 3)
         .arg(degrees2ddmm(waypointp->longitude), 11, 'f', 3);
     }
-  
+
     if (snopt) {
       key.append(waypointp->shortname);
     }

--- a/exif.cc
+++ b/exif.cc
@@ -209,7 +209,7 @@ ExifFormat::exif_read_str(ExifTag* tag)
   // Panasonic DMC-TZ10 stores datum with trailing spaces.
   // Kodak stores zero count ASCII tags.
   QByteArray buf = (tag->count == 0) ? QByteArray("") : tag->data.at(0).toByteArray();
-  // If the bytearray contains internal NULL(s), get rid of the first and 
+  // If the bytearray contains internal NULL(s), get rid of the first and
   // anything after it.
   if (auto idx = buf.indexOf('\0'); idx >= 0) {
     buf = buf.left(idx);
@@ -1574,7 +1574,7 @@ ExifFormat::write()
       exif_put_double(GPS_IFD, GPS_IFD_TAG_TIMESTAMP, 0, dt.time().hour());
       exif_put_double(GPS_IFD, GPS_IFD_TAG_TIMESTAMP, 1, dt.time().minute());
       exif_put_double(GPS_IFD, GPS_IFD_TAG_TIMESTAMP, 2,
-                      static_cast<double>(dt.time().second()) + 
+                      static_cast<double>(dt.time().second()) +
                       static_cast<double>(dt.time().msec())/1000.0);
 
       exif_put_str(GPS_IFD, GPS_IFD_TAG_DATESTAMP, CSTR(dt.toString(u"yyyy:MM:dd")));

--- a/filter_vecs.h
+++ b/filter_vecs.h
@@ -39,7 +39,7 @@ public:
   class fltinfo_t {
   public:
 
-    bool isDynamic() {
+    bool isDynamic() const {
       return factory != nullptr;
     }
     explicit operator bool() const {

--- a/gdb.h
+++ b/gdb.h
@@ -85,7 +85,7 @@ public:
        * it’s in <qhashfunctions.h>, a public header.
        */
       QtPrivate::QHashCombine hash;
-      
+
       seed = hash(seed, c.shortname.toUpper());
       seed = hash(seed, c.lat);
       seed = hash(seed, c.lon);

--- a/geo.cc
+++ b/geo.cc
@@ -33,7 +33,7 @@
 
 #define MYNAME "geo"
 
-void GeoFormat::GeoReadLoc(QXmlStreamReader& reader) const
+void GeoFormat::GeoReadLoc(QXmlStreamReader& reader)
 {
   Waypoint* wpt = nullptr;
   QString current_tag;

--- a/geo.h
+++ b/geo.h
@@ -60,7 +60,7 @@ private:
 
   /* Member Functions */
 
-  void GeoReadLoc(QXmlStreamReader& reader) const;
+  static void GeoReadLoc(QXmlStreamReader& reader);
   void geo_waypt_pr(const Waypoint*, QXmlStreamWriter& writer);
   static Geocache::container_t wpt_container(const QString&);
 

--- a/googletakeout.h
+++ b/googletakeout.h
@@ -75,7 +75,7 @@ public:
 
   ff_type get_type() const override
   {
-   return ff_type_file; 
+   return ff_type_file;
   }
 
   QVector<ff_cap> get_cap() const override
@@ -86,7 +86,7 @@ public:
   void rd_init(const QString& fname) override
   {}
   void read() override;
- 
+
 private:
   /* Constants */
 

--- a/gpx.cc
+++ b/gpx.cc
@@ -981,7 +981,7 @@ GpxFormat::qualifiedName() const
    * file.  So we map from the namespaceUris to the prefixes used in our
    * hash table.
    */
-  static const QHash<QString, QString> tag_ns_prefixes = { 
+  static const QHash<QString, QString> tag_ns_prefixes = {
     {"http://www.garmin.com/xmlschemas/GpxExtensions/v3", "gpxx"},
     {"http://www.garmin.com/xmlschemas/TrackPointExtension/v1", "gpxtpx"},
     {"http://www.groundspeak.com/cache/1/0", "groundspeak"},

--- a/gtm.cc
+++ b/gtm.cc
@@ -31,7 +31,7 @@
 #include <QString>              // for QString
 #include <QVector>              // for QVector
 
-#include "defs.h" 
+#include "defs.h"
 #include "gbfile.h"             // for gbfseek, gbfputc, gbfputint32, gbfputflt
 #include "jeeps/gpsmath.h"      // for GPS_Math_Known_Datum_To_WGS84_M
 #include "src/core/datetime.h"  // for DateTime

--- a/igc.cc
+++ b/igc.cc
@@ -636,7 +636,7 @@ QByteArray IgcFormat::latlon2str(const Waypoint* wpt)
   return str;
 }
 
-QByteArray IgcFormat::date2str(const gpsbabel::DateTime& dt) const
+QByteArray IgcFormat::date2str(const gpsbabel::DateTime& dt)
 {
   QByteArray str = dt.toUTC().toString("ddMMyy").toUtf8();
   if (str.size() != 6) {
@@ -645,7 +645,7 @@ QByteArray IgcFormat::date2str(const gpsbabel::DateTime& dt) const
   return str;
 }
 
-QByteArray IgcFormat::tod2str(const gpsbabel::DateTime& tod) const
+QByteArray IgcFormat::tod2str(const gpsbabel::DateTime& tod)
 {
   QByteArray str = tod.toUTC().toString("hhmmss").toUtf8();
   if (str.size() != 6) {
@@ -826,7 +826,7 @@ void IgcFormat::wr_fix_record(const Waypoint* wpt, int pres_alt, int gnss_alt)
  * @return The number of seconds to add to the GNSS track in order to align
  *         it with the pressure track.
  */
-int IgcFormat::correlate_tracks(const route_head* pres_track, const route_head* gnss_track) const
+int IgcFormat::correlate_tracks(const route_head* pres_track, const route_head* gnss_track)
 {
   double alt_diff;
   double speed;

--- a/igc.h
+++ b/igc.h
@@ -161,7 +161,7 @@ private:
    * A factor can never be zero, so this looks good to me.
    * Be careful.
    */
-  int get_ext_factor(igc_ext_type_t type) const
+  static int get_ext_factor(igc_ext_type_t type)
   {
     int ret = 0;
     switch (type) {
@@ -242,9 +242,9 @@ private:
   void detect_gnss_track(const route_head*);
   void detect_other_track(const route_head*, int& max_waypt_ct);
   void get_tracks(const route_head**, const route_head**);
-  QByteArray latlon2str(const Waypoint*);
-  QByteArray date2str(const gpsbabel::DateTime&) const;
-  QByteArray tod2str(const gpsbabel::DateTime&) const;
+  static QByteArray latlon2str(const Waypoint*);
+  static QByteArray date2str(const gpsbabel::DateTime&);
+  static QByteArray tod2str(const gpsbabel::DateTime&);
   void wr_header();
   void wr_task_wpt_name(const Waypoint*, const char*);
   void wr_task_hdr(const route_head*, unsigned int task_num);
@@ -252,7 +252,7 @@ private:
   void wr_task_tlr(const route_head*);
   void wr_tasks();
   void wr_fix_record(const Waypoint*, int, int);
-  int correlate_tracks(const route_head*, const route_head*) const;
+  static int correlate_tracks(const route_head*, const route_head*);
   void wr_track();
 
   /* Data Members */

--- a/kml.cc
+++ b/kml.cc
@@ -1226,7 +1226,7 @@ QString KmlFormat::kml_gc_mkstar(int rating)
 
 }
 
-QString KmlFormat::kml_geocache_get_logs(const Waypoint* wpt) const
+QString KmlFormat::kml_geocache_get_logs(const Waypoint* wpt)
 {
   QString r;
 

--- a/kml.h
+++ b/kml.h
@@ -179,7 +179,7 @@ private:
   static QString kml_lookup_gc_icon(const Waypoint* waypointp);
   static const char* kml_lookup_gc_container(const Waypoint* waypointp);
   static QString kml_gc_mkstar(int rating);
-  QString kml_geocache_get_logs(const Waypoint* wpt) const;
+  static QString kml_geocache_get_logs(const Waypoint* wpt);
   void kml_write_data_element(const QString& name, const QString& value) const;
   void kml_write_data_element(const QString& name, int value) const;
   void kml_write_data_element(const QString& name, double value) const;

--- a/position.cc
+++ b/position.cc
@@ -37,23 +37,23 @@ void PositionFilter::position_runqueue(const WaypointList& waypt_list, int qtype
 {
   if (!waypt_list.empty()) {
     QList<WptRecord> qlist;
-  
+
     for (auto* const waypointp : waypt_list) {
       qlist.append(WptRecord(waypointp));
     }
     int nelems = qlist.size();
-  
+
     for (int i = 0 ; i < nelems ; ++i) {
       if (!qlist.at(i).deleted) {
         bool something_deleted = false;
-  
+
         for (int j = i + 1 ; j < nelems ; ++j) {
           if (!qlist.at(j).deleted) {
             double dist = gc_distance(qlist.at(j).wpt->latitude,
                                       qlist.at(j).wpt->longitude,
                                       qlist.at(i).wpt->latitude,
                                       qlist.at(i).wpt->longitude);
-  
+
             if (dist <= pos_dist) {
               if (check_time) {
                 qint64 diff_time = std::abs(qlist.at(j).wpt->creation_time.msecsTo(qlist.at(i).wpt->creation_time));
@@ -61,7 +61,7 @@ void PositionFilter::position_runqueue(const WaypointList& waypt_list, int qtype
                   continue;
                 }
               }
-  
+
               qlist[j].deleted = true;
               qlist.at(j).wpt->wpt_flags.marked_for_deletion = 1;
               something_deleted = true;
@@ -75,7 +75,7 @@ void PositionFilter::position_runqueue(const WaypointList& waypt_list, int qtype
             }
           }
         }
-  
+
         if (something_deleted && (purge_duplicates != nullptr)) {
           qlist.at(i).wpt->wpt_flags.marked_for_deletion = 1;
         }

--- a/util.cc
+++ b/util.cc
@@ -351,7 +351,7 @@ make_datetime(QDate date, QTime time, bool is_localtime, bool force_utc, int utc
     result = date.startOfDay(timespec, offset);
 #endif
   }
- 
+
   return result;
 }
 
@@ -1066,7 +1066,7 @@ QString grapheme_truncate(const QString& input, unsigned int count)
 
 int xstrtoi(const char* str, char** str_end, int base)
 {
-  
+
   long value = strtol(str, str_end, base);
   if (value > INT_MAX) {
     errno = ERANGE;

--- a/vecs.h
+++ b/vecs.h
@@ -44,7 +44,7 @@ public:
   class fmtinfo_t {
   public:
 
-    bool isDynamic() {
+    bool isDynamic() const {
       return factory != nullptr;
     }
     explicit operator bool() const {


### PR DESCRIPTION
readability-convert-member-functions-to-static
readability-make-member-function-const
and
delete trailing space.