### PR TITLE
correct computation of timestamp with garmin real time positioning.

### DIFF
--- a/garmin.cc
+++ b/garmin.cc
@@ -22,7 +22,7 @@
 #include "garmin.h"
 
 #include <climits>               // for INT_MAX
-#include <cmath>                 // for atan2, floor, sqrt
+#include <cmath>                 // for atan2, modf, sqrt
 #include <cstdio>                // for fprintf, fflush, snprintf, snprintf
 #include <cstdint>               // for int32_t
 #include <cstdlib>               // for strtol
@@ -599,8 +599,9 @@ GarminFormat::pvt2wpt(GPS_PPvt_Data pvt, Waypoint* wpt)
   double wptime = 631065600.0 + pvt->wn_days * 86400.0  +
                   pvt->tow
                   - pvt->leap_scnds;
-  double wptimes = floor(wptime);
-  wpt->SetCreationTime(wptimes, 1000000.0 * (wptime - wptimes));
+  double wptime_integral_part;
+  double wptime_fractional_part = modf(wptime, &wptime_integral_part);
+  wpt->SetCreationTime(wptime_integral_part, 1000.0 * wptime_fractional_part);
 
   /*
    * The Garmin spec fifteen different models that use a different

--- a/garmin.cc
+++ b/garmin.cc
@@ -36,7 +36,7 @@
 #include <QString>               // for QString
 #include <QTextCodec>            // for QTextCodec
 #include <Qt>                    // for CaseInsensitive
-#include <QtGlobal>              // for qPrintable, foreach
+#include <QtGlobal>              // for qPrintable, qRound64, Q_INT64_C, qint64
 
 #include "defs.h"
 #include "formspec.h"            // for FormatSpecificDataList
@@ -596,12 +596,13 @@ GarminFormat::pvt2wpt(GPS_PPvt_Data pvt, Waypoint* wpt)
    * 3) The number of leap seconds that offset the current UTC and GPS
    *    reference clocks.
    */
-  double wptime = 631065600.0 + pvt->wn_days * 86400.0  +
-                  pvt->tow
-                  - pvt->leap_scnds;
-  double wptime_integral_part;
-  double wptime_fractional_part = modf(wptime, &wptime_integral_part);
-  wpt->SetCreationTime(wptime_integral_part, 1000.0 * wptime_fractional_part);
+  double tow_integral_part;
+  double tow_fractional_part = modf(pvt->tow, &tow_integral_part);
+  qint64 seconds = Q_INT64_C(631065600) + pvt->wn_days * Q_INT64_C(86400)  +
+                   qRound64(tow_integral_part)
+                   - pvt->leap_scnds;
+  qint64 milliseconds = qRound64(1000.0 * tow_fractional_part);
+  wpt->SetCreationTime(seconds, milliseconds);
 
   /*
    * The Garmin spec fifteen different models that use a different


### PR DESCRIPTION
Waypoint::SetCreationTime(qint64 t, qint64 ms = 0) arguments are seconds and milliseconds since epoch.

After converting from AM/PM to a 24 hour clock we can see the timestamp is incorrectly computed before this PR (the location has been redacted).
```
tsteven4@gen1ubuntu22:~/work/noa200links$ date -u ;sudo ./bld/gpsbabel -T -i garmin -f /dev/ttyS0
Sun Jul 21 09:05:42 PM UTC 2024
Sun Jul 21 21:22:22 2024 GMT * * *
Sun Jul 21 21:22:23 2024 GMT * * *
Sun Jul 21 21:22:24 2024 GMT * * *
```
But after the PR the timestamps are approximately correct:
```
tsteven4@gen1ubuntu22:~/work/noa200links$ date -u ;sudo ./bld/gpsbabel -T -i garmin -f /dev/ttyS0
Sun Jul 21 09:06:06 PM UTC 2024
Sun Jul 21 21:06:07 2024 GMT * * *
Sun Jul 21 21:06:08 2024 GMT * * *
Sun Jul 21 21:06:09 2024 GMT * * *
```