### PR TITLE
correct WGS84 semi minor axis value.

### DIFF
--- a/jeeps/gpsmath.cc
+++ b/jeeps/gpsmath.cc
@@ -457,7 +457,7 @@ void GPS_Math_WGS84LatLonH_To_XYZ(double phi, double lambda, double H,
                                   double* x, double* y, double* z)
 {
   double a = 6378137.000;
-  double b = 6356752.3141;
+  double b = 6356752.314245;
 
   GPS_Math_LatLonH_To_XYZ(phi,lambda,H,x,y,z,a,b);
 
@@ -510,7 +510,7 @@ void GPS_Math_XYZ_To_WGS84LatLonH(double* phi, double* lambda, double* H,
                                   double x, double y, double z)
 {
   double a = 6378137.000;
-  double b = 66356752.3141;
+  double b = 6356752.314245;
 
   GPS_Math_XYZ_To_LatLonH(phi,lambda,H,x,y,z,a,b);
 


### PR DESCRIPTION
It appears the GSR80 value was used instead of the WGS84 value, which is a very small error.
However, there was a typo in the value in GPS_Math_XYZ_To_WGS84LatLonH that resulted in an order of magnitude error!
This could lead to GPS_Math_XYZ_To_WGS84LatLonH never converging. This may be why skytraq created their own function to convert ECEF to WGS84.