### PR TITLE
explain humminbird geodetic to geocentric conversions.

### DIFF
--- a/humminbird.cc
+++ b/humminbird.cc
@@ -167,28 +167,40 @@ struct HumminbirdBase::group_body_t {
 };
 
 
-/* Takes a latitude in degrees,
- * returns a latitude in degrees. */
+/* Takes a geodetic latitude in degrees,
+ * returns a geocentric latitude in degrees. */
 double
 HumminbirdBase::geodetic_to_geocentric_hwr(const double gd_lat)
 {
-  constexpr double cos_ae = 0.9966349016452;
-  constexpr double cos2_ae = cos_ae * cos_ae;
+  /* For
+   * angular eccentricity α,
+   * flattening f, and
+   * eccentricity e
+   * the flattening is related to the angular eccentricity:
+   * f = 1 - cos(α)
+   * 1 - f = cos(α)
+   * the flattening is related to the eccentricity:
+   * f = 1 - sqrt(1-e^2)
+   * (1 - f)^2 = 1 - e^2
+   * Equation 3-28 of
+   * Snyder, J. P. Map projections — A working manual. Professional Paper 1395,
+   * U.S. Geological Survey, 1987
+   * relates the geocentric latitude to geodetic latitude in terms of
+   * 1 - e^2 which is equal to cos^2(α) as shown above.
+   */
   const double gdr = gd_lat * std::numbers::pi / 180.0;
 
-  return atan(cos2_ae * tan(gdr)) * 180.0 * std::numbers::inv_pi;
+  return atan(cos2_α * tan(gdr)) * 180.0 * std::numbers::inv_pi;
 }
 
-/* Takes a latitude in degrees,
- * returns a latitude in degrees. */
+/* Takes a geocentric latitude in degrees,
+ * returns a geodetic latitude in degrees. */
 double
 HumminbirdBase::geocentric_to_geodetic_hwr(const double gc_lat)
 {
-  constexpr double cos_ae = 0.9966349016452;
-  constexpr double cos2_ae = cos_ae * cos_ae;
   const double gcr = gc_lat * std::numbers::pi / 180.0;
 
-  return atan(tan(gcr)/cos2_ae) * 180.0 * std::numbers::inv_pi;
+  return atan(tan(gcr)/cos2_α) * 180.0 * std::numbers::inv_pi;
 }
 
 /* Takes a projected "north" value, returns latitude in degrees. */

--- a/humminbird.h
+++ b/humminbird.h
@@ -49,6 +49,12 @@ protected:
 
   /* Constants */
 
+  /* We use an empirically derived ellipse to convert between geocentric and geodetic latitudes.
+   * It is described by the cosine of it's angular eccentricty α.
+   */
+  static constexpr double cos_α = 0.9966349016452;
+  static constexpr double cos2_α = cos_α * cos_α;
+
   static constexpr const char* humminbird_icons[] = {
     "Normal",       /*  0 */
     "House",        /*  1 */


### PR DESCRIPTION
Document the humminbird geodetic to geocentric conversions. An ellipse was derived to match the data described in gpsbabel-code 2008-08-14. The related math is explained in terms of this derived parameter.