### PR TITLE
use a signed type for waypt_counts and route counts.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -490,7 +490,7 @@ void waypt_init();
 void waypt_add(Waypoint* wpt);
 void waypt_del(Waypoint* wpt);
 void del_marked_wpts();
-unsigned int waypt_count();
+int waypt_count();
 void waypt_status_disp(int total_ct, int myct);
 //void waypt_disp_all(waypt_cb); /* template */
 //void waypt_disp_session(const session_t* se, waypt_cb cb); /* template */
@@ -674,10 +674,10 @@ private:
 };
 
 void route_init();
-unsigned int route_waypt_count();
-unsigned int route_count();
-unsigned int track_waypt_count();
-unsigned int track_count();
+int route_waypt_count();
+int route_count();
+int track_waypt_count();
+int track_count();
 route_head* route_head_alloc();
 void route_add_head(route_head* rte);
 void route_del_head(route_head* rte);

--- a/kml.cc
+++ b/kml.cc
@@ -90,7 +90,7 @@ const QVector<KmlFormat::mt_field_t> KmlFormat::mt_fields_def = {
   { wp_field::sat, "satellites", "Satellites", "int" },
 };
 
-void KmlFormat::kml_init_color_sequencer(unsigned int steps_per_rev)
+void KmlFormat::kml_init_color_sequencer(int steps_per_rev)
 {
   if (rotate_colors) {
     float color_step = strtod(opt_rotate_colors, nullptr);

--- a/kml.h
+++ b/kml.h
@@ -132,7 +132,7 @@ private:
 
   /* Member Functions */
 
-  void kml_init_color_sequencer(unsigned int steps_per_rev);
+  void kml_init_color_sequencer(int steps_per_rev);
   static constexpr int kml_bgr_to_color(int blue, int green, int red)
   {
     return (blue)<<16 | (green)<<8 | (red);

--- a/route.cc
+++ b/route.cc
@@ -46,27 +46,27 @@ route_init()
   global_track_list = new RouteList;
 }
 
-unsigned int
+int
 route_waypt_count()
 {
   /* total waypoint count -- all routes */
   return global_route_list->waypt_count();
 }
 
-unsigned int
+int
 route_count()
 {
   return global_route_list->count();	/* total # of routes */
 }
 
-unsigned int
+int
 track_waypt_count()
 {
   /* total waypoint count -- all tracks */
   return global_track_list->waypt_count();
 }
 
-unsigned int
+int
 track_count()
 {
   return global_track_list->count();	/* total # of tracks */

--- a/tpg.h
+++ b/tpg.h
@@ -75,7 +75,7 @@ private:
   char* tpg_datum_opt{};
   int tpg_datum_idx{};
 
-  unsigned int waypt_out_count{};
+  int waypt_out_count{};
 
   QVector<arglist_t> tpg_args = {
     {"datum", &tpg_datum_opt, "Datum (default=NAD27)", "N. America 1927 mean", ARGTYPE_STRING, ARG_NOMINMAX, nullptr},

--- a/validate.cc
+++ b/validate.cc
@@ -64,10 +64,10 @@ void ValidateFilter::process()
   }
   waypt_disp_all(validate_point_f);
   if (debug) {
-    fprintf(stderr, "point ct: %u, waypt_count: %u\n", point_ct, waypt_count());
+    fprintf(stderr, "point ct: %d, waypt_count: %d\n", point_ct, waypt_count());
   }
   if (!debug && (point_ct != waypt_count())) {
-    fatal(MYNAME ":Waypoint count mismatch, expected %u, actual %u\n", waypt_count(), point_ct);
+    fatal(MYNAME ":Waypoint count mismatch, expected %d, actual %d\n", waypt_count(), point_ct);
   }
 
   head_ct = 0;
@@ -78,14 +78,14 @@ void ValidateFilter::process()
   }
   route_disp_all(validate_head_f, validate_head_trl_f, validate_point_f);
   if (debug) {
-    fprintf(stderr, "route head ct: %u, route_count: %u\n", head_ct, route_count());
-    fprintf(stderr, "total route point ct: %u, route_waypt_count: %u\n", point_ct, route_waypt_count());
+    fprintf(stderr, "route head ct: %d, route_count: %d\n", head_ct, route_count());
+    fprintf(stderr, "total route point ct: %d, route_waypt_count: %d\n", point_ct, route_waypt_count());
   }
   if (!debug && (head_ct != route_count())) {
-    fatal(MYNAME ":Route count mismatch, expected %u, actual %u\n", route_count(), head_ct);
+    fatal(MYNAME ":Route count mismatch, expected %d, actual %d\n", route_count(), head_ct);
   }
   if (!debug && (point_ct != route_waypt_count())) {
-    fatal(MYNAME ":Total route waypoint count mismatch, expected %u, actual %u\n", route_waypt_count(), point_ct);
+    fatal(MYNAME ":Total route waypoint count mismatch, expected %d, actual %d\n", route_waypt_count(), point_ct);
   }
 
   head_ct = 0;
@@ -96,14 +96,14 @@ void ValidateFilter::process()
   }
   track_disp_all(validate_head_f, validate_head_trl_f, validate_point_f);
   if (debug) {
-    fprintf(stderr, "track head ct: %u, track_count: %u\n", head_ct, track_count());
-    fprintf(stderr, "total track point ct: %u, track_waypt_count: %u\n", point_ct, track_waypt_count());
+    fprintf(stderr, "track head ct: %d, track_count: %d\n", head_ct, track_count());
+    fprintf(stderr, "total track point ct: %d, track_waypt_count: %d\n", point_ct, track_waypt_count());
   }
   if (!debug && (head_ct != track_count())) {
-    fatal(MYNAME ":Track count mismatch, expected %u, actual %u\n", track_count(), head_ct);
+    fatal(MYNAME ":Track count mismatch, expected %d, actual %d\n", track_count(), head_ct);
   }
   if (!debug && (point_ct != track_waypt_count())) {
-    fatal(MYNAME ":Total track waypoint count mismatch, expected %u, actual %u\n", track_waypt_count(), point_ct);
+    fatal(MYNAME ":Total track waypoint count mismatch, expected %d, actual %d\n", track_waypt_count(), point_ct);
   }
 
   if (checkempty) {

--- a/validate.h
+++ b/validate.h
@@ -44,9 +44,9 @@ private:
   bool debug{};
   char* opt_checkempty{};
   bool checkempty{};
-  unsigned int point_ct{};
-  unsigned int head_ct{};
-  unsigned int segment_ct_start{};
+  int point_ct{};
+  int head_ct{};
+  int segment_ct_start{};
   const char* segment_type{};
   QVector<arglist_t> args = {
     {

--- a/waypt.cc
+++ b/waypt.cc
@@ -73,7 +73,7 @@ del_marked_wpts()
   global_waypoint_list->del_marked_wpts();
 }
 
-unsigned int
+int
 waypt_count()
 {
   return global_waypoint_list->count();


### PR DESCRIPTION
Although larger in Qt6, the underlying type is signed.

This reduces the number of tidy bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions warnings by 108, without picking up any other tidy warnings.

Also see the discussion at https://google.github.io/styleguide/cppguide.html#Integer_Types