### PR TITLE
archive docs in CI

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -1,0 +1,59 @@
+name: "gendocs"
+
+on:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '27 4 * * 2'
+  workflow_dispatch:
+    inputs:
+      docversion:
+        required: false
+        type: string
+        default: 'development'
+
+jobs:
+  ubuntu:
+    name: ubuntu Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - IMAGE: 'jammy'
+            CMAKE_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/cmake/Qt6'
+            SCRIPT: './tools/build_and_test_cmake.sh'
+            RELEASE: true
+    container:
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_${{ matrix.IMAGE }}
+      env:
+        LC_ALL: 'C.UTF-8'
+        JOB_CMAKE_PREFIX_PATH: ${{ matrix.CMAKE_PREFIX_PATH }}
+        JOB_SCRIPT: ${{ matrix.SCRIPT }}
+        JOB_DOCVERSION: ${{ inputs.docversion }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: build_and_test
+      run: |
+        # when using containers manually whitelist the checkout directory to allow git commands to work
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+        if [ -n "${JOB_CMAKE_PREFIX_PATH}" ]; then
+          CMAKE_PREFIX_PATH="${JOB_CMAKE_PREFIX_PATH}"
+          export CMAKE_PREFIX_PATH
+        fi
+        "${JOB_SCRIPT}" "${JOB_DOCVERSION:-development}"
+
+    - name: 'Upload Artifacts'
+      if: matrix.RELEASE
+      uses: actions/upload-artifact@v3
+      with:
+        name: Documents
+        path: |
+          gpsbabel.org/
+          gpsbabel.pdf
+          gpsbabel.html
+          docbook.css
+        retention-days: 7

--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: build_and_test
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,9 +477,9 @@ endif()
 
 get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if((CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR) AND NOT _isMultiConfig)
-  set(WEB "gpsbabel.org" CACHE PATH "Path where the documentation will be stored for www.gpsbabel.org.")
+  set(GPSBABEL_WEB "gpsbabel.org" CACHE PATH "Path where the documentation will be stored for www.gpsbabel.org.")
   add_custom_target(gpsbabel.org
-                    ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_org.sh ${WEB} ${DOCVERSION}
+                    ${CMAKE_SOURCE_DIR}/tools/make_gpsbabel_org.sh ${GPSBABEL_WEB} ${GPSBABEL_DOCVERSION}
                     DEPENDS gpsbabel gpsbabel.pdf
                     VERBATIM
                     USES_TERMINAL)

--- a/INSTALL
+++ b/INSTALL
@@ -71,16 +71,16 @@ GPSBABEL_EXTRA_LINK_LIBRARIES:STRING
 GPSBABEL_EXTRA_LINK_OPTIONS:STRING
   Extra link options when building the target gpsbabel.
 
-DOCVERSION:STRING=...
+GPSBABEL_DOCVERSION:STRING=...
   string appended to documentation location for www.gpsbabel.org.  The default
   value is the version string, e.g. "1.7.0".  This is used by the gpsbabel.org
   target, you are unlikely to need it unless you are maintaining
   www.gpsbabel.org.
 
-WEB:STRING=DIR
+GPSBABEL_WEB:STRING=DIR
   Path where the documentation will be stored for www.gpsbabel.org.  This is
   used by the gpsbabel.org target, you are unlikely to need it unless you are
-  maintaining www.gpsbabel.org.  The default location is "../babelweb"
+  maintaining www.gpsbabel.org.  The default location is "gpsbabel.org".
 
 Targets:
 

--- a/gbversion.cmake
+++ b/gbversion.cmake
@@ -35,4 +35,4 @@ endif()
 string(TIMESTAMP GB.COPYRIGHT_YEAR "%Y" UTC)
 
 # may be overridden on cmake command line
-set(DOCVERSION ${GB.VERSION} CACHE STRING "String appended to documentation location for www.gpsbabel.org.")
+set(GPSBABEL_DOCVERSION ${GB.VERSION} CACHE STRING "String appended to documentation location for www.gpsbabel.org.")

--- a/gbversion.h.in
+++ b/gbversion.h.in
@@ -16,5 +16,5 @@
 #define VERSION "@GB.MAJOR@.@GB.MINOR@.@GB.MICRO@@GB.PACKAGE_RELEASE@"
 constexpr char kVersionSHA[] = "@GB.SHA@";
 constexpr char kVersionDate[] = "@GB.DATE@";
-#define WEB_DOC_DIR "https://www.gpsbabel.org/htmldoc-@DOCVERSION@"
+#define WEB_DOC_DIR "https://www.gpsbabel.org/htmldoc-@GPSBABEL_DOCVERSION@"
 #endif

--- a/tools/build_and_test_cmake.sh
+++ b/tools/build_and_test_cmake.sh
@@ -15,7 +15,11 @@ git --no-pager log -n 1
 # build and test keeping output within the pwd.
 export GBTEMP=$(pwd)/gbtemp
 mkdir -p "$GBTEMP"
-cmake . -G Ninja -DCMAKE_BUILD_TYPE=Release
+if [ -n "$1" ]; then
+  cmake . -G Ninja -DCMAKE_BUILD_TYPE=Release -DGPSABEL_DOCVERSION="$1"
+else
+  cmake . -G Ninja -DCMAKE_BUILD_TYPE=Release
+fi
 # As of 2018-10, all the virtualized travis build images are two cores per:
 # https://docs.travis-ci.com/user/reference/overview/
 # We'll be slightly abusive on CPU knowing that I/O is virtualized.

--- a/xmldoc/chapters/build.xml
+++ b/xmldoc/chapters/build.xml
@@ -289,7 +289,7 @@ distributed. The Qt provided translations still need to be distributed.
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>DOCVERSION</term>
+          <term>GPSBABEL_DOCVERSION</term>
           <listitem>
             <para>
 string appended to documentation location for www.gpsbabel.org.  The default
@@ -300,12 +300,12 @@ www.gpsbabel.org.
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>WEB</term>
+          <term>GPSBABEL_WEB</term>
           <listitem>
             <para>
 Path where the documentation will be stored for www.gpsbabel.org.  This is
 used by the gpsbabel.org target, you are unlikely to need it unless you are
-maintaining www.gpsbabel.org.  The default location is "../babelweb"
+maintaining www.gpsbabel.org.  The default location is "gpsbabel.org".
 </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
change cmake variable names to conform to cmake standards
  WEB -> GPSBABEL_WEB
  DOCVERSION -> GPSBABEL_DOCVERSION

add a configurable CI job, gendocs, to generate docs and archive them.  This can be manually triggered to run on any branch/tag using a specified value for DOCVERSION.  It will also be run on pushes to master and a schedule.