### PR TITLE
Use Helmert transform for conversions between OSGB36 and WSG84

### DIFF
--- a/garmin_txt.cc
+++ b/garmin_txt.cc
@@ -56,7 +56,7 @@
 #include "formspec.h"              // for FormatSpecificDataList
 #include "garmin_fs.h"             // for garmin_fs_t
 #include "garmin_tables.h"         // for gt_display_modes_e, gt_find_desc_from_icon_number, gt_find_icon_number_from_desc, gt_get_mps_grid_longname, gt_lookup_datum_index, gt_lookup_grid_type, GDB, gt_get_icao_cc, gt_get_icao_country, gt_get_mps_datum_name, gt_waypt_class_names, GT_DISPLAY_MODE...
-#include "jeeps/gpsmath.h"         // for GPS_Math_Known_Datum_To_UTM_EN, GPS_Math_WGS84_To_Known_Datum_M, GPS_Math_WGS84_To_Swiss_EN, GPS_Math_WGS84_To_UKOSMap_M
+#include "jeeps/gpsmath.h"         // for GPS_Math_Known_Datum_To_UTM_EN, GPS_Math_WGS84_To_Known_Datum_M, GPS_Math_WGS84_To_Swiss_EN, GPS_Math_WGS84_To_UKOSMap_H
 #include "src/core/datetime.h"     // for DateTime
 #include "src/core/logging.h"      // for FatalMsg
 #include "src/core/textstream.h"   // for TextStream
@@ -243,7 +243,7 @@ GarminTxtFormat::print_position(const Waypoint* wpt)
 
   case grid_bng:
 
-    valid = GPS_Math_WGS84_To_UKOSMap_M(wpt->latitude, wpt->longitude, &east, &north, map);
+    valid = GPS_Math_WGS84_To_UKOSMap_H(wpt->latitude, wpt->longitude, &east, &north, map);
     if (valid) {
       *fout << QString::asprintf("%s %5.0f %5.0f\t", map, east, north);
     }

--- a/jeeps/gpsmath.cc
+++ b/jeeps/gpsmath.cc
@@ -1543,17 +1543,16 @@ void GPS_Math_Helmert(double Sx, double Sy, double Sz,
                       double sppm,
                       double rXs, double rYs, double rZs)
 {
-  double s = sppm/1000000.0;
-  double rX = (rXs/(60.0*60.0))*GPS_PI/(180.0); /* radians */
-  double rY = (rYs/(60.0*60.0))*GPS_PI/(180.0); /* radians */
-  double rZ = (rZs/(60.0*60.0))*GPS_PI/(180.0); /* radians */
+  double s = sppm * 1e-6;
+  constexpr double radians_per_second = (1.0/(60.0*60.0)) * GPS_PI/180.0;
+  double rX = rXs * radians_per_second; /* radians */
+  double rY = rYs * radians_per_second; /* radians */
+  double rZ = rZs * radians_per_second; /* radians */
 
   // rotation/scaling matrix = [1+s -rz ry;rz 1+s -rx;-ry rx 1+s];
   *Dx = tX + (1 + s)*Sx + -rZ*Sy + rY*Sz;
   *Dy = tY + rZ*Sx + (1 + s)*Sy + -rX*Sz;
   *Dz = tZ + -rY*Sx + rX*Sy + (1 + s)*Sz;
-
-  return;
 }
 
 /* @func GPS_Math_Inverse_Helmert ***********************************
@@ -1584,10 +1583,11 @@ void GPS_Math_Inverse_Helmert(double Sx, double Sy, double Sz,
                               double sppm,
                               double rXs, double rYs, double rZs)
 {
-  double s = sppm/1000000.0;
-  double rX = (rXs/(60.0*60.0))*GPS_PI/(180.0); /* radians */
-  double rY = (rYs/(60.0*60.0))*GPS_PI/(180.0); /* radians */
-  double rZ = (rZs/(60.0*60.0))*GPS_PI/(180.0); /* radians */
+  double s = sppm * 1e-6;
+  constexpr double radians_per_second = (1.0/(60.0*60.0)) * GPS_PI/180.0;
+  double rX = rXs * radians_per_second; /* radians */
+  double rY = rYs * radians_per_second; /* radians */
+  double rZ = rZs * radians_per_second; /* radians */
 
   // forward rotation/scaling matrix is [1+s -rz ry;rz 1+s -rx;-ry rx 1+s]
   // compute inverse of forward Helmert rotation/scaling matrix
@@ -1606,8 +1606,6 @@ void GPS_Math_Inverse_Helmert(double Sx, double Sy, double Sz,
   *Dx = gain * ((r11 * (Sx-tX)) + (r12 * (Sy-tY)) + (r13 * (Sz-tZ)));
   *Dy = gain * ((r21 * (Sx-tX)) + (r22 * (Sy-tY)) + (r23 * (Sz-tZ)));
   *Dz = gain * ((r31 * (Sx-tX)) + (r32 * (Sy-tY)) + (r33 * (Sz-tZ)));
-
-  return;
 }
 
 /* @func GPS_Math_Known_Datum_To_WGS84_M **********************************

--- a/jeeps/gpsmath.cc
+++ b/jeeps/gpsmath.cc
@@ -4,6 +4,7 @@
 ** @author Copyright (C) 1999 Alan Bleasby
 ** @version 1.0
 ** @modified Dec 28 1999 Alan Bleasby. First version
+** @modified Copyright (C) 2024 Robert Lipe
 ** @@
 **
 ** This library is free software; you can redistribute it and/or

--- a/jeeps/gpsmath.h
+++ b/jeeps/gpsmath.h
@@ -72,6 +72,16 @@ void GPS_Math_Molodensky(double Sphi, double Slam, double SH, double Sa,
                          double Sif, double* Dphi, double* Dlam,
                          double* DH, double Da, double Dif, double dx,
                          double dy, double dz);
+void GPS_Math_Helmert(double Sx, double Sy, double Sz,
+                      double* Dx, double* Dy, double* Dz,
+                      double tX, double tY, double tZ,
+                      double sppm,
+                      double rXs, double rYs, double rZs);
+void GPS_Math_Inverse_Helmert(double Sx, double Sy, double Sz,
+                              double* Dx, double* Dy, double* Dz,
+                              double tX, double tY, double tZ,
+                              double sppm,
+                              double rXs, double rYs, double rZs);
 void GPS_Math_Known_Datum_To_WGS84_M(double Sphi, double Slam, double SH,
                                      double* Dphi, double* Dlam, double* DH,
                                      int32_t n);
@@ -95,6 +105,10 @@ void GPS_Math_Known_Datum_To_Known_Datum_C(double Sphi, double Slam, double SH,
 int32_t GPS_Math_WGS84_To_UKOSMap_M(double lat, double lon, double* mE,
                                     double* mN, char* map);
 int32_t GPS_Math_UKOSMap_To_WGS84_M(const char* map, double mE, double mN,
+                                    double* lat, double* lon);
+int32_t GPS_Math_WGS84_To_UKOSMap_H(double lat, double lon, double* mE,
+                                    double* mN, char* map);
+int32_t GPS_Math_UKOSMap_To_WGS84_H(const char* map, double mE, double mN,
                                     double* lat, double* lon);
 int32_t GPS_Math_WGS84_To_UKOSMap_C(double lat, double lon, double* mE,
                                     double* mN, char* map);

--- a/parse.cc
+++ b/parse.cc
@@ -221,7 +221,7 @@ parse_coordinates(const char* str, int datum, const grid_type grid,
                 &result);
     valid = (ct == 3);
     if (valid) {
-      if (! GPS_Math_UKOSMap_To_WGS84_M(map, lx, ly, &lat, &lon))
+      if (! GPS_Math_UKOSMap_To_WGS84_H(map, lx, ly, &lat, &lon))
         fatal("%s: Unable to convert BNG coordinates (%s)!\n",
               module, str);
     }

--- a/reference/bngtest.csv
+++ b/reference/bngtest.csv
@@ -1,0 +1,3 @@
+No,BNG-Zone,BNG-East,BNG-North,Name,Description,Date,Time
+1,ST,96552, 3097,"Badbury Rings Trig Point","Test Point 1",2024/08/05,00:00:00
+2,ST,91437, 1894,"Spettisbury Rings Trig Point","Test Point 2",2024/08/05,00:00:00

--- a/reference/bngtest.gpx
+++ b/reference/bngtest.gpx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
+  <time>1970-01-01T00:00:00Z</time>
+  <bounds minlat="50.816527458" minlon="-2.122918364" maxlat="50.827399509" maxlon="-2.050323375"/>
+  <wpt lat="50.827399509" lon="-2.050323375">
+    <time>2024-08-05T00:00:00Z</time>
+    <name>Badbury Rings Trig Point</name>
+    <cmt>Test Point 1</cmt>
+    <desc>Test Point 1</desc>
+  </wpt>
+  <wpt lat="50.816527458" lon="-2.122918364">
+    <time>2024-08-05T00:00:00Z</time>
+    <name>Spettisbury Rings Trig Point</name>
+    <cmt>Test Point 2</cmt>
+    <desc>Test Point 2</desc>
+  </wpt>
+</gpx>

--- a/reference/grid-bng~csv.gpx
+++ b/reference/grid-bng~csv.gpx
@@ -1,92 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
   <time>1970-01-01T00:00:00Z</time>
-  <bounds minlat="50.207517637" minlon="-7.489235773" maxlat="60.150151215" maxlon="1.296391371"/>
-  <wpt lat="58.007809302" lon="-6.751777638">
+  <bounds minlat="50.207588000" minlon="-7.489131627" maxlat="60.150023350" maxlon="1.296336192"/>
+  <wpt lat="58.007715417" lon="-6.751692412">
     <time>2008-08-23T20:56:12Z</time>
     <name>AlineLodge</name>
     <cmt>Aline Lodge</cmt>
     <desc>Aline Lodge</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="53.140870076" lon="-4.273683778">
+  <wpt lat="53.140881280" lon="-4.273629536">
     <time>2008-08-23T20:55:54Z</time>
     <name>Caernarfon</name>
     <cmt>Caernarfon</cmt>
     <desc>Caernarfon</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="50.207517637" lon="-5.295409028">
+  <wpt lat="50.207588000" lon="-5.295322139">
     <time>2008-08-23T20:55:39Z</time>
     <name>Camborne</name>
     <cmt>Camborne</cmt>
     <desc>Camborne</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="50.712891291" lon="-3.537602671">
+  <wpt lat="50.712954140" lon="-3.537551739">
     <time>2008-08-23T20:55:35Z</time>
     <name>Exeter</name>
     <cmt>Exeter</cmt>
     <desc>Exeter</desc>
     <sym>City (Medium)</sym>
   </wpt>
-  <wpt lat="56.634525358" lon="-2.889408436">
+  <wpt lat="56.634466571" lon="-2.889403757">
     <time>2008-08-23T20:55:22Z</time>
     <name>Forfar</name>
     <cmt>Forfar</cmt>
     <desc>Forfar</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="55.426025760" lon="-2.790531785">
+  <wpt lat="55.425992291" lon="-2.790521406">
     <time>2008-08-23T20:55:25Z</time>
     <name>Hawick</name>
     <cmt>Hawick</cmt>
     <desc>Hawick</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="57.621914847" lon="-7.489235773">
+  <wpt lat="57.621828070" lon="-7.489131627">
     <time>2008-08-23T20:56:17Z</time>
     <name>Hosta</name>
     <cmt>Hosta</cmt>
     <desc>Hosta</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="57.007373614" lon="-6.271139684">
+  <wpt lat="57.007301222" lon="-6.271060827">
     <time>2008-08-23T20:56:24Z</time>
     <name>IsleofRhum</name>
     <cmt>Isle of Rhum</cmt>
     <desc>Isle of Rhum</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="60.150151215" lon="-1.142586362">
+  <wpt lat="60.150023350" lon="-1.142651285">
     <time>2008-08-23T20:59:39Z</time>
     <name>Lerwick</name>
     <cmt>Lerwick</cmt>
     <desc>Lerwick</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="58.684841865" lon="-3.116680165">
+  <wpt lat="58.684740004" lon="-3.116684802">
     <time>2008-08-23T20:57:48Z</time>
     <name>Nethertown</name>
     <cmt>Nethertown</cmt>
     <desc>Nethertown</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="52.635495464" lon="1.296391371">
+  <wpt lat="52.635529557" lon="1.296336192">
     <time>2008-08-23T20:55:44Z</time>
     <name>Norwich</name>
     <cmt>Norwich</cmt>
     <desc>Norwich</desc>
     <sym>City (Medium)</sym>
   </wpt>
-  <wpt lat="50.741731984" lon="-0.782771513">
+  <wpt lat="50.741799943" lon="-0.782773783">
     <time>2008-08-23T20:57:02Z</time>
     <name>Selsey</name>
     <cmt>Selsey</cmt>
     <desc>Selsey</desc>
     <sym>City (Small)</sym>
   </wpt>
-  <wpt lat="53.393555571" lon="-1.494139002">
+  <wpt lat="53.393567062" lon="-1.494143092">
     <time>2008-08-23T20:55:01Z</time>
     <name>Sheffield</name>
     <cmt>Sheffield</cmt>

--- a/testo.d/unicsv.test
+++ b/testo.d/unicsv.test
@@ -59,3 +59,8 @@ compare ${REFERENCE}/pretty_degree2.csv ${TMPDIR}/pretty_degree2.csv
 gpsbabel -i unicsv -f ${REFERENCE}/unidelim.csv -o gpx -F ${TMPDIR}/unidelim.gpx
 compare ${REFERENCE}/unidelim.gpx ${TMPDIR}/unidelim.gpx
 
+gpsbabel -i unicsv,utc -f ${REFERENCE}/bngtest.csv -o gpx -F ${TMPDIR}/bngtest~csv.gpx
+compare ${REFERENCE}/bngtest.gpx ${TMPDIR}/bngtest~csv.gpx
+gpsbabel -i gpx -f ${REFERENCE}/bngtest.gpx -o unicsv,grid=bng,utc -F ${TMPDIR}/bngtest~gpx.csv
+compare ${REFERENCE}/bngtest.csv ${TMPDIR}/bngtest~gpx.csv
+

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -46,7 +46,7 @@
 #include "garmin_fs.h"             // for garmin_fs_t
 #include "garmin_tables.h"         // for gt_lookup_datum_index, gt_get_mps_grid_longname, gt_lookup_grid_type
 #include "geocache.h"              // for Geocache, Geocache::status_t, Geoc...
-#include "jeeps/gpsmath.h"         // for GPS_Math_UKOSMap_To_WGS84_M, GPS_Math_EN_To_UKOSNG_Map, GPS_Math_Known_Datum_To_UTM_EN, GPS_Math_Known_Datum_To_WGS84_M, GPS_Math_Swiss_EN_To_WGS84, GPS_Math_UTM_EN_To_Known_Datum, GPS_Math_WGS84_To_Known_Datum_M, GPS_Math_WGS84_To_Swiss_EN, GPS_Math_WGS...
+#include "jeeps/gpsmath.h"         // for GPS_Math_UKOSMap_To_WGS84_H, GPS_Math_EN_To_UKOSNG_Map, GPS_Math_Known_Datum_To_UTM_EN, GPS_Math_Known_Datum_To_WGS84_M, GPS_Math_Swiss_EN_To_WGS84, GPS_Math_UTM_EN_To_Known_Datum, GPS_Math_WGS84_To_Known_Datum_M, GPS_Math_WGS84_To_Swiss_EN, GPS_Math_WGS...
 #include "session.h"               // for session_t
 #include "src/core/datetime.h"     // for DateTime
 #include "src/core/logging.h"      // for Warning, Fatal
@@ -1017,13 +1017,13 @@ UnicsvFormat::unicsv_parse_one_line(const QString& ibuf)
           fatal(MYNAME ": Unable to convert BNG coordinates (%.f %.f)!\n",
                 bng_easting, bng_northing);
         }
-        if (! GPS_Math_UKOSMap_To_WGS84_M(
+        if (! GPS_Math_UKOSMap_To_WGS84_H(
               bngz, bnge, bngn,
               &wpt->latitude, &wpt->longitude))
           fatal(MYNAME ": Unable to convert BNG coordinates (%s %.f %.f)!\n",
                 bngz, bnge, bngn);
       } else { // traditional zone easting northing
-        if (! GPS_Math_UKOSMap_To_WGS84_M(
+        if (! GPS_Math_UKOSMap_To_WGS84_H(
               CSTR(bng_zone), bng_easting, bng_northing,
               &wpt->latitude, &wpt->longitude))
           fatal(MYNAME ": Unable to convert BNG coordinates (%s %.f %.f)!\n",
@@ -1322,7 +1322,7 @@ UnicsvFormat::unicsv_waypt_disp_cb(const Waypoint* wpt)
     double north;
     double east;
 
-    if (! GPS_Math_WGS84_To_UKOSMap_M(wpt->latitude, wpt->longitude, &east, &north, map)) {
+    if (! GPS_Math_WGS84_To_UKOSMap_H(wpt->latitude, wpt->longitude, &east, &north, map)) {
       unicsv_fatal_outside(wpt);
     }
     auto fieldWidth = fout->fieldWidth();

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -56,7 +56,7 @@
 #include "garmin_fs.h"             // for garmin_fs_t
 #include "geocache.h"              // for Geocache, Geocache::status_t, Geoc...
 #include "grtcirc.h"               // for RAD, gcdist, radtometers
-#include "jeeps/gpsmath.h"         // for GPS_Math_WGS84_To_UTM_EN, GPS_Lookup_Datum_Index, GPS_Math_Known_Datum_To_WGS84_M, GPS_Math_UTM_EN_To_Known_Datum, GPS_Math_WGS84_To_Known_Datum_M, GPS_Math_WGS84_To_UKOSMap_M
+#include "jeeps/gpsmath.h"         // for GPS_Math_WGS84_To_UTM_EN, GPS_Lookup_Datum_Index, GPS_Math_Known_Datum_To_WGS84_M, GPS_Math_UTM_EN_To_Known_Datum, GPS_Math_WGS84_To_Known_Datum_M, GPS_Math_WGS84_To_UKOSMap_H
 #include "jeeps/gpsport.h"         // for int32
 #include "session.h"               // for session_t
 #include "src/core/datetime.h"     // for DateTime
@@ -1227,7 +1227,7 @@ XcsvFormat::xcsv_waypt_pr(const Waypoint* wpt)
       char map[3];
       double north;
       double east;
-      if (! GPS_Math_WGS84_To_UKOSMap_M(wpt->latitude, wpt->longitude, &east, &north, map))
+      if (! GPS_Math_WGS84_To_UKOSMap_H(wpt->latitude, wpt->longitude, &east, &north, map))
         fatal(MYNAME ": Position (%.5f/%.5f) outside of BNG.\n",
               wpt->latitude, wpt->longitude);
       buff = QString::asprintf(fmp.printfc.constData(), map, qRound(east), qRound(north));


### PR DESCRIPTION
This came up on:
[Gpsbabel-misc] Accuracy of BNG > GPX (WGS84) transformation
Mon, 5 Aug 2024 19:37:42 +0200

Previously we used the Molodensky transform.  This PR adds an implementation of the Helmert transform, and uses it to transform between OSGB36 and WGS84.  Transforms between other coordinate systems still use Molodensky.  Using the Helmert transform for other use cases would require knowledge of the translation, rotation and scaling parameters between those coordinate systems.

https://www.ordnancesurvey.co.uk/documents/resources/guide-coordinate-systems-great-britain.pdf states that we should expect errors up to 3.5m with the Helmert transform.

This does NOT implement OSTN15.  If you really need better accuracy then you should convert your coordinates outside of GPSBabel.

