### PR TITLE
cleanup datetime.h tidy and g++ warnings.

### DIFF
--- a/src/core/datetime.h
+++ b/src/core/datetime.h
@@ -37,9 +37,11 @@
 // "Better" code in the callers.
 
 // Consider putting in a namespace instead of prefixing 'gb'.
-namespace gpsbabel {
+namespace gpsbabel
+{
 
-class DateTime : public QDateTime {
+class DateTime : public QDateTime
+{
 public:
   // As a crutch, mimic the old behaviour of an uninitialized creation time
   // being 1/1/1970.
@@ -52,35 +54,38 @@ public:
   // Qt::LocalTime compared to Qt::UTC on ubuntu bionic.
   // Note that these conversions can be required if the Qt::TimeSpec is
   // set to Qt:LocalTime after construction.
-  DateTime() : QDateTime(QDateTime::fromMSecsSinceEpoch(0, Qt::UTC)) {
+  DateTime() : QDateTime(QDateTime::fromMSecsSinceEpoch(0, Qt::UTC))
+  {
   }
 
   DateTime(const QDate& date, const QTime& time) : QDateTime(date, time) {}
   DateTime(const QDateTime& dt) : QDateTime(dt) {}
 
   // Temporary: Override the standard, also handle time_t 0 as invalid.
-  bool isValid() const {
+  [[nodiscard]] bool isValid() const
+  {
     return QDateTime::isValid() && (toSecsSinceEpoch() != 0);
   }
 
   // Like toString, but with subsecond time that's included only when
   // the trailing digits aren't .000.  Always UTC.
-  QString toPrettyString() const {
-    if (time().msec()) {
+  [[nodiscard]] QString toPrettyString() const
+  {
+    if (time().msec() != 0) {
       return toUTC().toString(QStringLiteral("yyyy-MM-ddTHH:mm:ss.zzzZ"));
-    } else {
-      return toUTC().toString(QStringLiteral("yyyy-MM-ddTHH:mm:ssZ"));
     }
+    return toUTC().toString(QStringLiteral("yyyy-MM-ddTHH:mm:ssZ"));
   }
 
   // QDateTime::toTime_t was deprecated in Qt5.8, and deleted in Qt6.
-  uint32_t toTime_t() const {
+  [[nodiscard]] uint32_t toTime_t() const
+  {
     if (!QDateTime::isValid()) {
-      return -1;
+      return UINT32_MAX;
     }
     long long secs_since_epoch = toSecsSinceEpoch();
-    if ((secs_since_epoch < 0) || (secs_since_epoch > 0xfffffffe)) {
-      return -1;
+    if ((secs_since_epoch < 0) || (secs_since_epoch >= UINT32_MAX)) {
+      return UINT32_MAX;
     }
     return secs_since_epoch;
   }


### PR DESCRIPTION
Because this header is included almost everywhere these tidy & gcc warnings have an overweight representation in the logs.  There is not functional change here.

Wsign-conversion
readability-implicit-bool-conversion
readability-else-after-return
cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers