### PR TITLE
correct simplify filter with maximum allowable error option and the metric being overall route length or relative error

### DIFF
--- a/parse.cc
+++ b/parse.cc
@@ -20,11 +20,15 @@
 
  */
 
-#include "defs.h"
-#include "jeeps/gpsmath.h"
-#include <cmath>
-#include <cstdio>
-#include <cstdlib> //strtod
+#include <cctype>           // for isspace
+#include <cmath>            // for fabs
+#include <cstdio>           // for sscanf
+#include <cstdlib>          // for strtod
+
+#include <QString>          // for QString
+
+#include "defs.h"           // for case_ignore_strcmp, fatal, KPH_TO_MPS, MPH_TO_MPS, warning, FEET_TO_METERS, KNOTS_TO_MPS, CSTR, FATHOMS_TO_METERS, MILES_TO_METERS, NMILES_TO_METERS, kDatumWGS84, grid_type, parse_coordinates, parse_distance, parse_speed, grid_bng, grid_lat_lon_ddd, grid_lat_lo...
+#include "jeeps/gpsmath.h"  // for GPS_Math_Known_Datum_To_WGS84_M, GPS_Math_Swiss_EN_To_WGS84, GPS_Math_UKOSMap_To_WGS84_H, GPS_Math_UTM_EN_To_Known_Datum
 
 /*
  * parse_distance:
@@ -83,7 +87,8 @@ parse_distance(const char* str, double* val, double scale, const char* module)
 }
 
 int
-parse_distance(const QString& str, double* val, double scale, const char* module) {
+parse_distance(const QString& str, double* val, double scale, const char* module)
+{
   return parse_distance(CSTR(str), val, scale, module);
 }
 

--- a/reference/simplify_error_length.gpx
+++ b/reference/simplify_error_length.gpx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
   <time>1970-01-01T00:00:00Z</time>
-  <bounds minlat="48.154215105" minlon="11.807058938" maxlat="48.198396452" maxlon="11.895879619"/>
+  <bounds minlat="48.154215105" minlon="11.807058938" maxlat="48.198396452" maxlon="11.895890348"/>
   <wpt lat="48.186895391" lon="11.858545868">
     <name>LAP001</name>
     <cmt>LAP001</cmt>
@@ -33,6 +33,16 @@
         <ele>510.200</ele>
         <time>2012-04-12T12:54:25Z</time>
         <speed>3.088000</speed>
+      </trkpt>
+      <trkpt lat="48.189168060" lon="11.857860480">
+        <ele>510.200</ele>
+        <time>2012-04-12T12:54:38Z</time>
+        <speed>5.925000</speed>
+      </trkpt>
+      <trkpt lat="48.188740415" lon="11.857657554">
+        <ele>510.200</ele>
+        <time>2012-04-12T12:54:46Z</time>
+        <speed>6.637000</speed>
       </trkpt>
       <trkpt lat="48.188369768" lon="11.857392518">
         <ele>511.400</ele>
@@ -151,6 +161,11 @@
         <time>2012-04-12T12:58:45Z</time>
         <speed>6.169000</speed>
       </trkpt>
+      <trkpt lat="48.185834829" lon="11.847133068">
+        <ele>519.200</ele>
+        <time>2012-04-12T12:58:48Z</time>
+        <speed>6.248000</speed>
+      </trkpt>
       <trkpt lat="48.185999533" lon="11.847155532">
         <ele>520.400</ele>
         <time>2012-04-12T12:58:51Z</time>
@@ -251,11 +266,6 @@
         <time>2012-04-12T13:03:14Z</time>
         <speed>7.546000</speed>
       </trkpt>
-      <trkpt lat="48.197662532" lon="11.833831156">
-        <ele>540.800</ele>
-        <time>2012-04-12T13:03:19Z</time>
-        <speed>8.935000</speed>
-      </trkpt>
       <trkpt lat="48.197656581" lon="11.832230547">
         <ele>538.600</ele>
         <time>2012-04-12T13:03:31Z</time>
@@ -281,6 +291,11 @@
         <time>2012-04-12T13:04:09Z</time>
         <speed>4.329000</speed>
       </trkpt>
+      <trkpt lat="48.198237866" lon="11.828006739">
+        <ele>536.600</ele>
+        <time>2012-04-12T13:04:12Z</time>
+        <speed>5.039000</speed>
+      </trkpt>
       <trkpt lat="48.197932346" lon="11.828151243">
         <ele>536.600</ele>
         <time>2012-04-12T13:04:18Z</time>
@@ -305,6 +320,11 @@
         <ele>538.600</ele>
         <time>2012-04-12T13:05:03Z</time>
         <speed>8.963000</speed>
+      </trkpt>
+      <trkpt lat="48.194401301" lon="11.829370558">
+        <ele>538.600</ele>
+        <time>2012-04-12T13:05:10Z</time>
+        <speed>8.420000</speed>
       </trkpt>
       <trkpt lat="48.194264760" lon="11.829374414">
         <ele>538.600</ele>
@@ -336,10 +356,10 @@
         <time>2012-04-12T13:05:27Z</time>
         <speed>7.927000</speed>
       </trkpt>
-      <trkpt lat="48.194508757" lon="11.827563839">
+      <trkpt lat="48.194518564" lon="11.827676324">
         <ele>536.400</ele>
-        <time>2012-04-12T13:05:33Z</time>
-        <speed>8.233000</speed>
+        <time>2012-04-12T13:05:32Z</time>
+        <speed>8.272000</speed>
       </trkpt>
       <trkpt lat="48.194524767" lon="11.826406214">
         <ele>536.400</ele>
@@ -370,11 +390,6 @@
         <ele>538.800</ele>
         <time>2012-04-12T13:06:21Z</time>
         <speed>8.439000</speed>
-      </trkpt>
-      <trkpt lat="48.195430264" lon="11.821646802">
-        <ele>538.800</ele>
-        <time>2012-04-12T13:06:27Z</time>
-        <speed>8.476000</speed>
       </trkpt>
       <trkpt lat="48.195509305" lon="11.821327871">
         <ele>538.800</ele>
@@ -516,11 +531,6 @@
         <time>2012-04-12T13:09:52Z</time>
         <speed>5.373000</speed>
       </trkpt>
-      <trkpt lat="48.190376647" lon="11.822674759">
-        <ele>541.600</ele>
-        <time>2012-04-12T13:09:59Z</time>
-        <speed>6.961000</speed>
-      </trkpt>
       <trkpt lat="48.190509081" lon="11.824321132">
         <ele>537.200</ele>
         <time>2012-04-12T13:10:15Z</time>
@@ -646,16 +656,6 @@
         <time>2012-04-12T13:14:14Z</time>
         <speed>6.347000</speed>
       </trkpt>
-      <trkpt lat="48.187041404" lon="11.829014327">
-        <ele>533.600</ele>
-        <time>2012-04-12T13:14:18Z</time>
-        <speed>6.408000</speed>
-      </trkpt>
-      <trkpt lat="48.186966889" lon="11.828252496">
-        <ele>533.600</ele>
-        <time>2012-04-12T13:14:27Z</time>
-        <speed>6.192000</speed>
-      </trkpt>
       <trkpt lat="48.186480068" lon="11.824992355">
         <ele>538.400</ele>
         <time>2012-04-12T13:15:06Z</time>
@@ -720,6 +720,16 @@
         <time>2012-04-12T13:17:37Z</time>
         <speed>7.587000</speed>
       </trkpt>
+      <trkpt lat="48.189039230" lon="11.820660168">
+        <ele>542.000</ele>
+        <time>2012-04-12T13:17:57Z</time>
+        <speed>6.804000</speed>
+      </trkpt>
+      <trkpt lat="48.189340811" lon="11.820678357">
+        <ele>542.000</ele>
+        <time>2012-04-12T13:18:02Z</time>
+        <speed>6.545000</speed>
+      </trkpt>
       <trkpt lat="48.189635267" lon="11.820620270">
         <ele>543.200</ele>
         <time>2012-04-12T13:18:07Z</time>
@@ -755,10 +765,10 @@
         <time>2012-04-12T13:18:27Z</time>
         <speed>5.492000</speed>
       </trkpt>
-      <trkpt lat="48.190378742" lon="11.818994517">
-        <ele>543.000</ele>
-        <time>2012-04-12T13:18:33Z</time>
-        <speed>7.660000</speed>
+      <trkpt lat="48.190338761" lon="11.819181601">
+        <ele>544.000</ele>
+        <time>2012-04-12T13:18:31Z</time>
+        <speed>7.097000</speed>
       </trkpt>
       <trkpt lat="48.190448228" lon="11.818801565">
         <ele>542.200</ele>
@@ -815,6 +825,11 @@
         <time>2012-04-12T13:20:17Z</time>
         <speed>4.790000</speed>
       </trkpt>
+      <trkpt lat="48.196312794" lon="11.811443930">
+        <ele>521.400</ele>
+        <time>2012-04-12T13:20:18Z</time>
+        <speed>4.333000</speed>
+      </trkpt>
       <trkpt lat="48.194731548" lon="11.811005138">
         <ele>520.000</ele>
         <time>2012-04-12T13:20:43Z</time>
@@ -849,6 +864,11 @@
         <ele>520.000</ele>
         <time>2012-04-12T13:21:25Z</time>
         <speed>5.026000</speed>
+      </trkpt>
+      <trkpt lat="48.194513032" lon="11.808237685">
+        <ele>520.000</ele>
+        <time>2012-04-12T13:21:35Z</time>
+        <speed>6.505000</speed>
       </trkpt>
       <trkpt lat="48.193316683" lon="11.807801994">
         <ele>520.000</ele>
@@ -949,6 +969,16 @@
         <ele>526.400</ele>
         <time>2012-04-12T13:26:09Z</time>
         <speed>8.019000</speed>
+      </trkpt>
+      <trkpt lat="48.174194880" lon="11.811118294">
+        <ele>526.400</ele>
+        <time>2012-04-12T13:26:25Z</time>
+        <speed>1.765000</speed>
+      </trkpt>
+      <trkpt lat="48.174158419" lon="11.811099015">
+        <ele>526.400</ele>
+        <time>2012-04-12T13:26:28Z</time>
+        <speed>1.335000</speed>
       </trkpt>
     </trkseg>
     <trkseg>
@@ -1068,16 +1098,6 @@
         <time>2012-04-12T13:30:16Z</time>
         <speed>7.009000</speed>
       </trkpt>
-      <trkpt lat="48.171093576" lon="11.820989074">
-        <ele>535.400</ele>
-        <time>2012-04-12T13:30:23Z</time>
-        <speed>6.641000</speed>
-      </trkpt>
-      <trkpt lat="48.170400225" lon="11.822248874">
-        <ele>539.400</ele>
-        <time>2012-04-12T13:30:42Z</time>
-        <speed>6.555000</speed>
-      </trkpt>
       <trkpt lat="48.169257939" lon="11.824626736">
         <ele>542.400</ele>
         <time>2012-04-12T13:31:16Z</time>
@@ -1087,6 +1107,11 @@
         <ele>543.800</ele>
         <time>2012-04-12T13:31:19Z</time>
         <speed>5.426000</speed>
+      </trkpt>
+      <trkpt lat="48.168991478" lon="11.824757243">
+        <ele>543.800</ele>
+        <time>2012-04-12T13:31:22Z</time>
+        <speed>5.012000</speed>
       </trkpt>
       <trkpt lat="48.167512827" lon="11.824777527">
         <ele>548.000</ele>
@@ -1117,21 +1142,6 @@
         <ele>542.800</ele>
         <time>2012-04-12T13:33:46Z</time>
         <speed>11.715000</speed>
-      </trkpt>
-      <trkpt lat="48.162197275" lon="11.837364715">
-        <ele>540.800</ele>
-        <time>2012-04-12T13:33:58Z</time>
-        <speed>10.787000</speed>
-      </trkpt>
-      <trkpt lat="48.162075402" lon="11.837575100">
-        <ele>540.000</ele>
-        <time>2012-04-12T13:34:00Z</time>
-        <speed>10.409000</speed>
-      </trkpt>
-      <trkpt lat="48.161988650" lon="11.837821864">
-        <ele>539.000</ele>
-        <time>2012-04-12T13:34:02Z</time>
-        <speed>10.124000</speed>
       </trkpt>
       <trkpt lat="48.161363695" lon="11.839118879">
         <ele>538.600</ele>
@@ -1198,11 +1208,6 @@
         <time>2012-04-12T13:36:25Z</time>
         <speed>10.073000</speed>
       </trkpt>
-      <trkpt lat="48.154548705" lon="11.851329636">
-        <ele>536.400</ele>
-        <time>2012-04-12T13:36:30Z</time>
-        <speed>10.149000</speed>
-      </trkpt>
       <trkpt lat="48.154550130" lon="11.851602551">
         <ele>535.400</ele>
         <time>2012-04-12T13:36:32Z</time>
@@ -1222,11 +1227,6 @@
         <ele>532.000</ele>
         <time>2012-04-12T13:36:56Z</time>
         <speed>7.019000</speed>
-      </trkpt>
-      <trkpt lat="48.154250979" lon="11.853869855">
-        <ele>532.000</ele>
-        <time>2012-04-12T13:36:59Z</time>
-        <speed>7.612000</speed>
       </trkpt>
       <trkpt lat="48.154215105" lon="11.855165530">
         <ele>532.000</ele>
@@ -1313,11 +1313,6 @@
         <time>2012-04-12T13:41:54Z</time>
         <speed>9.152000</speed>
       </trkpt>
-      <trkpt lat="48.159979759" lon="11.888612844">
-        <ele>529.600</ele>
-        <time>2012-04-12T13:42:01Z</time>
-        <speed>9.009000</speed>
-      </trkpt>
       <trkpt lat="48.160092160" lon="11.889433684">
         <ele>529.600</ele>
         <time>2012-04-12T13:42:08Z</time>
@@ -1347,6 +1342,16 @@
         <ele>527.600</ele>
         <time>2012-04-12T13:43:19Z</time>
         <speed>6.158000</speed>
+      </trkpt>
+      <trkpt lat="48.162526768" lon="11.895890348">
+        <ele>527.600</ele>
+        <time>2012-04-12T13:43:20Z</time>
+        <speed>6.444000</speed>
+      </trkpt>
+      <trkpt lat="48.163888659" lon="11.895550881">
+        <ele>527.600</ele>
+        <time>2012-04-12T13:43:44Z</time>
+        <speed>6.139000</speed>
       </trkpt>
       <trkpt lat="48.164182613" lon="11.895536128">
         <ele>527.600</ele>
@@ -1383,6 +1388,11 @@
         <time>2012-04-12T13:45:34Z</time>
         <speed>6.457000</speed>
       </trkpt>
+      <trkpt lat="48.170458144" lon="11.890335493">
+        <ele>529.600</ele>
+        <time>2012-04-12T13:45:36Z</time>
+        <speed>7.202000</speed>
+      </trkpt>
       <trkpt lat="48.170658723" lon="11.890327530">
         <ele>529.600</ele>
         <time>2012-04-12T13:45:39Z</time>
@@ -1402,11 +1412,6 @@
         <ele>528.600</ele>
         <time>2012-04-12T13:45:44Z</time>
         <speed>8.735000</speed>
-      </trkpt>
-      <trkpt lat="48.170755617" lon="11.890960112">
-        <ele>528.200</ele>
-        <time>2012-04-12T13:45:45Z</time>
-        <speed>9.047000</speed>
       </trkpt>
       <trkpt lat="48.170795348" lon="11.891068490">
         <ele>527.800</ele>
@@ -1448,6 +1453,11 @@
         <time>2012-04-12T13:46:06Z</time>
         <speed>6.894000</speed>
       </trkpt>
+      <trkpt lat="48.177311691" lon="11.883834992">
+        <ele>521.000</ele>
+        <time>2012-04-12T13:47:39Z</time>
+        <speed>8.741000</speed>
+      </trkpt>
       <trkpt lat="48.178511225" lon="11.882507466">
         <ele>521.000</ele>
         <time>2012-04-12T13:47:59Z</time>
@@ -1478,11 +1488,6 @@
         <time>2012-04-12T13:48:44Z</time>
         <speed>6.483000</speed>
       </trkpt>
-      <trkpt lat="48.180869054" lon="11.877523670">
-        <ele>521.000</ele>
-        <time>2012-04-12T13:49:09Z</time>
-        <speed>8.439000</speed>
-      </trkpt>
       <trkpt lat="48.181884857" lon="11.875377400">
         <ele>521.000</ele>
         <time>2012-04-12T13:49:32Z</time>
@@ -1507,6 +1512,11 @@
         <ele>525.200</ele>
         <time>2012-04-12T13:50:30Z</time>
         <speed>6.395000</speed>
+      </trkpt>
+      <trkpt lat="48.184036491" lon="11.869414765">
+        <ele>525.200</ele>
+        <time>2012-04-12T13:50:41Z</time>
+        <speed>7.643000</speed>
       </trkpt>
       <trkpt lat="48.184731184" lon="11.869372604">
         <ele>525.200</ele>
@@ -1553,25 +1563,10 @@
         <time>2012-04-12T13:51:37Z</time>
         <speed>5.394000</speed>
       </trkpt>
-      <trkpt lat="48.186184689" lon="11.865461441">
-        <ele>533.600</ele>
-        <time>2012-04-12T13:51:58Z</time>
-        <speed>6.307000</speed>
-      </trkpt>
-      <trkpt lat="48.186138505" lon="11.864733472">
-        <ele>536.400</ele>
-        <time>2012-04-12T13:52:08Z</time>
-        <speed>5.016000</speed>
-      </trkpt>
       <trkpt lat="48.186149569" lon="11.864121677">
         <ele>539.400</ele>
         <time>2012-04-12T13:52:17Z</time>
         <speed>4.804000</speed>
-      </trkpt>
-      <trkpt lat="48.186195418" lon="11.863884218">
-        <ele>540.200</ele>
-        <time>2012-04-12T13:52:21Z</time>
-        <speed>4.605000</speed>
       </trkpt>
       <trkpt lat="48.186216708" lon="11.863832669">
         <ele>540.200</ele>
@@ -1583,6 +1578,16 @@
         <time>2012-04-12T13:52:25Z</time>
         <speed>4.724000</speed>
       </trkpt>
+      <trkpt lat="48.186415443" lon="11.863702750">
+        <ele>542.400</ele>
+        <time>2012-04-12T13:52:27Z</time>
+        <speed>4.880000</speed>
+      </trkpt>
+      <trkpt lat="48.186930427" lon="11.863694368">
+        <ele>542.400</ele>
+        <time>2012-04-12T13:52:37Z</time>
+        <speed>5.821000</speed>
+      </trkpt>
       <trkpt lat="48.187041068" lon="11.863661427">
         <ele>542.400</ele>
         <time>2012-04-12T13:52:39Z</time>
@@ -1592,11 +1597,6 @@
         <ele>542.400</ele>
         <time>2012-04-12T13:52:41Z</time>
         <speed>6.516000</speed>
-      </trkpt>
-      <trkpt lat="48.187141400" lon="11.863372084">
-        <ele>542.400</ele>
-        <time>2012-04-12T13:52:43Z</time>
-        <speed>6.389000</speed>
       </trkpt>
       <trkpt lat="48.187122289" lon="11.863070419">
         <ele>542.400</ele>

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -126,8 +126,8 @@ double SimplifyRouteFilter::compute_track_error(const neighborhood& nb) const
                wpt2->latitude, wpt2->longitude,
                frac, &reslat, &reslon);
       track_error = radtometers(gcdist(
-                                  wpt3->latitude, wpt3->longitude,
-                                  reslat, reslon));
+                                  RAD(wpt3->latitude), RAD(wpt3->longitude),
+                                  RAD(reslat), RAD(reslon)));
     } else { // else distance to connecting line
       track_error = radtometers(linedist(
                                   wpt1->latitude, wpt1->longitude,

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -57,7 +57,7 @@
 */
 
 #include <cassert>
-#include <cstdlib>              // for strtol
+#include <cstdlib>              // for strtod, strtol
 #include <iterator>             // for prev
 
 #include <QDateTime>            // for QDateTime
@@ -297,11 +297,15 @@ void SimplifyRouteFilter::init()
     count = strtol(countopt, nullptr, 10);
     break;
   case limit_basis_t::error: {
-    int res = parse_distance(erroropt, &error, 1.0, MYNAME);
-    if (res == 0) {
-      error = 0;
-    } else if (res == 2) { /* parameter with unit */
-      error = METERS_TO_MILES(error);
+    if (metric == metric_t::relative) {
+      error = strtod(erroropt, nullptr);
+    } else {
+      int res = parse_distance(erroropt, &error, 1.0, MYNAME);
+      if (res == 0) {
+        error = 0;
+      } else if (res == 2) { /* parameter with unit */
+        error = METERS_TO_MILES(error);
+      }
     }
   }
   break;

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -109,7 +109,6 @@ double SimplifyRouteFilter::compute_track_error(const neighborhood& nb) const
                            RAD(wpt2->latitude), RAD(wpt2->longitude)) -
                     gcdist(RAD(wpt1->latitude), RAD(wpt1->longitude),
                            RAD(wpt2->latitude), RAD(wpt2->longitude)));
-//qDebug() << track_error;
     break;
   case metric_t::relative:
   default: // eliminate false positive warning with g++ 11.3.0: ‘error’ may be used uninitialized in this function [-Wmaybe-uninitialized]

--- a/smplrout.cc
+++ b/smplrout.cc
@@ -103,12 +103,13 @@ double SimplifyRouteFilter::compute_track_error(const neighborhood& nb) const
     break;
   case metric_t::length:
     track_error = radtomiles(
-                    gcdist(wpt1->latitude, wpt1->longitude,
-                           wpt3->latitude, wpt3->longitude) +
-                    gcdist(wpt3->latitude, wpt3->longitude,
-                           wpt2->latitude, wpt2->longitude) -
-                    gcdist(wpt1->latitude, wpt1->longitude,
-                           wpt2->latitude, wpt2->longitude));
+                    gcdist(RAD(wpt1->latitude), RAD(wpt1->longitude),
+                           RAD(wpt3->latitude), RAD(wpt3->longitude)) +
+                    gcdist(RAD(wpt3->latitude), RAD(wpt3->longitude),
+                           RAD(wpt2->latitude), RAD(wpt2->longitude)) -
+                    gcdist(RAD(wpt1->latitude), RAD(wpt1->longitude),
+                           RAD(wpt2->latitude), RAD(wpt2->longitude)));
+//qDebug() << track_error;
     break;
   case metric_t::relative:
   default: // eliminate false positive warning with g++ 11.3.0: ‘error’ may be used uninitialized in this function [-Wmaybe-uninitialized]

--- a/testo.d/simplify-relative.test
+++ b/testo.d/simplify-relative.test
@@ -4,3 +4,6 @@
 gpsbabel -i gpx -f ${REFERENCE}/track/simplify-relative.gpx -x simplify,relative,count=33 -o gpx -F ${TMPDIR}/simplify-relative2.gpx
 compare ${REFERENCE}/track/simplify-relative2.gpx ${TMPDIR}/simplify-relative2.gpx
 
+gpsbabel -i gpx -f ${REFERENCE}/track/simplify-relative.gpx -x simplify,relative,error=34.3 -o gpx -F ${TMPDIR}/simplify-relative3.gpx
+compare ${REFERENCE}/track/simplify-relative2.gpx ${TMPDIR}/simplify-relative3.gpx
+

--- a/testo.d/simplify-relative.test
+++ b/testo.d/simplify-relative.test
@@ -4,6 +4,6 @@
 gpsbabel -i gpx -f ${REFERENCE}/track/simplify-relative.gpx -x simplify,relative,count=33 -o gpx -F ${TMPDIR}/simplify-relative2.gpx
 compare ${REFERENCE}/track/simplify-relative2.gpx ${TMPDIR}/simplify-relative2.gpx
 
-gpsbabel -i gpx -f ${REFERENCE}/track/simplify-relative.gpx -x simplify,relative,error=34.3 -o gpx -F ${TMPDIR}/simplify-relative3.gpx
+gpsbabel -i gpx -f ${REFERENCE}/track/simplify-relative.gpx -x simplify,relative,error=0.61 -o gpx -F ${TMPDIR}/simplify-relative3.gpx
 compare ${REFERENCE}/track/simplify-relative2.gpx ${TMPDIR}/simplify-relative3.gpx
 

--- a/testo.d/simplify.test
+++ b/testo.d/simplify.test
@@ -28,8 +28,3 @@ gpsbabel -i gpx -f ${REFERENCE}/track/garmin-edge-800-output.gpx \
          -x simplify,error=0.01263869,length \
          -o gpx -F ${TMPDIR}/simplify_error_length_miles.gpx
 compare ${REFERENCE}/simplify_error_length.gpx ${TMPDIR}/simplify_error_length_miles.gpx
-
-gpsbabel -i gpx -f ${REFERENCE}/track/garmin-edge-800-output.gpx \
-         -x simplify,error=0.01263869mi,length \
-         -o gpx -F ${TMPDIR}/simplify_error_length_explicitmiles.gpx
-compare ${REFERENCE}/simplify_error_length.gpx ${TMPDIR}/simplify_error_length_explicitmiles.gpx

--- a/testo.d/simplify.test
+++ b/testo.d/simplify.test
@@ -19,7 +19,7 @@ gpsbabel -i gpx -f ${REFERENCE}/track/garmin-edge-800-output.gpx \
 compare ${REFERENCE}/simplify_error_crosstrack.gpx ${TMPDIR}/simplify_error.gpx
 
 gpsbabel -i gpx -f ${REFERENCE}/track/garmin-edge-800-output.gpx \
-         -x simplify,error=1000m,length \
+         -x simplify,error=20.34m,length \
          -o gpx -F ${TMPDIR}/simplify_error_length.gpx
 compare ${REFERENCE}/simplify_error_length.gpx ${TMPDIR}/simplify_error_length.gpx
 

--- a/testo.d/simplify.test
+++ b/testo.d/simplify.test
@@ -23,3 +23,13 @@ gpsbabel -i gpx -f ${REFERENCE}/track/garmin-edge-800-output.gpx \
          -o gpx -F ${TMPDIR}/simplify_error_length.gpx
 compare ${REFERENCE}/simplify_error_length.gpx ${TMPDIR}/simplify_error_length.gpx
 
+# check default error units are miles
+gpsbabel -i gpx -f ${REFERENCE}/track/garmin-edge-800-output.gpx \
+         -x simplify,error=0.01263869,length \
+         -o gpx -F ${TMPDIR}/simplify_error_length_miles.gpx
+compare ${REFERENCE}/simplify_error_length.gpx ${TMPDIR}/simplify_error_length_miles.gpx
+
+gpsbabel -i gpx -f ${REFERENCE}/track/garmin-edge-800-output.gpx \
+         -x simplify,error=0.01263869mi,length \
+         -o gpx -F ${TMPDIR}/simplify_error_length_explicitmiles.gpx
+compare ${REFERENCE}/simplify_error_length.gpx ${TMPDIR}/simplify_error_length_explicitmiles.gpx

--- a/xmldoc/filters/options/simplify-error.xml
+++ b/xmldoc/filters/options/simplify-error.xml
@@ -3,7 +3,8 @@ This option specifies the maximum allowable error that may be introduced
 by removing a single point. Used with the <option>length</option>
 and <option>crosstrack</option> methods, the value of this option is a distance,
 specified in miles by default.  You may also specify the distance in
-kilometers by adding a 'k' to the end of the number.
+kilometers by adding a 'k' to the end of the number, meters by adding a 'm', or
+feet by adding 'ft'.
 For the <option>relative</option> method it is a dimensionless quantity.
 </para>
 <para>


### PR DESCRIPTION
Both these combinations suffered from passing locations in degrees to gcdist instead of the required radians.

For the error option using the overall route length:
- the existing code sets a limit of 1000m, but the actual route length changes by -21.459m leaving 333 points.
- the modified code set a limit of 20.34m and the actual route length changes by -20.259m leaving 333 points.
- the existing and modified code each keep a different set of 333 points.
- the change in route length is lower with the modified code than the existing code even though both keep 333 points.

  | error(m) | total length(km) | delta length(m) | points
-- | -- | -- | -- | --
garmin-edge-800-output.gpx |   | 25.169843 |   | 1286
ref | 1000 | 25.148384 | -21.459 | 333
dut | 20.2 | 25.149752 | -20.091 | 334
dut | 20.34 | 25.149584 | -20.259 | 333
dut | 20.5 | 25.149415 | -20.428 | 332

For the error option using the relative error based on HDOP:
- the new simplify-relative test (without the corrections to the call to gcdist) uses a limit of 34.3 and keeps 33 out of 100 points.
- the new simplify-relative test with the corrections to the call to gcdist uses a limit of 0.61 and keeps the same 33 points.  The limit to keep the same number of points has changed to approximately (pi/180)*34.3 = 0.60.





