### PR TITLE
refactor PVT interface

### DIFF
--- a/garmin.cc
+++ b/garmin.cc
@@ -657,7 +657,7 @@ GarminFormat::rd_position(posn_status* posn_status)
   auto* wpt = new Waypoint;
   GPS_PPvt_Data pvt = GPS_Pvt_New();
 
-  if (GPS_Command_Pvt_Get(&pvt_fd, &pvt)) {
+  if (GPS_Command_Pvt_Get(pvt_fd, &pvt)) {
     pvt2wpt(pvt, wpt);
     GPS_Pvt_Del(&pvt);
 

--- a/jeeps/gpsapp.cc
+++ b/jeeps/gpsapp.cc
@@ -361,7 +361,7 @@ static int32_t GPS_A000(const char* port)
 carry_on:
   /* Make sure PVT is off as some GPS' have it on by default */
   if (gps_pvt_transfer != -1) {
-    GPS_A800_Off(port,&fd);
+    GPS_A800_Off(fd);
   }
 
   if (!GPS_Device_Off(fd)) {
@@ -6126,12 +6126,11 @@ int32_t GPS_A800_On(const char* port, gpsdevh** fd)
 **
 ** Turn off GPS PVT
 **
-** @param [r] port [const char *] port
-** @param [w] fd [int32 *] file descriptor
+** @param [r] fd [int32] file descriptor
 **
 ** @return [int32] success
 ************************************************************************/
-int32_t GPS_A800_Off(const char* /*unused*/, gpsdevh** fd)
+int32_t GPS_A800_Off(gpsdevh* fd)
 {
   static UC data[2];
   GPS_Packet tra;
@@ -6142,10 +6141,10 @@ int32_t GPS_A800_Off(const char* /*unused*/, gpsdevh** fd)
                      COMMAND_ID[gps_device_command].Cmnd_Stop_Pvt_Data);
   GPS_Make_Packet(&tra, LINK_ID[gps_link_type].Pid_Command_Data,
                   data,2);
-  if (!GPS_Write_Packet(*fd,tra)) {
+  if (!GPS_Write_Packet(fd,tra)) {
     return gps_errno;
   }
-  if (!GPS_Get_Ack(*fd, &tra, &rec)) {
+  if (!GPS_Get_Ack(fd, &tra, &rec)) {
     GPS_Error("A800_Off: Not acknowledged");
     return FRAMING_ERROR;
   }
@@ -6162,22 +6161,22 @@ int32_t GPS_A800_Off(const char* /*unused*/, gpsdevh** fd)
 **
 ** make a position packet for sending to the GPS
 **
-** @param [r] fd [int32 *] file descriptor
+** @param [r] fd [int32] file descriptor
 ** @param [w] packet [GPS_PPvt_Data *] packet
 **
 ** @return [int32] success
 ************************************************************************/
-int32_t GPS_A800_Get(gpsdevh** fd, GPS_PPvt_Data* packet)
+int32_t GPS_A800_Get(gpsdevh* fd, GPS_PPvt_Data* packet)
 {
   GPS_Packet tra;
   GPS_Packet rec;
 
 
-  if (!GPS_Packet_Read(*fd, &rec)) {
+  if (!GPS_Packet_Read(fd, &rec)) {
     return gps_errno;
   }
 
-  if (!GPS_Send_Ack(*fd, &tra, &rec)) {
+  if (!GPS_Send_Ack(fd, &tra, &rec)) {
     return gps_errno;
   }
 

--- a/jeeps/gpsapp.h
+++ b/jeeps/gpsapp.h
@@ -51,8 +51,8 @@ void   GPS_D700_Get(const GPS_Packet& packet, double* lat, double* lon);
 void   GPS_D700_Send(GPS_Packet& packet, double lat, double lon);
 
 int32_t GPS_A800_On(const char* port, gpsdevh** fd);
-int32_t GPS_A800_Off(const char* port, gpsdevh** fd);
-int32_t GPS_A800_Get(gpsdevh** fd, GPS_PPvt_Data* packet);
+int32_t GPS_A800_Off(gpsdevh* fd);
+int32_t GPS_A800_Get(gpsdevh* fd, GPS_PPvt_Data* packet);
 void   GPS_D800_Get(const GPS_Packet& packet, GPS_PPvt_Data* pvt);
 
 int32_t GPS_A906_Get(const char* port, GPS_PLap** lap, pcb_fn cb);

--- a/jeeps/gpscom.cc
+++ b/jeeps/gpscom.cc
@@ -580,13 +580,12 @@ int32_t GPS_Command_Pvt_On(const char* port, gpsdevh** fd)
 **
 ** Instruct GPS to stop sending Pvt data every second
 **
-** @param [r] port [const char *] serial port
-** @param [w] fd [int32 *] file descriptor
+** @param [r] fd [int32] file descriptor
 **
 ** @return [int32] success
 ************************************************************************/
 
-int32_t GPS_Command_Pvt_Off(const char* port, gpsdevh** fd)
+int32_t GPS_Command_Pvt_Off(gpsdevh* fd)
 {
 	int32_t ret = 0;
 
@@ -597,7 +596,7 @@ int32_t GPS_Command_Pvt_Off(const char* port, gpsdevh** fd)
 
   switch (gps_pvt_transfer) {
   case pA800:
-    ret = GPS_A800_Off(port,fd);
+    ret = GPS_A800_Off(fd);
     break;
   default:
     GPS_Error("Pvt_Off: Unknown position protocol");
@@ -613,13 +612,13 @@ int32_t GPS_Command_Pvt_Off(const char* port, gpsdevh** fd)
 **
 ** Get a single PVT info entry
 **
-** @param [w] fd [int32 *] file descriptor
+** @param [r] fd [int32] file descriptor
 ** @param [w] pvt [GPS_PPvt_Data *] pvt data structure to fill
 **
 ** @return [int32] success
 ************************************************************************/
 
-int32_t GPS_Command_Pvt_Get(gpsdevh** fd, GPS_PPvt_Data* pvt)
+int32_t GPS_Command_Pvt_Get(gpsdevh* fd, GPS_PPvt_Data* pvt)
 {
 	int32_t ret = 0;
 

--- a/jeeps/gpscom.h
+++ b/jeeps/gpscom.h
@@ -14,8 +14,8 @@ int32_t GPS_Command_Get_Position(const char* port, double* lat, double* lon);
 int32_t GPS_Command_Send_Position(const char* port, double lat, double lon);
 
 int32_t GPS_Command_Pvt_On(const char* port, gpsdevh** fd);
-int32_t GPS_Command_Pvt_Off(const char* port, gpsdevh** fd);
-int32_t GPS_Command_Pvt_Get(gpsdevh** fd, GPS_PPvt_Data* pvt);
+int32_t GPS_Command_Pvt_Off(gpsdevh* fd);
+int32_t GPS_Command_Pvt_Get(gpsdevh* fd, GPS_PPvt_Data* pvt);
 
 int32_t GPS_Command_Get_Almanac(const char* port, GPS_PAlmanac** alm);
 int32_t GPS_Command_Send_Almanac(const char* port, GPS_PAlmanac* alm, int32_t n);


### PR DESCRIPTION
- eliminate unused parameters
- pass gpsdevh* instead of gpsdevh** when function doesn't modify the original.