### PR TITLE
don't send links with GPS_A200_Send.

### DIFF
--- a/jeeps/gpsapp.cc
+++ b/jeeps/gpsapp.cc
@@ -3152,9 +3152,6 @@ int32_t GPS_A200_Send(const char* port, GPS_PWay* way, int32_t n)
   gpsdevh* fd;
   GPS_Packet tra;
   GPS_Packet rec;
-  int32_t i;
-  int32_t len;
-  US  method;
 
   if (!GPS_Device_On(port,&fd)) {
     return gps_errno;
@@ -3172,7 +3169,10 @@ int32_t GPS_A200_Send(const char* port, GPS_PWay* way, int32_t n)
   }
 
 
-  for (i=0; i<n; ++i) {
+  for (int32_t i=0; i<n; ++i) {
+    US  method;
+    int32_t len;
+
     if (way[i]->isrte) {
       method = LINK_ID[gps_link_type].Pid_Rte_Hdr;
 
@@ -3190,6 +3190,8 @@ int32_t GPS_A200_Send(const char* port, GPS_PWay* way, int32_t n)
         GPS_Error("A200_Send: Unknown route protocol");
         return PROTOCOL_ERROR;
       }
+    } else if (way[i]->islink) {
+      continue; // links not supported.  can cause "Route Waypoint was Deleted" and "Received an Invalid WPT" on device.
     } else {
       method = LINK_ID[gps_link_type].Pid_Rte_Wpt_Data;
 


### PR DESCRIPTION
This resolves #1293.

Note that comparing:

Garmin Device Interface Specification 
September 16, 2004 
Drawing Number: 001-00063-00 Rev. B

"6.6.2 A200 – Route Transfer Protocol" and "6.6.3 A201 – Route Transfer Protocol"

shows that the links are used in A201 and not A200.