### PR TITLE
exclude qt .ts files from codacy analysis.

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,12 +1,14 @@
 exclude_paths:
-  - 'deprecated/**'
-  - 'mac/libusb/**'
-  - 'reference/**'
-  - 'shapelib/**'
-  - 'strptime/**'
-  - 'zlib/**'
-  - coverity_model.cc
-  - jeeps/gpsproj.cc
-  - jeeps/gpsproj.h
-  - tools/qtci/README.md
-  - tools/uploadtool/README.md
+  - "coverity_model.cc"
+  - "deprecated/**"
+  - "gui/coretool/gpsbabel_*.ts"
+  - "gui/gpsbabelfe_*.ts"
+  - "jeeps/gpsproj.cc"
+  - "jeeps/gpsproj.h"
+  - "mac/libusb/**"
+  - "reference/**"
+  - "shapelib/**"
+  - "strptime/**"
+  - "tools/qtci/README.md"
+  - "tools/uploadtool/README.md"
+  - "zlib/**"


### PR DESCRIPTION
they confuse eslint which thinks they are TypeScript.