### PR TITLE
bump qt build from 6.5.2 to 6.5.3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
             GENERATOR: 'Ninja'
             RELEASE: true
             os: macos-12
-          - QT_VERSION: '6.5.2'
+          - QT_VERSION: '6.5.3'
             XCODE_VERSION: '14.2'
             GENERATOR: 'Ninja'
             RELEASE: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
             GENERATOR: 'Visual Studio 17 2022'
             RELEASE: false
             os: windows-latest
-          - QT_VERSION: '6.5.2'
+          - QT_VERSION: '6.5.3'
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'


### PR DESCRIPTION
Shall we designate 6.5.3 for release on macOS, or continue to use 6.2.4 for release on that platform?

6.5 targets macOS 11, 12, 13.
6.2 targets macOS macOS 10.14, 10.15, 11, 12.

We set the deployment target in tools/ci_script_osx.sh based on this.

