### PR TITLE
update macos github workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,25 +19,25 @@ jobs:
       matrix:
         include:
           - QT_VERSION: '5.15.2'
-            XCODE_VERSION: '12.5.1'
+            XCODE_VERSION: '13.2.1'
             GENERATOR: 'Ninja'
             RELEASE: false
-            os: macos-11
+            os: macos-12
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '13.4.1'
             GENERATOR: 'Xcode'
             RELEASE: false
-            os: macos-12
+            os: macos-13
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '13.4.1'
             GENERATOR: 'Ninja'
             RELEASE: true
-            os: macos-12
+            os: macos-13
           - QT_VERSION: '6.5.3'
             XCODE_VERSION: '14.2'
             GENERATOR: 'Ninja'
             RELEASE: false
-            os: macos-12
+            os: macos-13
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,7 +54,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: Qt install
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,25 +22,21 @@ jobs:
             XCODE_VERSION: '13.2.1'
             GENERATOR: 'Ninja'
             RELEASE: false
-            XML_CATALOG_FILES: '/usr/local/etc/xml/catalog'
             os: macos-12
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '14.2'
             GENERATOR: 'Xcode'
             RELEASE: false
-            XML_CATALOG_FILES: '/usr/local/etc/xml/catalog'
             os: macos-13
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '14.2'
             GENERATOR: 'Ninja'
             RELEASE: true
-            XML_CATALOG_FILES: '/usr/local/etc/xml/catalog'
             os: macos-13
           - QT_VERSION: '6.5.3'
             XCODE_VERSION: '15.2'
             GENERATOR: 'Ninja'
             RELEASE: false
-            XML_CATALOG_FILES: '/opt/homebrew/etc/xml/catalog'
             os: macos-14
 
     steps:
@@ -86,7 +82,7 @@ jobs:
 
     - name: Script
       env:
-        XML_CATALOG_FILES: ${{ matrix.XML_CATALOG_FILES }}
+        XML_CATALOG_FILES: ${{ matrix.os == 'macos-14' && '/opt/homebrew/etc/xml/catalog' || '/usr/local/etc/xml/catalog' }}
       run: |
         source ${HOME}/Cache/qt-${{ matrix.QT_VERSION }}.env
         sudo xcode-select --switch /Applications/Xcode_${{ matrix.XCODE_VERSION }}.app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Script
       env:
-        XML_CATALOG_FILES: ${{ matrix.os == 'macos-14' && '/opt/homebrew/etc/xml/catalog' || '/usr/local/etc/xml/catalog' }}
+        XML_CATALOG_FILES: ${{  runner.arch == 'ARM64' && '/opt/homebrew/etc/xml/catalog' || '/usr/local/etc/xml/catalog' }}
       run: |
         source ${HOME}/Cache/qt-${{ matrix.QT_VERSION }}.env
         sudo xcode-select --switch /Applications/Xcode_${{ matrix.XCODE_VERSION }}.app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,21 +22,25 @@ jobs:
             XCODE_VERSION: '13.2.1'
             GENERATOR: 'Ninja'
             RELEASE: false
+            XML_CATALOG_FILES: '/usr/local/etc/xml/catalog'
             os: macos-12
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '14.2'
             GENERATOR: 'Xcode'
             RELEASE: false
+            XML_CATALOG_FILES: '/usr/local/etc/xml/catalog'
             os: macos-13
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '14.2'
             GENERATOR: 'Ninja'
             RELEASE: true
+            XML_CATALOG_FILES: '/usr/local/etc/xml/catalog'
             os: macos-13
           - QT_VERSION: '6.5.3'
             XCODE_VERSION: '15.2'
             GENERATOR: 'Ninja'
             RELEASE: false
+            XML_CATALOG_FILES: '/opt/homebrew/etc/xml/catalog'
             os: macos-14
 
     steps:
@@ -82,7 +86,7 @@ jobs:
 
     - name: Script
       env:
-        XML_CATALOG_FILES: /usr/local/etc/xml/catalog
+        XML_CATALOG_FILES: ${{ matrix.XML_CATALOG_FILES }}
       run: |
         source ${HOME}/Cache/qt-${{ matrix.QT_VERSION }}.env
         sudo xcode-select --switch /Applications/Xcode_${{ matrix.XCODE_VERSION }}.app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,22 +19,22 @@ jobs:
       matrix:
         include:
           - QT_VERSION: '5.15.2'
-            XCODE_VERSION: '13.2.1'
+            XCODE_VERSION: '13.4.1'
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-12
           - QT_VERSION: '6.2.4'
-            XCODE_VERSION: '14.2'
+            XCODE_VERSION: '14.3.1'
             GENERATOR: 'Xcode'
             RELEASE: false
             os: macos-13
           - QT_VERSION: '6.2.4'
-            XCODE_VERSION: '14.2'
+            XCODE_VERSION: '14.3.1'
             GENERATOR: 'Ninja'
             RELEASE: true
             os: macos-13
           - QT_VERSION: '6.5.3'
-            XCODE_VERSION: '15.2'
+            XCODE_VERSION: '15.3'
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-14

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,20 +24,20 @@ jobs:
             RELEASE: false
             os: macos-12
           - QT_VERSION: '6.2.4'
-            XCODE_VERSION: '13.4.1'
+            XCODE_VERSION: '14.2'
             GENERATOR: 'Xcode'
             RELEASE: false
             os: macos-13
           - QT_VERSION: '6.2.4'
-            XCODE_VERSION: '13.4.1'
+            XCODE_VERSION: '14.2'
             GENERATOR: 'Ninja'
             RELEASE: true
             os: macos-13
           - QT_VERSION: '6.5.3'
-            XCODE_VERSION: '14.2'
+            XCODE_VERSION: '15.2'
             GENERATOR: 'Ninja'
             RELEASE: false
-            os: macos-13
+            os: macos-14
 
     steps:
     - name: Checkout repository

--- a/tools/fixdoc
+++ b/tools/fixdoc
@@ -12,9 +12,10 @@ DIR=$1
 TITLE=$2
 
 SED="sed"
-# MacOS using Homebrew
-[ -f /usr/local/bin/gsed ] && SED=/usr/local/bin/gsed
-[ -f /opt/local/bin/gsed ] && SED=/opt/local/bin/gsed
+# macOS using Homebrew may be /usr/local (macOS intel) or /opt/homebrew (apple silicion) ... 
+if command -v gsed >/dev/null 2>&1; then
+  SED=$(command -v gsed)
+fi
 
 [ ! -d "$DIR/tpl" ] && mkdir -p "$DIR/tpl"
 


### PR DESCRIPTION
the macos-11 runner is deprecated.  update to used macos-12, macos-13, macos-14.

the trick here is macos-14 is running on apple silicon, and the brew path depends on intel vs. apple.
we solved this in two different ways:
1) in the workflow file we assume we can predict the path based on the runner architecture.  we did this instead of something like `brew --prefix` because of the limitations of the workflow yaml.
2) in fixdoc we use `command -v` to search for gsed, and if found use whatever path it was found on.  this works for homebrew on intel and apple silicon as well as MacPorts assuming the relevant path is on the PATH.

the xcode changes will update the minimum support macOS version _to run the compiler_.  For our release build the minimum moves from 12.0 to ~~12.5 (monterey)~~ _13.0 (ventura)_.