### PR TITLE
Humminbirdhash

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -1013,9 +1013,6 @@ enum grid_type {
 #define GRID_INDEX_MIN	grid_lat_lon_ddd
 #define GRID_INDEX_MAX	grid_swiss
 
-void* gb_int2ptr(int i);
-int gb_ptr2int(const void* p);
-
 QTextCodec* get_codec(const QByteArray& cs_name);
 void list_codecs();
 void list_timezones();

--- a/humminbird.cc
+++ b/humminbird.cc
@@ -223,7 +223,7 @@ HumminbirdBase::humminbird_rd_deinit() const
 void
 HumminbirdBase::humminbird_read_wpt(gbfile* fin)
 {
-  humminbird_waypt_t w{0};
+  humminbird_waypt_t w{};
 
   if (! gbfread(&w, 1, sizeof(w), fin)) {
     fatal(MYNAME ": Unexpected end of file!\n");
@@ -285,7 +285,7 @@ void
 HumminbirdBase::humminbird_read_route(gbfile* fin) const
 {
 
-  humminbird_rte_t hrte{0};
+  humminbird_rte_t hrte{};
 
   if (! gbfread(&hrte, 1, sizeof(hrte), fin)) {
     fatal(MYNAME ": Unexpected end of file!\n");
@@ -317,7 +317,7 @@ void
 HumminbirdBase::humminbird_read_track(gbfile* fin)
 {
 
-  humminbird_trk_header_t th{0};
+  humminbird_trk_header_t th{};
 
   if (! gbfread(&th, 1, sizeof(th), fin)) {
     fatal(MYNAME ": Unexpected end of file reading header!\n");
@@ -425,7 +425,7 @@ void
 HumminbirdBase::humminbird_read_track_old(gbfile* fin)
 {
 
-  humminbird_trk_header_old_t th{0};
+  humminbird_trk_header_old_t th{};
   constexpr int file_len = 8048;
   char namebuf[TRK_NAME_LEN];
 
@@ -609,7 +609,7 @@ HumminbirdBase::humminbird_wr_deinit()
 void
 HumminbirdFormat::humminbird_write_waypoint(const Waypoint* wpt)
 {
-  humminbird_waypt_t hum{0};
+  humminbird_waypt_t hum{};
   int num_icons = std::size(humminbird_icons);
 
   be_write16(&hum.num, waypoint_num++);

--- a/humminbird.h
+++ b/humminbird.h
@@ -21,7 +21,7 @@
 #ifndef HUMMINBIRD_H_INCLUDED_
 #define HUMMINBIRD_H_INCLUDED_
 
-#include <QMap>      // for QMap
+#include <QHash>     // for QHash
 #include <QString>   // for QString
 #include <QVector>   // for QVector
 
@@ -48,6 +48,15 @@ protected:
   struct group_body_t;
 
   /* Constants */
+
+  // constants related to position conversions.
+  static constexpr double i1924_equ_axis = 6378388.0;
+  static constexpr double EAST_SCALE = 20038297.0; /* this is i1924_equ_axis*pi */
+  // static constexpr double i1924_polar_axis = 6356911.946;
+  // We use a modified international 1924 ellipse with a different flattening,
+  // defined by cos_ae = cos(angular eccentricity).
+  static constexpr double cos_ae = 0.9966349016452;
+  static constexpr double cos2_ae = cos_ae * cos_ae;
 
   static constexpr const char* humminbird_icons[] = {
     "Normal",       /*  0 */
@@ -108,7 +117,8 @@ protected:
   MakeShort* trkname_sh{};
   humminbird_rte_t* humrte{};
   int rte_num_{};
-  QMap<QString, Waypoint*> map;
+  QHash<unsigned int, const Waypoint*> wpt_num_to_wpt_hash;
+  QHash<QString, unsigned int> wpt_id_to_wpt_num_hash;
 
   humminbird_trk_header_t* trk_head{};
   humminbird_trk_point_t* trk_points{};
@@ -151,6 +161,7 @@ private:
 
   void humminbird_rte_head(const route_head* rte);
   void humminbird_rte_tail(const route_head* rte);
+  static QString wpt_to_id(const Waypoint*);
   void humminbird_write_rtept(const Waypoint* wpt) const;
   void humminbird_write_waypoint(const Waypoint* wpt);
   void humminbird_write_waypoint_wrapper(const Waypoint* wpt);

--- a/util.cc
+++ b/util.cc
@@ -958,33 +958,6 @@ QString get_filename(const QString& fname)
   return QFileInfo(fname).fileName();
 }
 
-/*
- * gb_int2ptr: Needed, when sizeof(*void) != sizeof(int) ! compiler warning !
- */
-void* gb_int2ptr(const int i)
-{
-  union {
-    void* p;
-    int i;
-  } x = { nullptr };
-
-  x.i = i;
-  return x.p;
-}
-
-/*
- * gb_ptr2int: Needed, when sizeof(*void) != sizeof(int) ! compiler warning !
- */
-int gb_ptr2int(const void* p)
-{
-  union {
-    const void* p;
-    int i;
-  } x = { p };
-
-  return x.i;
-}
-
 QTextCodec* get_codec(const QByteArray& cs_name)
 {
   QTextCodec* codec = QTextCodec::codecForName(cs_name);


### PR DESCRIPTION
- refactor humminbird handling of wpt numbers.  This fixed some subtle bugs.  

  1. The map was shared and not cleared allowing communication between invocations of the humminbird reader & writer (reader->reader, reader->writer, writer->writer, etc.)
  2. When reading, waypoints that were dropped due to their status were still registered in the map.  If they happened to referred to by a route then deallocated memory would be accessed.
  3. humminbird_write_waypt_wrapper checked the map using the [] operator, which causes a silent insertion.  However, in this case the silently inserted entry was overwritten a few lines later with the correct value.

  It also allows gb_int2ptr and gb_ptr2int to be retired.

- convert some macros to constexpr.
- consistently use strncpy to move strings to humminbird char arrays.`
- fix clang-diagnostic-missing-field-initializers