### PR TITLE
support builds with shapelib (as documented).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,6 @@ target_sources(gpsbabel PRIVATE ${SOURCES} ${HEADERS})
 # We don't care about stripping things out of the build.  Full monty, baby.
 target_compile_definitions(gpsbabel PRIVATE MAXIMAL_ENABLED)
 target_compile_definitions(gpsbabel PRIVATE FILTERS_ENABLED)
-target_compile_definitions(gpsbabel PRIVATE SHAPELIB_ENABLED)
 target_compile_definitions(gpsbabel PRIVATE CSVFMTS_ENABLED)
 
 target_link_libraries(gpsbabel PRIVATE ${QT_LIBRARIES} ${LIBS})


### PR DESCRIPTION
we document the ability to build without shapelib:
```
GPSBABEL_WITH_SHAPELIB:STRING=no|pkgconfig|included*|custom
  no: build without shapelib.  functionality will be limited.
```
This is supported in shapelib.cmake, but CMakeLists.txt defeats this functionality by always defining SHAPELIB_ENABLED.