### PR TITLE
fix bugs with gpx passthrough.

### DIFF
--- a/reference/gpxpassthrough10.gpx
+++ b/reference/gpxpassthrough10.gpx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xmlns:foreign="http://www.gpsbabel.org/testonlyschema" version="1.0" creator="hand crafted" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+  <time>2010-10-16T14:27:17Z</time>
+  <wpt lat="36.339560000" lon="-117.422570000">
+    <ele>479.300</ele>
+    <name>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</name>
+    <cmt>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</cmt>
+    <desc>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</desc>
+  </wpt>
+  <wpt lat="36.460850000" lon="-116.865460000">
+    <ele>-55.600</ele>
+    <name>Turn right at Airport Rd</name>
+    <cmt>Turn right at Airport Rd</cmt>
+    <desc>Turn right at Airport Rd</desc>
+    <foreign:something>wpt</foreign:something>
+  </wpt>
+  <wpt lat="36.463640000" lon="-116.879200000">
+    <ele>-67.300</ele>
+    <name>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</name>
+    <cmt>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</cmt>
+    <desc>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</desc>
+  </wpt>
+  <rte>
+    <name>Low Road</name>
+    <desc>Generated from track Route</desc>
+    <foreign:something>rte</foreign:something>
+    <rtept lat="36.339560000" lon="-117.422570000">
+      <ele>479.300</ele>
+      <name>RPT001</name>
+    </rtept>
+    <rtept lat="36.345010000" lon="-117.354270000">
+      <ele>624.300</ele>
+      <name>RPT005</name>
+      <foreign:something>rtept</foreign:something>
+    </rtept>
+    <rtept lat="36.344640000" lon="-117.349030000">
+      <ele>663.700</ele>
+      <name>RPT011</name>
+    </rtept>
+  </rte>
+  <trk>
+    <name>meridian</name>
+    <foreign:something>trk</foreign:something>
+    <trkseg>
+      <trkpt lat="30.062183333" lon="-91.610350000">
+        <ele>1.000</ele>
+        <time>2002-05-25T17:06:21.250Z</time>
+      </trkpt>
+      <trkpt lat="30.062783333" lon="-91.610566667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:09:55.190Z</time>
+        <foreign:something>trkpt</foreign:something>
+      </trkpt>
+      <trkpt lat="30.062700000" lon="-91.608266667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:12:00.200Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+  <foreign:something>eof</foreign:something>
+</gpx>

--- a/reference/gpxpassthrough10~gpx.gpx
+++ b/reference/gpxpassthrough10~gpx.gpx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:foreign="http://www.gpsbabel.org/testonlyschema">
+  <time>1970-01-01T00:00:00Z</time>
+  <bounds minlat="30.062183333" minlon="-117.422570000" maxlat="36.463640000" maxlon="-91.608266667"/>
+  <wpt lat="36.339560000" lon="-117.422570000">
+    <ele>479.300</ele>
+    <name>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</name>
+    <cmt>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</cmt>
+    <desc>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</desc>
+  </wpt>
+  <wpt lat="36.460850000" lon="-116.865460000">
+    <ele>-55.600</ele>
+    <name>Turn right at Airport Rd</name>
+    <cmt>Turn right at Airport Rd</cmt>
+    <desc>Turn right at Airport Rd</desc>
+    <foreign:something>wpt</foreign:something>
+  </wpt>
+  <wpt lat="36.463640000" lon="-116.879200000">
+    <ele>-67.300</ele>
+    <name>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</name>
+    <cmt>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</cmt>
+    <desc>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</desc>
+  </wpt>
+  <rte>
+    <name>Low Road</name>
+    <desc>Generated from track Route</desc>
+    <foreign:something>rte</foreign:something>
+    <rtept lat="36.339560000" lon="-117.422570000">
+      <ele>479.300</ele>
+      <name>RPT001</name>
+    </rtept>
+    <rtept lat="36.345010000" lon="-117.354270000">
+      <ele>624.300</ele>
+      <name>RPT005</name>
+      <foreign:something>rtept</foreign:something>
+    </rtept>
+    <rtept lat="36.344640000" lon="-117.349030000">
+      <ele>663.700</ele>
+      <name>RPT011</name>
+    </rtept>
+  </rte>
+  <trk>
+    <name>meridian</name>
+    <foreign:something>trk</foreign:something>
+    <trkseg>
+      <trkpt lat="30.062183333" lon="-91.610350000">
+        <ele>1.000</ele>
+        <time>2002-05-25T17:06:21.250Z</time>
+      </trkpt>
+      <trkpt lat="30.062783333" lon="-91.610566667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:09:55.190Z</time>
+        <foreign:something>trkpt</foreign:something>
+      </trkpt>
+      <trkpt lat="30.062700000" lon="-91.608266667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:12:00.200Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/reference/gpxpassthrough11.gpx
+++ b/reference/gpxpassthrough11.gpx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xmlns:foreign="http://www.gpsbabel.org/testonlyschema" version="1.1" creator="hand crafted" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+  <metadata>
+    <time>2010-10-16T14:27:17Z</time>
+    <extensions>
+      <foreign:something>metadata</foreign:something>
+    </extensions>
+  </metadata>
+  <wpt lat="36.339560000" lon="-117.422570000">
+    <ele>479.300</ele>
+    <name>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</name>
+    <cmt>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</cmt>
+    <desc>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</desc>
+  </wpt>
+  <wpt lat="36.460850000" lon="-116.865460000">
+    <ele>-55.600</ele>
+    <name>Turn right at Airport Rd</name>
+    <cmt>Turn right at Airport Rd</cmt>
+    <desc>Turn right at Airport Rd</desc>
+    <extensions>
+      <foreign:something>wpt</foreign:something>
+    </extensions>
+  </wpt>
+  <wpt lat="36.463640000" lon="-116.879200000">
+    <ele>-67.300</ele>
+    <name>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</name>
+    <cmt>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</cmt>
+    <desc>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</desc>
+  </wpt>
+  <rte>
+    <name>Low Road</name>
+    <desc>Generated from track Route</desc>
+    <extensions>
+      <foreign:something>rte</foreign:something>
+    </extensions>
+    <rtept lat="36.339560000" lon="-117.422570000">
+      <ele>479.300</ele>
+      <name>RPT001</name>
+    </rtept>
+    <rtept lat="36.345010000" lon="-117.354270000">
+      <ele>624.300</ele>
+      <name>RPT005</name>
+      <extensions>
+        <foreign:something>rtept</foreign:something>
+      </extensions>
+    </rtept>
+    <rtept lat="36.344640000" lon="-117.349030000">
+      <ele>663.700</ele>
+      <name>RPT011</name>
+    </rtept>
+  </rte>
+  <trk>
+    <name>meridian</name>
+    <extensions>
+      <foreign:something>trk</foreign:something>
+    </extensions>
+    <trkseg>
+      <trkpt lat="30.062183333" lon="-91.610350000">
+        <ele>1.000</ele>
+        <time>2002-05-25T17:06:21.250Z</time>
+      </trkpt>
+      <trkpt lat="30.062783333" lon="-91.610566667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:09:55.190Z</time>
+        <extensions>
+          <foreign:something>trkpt</foreign:something>
+        </extensions>
+      </trkpt>
+      <trkpt lat="30.062700000" lon="-91.608266667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:12:00.200Z</time>
+      </trkpt>
+      <extensions>
+        <foreign:something>trkseg</foreign:something>
+      </extensions>
+    </trkseg>
+  </trk>
+  <extensions>
+    <foreign:something>eof</foreign:something>
+  </extensions>
+</gpx>

--- a/reference/gpxpassthrough11~gpx.gpx
+++ b/reference/gpxpassthrough11~gpx.gpx
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:foreign="http://www.gpsbabel.org/testonlyschema">
+  <metadata>
+    <time>1970-01-01T00:00:00Z</time>
+    <bounds minlat="30.062183333" minlon="-117.422570000" maxlat="36.463640000" maxlon="-91.608266667"/>
+  </metadata>
+  <wpt lat="36.339560000" lon="-117.422570000">
+    <ele>479.300</ele>
+    <name>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</name>
+    <cmt>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</cmt>
+    <desc>Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E</desc>
+  </wpt>
+  <wpt lat="36.460850000" lon="-116.865460000">
+    <ele>-55.600</ele>
+    <name>Turn right at Airport Rd</name>
+    <cmt>Turn right at Airport Rd</cmt>
+    <desc>Turn right at Airport Rd</desc>
+    <extensions>
+      <foreign:something>wpt</foreign:something>
+    </extensions>
+  </wpt>
+  <wpt lat="36.463640000" lon="-116.879200000">
+    <ele>-67.300</ele>
+    <name>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</name>
+    <cmt>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</cmt>
+    <desc>Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328</desc>
+  </wpt>
+  <rte>
+    <name>Low Road</name>
+    <desc>Generated from track Route</desc>
+    <extensions>
+      <foreign:something>rte</foreign:something>
+    </extensions>
+    <rtept lat="36.339560000" lon="-117.422570000">
+      <ele>479.300</ele>
+      <name>RPT001</name>
+    </rtept>
+    <rtept lat="36.345010000" lon="-117.354270000">
+      <ele>624.300</ele>
+      <name>RPT005</name>
+      <extensions>
+        <foreign:something>rtept</foreign:something>
+      </extensions>
+    </rtept>
+    <rtept lat="36.344640000" lon="-117.349030000">
+      <ele>663.700</ele>
+      <name>RPT011</name>
+    </rtept>
+  </rte>
+  <trk>
+    <name>meridian</name>
+    <extensions>
+      <foreign:something>trk</foreign:something>
+    </extensions>
+    <trkseg>
+      <trkpt lat="30.062183333" lon="-91.610350000">
+        <ele>1.000</ele>
+        <time>2002-05-25T17:06:21.250Z</time>
+      </trkpt>
+      <trkpt lat="30.062783333" lon="-91.610566667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:09:55.190Z</time>
+        <extensions>
+          <foreign:something>trkpt</foreign:something>
+        </extensions>
+      </trkpt>
+      <trkpt lat="30.062700000" lon="-91.608266667">
+        <ele>0.000</ele>
+        <time>2002-05-25T17:12:00.200Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/testo.d/gpx.test
+++ b/testo.d/gpx.test
@@ -66,6 +66,19 @@ compare ${REFERENCE}/track/garminconnect.csv ${TMPDIR}/garminconnect.csv
 gpsbabel -i gpx -f ${REFERENCE}/wptsequence.gpx -o gpx -F ${TMPDIR}/wptsequence.gpx
 compare ${REFERENCE}/wptsequence.gpx ${TMPDIR}/wptsequence.gpx
 
+# passthrough
+# gpx 1.0
+# we lose any extensions at the end of file - we don't have a place to store them.
+gpsbabel -i gpx -f ${REFERENCE}/gpxpassthrough10.gpx -o gpx -F ${TMPDIR}/gpxpassthrough10~gpx.gpx
+compare ${REFERENCE}/gpxpassthrough10~gpx.gpx ${TMPDIR}/gpxpassthrough10~gpx.gpx
+
+# gpx 1.1
+# we lose the any extensions in metadata, but we are constructing metadata anyway
+# we lose any extensions at the end of each trkseg  - we don't have a place to store them.
+# we lose any extensions at the end of file - we don't have a place to store them.
+gpsbabel -i gpx -f ${REFERENCE}/gpxpassthrough11.gpx -o gpx -F ${TMPDIR}/gpxpassthrough11~gpx.gpx
+compare ${REFERENCE}/gpxpassthrough11~gpx.gpx ${TMPDIR}/gpxpassthrough11~gpx.gpx
+
 if [ -z "${VALGRIND}" ]; then
   set -e
   if command -v xmllint > /dev/null;

--- a/tools/schema/gpx/master.xsd
+++ b/tools/schema/gpx/master.xsd
@@ -11,5 +11,6 @@
 <xsd:import namespace="http://www.groundspeak.com/cache/1/0/1" schemaLocation="groundspeak/cache101.xsd"/>
 <xsd:import namespace="http://www.groundspeak.com/cache/1/1" schemaLocation="groundspeak/cache11.xsd"/>
 <xsd:import namespace="http://www.groundspeak.com/cache/1/2" schemaLocation="groundspeak/cache12.xsd"/>
+<xsd:import namespace="http://www.gpsbabel.org/testonlyschema" schemaLocation="testonlyschema.xsd"/>
 
 </xsd:schema>

--- a/tools/schema/gpx/testonlyschema.xsd
+++ b/tools/schema/gpx/testonlyschema.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:foreign="http://www.gpsbabel.org/testonlyschema"
+	targetNamespace="http://www.gpsbabel.org/testonlyschema"
+	elementFormDefault="qualified">
+
+  <xsd:annotation>
+    <xsd:documentation>
+      This schema exist only for regression testing of gpsbabel.
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:element name="something" type="xsd:string"/>
+</xsd:schema> 


### PR DESCRIPTION
These bugs exist for gpx 1.0 -> gpx 1.0 passthrough, and gpx 1.1 to gpx 1.1 passthrough.  This work does not consider passthrough between different versions(#1194).

with gpx 1.0, any extension data that was a child of rte or trk was lost.  I believe this used to work but has been broken for quite a while.

with gpx 1.0 extension data that was a child of gpx could be erroneously rewritten as part of the final wpt/rtept/trkpt.

with gpx 1.1 extension data that was a child of trkseg could be erroneously rewritten as part of the final wpt/rtept/trkpt.

with gpx 1.1 extension data that was a child of gpx could be erroneously rewritten as part of the final wpt/rtept/trkpt.

with gpx 1.1 extension data that was a child of waypoint and passed through would result in a schema violation, the required extension element was lost.

I note we currently drop any extension data that is a child of gpx, ,a child of trkseg, or a child of metadata.