### PR TITLE
remove gpx reader support for probelmatic extensions.

### DIFF
--- a/gpx.cc
+++ b/gpx.cc
@@ -1033,6 +1033,7 @@ GpxFormat::qualifiedName() const
     {"http://www.garmin.com/xmlschemas/GpxExtensions/v3", "gpxx"},
     {"http://www.garmin.com/xmlschemas/TrackPointExtension/v1", "gpxtpx"},
     {"http://www.groundspeak.com/cache/1/0", "groundspeak"},
+    {"http://www.groundspeak.com/cache/1/0/1", "groundspeak"},
     {"http://humminbird.com", "h"}
   };
 

--- a/gpx.h
+++ b/gpx.h
@@ -326,9 +326,7 @@ private:
   {"/gpx/metadata/" name, {type, false}}
 
 #define GEOTAG(type,name) \
-  {"/gpx/wpt/groundspeak:cache/groundspeak:" name, {type, true}}, \
-  {"/gpx/wpt/extensions/cache/" name, {type, true}}, \
-  {"/gpx/wpt/geocache/" name, {type, true}}	/* opencaching.de */
+  {"/gpx/wpt/groundspeak:cache/groundspeak:" name, {type, true}}
 
 #define GPXWPTTYPETAG(name,type,passthrough) \
   {"/gpx/wpt/" name, {type, passthrough}}, \
@@ -366,18 +364,14 @@ private:
     GEOTAG(tt_cache_difficulty, "difficulty"),
     GEOTAG(tt_cache_terrain, "terrain"),
     GEOTAG(tt_cache_hint, "encoded_hints"),
-    GEOTAG(tt_cache_hint, "hints"),	/* opencaching.de */
     GEOTAG(tt_cache_desc_short, "short_description"),
     GEOTAG(tt_cache_desc_long, "long_description"),
     GEOTAG(tt_cache_placer, "owner"),
     GEOTAG(tt_cache_favorite_points, "favorite_points"),
     GEOTAG(tt_cache_personal_note, "personal_note"),
     {"/gpx/wpt/groundspeak:cache/groundspeak:logs/groundspeak:log/groundspeak:log_wpt", {tt_cache_log_wpt, true}},
-    {"/gpx/wpt/extensions/cache/logs/log/log_wpt", {tt_cache_log_wpt, true}},
     {"/gpx/wpt/groundspeak:cache/groundspeak:logs/groundspeak:log/groundspeak:type", {tt_cache_log_type, true}},
-    {"/gpx/wpt/extensions/cache/logs/log/type", {tt_cache_log_type, true}},
     {"/gpx/wpt/groundspeak:cache/groundspeak:logs/groundspeak:log/groundspeak:date", {tt_cache_log_date, true}},
-    {"/gpx/wpt/extensions/cache/logs/log/date", {tt_cache_log_date, true}},
 
     {"/gpx/wpt/extensions", {tt_wpt_extensions, false}},
 


### PR DESCRIPTION
This resolves #1195.

1. groundspeak is generally used with gpx 1.0.  Our attempt to support it with gpx 1.1 required schema violations.

2. opencaching.de no longer uses the geocache element.  Our implementation required schema violations.