### PR TITLE
fix faulty assertion in garmin.

### DIFF
--- a/garmin.h
+++ b/garmin.h
@@ -24,7 +24,6 @@
 #include <cstdio>              // for size_t
 
 #include <QByteArray>          // for QByteArray
-#include <QRegularExpression>  // for QRegularExpression
 #include <QString>             // for QString
 #include <QTextCodec>          // for QTextCodec
 #include <QVector>             // for QVector
@@ -135,7 +134,7 @@ private:
   bool receiver_must_upper = true;
   QTextCodec* codec{nullptr};
 
-  QRegularExpression invalid_char_re;
+  QString valid_chars;
 
   QVector<arglist_t> garmin_args = {
     {


### PR DESCRIPTION
This was reported on gpsbabel-code by Dirk.

> I'm using GPSBabel with a Garmin eTrex H. Recently updated to Ubuntu MATE 24.04 LTS and since then GPSBabel crashes with the following error message:

> gpsbabel: ./garmin.cc:380: void rw_init(const QString&): Zusicherung »!QString(valid_waypt_chars).contains('-')« nicht erfüllt.

> '-' can be a valid waypoint character for some older Garmin devices as correctly defined in garmin.cc.
> Hence line 306 of the current garmin.cc

> assert(!QString(valid_waypt_chars).contains('-'));

> makes GPSBabel unusable for those devices.

The purpose of the assertion was to make sure we didn't have any PCRE metacharacters in our character class definition that we invert to get the invalid characters.  In practice the dash was the last character in the class so wouldn't be considered a metacharacter anyway, but our assertion check wasn't sophisticated enough to allow this.

It appears that some distributions don't set CMAKE_BUILD_TYPE to something like Release that causes NDEBUG to be defined, thus assertions are enabled in their released code.

In any event, now that we have a requirement for Qt >= 6.2, we can use QString::removeIf(Predicate pred) and avoid QRegularExpression entirely.