### PR TITLE
fix leak in jeeps serial comm on posix.

### DIFF
--- a/jeeps/gpsserial.cc
+++ b/jeeps/gpsserial.cc
@@ -604,6 +604,7 @@ int32_t GPS_Serial_Off(gpsdevh* dh)
     gps_errno = HARDWARE_ERROR;
     return 0;
   }
+  xfree(dh);
   return 1;
 }
 


### PR DESCRIPTION
This resolves #1221

I have tested this with a GPS12, "vtesto -l -j vg.log sgt.test", and:
gpsbabel -D3 -i garmin -f /dev/ttyS0
gpsbabel -D3 -i gpx -f w.gpx -o garmin -F /dev/ttyS0

both operations succeeded and no leaks were detected.

- This test was done on a hyper-v gen 1 ubuntu 22 guest running under a windows 11 host.
- The serial port was emulated through a USB to RS232 Converter Cable https://ftdichip.com/products/chipi-x10/.
- A windows named pipe was connected to the emulated serial port via https://github.com/tdhoward/COMpipe with the command `"COMpipe.exe -b 9600 -c \\.\COM3 -p \\.\pipe\gen1ubuntu22"`. 
- The hyper-v guest settings set guest COM 1 to the named pipe gen1ubuntu22.  

