### PR TITLE
normalize waypoint position.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -357,6 +357,7 @@ public:
   void SetCreationTime(qint64 t, qint64 ms = 0);
   Geocache* AllocGCData();
   int EmptyGCData() const;
+  void NormalizePosition();
   PositionDeg position() const {return PositionDeg(latitude, longitude);}
   void SetPosition(const PositionDeg& pos)
   {

--- a/waypt.cc
+++ b/waypt.cc
@@ -560,31 +560,53 @@ Waypoint::EmptyGCData() const
   return (gc_data == &Waypoint::empty_gc_data);
 }
 
+void Waypoint::NormalizePosition()
+{
+  double lat_orig = this->latitude;
+  double lon_orig = this->longitude;
+
+  if (this->latitude < -90.0 || this->latitude > 90.0) {
+    bool fliplon = false;
+    this->latitude = remainder(this->latitude, 360.0); // -180 <= this->latitude <= 180
+    if (this->latitude < -90.0) {
+      this->latitude = -180.0 - this->latitude;
+      fliplon = true;
+    } else if (this->latitude > 90.0) {
+      this->latitude = 180.0 - this->latitude;
+      fliplon = true;
+    }
+
+    if (fliplon) {
+      if (this->longitude < 0.0) {
+        this->longitude += 180.0;
+      } else {
+        this->longitude -= 180.0;
+      }
+    }
+  }
+
+  if (this->longitude < -180.0 || this->longitude >= 180.0) {
+    this->longitude = remainder(this->longitude, 360.0); // -180 <= this->longitude <= 180
+    if (this->longitude == 180.0) {
+      this->longitude = -180.0;
+    }
+  }
+
+  if ((this->latitude < -90) || (this->latitude > 90.0))
+    fatal(FatalMsg() << this->session->name
+          << "Invalid latitude" << lat_orig << "in waypoint"
+          << this->shortname);
+  if ((this->longitude < -180) || (this->longitude > 180.0))
+    fatal(FatalMsg() << "Invalid longitude" << lon_orig << "in waypoint"
+          << this->shortname);
+}
+
 void
 WaypointList::waypt_add(Waypoint* wpt)
 {
-  double lat_orig = wpt->latitude;
-  double lon_orig = wpt->longitude;
   append(wpt);
 
-  if (wpt->latitude < -90) {
-    wpt->latitude += 180;
-  } else if (wpt->latitude > +90) {
-    wpt->latitude -= 180;
-  }
-  if (wpt->longitude < -180) {
-    wpt->longitude += 360;
-  } else if (wpt->longitude > +180) {
-    wpt->longitude -= 360;
-  }
-
-  if ((wpt->latitude < -90) || (wpt->latitude > 90.0))
-    fatal(FatalMsg() << wpt->session->name
-          << "Invalid latitude" << lat_orig << "in waypoint"
-          << wpt->shortname);
-  if ((wpt->longitude < -180) || (wpt->longitude > 180.0))
-    fatal(FatalMsg() << "Invalid longitude" << lon_orig << "in waypoint"
-          << wpt->shortname);
+  wpt->NormalizePosition();
 
   /*
    * Some input may not have one or more of these types so we
@@ -620,6 +642,8 @@ void
 WaypointList::add_rte_waypt(int waypt_ct, Waypoint* wpt, bool synth, QStringView namepart, int number_digits)
 {
   append(wpt);
+
+  wpt->NormalizePosition();
 
   if (synth && wpt->shortname.isEmpty()) {
     wpt->shortname = QStringLiteral("%1%2").arg(namepart).arg(waypt_ct, number_digits, 10, QChar('0'));


### PR DESCRIPTION
This PR changes the way we normalize latitude and longitude, and applies it not only to waypoints, but to routes and tracks as well.

Our latitude normalization was problematic.  This resolves #1329.

This also resolves the creation of kml and gpx files that violates the respective schemas because of the restriction on the range of latitudes and longitudes by these schemas.  Previously it was possible to violate the schemas by reading a xcsv style with LAT_DECIMAL and LON_DECIMAL fields and csv input that had points outside [-90,90] for latitude and [-180,180) for longitude.  If a gpx or kml file was written with this data schema violations could occur.  A style file and csv input demonstrating this are attached.
[poswraps_style.txt](https://github.com/user-attachments/files/16789732/poswraps_style.txt)
[poswraps.csv](https://github.com/user-attachments/files/16789733/poswraps.csv)
