### PR TITLE
simplify usage of homebrew on CI macos-11.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,7 +75,10 @@ jobs:
         # brew update # skip update for now to avoid link issues AND many slow dependency upGRADES.
         brew install ninja
         brew install docbook docbook-xsl fop gnu-sed
-        brew install jing-trang
+        # brew install is taking forever on macos-11, skip jing-trang and all it's dependencies.
+        if [ "${{ matrix.os }}" != "macos-11" ]; then
+          brew install jing-trang
+        fi
 
     - name: Script
       env:


### PR DESCRIPTION
homebrew installs are taking an extreme amount of time on macos-11, with the following message:
  Warning: You are using macOS 11.
  We (and Apple) do not provide support for this old version.
  It is expected behaviour that some formulae will fail to build in this old version.
  It is expected behaviour that Homebrew will be buggy and slow.
To alleviate this pain skip the installation of jing and all it's dependencies on macos-11.