### PR TITLE
Remove per-ext IGC specific logic from KML writer

### DIFF
--- a/igc.cc
+++ b/igc.cc
@@ -52,6 +52,7 @@
 #include "grtcirc.h"            // for RAD, gcdist, radtometers
 #include "src/core/datetime.h"  // for DateTime
 #include "formspec.h"           // for FormatSpecificData, kFsIGC
+#include "kml.h"                // for KmlFormat::igc_mt_fields_def
 
 
 
@@ -59,6 +60,19 @@
 #define HDRMAGIC "IGCHDRS"
 #define HDRDELIM "~"
 #define DATEMAGIC "IGCDATE"
+
+const QVector<KmlFormat::igc_mt_field_t> KmlFormat::igc_mt_fields_def = {
+  { IgcFormat::igc_wp_field::igc_enl, "igc_enl", "Engine Noise", "double" },
+  { IgcFormat::igc_wp_field::igc_tas, "igc_tas", "True Airspd", "double" },
+  { IgcFormat::igc_wp_field::igc_oat, "igc_oat", "Otsd Air Temp", "double" },
+  { IgcFormat::igc_wp_field::igc_vat, "igc_vat", "Ttl Enrg Vario", "double" },
+  { IgcFormat::igc_wp_field::igc_gsp, "igc_gsp", "Ground Speed", "double" },
+  { IgcFormat::igc_wp_field::igc_fxa, "igc_fxa", "Fix Accuracy", "double" },
+  { IgcFormat::igc_wp_field::igc_gfo, "igc_gfo", "G Force?", "double" },
+  { IgcFormat::igc_wp_field::igc_acz, "igc_acz", "Z Accel", "double" },
+  { IgcFormat::igc_wp_field::igc_siu, "igc_siu", "# Of Sats", "double" },
+  { IgcFormat::igc_wp_field::igc_trt, "igc_trt", "True Track", "double" },
+};
 
 /*
  * See if two lat/lon pairs are approximately equal.


### PR DESCRIPTION
This removes quite a bit of IGC specific code from kml.h and kml.cc, including most data structure definitions and most loops/if ladders/switch blocks that iterate over IGC data structures by name, and replaces those with much more generic logic. It places all this in igc.h and igc.cc. There's two edge cases (overriding wpt->temperature and wpt->sat) that kml.cc still has logic for.

kml.h defines a `igc_mt_field_t` struct, which is populated in igc.h. The thinking there is that `igc_mt_field_t` is useful *only* to the KML writer, however the IGC parts should be defining the metadata. `igc_wp_field`, for example, may be useful to CSV or GeoJSON writers, so should be defined in igc.h rather than kml.h.

Note that this will currently fail tests. That's because the tests for `kIncludeIGCSIU` and `kIncludeIGCTRT` have been removed. #1180 resolves this by replacing those with default options. #1180 should be merged before this PR. After rebasing, this should pass tests.

Of course, there may be far better ways to achieve this, but this works, and I think y'all get the idea of what I'm trying to do here.

Marking as draft is it can't be merged before #1180 and is failing tests.