### PR TITLE
cleanup great circle.

### DIFF
--- a/grtcirc.cc
+++ b/grtcirc.cc
@@ -111,7 +111,7 @@ double heading_true_degrees(double lat1, double lon1, double lat2, double lon2)
 {
   double h = 360.0 + DEG(heading(lat1, lon1, lat2, lon2));
   if (h >= 360.0) {
-     h -= 360.0;
+    h -= 360.0;
   }
 
   return h;

--- a/grtcirc.h
+++ b/grtcirc.h
@@ -25,7 +25,6 @@
 #include <numbers>  // for inv_pi
 
 double gcdist(double lat1, double lon1, double lat2, double lon2);
-double heading(double lat1, double lon1, double lat2, double lon2);
 double heading_true_degrees(double lat1, double lon1, double lat2, double lon2);
 
 double linedistprj(double lat1, double lon1,


### PR DESCRIPTION
All these changes are semantic, although one deserves some explanation.

Originally the results from heading and heading_true_degrees had opposite signs after allowing for modulo arithemetic.  The formulas for heading may have came from https://www.edwilliams.org/avform147.htm#Crs.  This reference had a caveat in the introduction: 

> For the convenience of North Americans I will take North latitudes and West longitudes as positive and South and East negative. The longitude is the opposite of the usual mathematical convention.

It appears that the sign in heading_true_degrees was inverted to make up for this.

As

-  sin(-x) = -sin(x)
- cos(-x) = cos(-x)
- atan(-x) = -(atan(x))

one can conclude v1 changes sign, v2 is identical, and the return of heading changes sign.  Thus no inversion of the sign in heading_true_degrees is needed.

These changes are in agreement with https://www.movable-type.co.uk/scripts/latlong.html which doesn't make the odd assumption about west latitudes.