### PR TITLE
update macos release to Qt 6.5.3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,18 +25,18 @@ jobs:
             os: macos-12
           - QT_VERSION: '6.2.4'
             XCODE_VERSION: '14.3.1'
-            GENERATOR: 'Xcode'
-            RELEASE: false
-            os: macos-13
-          - QT_VERSION: '6.2.4'
-            XCODE_VERSION: '14.3.1'
             GENERATOR: 'Ninja'
-            RELEASE: true
+            RELEASE: false
             os: macos-13
           - QT_VERSION: '6.5.3'
-            XCODE_VERSION: '15.3'
-            GENERATOR: 'Ninja'
+            XCODE_VERSION: '15.4'
+            GENERATOR: 'Xcode'
             RELEASE: false
+            os: macos-14
+          - QT_VERSION: '6.5.3'
+            XCODE_VERSION: '15.4'
+            GENERATOR: 'Ninja'
+            RELEASE: true
             os: macos-14
 
     steps:


### PR DESCRIPTION
This avoids warnings for our release build on macos with Qt 6.2.4 like:
```
CMake Warning at /Users/runner/Cache/Qt/6.2.4/macos/lib/cmake/Qt6/FindWrapOpenGL.cmake:41 (target_link_libraries):
-- Generating done (0.0s)
  Target "gpsbabelfe" requests linking to directory
-- Build files have been written to: /Users/runner/work/gpsbabel/gpsbabel
  "/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/Library/Frameworks".
  Targets may link only to libraries.  CMake is dropping the item.
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.29.3/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  /Users/runner/Cache/Qt/6.2.4/macos/lib/cmake/Qt6Gui/Qt6GuiDependencies.cmake:48 (find_dependency)
  /Users/runner/Cache/Qt/6.2.4/macos/lib/cmake/Qt6Gui/Qt6GuiConfig.cmake:40 (include)
  /Users/runner/Cache/Qt/6.2.4/macos/lib/cmake/Qt6/Qt6Config.cmake:209 (find_package)
  gui/CMakeLists.txt:25 (find_package)
```