### PR TITLE
create docker images with historical releases.

### DIFF
--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.0
@@ -59,13 +59,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /home/gpsbabel
 
-COPY gpsbabel_1_5_1.patch /home/gpsbabel
+COPY gpsbabel_1_5_0.patch /home/gpsbabel
 
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_0 \
  && cd gpsbabel \
- && patch < /home/gpsbabel/gpsbabel_1_5_1.patch \
+ && patch < /home/gpsbabel/gpsbabel_1_5_0.patch \
+ && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
  && rm $(pwd)/gui/GPSBabel1.5.0.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabel /usr/local/bin \

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.0
@@ -1,0 +1,73 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+    patch \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    libqt5webkit5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+COPY gpsbabel_1_5_1.patch /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_5_0 \
+ && cd gpsbabel \
+ && patch < /home/gpsbabel/gpsbabel_1_5_1.patch \
+ && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.0
@@ -67,6 +67,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel \
  && patch < /home/gpsbabel/gpsbabel_1_5_1.patch \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && rm $(pwd)/gui/GPSBabel1.5.0.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.0
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
-    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -65,10 +64,9 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_0 \
  && cd gpsbabel \
- && patch < /home/gpsbabel/gpsbabel_1_5_0.patch \
+ && git apply /home/gpsbabel/gpsbabel_1_5_0.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && rm $(pwd)/gui/GPSBabel1.5.0.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.1
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.1
@@ -1,0 +1,73 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+    patch \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    libqt5webkit5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+COPY gpsbabel_1_5_1.patch /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_5_1 \
+ && cd gpsbabel \
+ && patch < /home/gpsbabel/gpsbabel_1_5_1.patch \
+ && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.1
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.1
@@ -66,6 +66,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && git checkout gpsbabel_1_5_1 \
  && cd gpsbabel \
  && patch < /home/gpsbabel/gpsbabel_1_5_1.patch \
+ && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
  && rm $(pwd)/gui/GPSBabel1.5.1.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabel /usr/local/bin \

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.1
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.1
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
-    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -65,10 +64,9 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_1 \
  && cd gpsbabel \
- && patch < /home/gpsbabel/gpsbabel_1_5_1.patch \
+ && git apply /home/gpsbabel/gpsbabel_1_5_1.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && rm $(pwd)/gui/GPSBabel1.5.1.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.1
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.1
@@ -67,6 +67,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel \
  && patch < /home/gpsbabel/gpsbabel_1_5_1.patch \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && rm $(pwd)/gui/GPSBabel1.5.1.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.2
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.2
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
-    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -65,10 +64,9 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_2 \
  && cd gpsbabel \
- && patch < /home/gpsbabel/gpsbabel_1_5_2.patch \
+ && git apply /home/gpsbabel/gpsbabel_1_5_2.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && rm $(pwd)/gui/GPSBabel1.5.2.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.2
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.2
@@ -67,6 +67,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel \
  && patch < /home/gpsbabel/gpsbabel_1_5_2.patch \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && rm $(pwd)/gui/GPSBabel1.5.2.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.2
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.2
@@ -1,0 +1,75 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+    patch \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    libqt5webkit5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+COPY gpsbabel_1_5_2.patch /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_5_2 \
+ && cd gpsbabel \
+ && patch < /home/gpsbabel/gpsbabel_1_5_2.patch \
+ && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabelfe /usr/local/bin 
+
+#ENTRYPOINT ["/usr/local/bin/gpsbabel"]
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.2
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.2
@@ -66,6 +66,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && git checkout gpsbabel_1_5_2 \
  && cd gpsbabel \
  && patch < /home/gpsbabel/gpsbabel_1_5_2.patch \
+ && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
  && rm $(pwd)/gui/GPSBabel1.5.2.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabel /usr/local/bin \

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.3
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.3
@@ -66,6 +66,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && git checkout gpsbabel_1_5_3 \
  && patch < /home/gpsbabel/gpsbabel_1_5_4.patch \
  && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && rm $(pwd)/gui/GPSBabel1.5.3.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.3
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.3
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
-    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -64,10 +63,9 @@ COPY gpsbabel_1_5_3.patch /home/gpsbabel
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_3 \
- && patch < /home/gpsbabel/gpsbabel_1_5_3.patch \
+ && git apply /home/gpsbabel/gpsbabel_1_5_3.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && rm $(pwd)/gui/GPSBabel1.5.3.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.3
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.3
@@ -1,0 +1,72 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+    patch \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    libqt5webkit5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+COPY gpsbabel_1_5_4.patch /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_5_3 \
+ && patch < /home/gpsbabel/gpsbabel_1_5_4.patch \
+ && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.3
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.3
@@ -59,13 +59,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /home/gpsbabel
 
-COPY gpsbabel_1_5_4.patch /home/gpsbabel
+COPY gpsbabel_1_5_3.patch /home/gpsbabel
 
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_3 \
- && patch < /home/gpsbabel/gpsbabel_1_5_4.patch \
- && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && patch < /home/gpsbabel/gpsbabel_1_5_3.patch \
+ && rm -fr zlib \
+ && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
  && rm $(pwd)/gui/GPSBabel1.5.3.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabelfe /usr/local/bin 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.4
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.4
@@ -1,0 +1,72 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+    patch \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    qtwebengine5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+COPY gpsbabel_1_5_4.patch /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_5_4 \
+ && patch < /home/gpsbabel/gpsbabel_1_5_4.patch \
+ && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.4
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.4
@@ -66,6 +66,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && git checkout gpsbabel_1_5_4 \
  && patch < /home/gpsbabel/gpsbabel_1_5_4.patch \
  && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && rm $(pwd)/gui/GPSBabel1.5.4.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.4
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.4
@@ -65,7 +65,8 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_4 \
  && patch < /home/gpsbabel/gpsbabel_1_5_4.patch \
- && ./configure --with-zlib=system && make -j 10 linux-gui \
+ && rm -fr zlib \
+ && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
  && rm $(pwd)/gui/GPSBabel1.5.4.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabelfe /usr/local/bin 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.4
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.4
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
-    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -64,10 +63,9 @@ COPY gpsbabel_1_5_4.patch /home/gpsbabel
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_5_4 \
- && patch < /home/gpsbabel/gpsbabel_1_5_4.patch \
+ && git apply /home/gpsbabel/gpsbabel_1_5_4.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && rm $(pwd)/gui/GPSBabel1.5.4.tar.bz2 \
  && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.6.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.6.0
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
+    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -58,9 +59,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /home/gpsbabel
 
+COPY gpsbabel_1_6_0.patch /home/gpsbabel
+
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_6_0.1 \
+ && patch < /home/gpsbabel/gpsbabel_1_6_0.patch \
+ && rm -fr zlib \
  && ./configure --with-zlib=system && make -j 10 linux-gui && make check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.6.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.6.0
@@ -1,0 +1,68 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    qtwebengine5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_6_0.1 \
+ && ./configure --with-zlib=system && make -j 10 linux-gui && make check \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.7.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.7.0
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
+    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -58,9 +59,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /home/gpsbabel
 
+COPY gpsbabel_1_7_0.patch /home/gpsbabel
+
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_7_0 \
+ && patch < /home/gpsbabel/gpsbabel_1_7_0.patch \
+ && rm -fr zlib \
  && ./configure --with-zlib=system && make -j 10 linux-gui && make check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.7.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.7.0
@@ -1,0 +1,68 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-1.0-0-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt5-default \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    qtwebengine5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_7_0 \
+ && ./configure --with-zlib=system && make -j 10 linux-gui && make check \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.7.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.7.0
@@ -1,6 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 LABEL maintainer="https://github.com/tsteven4"
 
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # pkgs with qt used by gpsbabel
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    qt5-default \
+    qtbase5-dev \
     qttools5-dev \
     qttools5-dev-tools \
     qttranslations5-l10n \

--- a/tools/archive_images/Dockerfile_gpsbabel_1.8.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.8.0
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-1.0-0-dev \
     pkg-config \
     libudev-dev \
+    libshp-dev \
     zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
@@ -62,8 +63,9 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_8_0 \
  && rm -fr zlib \
+ && rm -fr shapelib \
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
- && qmake WITH_ZLIB=pkgconfig && make -j 10 unix-gui && make check \
+ && qmake WITH_ZLIB=pkgconfig WITH_SHAPELIB=pkgconfig && make -j 10 unix-gui && make check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
 

--- a/tools/archive_images/Dockerfile_gpsbabel_1.8.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.8.0
@@ -61,6 +61,7 @@ WORKDIR /home/gpsbabel
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_8_0 \
+ && rm -fr zlib \
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
  && qmake WITH_ZLIB=pkgconfig && make -j 10 unix-gui && make check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \

--- a/tools/archive_images/Dockerfile_gpsbabel_1.8.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.8.0
@@ -1,0 +1,69 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:jammy
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    autoconf \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-1.0-0-dev \
+    pkg-config \
+    libudev-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qtbase5-dev \
+    qttools5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    qtwebengine5-dev \
+    libqt5serialport5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_8_0 \
+ && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
+ && qmake WITH_ZLIB=pkgconfig && make -j 10 unix-gui && make check \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.9.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.9.0
@@ -1,0 +1,82 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:jammy
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-1.0-0-dev \
+    pkg-config \
+    libudev-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt6-base-dev \
+    libqt6core5compat6-dev \
+    libqt6opengl6-dev \
+    libqt6serialport6-dev \
+    libqt6webenginecore6-bin \
+    libgl-dev \
+    libopengl-dev \
+    libvulkan-dev \
+    libx11-xcb-dev \
+    libxkbcommon-dev \
+    qt6-l10n-tools \
+    qt6-tools-dev \
+    qt6-tools-dev-tools \
+    qt6-translations-l10n \
+    qt6-webengine-dev \
+    qt6-webengine-dev-tools \
+    qt6-wayland \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+    tzdata \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git checkout gpsbabel_1_9_0 \
+ && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
+ && mkdir bld \
+ && cd bld \
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 .. \
+ && cmake --build . --target package_app \
+ && cmake --build . --target check \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/Dockerfile_gpsbabel_1.9.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.9.0
@@ -33,6 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-1.0-0-dev \
     pkg-config \
     libudev-dev \
+    libshp-dev \
+    zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with qt used by gpsbabel
@@ -70,10 +72,12 @@ WORKDIR /home/gpsbabel
 RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && cd gpsbabel-build \
  && git checkout gpsbabel_1_9_0 \
+ && rm -fr zlib \
+ && rm -fr shapelib \
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
  && mkdir bld \
  && cd bld \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 .. \
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig .. \
  && cmake --build . --target package_app \
  && cmake --build . --target check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \

--- a/tools/archive_images/Dockerfile_gpsbabel_dev
+++ b/tools/archive_images/Dockerfile_gpsbabel_dev
@@ -1,0 +1,81 @@
+# this file is used to build the image gpsbabel_build_environment used by travis.
+
+FROM ubuntu:noble
+
+LABEL maintainer="https://github.com/tsteven4"
+
+WORKDIR /app
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# install packages needed for gpsbabel build
+# split into multiple commands to limit layer size
+
+# basic build and test tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    git \
+    expat \
+    libxml2-utils \
+    cmake \
+    ninja-build \
+    curl \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with libraries needed by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-1.0-0-dev \
+    pkg-config \
+    libudev-dev \
+    libshp-dev \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# pkgs with qt used by gpsbabel
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qt6-base-dev \
+    qt6-5compat-dev \
+    qt6-serialport-dev \
+    libx11-xcb-dev \
+    libxkbcommon-dev \
+    qt6-tools-dev \
+    qt6-translations-l10n \
+    qt6-webengine-dev \
+    qt6-wayland \
+ && rm -rf /var/lib/apt/lists/*
+
+# install environment for locale test
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+    tzdata \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/^# *\(en_US ISO-8859-1\)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && locale -a
+
+WORKDIR /home/gpsbabel
+
+COPY gpsbabel_dev.patch /home/gpsbabel
+
+RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
+ && cd gpsbabel-build \
+ && git apply /home/gpsbabel/gpsbabel_dev.patch \
+ && rm -fr zlib \
+ && rm -fr shapelib \
+ && rm -f testo.d/serialization.test \
+ && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
+ && mkdir bld \
+ && cd bld \
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGB.PACKAGE_RELEASE="+$(git log -1 --format=%h)" .. \
+ && cmake --build . --target package_app \
+ && cmake --build . --target check \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+
+COPY setup_user.sh /usr/local/bin

--- a/tools/archive_images/gpsbabel_1_5_0.patch
+++ b/tools/archive_images/gpsbabel_1_5_0.patch
@@ -1,203 +1,205 @@
 diff --git a/gpsbabel/Makefile.in b/gpsbabel/Makefile.in
-index c767fe22..4a24be80 100644
+index f9f7cf66..877c8dd3 100644
 --- a/gpsbabel/Makefile.in
 +++ b/gpsbabel/Makefile.in
-@@ -421,93 +421,93 @@ cov-upload: FORCE
+@@ -426,30 +426,30 @@ cov-upload: FORCE
  	cov-upload
  
  # Machine generated from here down. 
 -alan.o: alan.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +alan.o: alan.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -an1.o: an1.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +an1.o: an1.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h an1sym.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h an1sym.h
 -arcdist.o: arcdist.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +arcdist.o: arcdist.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h \
-   grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
 -bcr.o: bcr.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +bcr.o: bcr.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h csv_util.h \
-   garmin_tables.h cet_util.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
+   garmin_tables.h
 -bend.o: bend.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +bend.o: bend.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h filterdefs.h grtcirc.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h filterdefs.h \
+   grtcirc.h
 -brauniger_iq.o: brauniger_iq.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +brauniger_iq.o: brauniger_iq.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   gbser.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h
 -bushnell.o: bushnell.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +bushnell.o: bushnell.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -bushnell_trl.o: bushnell_trl.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--cet.o: cet.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +bushnell_trl.o: bushnell_trl.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-cet.o: cet.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +cet.o: cet.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -cet_util.o: cet_util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +cet_util.o: cet_util.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
-   cet/ansi_x3_4_1968.h cet/cp1252.h cet/iso_8859_8.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   cet/ansi_x3_4_1968.h cet/iso_8859_1.h cet/iso_8859_8.h \
+   cet/iso_8859_15.h cet/cp1252.h cet/cp1255.h cet/iso_8859_2.h \
+@@ -461,67 +461,67 @@ cet_util.o: cet_util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
+   cet/iso_8859_13.h cet/iso_8859_14.h cet/iso_8859_3.h cet/iso_8859_4.h \
+   cet/iso_8859_5.h cet/iso_8859_6.h cet/iso_8859_7.h cet/iso_8859_9.h \
+   cet/koi8_r.h cet/koi8_ru.h cet/koi_8.h
 -compegps.o: compegps.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +compegps.o: compegps.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
 -cst.o: cst.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +cst.o: cst.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h strptime.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h strptime.h
 -csv_util.o: csv_util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +csv_util.o: csv_util.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
-   csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   grtcirc.h src/core/logging.h strptime.h xcsv_tokens.gperf
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h grtcirc.h strptime.h jeeps/gpsmath.h jeeps/gpsport.h \
+   garmin_fs.h jeeps/gps.h jeeps/gpsdevice.h jeeps/gpssend.h \
+   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   jeeps/gpsinput.h jeeps/gpsproj.h xcsv_tokens.gperf
 -delbin.o: delbin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +delbin.o: delbin.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    src/core/xmltag.h
 -delgpl.o: delgpl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +delgpl.o: delgpl.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -destinator.o: destinator.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +destinator.o: destinator.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   cet_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   strptime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h strptime.h
 -dg-100.o: dg-100.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +dg-100.o: dg-100.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h gbser.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h
 -discard.o: discard.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +discard.o: discard.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
 -dmtlog.o: dmtlog.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +dmtlog.o: dmtlog.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h xmlgeneric.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h xmlgeneric.h
 -duplicate.o: duplicate.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +duplicate.o: duplicate.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   filterdefs.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
 -easygps.o: easygps.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +easygps.o: easygps.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
--energympro.o: energympro.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -enigma.o: enigma.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
-+energympro.o: energympro.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
 +enigma.o: enigma.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -exif.o: exif.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +exif.o: exif.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h garmin_tables.h \
-   jeeps/gpsmath.h jeeps/gpsport.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
 -explorist_ini.o: explorist_ini.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +explorist_ini.o: explorist_ini.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   explorist_ini.h
--f90g_track.o: f90g_track.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h explorist_ini.h
 -fatal.o: fatal.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
-+f90g_track.o: f90g_track.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
 +fatal.o: fatal.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -filter_vecs.o: filter_vecs.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +filter_vecs.o: filter_vecs.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   filterdefs.h gbversion.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h gbversion.h
 -formspec.o: formspec.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +formspec.o: formspec.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -g7towin.o: g7towin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +g7towin.o: g7towin.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h csv_util.h \
-   cet_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
    jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
    jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
    jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
    garmin_tables.h strptime.h
 -garmin.o: garmin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +garmin.o: garmin.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    grtcirc.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
    jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-@@ -515,82 +515,82 @@ garmin.o: garmin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
+@@ -529,165 +529,165 @@ garmin.o: garmin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
    jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/gpsserial.h garmin_tables.h garmin_fs.h garmin_device_xml.h
+   garmin_tables.h garmin_fs.h garmin_device_xml.h
  garmin_device_xml.o: garmin_device_xml.cc defs.h config.h queue.h \
--  zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+    gbfile.h cet.h inifile.h session.h \
+-  zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++    gbfile.h cet.h cet_util.h inifile.h session.h \
    src/core/datetime.h xmlgeneric.h garmin_device_xml.h
 -garmin_fit.o: garmin_fit.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--garmin_fs.o: garmin_fs.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +garmin_fit.o: garmin_fit.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-garmin_fs.o: garmin_fs.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +garmin_fs.o: garmin_fs.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   cet_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   garmin_tables.h
--garmin_gpi.o: garmin_gpi.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-+garmin_gpi.o: garmin_gpi.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   cet_util.h jeeps/gpsmath.h jeeps/gpsport.h garmin_fs.h jeeps/gps.h \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h \
    jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
    jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   garmin_gpi.h
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h garmin_tables.h
+-garmin_gpi.o: garmin_gpi.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++garmin_gpi.o: garmin_gpi.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h jeeps/gpsmath.h jeeps/gpsport.h garmin_fs.h \
+   jeeps/gps.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h garmin_gpi.h
  garmin_tables.o: garmin_tables.cc garmin_tables.h defs.h config.h queue.h \
--  zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+    gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h src/core/logging.h jeeps/gpsmath.h jeeps/gpsport.h
+-  zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++    gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h jeeps/gpsmath.h jeeps/gpsport.h
 -garmin_txt.o: garmin_txt.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +garmin_txt.o: garmin_txt.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   cet_util.h csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h \
    jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
    jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
    jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
    jeeps/gpsproj.h garmin_tables.h grtcirc.h strptime.h
 -garmin_xt.o: garmin_xt.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--gbfile.o: gbfile.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +garmin_xt.o: garmin_xt.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-gbfile.o: gbfile.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gbfile.o: gbfile.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   src/core/logging.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -gbser.o: gbser.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gbser.o: gbser.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h gbser.h \
-   gbser_private.h
--gbser_posix.o: gbser_posix.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-+gbser_posix.o: gbser_posix.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    gbser.h gbser_private.h
+-gbser_posix.o: gbser_posix.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++gbser_posix.o: gbser_posix.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h gbser_private.h
  gbsleep.o: gbsleep.cc config.h
 -gdb.o: gdb.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +gdb.o: gdb.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h csv_util.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
    garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
    jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
    jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
@@ -205,517 +207,533 @@ index c767fe22..4a24be80 100644
    garmin_tables.h grtcirc.h
 -geo.o: geo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +geo.o: geo.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h src/core/file.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   src/core/file.h
 -ggv_log.o: ggv_log.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +ggv_log.o: ggv_log.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h grtcirc.h \
-   jeeps/gpsmath.h jeeps/gpsport.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h jeeps/gpsmath.h jeeps/gpsport.h
 -ggv_ovl.o: ggv_ovl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +ggv_ovl.o: ggv_ovl.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    grtcirc.h
 -globals.o: globals.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +globals.o: globals.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h gbversion.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbversion.h
 -glogbook.o: glogbook.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +glogbook.o: glogbook.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
-   src/core/file.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h src/core/file.h
 -gnav_trl.o: gnav_trl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gnav_trl.o: gnav_trl.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -google.o: google.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +google.o: google.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
--googledir.o: googledir.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-+googledir.o: googledir.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    xmlgeneric.h
+-googledir.o: googledir.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++googledir.o: googledir.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h xmlgeneric.h
 -gopal.o: gopal.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gopal.o: gopal.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    csv_util.h strptime.h jeeps/gpsmath.h jeeps/gpsport.h grtcirc.h
 -gpssim.o: gpssim.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gpssim.o: gpssim.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -gpsutil.o: gpsutil.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gpsutil.o: gpsutil.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    magellan.h
 -gpx.o: gpx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +gpx.o: gpx.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h garmin_fs.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h garmin_fs.h \
    jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
    jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-@@ -598,79 +598,79 @@ gpx.o: gpx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h garmin_tables.h \
-   src/core/logging.h src/core/file.h src/core/xmlstreamwriter.h \
-   src/core/xmltag.h
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h src/core/file.h \
+   src/core/xmlstreamwriter.h src/core/xmltag.h
 -grtcirc.o: grtcirc.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +grtcirc.o: grtcirc.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
 -gtm.o: gtm.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +gtm.o: gtm.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
 -gtrnctr.o: gtrnctr.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gtrnctr.o: gtrnctr.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
 -height.o: height.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +height.o: height.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h \
-   height.h
--hiketech.o: hiketech.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
-+hiketech.o: hiketech.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
-   src/core/xmlstreamwriter.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h height.h
+ hiketech.o: hiketech.cc src/core/xmlstreamwriter.h defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h xmlgeneric.h
 -holux.o: holux.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +holux.o: holux.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h holux.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   holux.h
 -html.o: html.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +html.o: html.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h src/core/xmltag.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
 -humminbird.o: humminbird.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--igc.o: igc.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +humminbird.o: humminbird.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-igc.o: igc.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +igc.o: igc.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -ignrando.o: ignrando.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +ignrando.o: ignrando.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
 -igo8.o: igo8.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +igo8.o: igo8.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -ik3d.o: ik3d.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +ik3d.o: ik3d.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h
 -inifile.o: inifile.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +inifile.o: inifile.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -internal_styles.o: internal_styles.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--interpolate.o: interpolate.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +internal_styles.o: internal_styles.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-interpolate.o: interpolate.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +interpolate.o: interpolate.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   filterdefs.h grtcirc.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h grtcirc.h
 -itracku.o: itracku.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +itracku.o: itracku.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h gbser.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h
  jeeps/gpsapp.o: jeeps/gpsapp.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h jeeps/garminusb.h \
-   jeeps/gpsusbint.h jeeps/gpsserial.h
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/garminusb.h jeeps/gpsusbint.h
  jeeps/gpscom.o: jeeps/gpscom.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
  jeeps/gpsdevice.o: jeeps/gpsdevice.cc jeeps/gps.h jeeps/../defs.h \
--  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h \
-+  config.h queue.h   gbfile.h cet.h inifile.h \
-   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/gpsserial.h
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/gpsserial.h
  jeeps/gpsdevice_ser.o: jeeps/gpsdevice_ser.cc jeeps/gps.h jeeps/../defs.h \
--  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h \
-+  config.h queue.h   gbfile.h cet.h inifile.h \
-   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/gpsserial.h
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/gpsserial.h
  jeeps/gpsdevice_usb.o: jeeps/gpsdevice_usb.cc jeeps/gps.h jeeps/../defs.h \
--  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h \
-+  config.h queue.h   gbfile.h cet.h inifile.h \
-   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/garminusb.h jeeps/gpsusbint.h jeeps/gpsusbcommon.h
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+@@ -695,7 +695,7 @@ jeeps/gpsdevice_usb.o: jeeps/gpsdevice_usb.cc jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbint.h \
+   jeeps/gpsusbcommon.h
  jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
 -  jeeps/gps.h jeeps/../defs.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +  jeeps/gps.h jeeps/../defs.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+@@ -703,93 +703,93 @@ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
+   jeeps/gpsinput.h jeeps/gpsproj.h jeeps/garminusb.h \
+   jeeps/gpsusbcommon.h jeeps/../garmin_device_xml.h
+ jeeps/gpsmath.o: jeeps/gpsmath.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/gpsdatum.h
+ jeeps/gpsmem.o: jeeps/gpsmem.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+ jeeps/gpsprot.o: jeeps/gpsprot.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+ jeeps/gpsread.o: jeeps/gpsread.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/gpsserial.h
+ jeeps/gpsrqst.o: jeeps/gpsrqst.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+ jeeps/gpssend.o: jeeps/gpssend.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/gpsserial.h
+ jeeps/gpsserial.o: jeeps/gpsserial.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
    jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
    jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
-@@ -678,89 +678,89 @@ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
-   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbcommon.h \
-   jeeps/../garmin_device_xml.h
- jeeps/gpsmath.o: jeeps/gpsmath.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h jeeps/gpsdatum.h
- jeeps/gpsmem.o: jeeps/gpsmem.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
- jeeps/gpsprot.o: jeeps/gpsprot.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
- jeeps/gpsread.o: jeeps/gpsread.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h jeeps/gpsserial.h
- jeeps/gpsrqst.o: jeeps/gpsrqst.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
- jeeps/gpssend.o: jeeps/gpssend.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h jeeps/gpsserial.h
- jeeps/gpsserial.o: jeeps/gpsserial.cc jeeps/gps.h jeeps/../defs.h \
--  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h \
-+  config.h queue.h   gbfile.h cet.h inifile.h \
-   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/gpsserial.h jeeps/../gbser.h gbser_posix.h
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/gpsserial.h jeeps/../gbser.h
  jeeps/gpsusbcommon.o: jeeps/gpsusbcommon.cc jeeps/gps.h jeeps/../defs.h \
--  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h \
-+  config.h queue.h   gbfile.h cet.h inifile.h \
-   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/garminusb.h jeeps/gpsusbcommon.h
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbcommon.h
  jeeps/gpsusbread.o: jeeps/gpsusbread.cc jeeps/gps.h jeeps/../defs.h \
--  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h \
-+  config.h queue.h   gbfile.h cet.h inifile.h \
-   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
-   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/garminusb.h jeeps/gpsusbint.h
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbint.h
  jeeps/gpsusbsend.o: jeeps/gpsusbsend.cc jeeps/gps.h jeeps/../defs.h \
--  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h \
-+  config.h queue.h   gbfile.h cet.h inifile.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbint.h
+ jeeps/jgpsutil.o: jeeps/jgpsutil.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
    session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
    jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
    jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   jeeps/garminusb.h jeeps/gpsusbint.h
- jeeps/jgpsutil.o: jeeps/jgpsutil.cc jeeps/gps.h jeeps/../defs.h config.h \
--  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h inifile.h session.h \
-+  queue.h   gbfile.h cet.h inifile.h session.h \
-   src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
 -jogmap.o: jogmap.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +jogmap.o: jogmap.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h garmin_tables.h \
-   jeeps/gpsmath.h jeeps/gpsport.h xmlgeneric.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h jeeps/gpsmath.h jeeps/gpsport.h garmin_tables.h
 -jtr.o: jtr.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +jtr.o: jtr.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h csv_util.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h
 -kml.o: kml.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +kml.o: kml.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h grtcirc.h \
-   src/core/file.h src/core/xmlstreamwriter.h src/core/xmltag.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
+   grtcirc.h src/core/file.h src/core/xmlstreamwriter.h src/core/xmltag.h
 -lmx.o: lmx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +lmx.o: lmx.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h
 -lowranceusr.o: lowranceusr.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--lowranceusr4.o: lowranceusr4.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +lowranceusr.o: lowranceusr.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-lowranceusr4.o: lowranceusr4.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +lowranceusr4.o: lowranceusr4.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
  mac/libusb/darwin.o: mac/libusb/darwin.c config.h mac/libusb/usbi.h \
    mac/libusb/usb.h mac/libusb/error.h
- mac/libusb/descriptors.o: mac/libusb/descriptors.c mac/libusb/usbi.h \
-@@ -769,261 +769,233 @@ mac/libusb/error.o: mac/libusb/error.c mac/libusb/usb.h \
+@@ -799,271 +799,243 @@ mac/libusb/error.o: mac/libusb/error.c mac/libusb/usb.h \
    mac/libusb/error.h
  mac/libusb/usb.o: mac/libusb/usb.c mac/libusb/usbi.h mac/libusb/usb.h \
    mac/libusb/error.h
 -maggeo.o: maggeo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +maggeo.o: maggeo.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h csv_util.h \
-   xmlgeneric.h magellan.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h xmlgeneric.h magellan.h
 -magproto.o: magproto.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +magproto.o: magproto.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h magellan.h \
-   gbser.h explorist_ini.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   magellan.h gbser.h explorist_ini.h
 -main.o: main.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +main.o: main.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h filterdefs.h cet_util.h \
-   csv_util.h src/core/usasciicodec.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h filterdefs.h \
+   csv_util.h
 -mapasia.o: mapasia.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +mapasia.o: mapasia.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -mapbar_track.o: mapbar_track.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--mapfactor.o: mapfactor.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +mapbar_track.o: mapbar_track.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
-+mapfactor.o: mapfactor.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   src/core/file.h src/core/xmlstreamwriter.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
 -mapsend.o: mapsend.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +mapsend.o: mapsend.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h mapsend.h \
-   magellan.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   mapsend.h magellan.h
 -mapsource.o: mapsource.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +mapsource.o: mapsource.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
 -mkshort.o: mkshort.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +mkshort.o: mkshort.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -mmo.o: mmo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +mmo.o: mmo.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -mtk_locus.o: mtk_locus.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +mtk_locus.o: mtk_locus.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   gbser.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h
 -mtk_logger.o: mtk_logger.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +mtk_logger.o: mtk_logger.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   gbser.h
--mynav.o: mynav.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
-+mynav.o: mynav.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h
 -navicache.o: navicache.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +navicache.o: navicache.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   cet_util.h src/core/file.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h src/core/file.h
 -naviguide.o: naviguide.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +naviguide.o: naviguide.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
 -navilink.o: navilink.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +navilink.o: navilink.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h gbser.h \
-   jeeps/gpsmath.h jeeps/gpsport.h navilink.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h jeeps/gpsmath.h jeeps/gpsport.h navilink.h
 -navitel.o: navitel.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +navitel.o: navitel.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
 -netstumbler.o: netstumbler.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +netstumbler.o: netstumbler.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   cet_util.h csv_util.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h
 -nmea.o: nmea.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +nmea.o: nmea.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h gbser.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h gbser.h \
    strptime.h jeeps/gpsmath.h jeeps/gpsport.h
 -nmn4.o: nmn4.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +nmn4.o: nmn4.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h csv_util.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h
 -nukedata.o: nukedata.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +nukedata.o: nukedata.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
 -osm.o: osm.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +osm.o: osm.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h
 -ozi.o: ozi.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +ozi.o: ozi.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h csv_util.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
    jeeps/gpsmath.h jeeps/gpsport.h
 -parse.o: parse.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +parse.o: parse.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h strptime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h strptime.h
 -pcx.o: pcx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +pcx.o: pcx.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h garmin_tables.h \
-   cet_util.h csv_util.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_tables.h csv_util.h
 -pocketfms_bc.o: pocketfms_bc.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--pocketfms_fp.o: pocketfms_fp.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +pocketfms_bc.o: pocketfms_bc.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-pocketfms_fp.o: pocketfms_fp.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +pocketfms_fp.o: pocketfms_fp.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   xmlgeneric.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h xmlgeneric.h
 -pocketfms_wp.o: pocketfms_wp.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +pocketfms_wp.o: pocketfms_wp.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   csv_util.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h
 -polygon.o: polygon.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +polygon.o: polygon.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
 -position.o: position.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +position.o: position.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h \
-   grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
 -psitrex.o: psitrex.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +psitrex.o: psitrex.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h garmin_tables.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_tables.h
  queue.o: queue.cc queue.h
 -radius.o: radius.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +radius.o: radius.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h \
-   grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
 -random.o: random.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +random.o: random.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h garmin_fs.h \
-   jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
-   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
-   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
 -raymarine.o: raymarine.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +raymarine.o: raymarine.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   cet_util.h csv_util.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h
 -reverse_route.o: reverse_route.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +reverse_route.o: reverse_route.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   filterdefs.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
 -rgbcolors.o: rgbcolors.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--route.o: route.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +rgbcolors.o: rgbcolors.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-route.o: route.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +route.o: route.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
 -saroute.o: saroute.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +saroute.o: saroute.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
 -sbn.o: sbn.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +sbn.o: sbn.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h navilink.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h navilink.h
 -sbp.o: sbp.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +sbp.o: sbp.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h navilink.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h navilink.h
 -session.o: session.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +session.o: session.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -shape.o: shape.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +shape.o: shape.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    shapelib/shapefil.h
  shapelib/dbfopen.o: shapelib/dbfopen.c shapelib/shapefil.h
  shapelib/safileio.o: shapelib/safileio.c shapelib/shapefil.h
  shapelib/shpopen.o: shapelib/shpopen.c shapelib/shapefil.h
 -skyforce.o: skyforce.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +skyforce.o: skyforce.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -skytraq.o: skytraq.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +skytraq.o: skytraq.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h gbser.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h
 -smplrout.o: smplrout.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +smplrout.o: smplrout.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h \
-   grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
 -sort.o: sort.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +sort.o: sort.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h filterdefs.h
- src/core/usasciicodec.o: src/core/usasciicodec.cc src/core/usasciicodec.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h filterdefs.h
  src/core/xmlstreamwriter.o: src/core/xmlstreamwriter.cc \
    src/core/xmlstreamwriter.h
 -stackfilter.o: stackfilter.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +stackfilter.o: stackfilter.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   filterdefs.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
 -stmsdf.o: stmsdf.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +stmsdf.o: stmsdf.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    csv_util.h strptime.h jeeps/gpsmath.h jeeps/gpsport.h grtcirc.h
 -stmwpp.o: stmwpp.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +stmwpp.o: stmwpp.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h csv_util.h \
-   cet_util.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h
  strptime.o: strptime.c config.h strptime.h
 -subrip.o: subrip.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +subrip.o: subrip.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -swapdata.o: swapdata.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +swapdata.o: swapdata.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
 -tef_xml.o: tef_xml.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +tef_xml.o: tef_xml.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
 -teletype.o: teletype.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +teletype.o: teletype.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -text.o: text.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +text.o: text.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h src/core/xmltag.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
 -tiger.o: tiger.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +tiger.o: tiger.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    csv_util.h
 -tmpro.o: tmpro.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +tmpro.o: tmpro.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    csv_util.h
 -tomtom.o: tomtom.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +tomtom.o: tomtom.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -tpg.o: tpg.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +tpg.o: tpg.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
 -tpo.o: tpo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +tpo.o: tpo.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
 -trackfilter.o: trackfilter.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +trackfilter.o: trackfilter.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   filterdefs.h grtcirc.h strptime.h xmlgeneric.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h strptime.h grtcirc.h xmlgeneric.h
 -transform.o: transform.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +transform.o: transform.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   filterdefs.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
 -unicsv.o: unicsv.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +unicsv.o: unicsv.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
    jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
    jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
@@ -723,77 +741,82 @@ index c767fe22..4a24be80 100644
    garmin_tables.h
 -units.o: units.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +units.o: units.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -util.o: util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +util.o: util.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h src/core/xmltag.h \
-   jeeps/gpsmath.h jeeps/gpsport.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   src/core/xmltag.h jeeps/gpsmath.h jeeps/gpsport.h
  util_crc.o: util_crc.cc
 -v900.o: v900.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +v900.o: v900.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -validate.o: validate.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +validate.o: validate.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h filterdefs.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
 -vcf.o: vcf.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +vcf.o: vcf.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h jeeps/gpsmath.h \
-   jeeps/gpsport.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
 -vecs.o: vecs.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +vecs.o: vecs.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h csv_util.h gbversion.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
+   gbversion.h
 -vidaone.o: vidaone.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +vidaone.o: vidaone.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -vitosmt.o: vitosmt.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +vitosmt.o: vitosmt.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
 -vitovtt.o: vitovtt.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +vitovtt.o: vitovtt.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -vpl.o: vpl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +vpl.o: vpl.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
 -waypt.o: waypt.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +waypt.o: waypt.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    grtcirc.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
    jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
    jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
-   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
-   src/core/logging.h
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
 -wbt-200.o: wbt-200.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +wbt-200.o: wbt-200.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h gbser.h \
-   grtcirc.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h grtcirc.h
 -wfff_xml.o: wfff_xml.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +wfff_xml.o: wfff_xml.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
 -wintec_tes.o: wintec_tes.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h
--xcsv.o: xcsv.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +wintec_tes.o: wintec_tes.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-xcsv.o: xcsv.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +xcsv.o: xcsv.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h cet_util.h csv_util.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
    jeeps/gpsmath.h jeeps/gpsport.h
  xhtmlent.o: xhtmlent.cc
 -xmlgeneric.o: xmlgeneric.cc defs.h config.h queue.h zlib/zlib.h \
--  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
 +xmlgeneric.o: xmlgeneric.cc defs.h config.h queue.h  \
-+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
-   xmlgeneric.h cet_util.h src/core/file.h
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h xmlgeneric.h src/core/file.h
 -xmltag.o: xmltag.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +xmltag.o: xmltag.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
    src/core/xmltag.h
 -xol.o: xol.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +xol.o: xol.cc defs.h config.h queue.h   gbfile.h \
-   cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
    jeeps/gpsmath.h jeeps/gpsport.h garmin_tables.h
 -yahoo.o: yahoo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +yahoo.o: yahoo.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
 -zlib/adler32.o: zlib/adler32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
 -  config.h
 -zlib/compress.o: zlib/compress.c zlib/zlib.h zlib/zconf.h config.h
@@ -825,26 +848,109 @@ index c767fe22..4a24be80 100644
  internal_styles.cc: mkstyle.sh $(srcdir)/style/*.style
  	$(srcdir)/mkstyle.sh > internal_styles.cc || (rm -f internal_styles.cc ; exit 1)
 diff --git a/gpsbabel/configure.in b/gpsbabel/configure.in
-index e10ee475..1aa48807 100644
+index db98f6db..567ac1f1 100644
 --- a/gpsbabel/configure.in
 +++ b/gpsbabel/configure.in
-@@ -325,13 +325,13 @@ case "$target" in
- 		}])],
- 		[AC_MSG_RESULT(no)],
- 		[OCXXFLAGS="$CXXFLAGS"
--		CXXFLAGS="$CXXFLAGS -fPIE"
+@@ -55,6 +55,7 @@ AC_ARG_WITH(cet,[  --with-cet=(default,all,minimal)],
+ 
+ if test $GCC = yes; then
+  CFLAGS="$CFLAGS -Wall"
++ CXXFLAGS="$CXXFLAGS -Wall"
+ fi
+ 
+ if test "$cet" = "all"; then
+@@ -156,15 +157,21 @@ AC_SUBST(RC)
+ # On RHEL/OEL/SL/CENTOS/FEDORA qmake is from Qt3, and qmake-qt4 is from Qt4.
+ # If qmake-qt4 isn't found look for the standard name qmake and assume it is
+ # from a useful version Qt.
+-AC_CHECK_TOOLS(QMAKE, [qmake-qt4 qmake], "no")
+-AC_CHECK_PROGS(LUPDATE, [lupdate-qt4 lupdate])
+-AC_CHECK_PROGS(LRELEASE, [lrelease-qt4 lrelease])
++AC_CHECK_TOOLS(QMAKE, [qmake-qt5 qmake-qt4 qmake], "no")
++AC_CHECK_TOOLS(LUPDATE, [lupdate-qt5 lupdate-qt4 lupdate])
++AC_CHECK_TOOLS(LRELEASE, [lrelease-qt5 lrelease-qt4 lrelease])
+ 
+ if test "$QMAKE" = no ; then
+-  AC_MSG_ERROR([Qt4 is required, but not found]);
++  AC_MSG_ERROR([Qt4 or Qt5 is required, but neither was found]);
+ fi
+ 
+-QT_LIBS="-L$($QMAKE -query QT_INSTALL_LIBS) -l QtCore"
++# guess the name of the Qt Core library.
++QT_LIBVER=$($QMAKE -query -query QT_VERSION | sed -e 's/\..*//')
++if test "$QT_LIBVER" -ge 5 ; then
++	QT_LIBS="-L$($QMAKE -query QT_INSTALL_LIBS) -lQt${QT_LIBVER}Core"
++else
++	QT_LIBS="-L$($QMAKE -query QT_INSTALL_LIBS) -lQtCore"
++fi
+ QT_INC=$($QMAKE -query QT_INSTALL_HEADERS)
+ QT_INC_OPT="-I"
+ QT_SYSINC_OPT="-isystem"
+@@ -222,6 +229,28 @@ case "$target" in
+       QT_INC_OPT="-F"
+       QT_SYSINC_OPT="-iframework"
+       ;;
++    *-*-freebsd*)
++	GBSER=gbser_posix.o
++	AC_MSG_CHECKING(for libusb)
++	if test "$with_libusb" = no ; then
++		AC_MSG_RESULT(check not done)
++		OSJEEPS=jeeps/gpsusbstub.o
++	else
++		OLDFLAGS=$LDFLAGS
++		OCFLAGS=$CFLAGS
++		LDFLAGS="$LDFLAGS -lusb"
++		CFLAGS="$OCFLAGS"
++
++		AC_CHECK_LIB([usb], [usb_interrupt_read],
++			AC_DEFINE(HAVE_LIBUSB, 1, [Defined if you have libusb])
++			[USB_CFLAGS=""]
++			[USB_LIBS="-lusb"]
++#			,[AC_MSG_ERROR([libusb is needed])]
++			)
++		OSJEEPS=jeeps/gpslibusb.o
++		CFLAGS="$OCFLAGS"
++	fi
++	;;
+     *)
+ 	GBSER=gbser_posix.o
+ 	AC_MSG_CHECKING(for libusb)
+@@ -283,6 +312,34 @@ case "$target" in
+ 	;;
+ esac
+ 
++case "$target" in
++	*-*-darwin*)
++	;;
++	*)
++	AC_MSG_CHECKING(for reduce relocations)
++	OCPPFLAGS="$CPPFLAGS"
++	CPPFLAGS="$CPPFLAGS -I$QT_INC"
++	AC_COMPILE_IFELSE([AC_LANG_SOURCE([
++		#include <QtCore/QString>
++		void f(void) {
++		}])],
++		[AC_MSG_RESULT(no)],
++		[OCXXFLAGS="$CXXFLAGS"
 +		CXXFLAGS="$CXXFLAGS -fPIC"
- 		AC_COMPILE_IFELSE([AC_LANG_SOURCE([
- 			#include <QtCore/QString>
- 			void f(void) {
- 			}])],
- 			[AC_MSG_RESULT(yes)
--			CFLAGS="$CFLAGS -fPIE"],
++		AC_COMPILE_IFELSE([AC_LANG_SOURCE([
++			#include <QtCore/QString>
++			void f(void) {
++			}])],
++			[AC_MSG_RESULT(yes)
 +			CFLAGS="$CFLAGS -fPIC"],
- 			[AC_MSG_RESULT(unknown)
- 			CXXFLAGS="$OCXXFLAGS"]
- 			)]
-@@ -397,7 +397,7 @@ AC_SUBST(QT_INC_OPT)
++			[AC_MSG_RESULT(unknown)
++			CXXFLAGS="$OCXXFLAGS"]
++			)]
++		)
++	CPPFLAGS="$OCPPFLAGS"
++	;;
++esac
++
+ AC_MSG_CHECKING(for random stuff to make you feel better)
+ AC_MSG_RESULT(failed)
+ 
+@@ -386,7 +443,7 @@ AC_SUBST(QT_INC_OPT)
  AC_SUBST(QT_SYSINC_OPT)
  AC_SUBST(QT_LIBS)
  
@@ -853,6 +959,18 @@ index e10ee475..1aa48807 100644
  AC_CONFIG_FILES([gui/makelinuxdist.sh], [chmod +x gui/makelinuxdist.sh])
  AC_OUTPUT
  
+diff --git a/gpsbabel/gbfile.cc b/gpsbabel/gbfile.cc
+index 1b5d3f54..8134e074 100644
+--- a/gpsbabel/gbfile.cc
++++ b/gpsbabel/gbfile.cc
+@@ -21,7 +21,6 @@
+  */
+ 
+ #include "defs.h"
+-#include "zlib/zconf.h"
+ #include "gbfile.h"
+ 
+ #include <assert.h>
 diff --git a/gpsbabel/tef_xml.cc b/gpsbabel/tef_xml.cc
 index c8a64f8d..134eaa17 100644
 --- a/gpsbabel/tef_xml.cc

--- a/tools/archive_images/gpsbabel_1_5_0.patch
+++ b/tools/archive_images/gpsbabel_1_5_0.patch
@@ -971,6 +971,63 @@ index 1b5d3f54..8134e074 100644
  #include "gbfile.h"
  
  #include <assert.h>
+diff --git a/gpsbabel/gui/makelinuxdist.sh.in b/gpsbabel/gui/makelinuxdist.sh.in
+index 72707f7a..8176d457 100644
+--- a/gpsbabel/gui/makelinuxdist.sh.in
++++ b/gpsbabel/gui/makelinuxdist.sh.in
+@@ -7,32 +7,9 @@ DISTNAME=GPSBabel@PACKAGE_VERSION@@PACKAGE_RELEASE@
+ DISTDIR=$DISTNAME
+ rm -rf $DISTDIR
+ mkdir $DISTDIR
+-mkdir $DISTDIR/plugins
+ mkdir $DISTDIR/translations
+ mkdir $DISTDIR/help
+ 
+-QT_LIBS=`ldd objects/gpsbabelfe-bin | grep libQt | awk '{print $3}'`
+-for lib in $QT_LIBS
+-do
+-	cp $lib $DISTDIR
+-done
+-#cp `ldd objects/gpsbabelfe-bin  | grep libphonon |awk '{print $3}'` $DISTDIR
+-#cp `ldd objects/gpsbabelfe-bin  | grep libaudio   |awk '{print $3}'` $DISTDIR
+-
+-cp -r $QT_INSTALL_PLUGINS/imageformats $DISTDIR/plugins
+-if [ -e $QT_INSTALL_PLUGINS/codecs ]
+-then
+-  cp -r $QT_INSTALL_PLUGINS/codecs $DISTDIR/plugins
+-else
+-  echo "Warning: $QT_INSTALL_PLUGINS/codecs not found, perhaps this is normal for Qt5"
+-fi
+-if [ -e $QT_INSTALL_PLUGINS/platforms ]
+-then
+-#  we need at least platforms/libqxcb.so
+-  cp -r $QT_INSTALL_PLUGINS/platforms $DISTDIR/plugins
+-else
+-  echo "Wanring: $QT_INSTALL_PLUGINS/platforms not found, this is normal for Qt4"
+-fi
+ cp $QT_INSTALL_TRANSLATIONS/qt_*.qm $DISTDIR/translations/
+ 
+ # copy the compiled translations
+@@ -40,10 +17,7 @@ cp *.qm $DISTDIR/translations
+ 
+ # Now our gui
+ cp gmapbase.html $DISTDIR/
+-cp gpsbabelfe $DISTDIR/
+-chmod +x $DISTDIR/gpsbabelfe
+-cp objects/gpsbabelfe-bin $DISTDIR
+-cp qt.conf $DISTDIR/
++cp objects/gpsbabelfe-bin $DISTDIR/gpsbabelfe
+ cp ../gpsbabel $DISTDIR/
+ #
+ cp -r help/*.html $DISTDIR/help
+@@ -53,7 +27,3 @@ cp ../COPYING $DISTDIR/
+ cp ../README* $DISTDIR/
+ 
+ 
+-rm -f $DISTDIR.tar $DISTDIR.tar.bz2
+-tar cvf $DISTDIR.tar $DISTDIR
+-bzip2 $DISTDIR.tar
+-
 diff --git a/gpsbabel/tef_xml.cc b/gpsbabel/tef_xml.cc
 index c8a64f8d..134eaa17 100644
 --- a/gpsbabel/tef_xml.cc

--- a/tools/archive_images/gpsbabel_1_5_1.patch
+++ b/tools/archive_images/gpsbabel_1_5_1.patch
@@ -959,6 +959,63 @@ index 44b4c93b..bd622313 100644
  AC_CONFIG_FILES([gui/makelinuxdist.sh], [chmod +x gui/makelinuxdist.sh])
  AC_OUTPUT
  
+diff --git a/gpsbabel/gui/makelinuxdist.sh.in b/gpsbabel/gui/makelinuxdist.sh.in
+index 72707f7a..8176d457 100644
+--- a/gpsbabel/gui/makelinuxdist.sh.in
++++ b/gpsbabel/gui/makelinuxdist.sh.in
+@@ -7,32 +7,9 @@ DISTNAME=GPSBabel@PACKAGE_VERSION@@PACKAGE_RELEASE@
+ DISTDIR=$DISTNAME
+ rm -rf $DISTDIR
+ mkdir $DISTDIR
+-mkdir $DISTDIR/plugins
+ mkdir $DISTDIR/translations
+ mkdir $DISTDIR/help
+ 
+-QT_LIBS=`ldd objects/gpsbabelfe-bin | grep libQt | awk '{print $3}'`
+-for lib in $QT_LIBS
+-do
+-	cp $lib $DISTDIR
+-done
+-#cp `ldd objects/gpsbabelfe-bin  | grep libphonon |awk '{print $3}'` $DISTDIR
+-#cp `ldd objects/gpsbabelfe-bin  | grep libaudio   |awk '{print $3}'` $DISTDIR
+-
+-cp -r $QT_INSTALL_PLUGINS/imageformats $DISTDIR/plugins
+-if [ -e $QT_INSTALL_PLUGINS/codecs ]
+-then
+-  cp -r $QT_INSTALL_PLUGINS/codecs $DISTDIR/plugins
+-else
+-  echo "Warning: $QT_INSTALL_PLUGINS/codecs not found, perhaps this is normal for Qt5"
+-fi
+-if [ -e $QT_INSTALL_PLUGINS/platforms ]
+-then
+-#  we need at least platforms/libqxcb.so
+-  cp -r $QT_INSTALL_PLUGINS/platforms $DISTDIR/plugins
+-else
+-  echo "Wanring: $QT_INSTALL_PLUGINS/platforms not found, this is normal for Qt4"
+-fi
+ cp $QT_INSTALL_TRANSLATIONS/qt_*.qm $DISTDIR/translations/
+ 
+ # copy the compiled translations
+@@ -40,10 +17,7 @@ cp *.qm $DISTDIR/translations
+ 
+ # Now our gui
+ cp gmapbase.html $DISTDIR/
+-cp gpsbabelfe $DISTDIR/
+-chmod +x $DISTDIR/gpsbabelfe
+-cp objects/gpsbabelfe-bin $DISTDIR
+-cp qt.conf $DISTDIR/
++cp objects/gpsbabelfe-bin $DISTDIR/gpsbabelfe
+ cp ../gpsbabel $DISTDIR/
+ #
+ cp -r help/*.html $DISTDIR/help
+@@ -53,7 +27,3 @@ cp ../COPYING $DISTDIR/
+ cp ../README* $DISTDIR/
+ 
+ 
+-rm -f $DISTDIR.tar $DISTDIR.tar.bz2
+-tar cvf $DISTDIR.tar $DISTDIR
+-bzip2 $DISTDIR.tar
+-
 diff --git a/gpsbabel/tef_xml.cc b/gpsbabel/tef_xml.cc
 index c8a64f8d..134eaa17 100644
 --- a/gpsbabel/tef_xml.cc

--- a/tools/archive_images/gpsbabel_1_5_1.patch
+++ b/tools/archive_images/gpsbabel_1_5_1.patch
@@ -1,5 +1,854 @@
+diff --git a/gpsbabel/Makefile.in b/gpsbabel/Makefile.in
+index fab6dd8d..2e13bef1 100644
+--- a/gpsbabel/Makefile.in
++++ b/gpsbabel/Makefile.in
+@@ -419,30 +419,30 @@ cov-upload: FORCE
+ 	cov-upload
+ 
+ # Machine generated from here down. 
+-alan.o: alan.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++alan.o: alan.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-an1.o: an1.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++an1.o: an1.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h an1sym.h
+-arcdist.o: arcdist.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++arcdist.o: arcdist.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
+-bcr.o: bcr.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++bcr.o: bcr.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
+   garmin_tables.h
+-bend.o: bend.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++bend.o: bend.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h filterdefs.h \
+   grtcirc.h
+-brauniger_iq.o: brauniger_iq.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++brauniger_iq.o: brauniger_iq.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h
+-bushnell.o: bushnell.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++bushnell.o: bushnell.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-bushnell_trl.o: bushnell_trl.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++bushnell_trl.o: bushnell_trl.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-cet.o: cet.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++cet.o: cet.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-cet_util.o: cet_util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++cet_util.o: cet_util.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   cet/ansi_x3_4_1968.h cet/iso_8859_1.h cet/iso_8859_8.h \
+   cet/iso_8859_15.h cet/cp1252.h cet/cp1255.h cet/iso_8859_2.h \
+@@ -454,67 +454,67 @@ cet_util.o: cet_util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
+   cet/iso_8859_13.h cet/iso_8859_14.h cet/iso_8859_3.h cet/iso_8859_4.h \
+   cet/iso_8859_5.h cet/iso_8859_6.h cet/iso_8859_7.h cet/iso_8859_9.h \
+   cet/koi8_r.h cet/koi8_ru.h cet/koi_8.h
+-compegps.o: compegps.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++compegps.o: compegps.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
+-cst.o: cst.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++cst.o: cst.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h strptime.h
+-csv_util.o: csv_util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++csv_util.o: csv_util.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h grtcirc.h strptime.h jeeps/gpsmath.h jeeps/gpsport.h \
+   garmin_fs.h jeeps/gps.h jeeps/gpsdevice.h jeeps/gpssend.h \
+   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   jeeps/gpsinput.h jeeps/gpsproj.h xcsv_tokens.gperf
+-delbin.o: delbin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++delbin.o: delbin.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   src/core/xmltag.h
+-delgpl.o: delgpl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++delgpl.o: delgpl.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-destinator.o: destinator.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++destinator.o: destinator.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h strptime.h
+-dg-100.o: dg-100.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++dg-100.o: dg-100.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h
+-discard.o: discard.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++discard.o: discard.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
+-dmtlog.o: dmtlog.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++dmtlog.o: dmtlog.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h xmlgeneric.h
+-duplicate.o: duplicate.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++duplicate.o: duplicate.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
+-easygps.o: easygps.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++easygps.o: easygps.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-enigma.o: enigma.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++enigma.o: enigma.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-exif.o: exif.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++exif.o: exif.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
+-explorist_ini.o: explorist_ini.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++explorist_ini.o: explorist_ini.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h explorist_ini.h
+-fatal.o: fatal.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++fatal.o: fatal.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-filter_vecs.o: filter_vecs.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++filter_vecs.o: filter_vecs.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h gbversion.h
+-formspec.o: formspec.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++formspec.o: formspec.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-g7towin.o: g7towin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++g7towin.o: g7towin.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   garmin_tables.h strptime.h
+-garmin.o: garmin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++garmin.o: garmin.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+@@ -522,165 +522,165 @@ garmin.o: garmin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   garmin_tables.h garmin_fs.h garmin_device_xml.h
+ garmin_device_xml.o: garmin_device_xml.cc defs.h config.h queue.h \
+-  zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++    gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h xmlgeneric.h garmin_device_xml.h
+-garmin_fit.o: garmin_fit.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++garmin_fit.o: garmin_fit.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-garmin_fs.o: garmin_fs.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++garmin_fs.o: garmin_fs.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h garmin_tables.h
+-garmin_gpi.o: garmin_gpi.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++garmin_gpi.o: garmin_gpi.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h jeeps/gpsmath.h jeeps/gpsport.h garmin_fs.h \
+   jeeps/gps.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h garmin_gpi.h
+ garmin_tables.o: garmin_tables.cc garmin_tables.h defs.h config.h queue.h \
+-  zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++    gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h jeeps/gpsmath.h jeeps/gpsport.h
+-garmin_txt.o: garmin_txt.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++garmin_txt.o: garmin_txt.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h garmin_tables.h grtcirc.h strptime.h
+-garmin_xt.o: garmin_xt.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++garmin_xt.o: garmin_xt.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-gbfile.o: gbfile.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++gbfile.o: gbfile.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-gbser.o: gbser.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++gbser.o: gbser.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h gbser_private.h
+-gbser_posix.o: gbser_posix.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++gbser_posix.o: gbser_posix.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h gbser_private.h
+ gbsleep.o: gbsleep.cc config.h
+-gdb.o: gdb.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++gdb.o: gdb.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
+   garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   garmin_tables.h grtcirc.h
+-geo.o: geo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++geo.o: geo.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   src/core/file.h
+-ggv_log.o: ggv_log.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++ggv_log.o: ggv_log.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h jeeps/gpsmath.h jeeps/gpsport.h
+-ggv_ovl.o: ggv_ovl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++ggv_ovl.o: ggv_ovl.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
+-globals.o: globals.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++globals.o: globals.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbversion.h
+-glogbook.o: glogbook.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++glogbook.o: glogbook.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h src/core/file.h
+-gnav_trl.o: gnav_trl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++gnav_trl.o: gnav_trl.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-google.o: google.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++google.o: google.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
+-googledir.o: googledir.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++googledir.o: googledir.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h xmlgeneric.h
+-gopal.o: gopal.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++gopal.o: gopal.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h strptime.h jeeps/gpsmath.h jeeps/gpsport.h grtcirc.h
+-gpssim.o: gpssim.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++gpssim.o: gpssim.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-gpsutil.o: gpsutil.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++gpsutil.o: gpsutil.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   magellan.h
+-gpx.o: gpx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++gpx.o: gpx.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h garmin_fs.h \
+   jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+   jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h src/core/file.h \
+   src/core/xmlstreamwriter.h src/core/xmltag.h
+-grtcirc.o: grtcirc.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++grtcirc.o: grtcirc.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
+-gtm.o: gtm.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++gtm.o: gtm.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-gtrnctr.o: gtrnctr.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++gtrnctr.o: gtrnctr.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
+-height.o: height.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++height.o: height.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h height.h
+ hiketech.o: hiketech.cc src/core/xmlstreamwriter.h defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h xmlgeneric.h
+-holux.o: holux.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++holux.o: holux.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   holux.h
+-html.o: html.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++html.o: html.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
+-humminbird.o: humminbird.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++humminbird.o: humminbird.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-igc.o: igc.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++igc.o: igc.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-ignrando.o: ignrando.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++ignrando.o: ignrando.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
+-igo8.o: igo8.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++igo8.o: igo8.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-ik3d.o: ik3d.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++ik3d.o: ik3d.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+-inifile.o: inifile.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++inifile.o: inifile.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-internal_styles.o: internal_styles.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++internal_styles.o: internal_styles.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-interpolate.o: interpolate.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++interpolate.o: interpolate.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h grtcirc.h
+-itracku.o: itracku.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++itracku.o: itracku.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h
+ jeeps/gpsapp.o: jeeps/gpsapp.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/garminusb.h jeeps/gpsusbint.h
+ jeeps/gpscom.o: jeeps/gpscom.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+ jeeps/gpsdevice.o: jeeps/gpsdevice.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/gpsserial.h
+ jeeps/gpsdevice_ser.o: jeeps/gpsdevice_ser.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/gpsserial.h
+ jeeps/gpsdevice_usb.o: jeeps/gpsdevice_usb.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+@@ -688,7 +688,7 @@ jeeps/gpsdevice_usb.o: jeeps/gpsdevice_usb.cc jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbint.h \
+   jeeps/gpsusbcommon.h
+ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
+-  jeeps/gps.h jeeps/../defs.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++  jeeps/gps.h jeeps/../defs.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+@@ -696,93 +696,93 @@ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
+   jeeps/gpsinput.h jeeps/gpsproj.h jeeps/garminusb.h \
+   jeeps/gpsusbcommon.h jeeps/../garmin_device_xml.h
+ jeeps/gpsmath.o: jeeps/gpsmath.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/gpsdatum.h
+ jeeps/gpsmem.o: jeeps/gpsmem.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+ jeeps/gpsprot.o: jeeps/gpsprot.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+ jeeps/gpsread.o: jeeps/gpsread.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/gpsserial.h
+ jeeps/gpsrqst.o: jeeps/gpsrqst.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+ jeeps/gpssend.o: jeeps/gpssend.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   jeeps/gpsserial.h
+ jeeps/gpsserial.o: jeeps/gpsserial.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/gpsserial.h jeeps/../gbser.h
+ jeeps/gpsusbcommon.o: jeeps/gpsusbcommon.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbcommon.h
+ jeeps/gpsusbread.o: jeeps/gpsusbread.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbint.h
+ jeeps/gpsusbsend.o: jeeps/gpsusbsend.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h \
++  config.h queue.h   gbfile.h cet.h cet_util.h \
+   inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h \
+   jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbint.h
+ jeeps/jgpsutil.o: jeeps/jgpsutil.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  queue.h zlib/zlib.h zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h \
++  queue.h   gbfile.h cet.h cet_util.h inifile.h \
+   session.h src/core/datetime.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+-jogmap.o: jogmap.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++jogmap.o: jogmap.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h jeeps/gpsmath.h jeeps/gpsport.h garmin_tables.h
+-jtr.o: jtr.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++jtr.o: jtr.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h
+-kml.o: kml.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++kml.o: kml.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
+   grtcirc.h src/core/file.h src/core/xmlstreamwriter.h src/core/xmltag.h
+-lmx.o: lmx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++lmx.o: lmx.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+-lowranceusr.o: lowranceusr.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++lowranceusr.o: lowranceusr.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-lowranceusr4.o: lowranceusr4.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++lowranceusr4.o: lowranceusr4.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+ mac/libusb/darwin.o: mac/libusb/darwin.c config.h mac/libusb/usbi.h \
+   mac/libusb/usb.h mac/libusb/error.h
+@@ -792,271 +792,243 @@ mac/libusb/error.o: mac/libusb/error.c mac/libusb/usb.h \
+   mac/libusb/error.h
+ mac/libusb/usb.o: mac/libusb/usb.c mac/libusb/usbi.h mac/libusb/usb.h \
+   mac/libusb/error.h
+-maggeo.o: maggeo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++maggeo.o: maggeo.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h xmlgeneric.h magellan.h
+-magproto.o: magproto.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++magproto.o: magproto.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   magellan.h gbser.h explorist_ini.h
+-main.o: main.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++main.o: main.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h filterdefs.h \
+   csv_util.h
+-mapasia.o: mapasia.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++mapasia.o: mapasia.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-mapbar_track.o: mapbar_track.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++mapbar_track.o: mapbar_track.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-mapsend.o: mapsend.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++mapsend.o: mapsend.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   mapsend.h magellan.h
+-mapsource.o: mapsource.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++mapsource.o: mapsource.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
+-mkshort.o: mkshort.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++mkshort.o: mkshort.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-mmo.o: mmo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++mmo.o: mmo.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-mtk_locus.o: mtk_locus.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++mtk_locus.o: mtk_locus.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h
+-mtk_logger.o: mtk_logger.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++mtk_logger.o: mtk_logger.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h gbser.h
+-navicache.o: navicache.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++navicache.o: navicache.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h src/core/file.h
+-naviguide.o: naviguide.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++naviguide.o: naviguide.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
+-navilink.o: navilink.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++navilink.o: navilink.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h jeeps/gpsmath.h jeeps/gpsport.h navilink.h
+-navitel.o: navitel.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++navitel.o: navitel.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-netstumbler.o: netstumbler.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++netstumbler.o: netstumbler.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h
+-nmea.o: nmea.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++nmea.o: nmea.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h gbser.h \
+   strptime.h jeeps/gpsmath.h jeeps/gpsport.h
+-nmn4.o: nmn4.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++nmn4.o: nmn4.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h
+-nukedata.o: nukedata.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++nukedata.o: nukedata.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
+-osm.o: osm.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++osm.o: osm.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h
+-ozi.o: ozi.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++ozi.o: ozi.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-parse.o: parse.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++parse.o: parse.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h strptime.h
+-pcx.o: pcx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++pcx.o: pcx.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_tables.h csv_util.h
+-pocketfms_bc.o: pocketfms_bc.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++pocketfms_bc.o: pocketfms_bc.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-pocketfms_fp.o: pocketfms_fp.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++pocketfms_fp.o: pocketfms_fp.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h xmlgeneric.h
+-pocketfms_wp.o: pocketfms_wp.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++pocketfms_wp.o: pocketfms_wp.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h
+-polygon.o: polygon.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++polygon.o: polygon.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
+-position.o: position.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++position.o: position.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
+-psitrex.o: psitrex.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++psitrex.o: psitrex.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_tables.h
+ queue.o: queue.cc queue.h
+-radius.o: radius.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++radius.o: radius.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
+-random.o: random.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++random.o: random.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+-raymarine.o: raymarine.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++raymarine.o: raymarine.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h csv_util.h
+-reverse_route.o: reverse_route.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++reverse_route.o: reverse_route.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
+-rgbcolors.o: rgbcolors.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++rgbcolors.o: rgbcolors.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-route.o: route.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++route.o: route.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
+-saroute.o: saroute.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++saroute.o: saroute.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
+-sbn.o: sbn.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++sbn.o: sbn.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h navilink.h
+-sbp.o: sbp.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++sbp.o: sbp.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h navilink.h
+-session.o: session.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++session.o: session.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-shape.o: shape.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++shape.o: shape.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   shapelib/shapefil.h
+ shapelib/dbfopen.o: shapelib/dbfopen.c shapelib/shapefil.h
+ shapelib/safileio.o: shapelib/safileio.c shapelib/shapefil.h
+ shapelib/shpopen.o: shapelib/shpopen.c shapelib/shapefil.h
+-skyforce.o: skyforce.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++skyforce.o: skyforce.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-skytraq.o: skytraq.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++skytraq.o: skytraq.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h
+-smplrout.o: smplrout.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++smplrout.o: smplrout.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h grtcirc.h
+-sort.o: sort.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++sort.o: sort.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h filterdefs.h
+ src/core/xmlstreamwriter.o: src/core/xmlstreamwriter.cc \
+   src/core/xmlstreamwriter.h
+-stackfilter.o: stackfilter.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++stackfilter.o: stackfilter.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
+-stmsdf.o: stmsdf.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++stmsdf.o: stmsdf.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h strptime.h jeeps/gpsmath.h jeeps/gpsport.h grtcirc.h
+-stmwpp.o: stmwpp.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++stmwpp.o: stmwpp.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h
+ strptime.o: strptime.c config.h strptime.h
+-subrip.o: subrip.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++subrip.o: subrip.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-swapdata.o: swapdata.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++swapdata.o: swapdata.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
+-tef_xml.o: tef_xml.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++tef_xml.o: tef_xml.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
+-teletype.o: teletype.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++teletype.o: teletype.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-text.o: text.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++text.o: text.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
+-tiger.o: tiger.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++tiger.o: tiger.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h
+-tmpro.o: tmpro.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++tmpro.o: tmpro.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h
+-tomtom.o: tomtom.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++tomtom.o: tomtom.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-tpg.o: tpg.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++tpg.o: tpg.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-tpo.o: tpo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++tpo.o: tpo.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-trackfilter.o: trackfilter.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++trackfilter.o: trackfilter.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h strptime.h grtcirc.h xmlgeneric.h
+-transform.o: transform.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++transform.o: transform.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h filterdefs.h
+-unicsv.o: unicsv.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++unicsv.o: unicsv.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   csv_util.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
+   garmin_tables.h
+-units.o: units.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++units.o: units.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-util.o: util.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++util.o: util.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   src/core/xmltag.h jeeps/gpsmath.h jeeps/gpsport.h
+ util_crc.o: util_crc.cc
+-v900.o: v900.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++v900.o: v900.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-validate.o: validate.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++validate.o: validate.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   filterdefs.h
+-vcf.o: vcf.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++vcf.o: vcf.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-vecs.o: vecs.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++vecs.o: vecs.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
+   gbversion.h
+-vidaone.o: vidaone.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++vidaone.o: vidaone.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-vitosmt.o: vitosmt.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++vitosmt.o: vitosmt.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h
+-vitovtt.o: vitovtt.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++vitovtt.o: vitovtt.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-vpl.o: vpl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++vpl.o: vpl.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h
+-waypt.o: waypt.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++waypt.o: waypt.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   grtcirc.h garmin_fs.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h
+-wbt-200.o: wbt-200.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++wbt-200.o: wbt-200.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   gbser.h grtcirc.h
+-wfff_xml.o: wfff_xml.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++wfff_xml.o: wfff_xml.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
+-wintec_tes.o: wintec_tes.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++wintec_tes.o: wintec_tes.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h
+-xcsv.o: xcsv.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++xcsv.o: xcsv.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h csv_util.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+ xhtmlent.o: xhtmlent.cc
+-xmlgeneric.o: xmlgeneric.cc defs.h config.h queue.h zlib/zlib.h \
+-  zlib/zconf.h gbfile.h cet.h cet_util.h inifile.h session.h \
++xmlgeneric.o: xmlgeneric.cc defs.h config.h queue.h  \
++   gbfile.h cet.h cet_util.h inifile.h session.h \
+   src/core/datetime.h xmlgeneric.h src/core/file.h
+-xmltag.o: xmltag.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++xmltag.o: xmltag.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   src/core/xmltag.h
+-xol.o: xol.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
++xol.o: xol.cc defs.h config.h queue.h   gbfile.h \
+   cet.h cet_util.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
+   jeeps/gpsmath.h jeeps/gpsport.h garmin_tables.h
+-yahoo.o: yahoo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++yahoo.o: yahoo.cc defs.h config.h queue.h   \
+   gbfile.h cet.h cet_util.h inifile.h session.h src/core/datetime.h \
+   xmlgeneric.h
+-zlib/adler32.o: zlib/adler32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/compress.o: zlib/compress.c zlib/zlib.h zlib/zconf.h config.h
+-zlib/crc32.o: zlib/crc32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h config.h \
+-  zlib/crc32.h
+-zlib/deflate.o: zlib/deflate.c zlib/deflate.h zlib/zutil.h zlib/zlib.h \
+-  zlib/zconf.h config.h
+-zlib/gzclose.o: zlib/gzclose.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzlib.o: zlib/gzlib.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzread.o: zlib/gzread.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzwrite.o: zlib/gzwrite.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/infback.o: zlib/infback.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h zlib/inffixed.h
+-zlib/inffast.o: zlib/inffast.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h
+-zlib/inflate.o: zlib/inflate.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h zlib/inffixed.h
+-zlib/inftrees.o: zlib/inftrees.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h
+-zlib/trees.o: zlib/trees.c zlib/deflate.h zlib/zutil.h zlib/zlib.h \
+-  zlib/zconf.h config.h zlib/trees.h
+-zlib/uncompr.o: zlib/uncompr.c zlib/zlib.h zlib/zconf.h config.h
+-zlib/zutil.o: zlib/zutil.c zlib/zutil.h zlib/zlib.h zlib/zconf.h config.h \
+-  zlib/gzguts.h
+ internal_styles.cc: mkstyle.sh $(srcdir)/style/*.style
+ 	$(srcdir)/mkstyle.sh > internal_styles.cc || (rm -f internal_styles.cc ; exit 1)
 diff --git a/gpsbabel/configure.in b/gpsbabel/configure.in
-index 44b4c93b..984b9e7a 100644
+index 44b4c93b..bd622313 100644
 --- a/gpsbabel/configure.in
 +++ b/gpsbabel/configure.in
 @@ -55,6 +55,7 @@ AC_ARG_WITH(cet,[  --with-cet=(default,all,minimal)],
@@ -100,6 +949,15 @@ index 44b4c93b..984b9e7a 100644
 +
  AC_MSG_CHECKING(for random stuff to make you feel better)
  AC_MSG_RESULT(failed)
+ 
+@@ -340,7 +397,7 @@ AC_SUBST(QT_INC_OPT)
+ AC_SUBST(QT_SYSINC_OPT)
+ AC_SUBST(QT_LIBS)
+ 
+-AC_CONFIG_FILES([Makefile gbversion.h gui/setup.iss xmldoc/makedoc tools/mkcapabilities win32/gpsbabel.rc jeeps/Makefile shapelib/Makefile zlib/empty])
++AC_CONFIG_FILES([Makefile gbversion.h gui/setup.iss xmldoc/makedoc tools/mkcapabilities win32/gpsbabel.rc jeeps/Makefile shapelib/Makefile])
+ AC_CONFIG_FILES([gui/makelinuxdist.sh], [chmod +x gui/makelinuxdist.sh])
+ AC_OUTPUT
  
 diff --git a/gpsbabel/tef_xml.cc b/gpsbabel/tef_xml.cc
 index c8a64f8d..134eaa17 100644

--- a/tools/archive_images/gpsbabel_1_5_1.patch
+++ b/tools/archive_images/gpsbabel_1_5_1.patch
@@ -1,0 +1,162 @@
+diff --git a/gpsbabel/configure.in b/gpsbabel/configure.in
+index 44b4c93b..984b9e7a 100644
+--- a/gpsbabel/configure.in
++++ b/gpsbabel/configure.in
+@@ -55,6 +55,7 @@ AC_ARG_WITH(cet,[  --with-cet=(default,all,minimal)],
+ 
+ if test $GCC = yes; then
+  CFLAGS="$CFLAGS -Wall"
++ CXXFLAGS="$CXXFLAGS -Wall"
+ fi
+ 
+ if test "$cet" = "all"; then
+@@ -156,15 +157,21 @@ AC_SUBST(RC)
+ # On RHEL/OEL/SL/CENTOS/FEDORA qmake is from Qt3, and qmake-qt4 is from Qt4.
+ # If qmake-qt4 isn't found look for the standard name qmake and assume it is
+ # from a useful version Qt.
+-AC_CHECK_TOOLS(QMAKE, [qmake-qt4 qmake], "no")
+-AC_CHECK_PROGS(LUPDATE, [lupdate-qt4 lupdate])
+-AC_CHECK_PROGS(LRELEASE, [lrelease-qt4 lrelease])
++AC_CHECK_TOOLS(QMAKE, [qmake-qt5 qmake-qt4 qmake], "no")
++AC_CHECK_TOOLS(LUPDATE, [lupdate-qt5 lupdate-qt4 lupdate])
++AC_CHECK_TOOLS(LRELEASE, [lrelease-qt5 lrelease-qt4 lrelease])
+ 
+ if test "$QMAKE" = no ; then
+-  AC_MSG_ERROR([Qt4 is required, but not found]);
++  AC_MSG_ERROR([Qt4 or Qt5 is required, but neither was found]);
+ fi
+ 
+-QT_LIBS="-L$($QMAKE -query QT_INSTALL_LIBS) -l QtCore"
++# guess the name of the Qt Core library.
++QT_LIBVER=$($QMAKE -query -query QT_VERSION | sed -e 's/\..*//')
++if test "$QT_LIBVER" -ge 5 ; then
++	QT_LIBS="-L$($QMAKE -query QT_INSTALL_LIBS) -lQt${QT_LIBVER}Core"
++else
++	QT_LIBS="-L$($QMAKE -query QT_INSTALL_LIBS) -lQtCore"
++fi
+ QT_INC=$($QMAKE -query QT_INSTALL_HEADERS)
+ QT_INC_OPT="-I"
+ QT_SYSINC_OPT="-isystem"
+@@ -222,6 +229,28 @@ case "$target" in
+       QT_INC_OPT="-F"
+       QT_SYSINC_OPT="-iframework"
+       ;;
++    *-*-freebsd*)
++	GBSER=gbser_posix.o
++	AC_MSG_CHECKING(for libusb)
++	if test "$with_libusb" = no ; then
++		AC_MSG_RESULT(check not done)
++		OSJEEPS=jeeps/gpsusbstub.o
++	else
++		OLDFLAGS=$LDFLAGS
++		OCFLAGS=$CFLAGS
++		LDFLAGS="$LDFLAGS -lusb"
++		CFLAGS="$OCFLAGS"
++
++		AC_CHECK_LIB([usb], [usb_interrupt_read],
++			AC_DEFINE(HAVE_LIBUSB, 1, [Defined if you have libusb])
++			[USB_CFLAGS=""]
++			[USB_LIBS="-lusb"]
++#			,[AC_MSG_ERROR([libusb is needed])]
++			)
++		OSJEEPS=jeeps/gpslibusb.o
++		CFLAGS="$OCFLAGS"
++	fi
++	;;
+     *)
+ 	GBSER=gbser_posix.o
+ 	AC_MSG_CHECKING(for libusb)
+@@ -283,6 +312,34 @@ case "$target" in
+ 	;;
+ esac
+ 
++case "$target" in
++	*-*-darwin*)
++	;;
++	*)
++	AC_MSG_CHECKING(for reduce relocations)
++	OCPPFLAGS="$CPPFLAGS"
++	CPPFLAGS="$CPPFLAGS -I$QT_INC"
++	AC_COMPILE_IFELSE([AC_LANG_SOURCE([
++		#include <QtCore/QString>
++		void f(void) {
++		}])],
++		[AC_MSG_RESULT(no)],
++		[OCXXFLAGS="$CXXFLAGS"
++		CXXFLAGS="$CXXFLAGS -fPIC"
++		AC_COMPILE_IFELSE([AC_LANG_SOURCE([
++			#include <QtCore/QString>
++			void f(void) {
++			}])],
++			[AC_MSG_RESULT(yes)
++			CFLAGS="$CFLAGS -fPIC"],
++			[AC_MSG_RESULT(unknown)
++			CXXFLAGS="$OCXXFLAGS"]
++			)]
++		)
++	CPPFLAGS="$OCPPFLAGS"
++	;;
++esac
++
+ AC_MSG_CHECKING(for random stuff to make you feel better)
+ AC_MSG_RESULT(failed)
+ 
+diff --git a/gpsbabel/tef_xml.cc b/gpsbabel/tef_xml.cc
+index c8a64f8d..134eaa17 100644
+--- a/gpsbabel/tef_xml.cc
++++ b/gpsbabel/tef_xml.cc
+@@ -72,11 +72,11 @@ tef_start(xg_string args, const QXmlStreamAttributes* attrv)
+   bool valid = false;
+ 
+   foreach(QXmlStreamAttribute attr, *attrv) {
+-    if (attr.name().compare("Comment", Qt::CaseInsensitive) == 0) {
+-      if (attr.value().compare("TourExchangeFormat", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("Comment"), Qt::CaseInsensitive) == 0) {
++      if (attr.value().compare(QLatin1String("TourExchangeFormat"), Qt::CaseInsensitive) == 0) {
+         valid = true;
+       }
+-    } else if (attr.name().compare("Version", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Version"), Qt::CaseInsensitive) == 0) {
+       version = attr.value().toString().toDouble();
+     }
+   }
+@@ -95,9 +95,9 @@ tef_header(xg_string args, const QXmlStreamAttributes* attrv)
+ {
+   route = route_head_alloc();
+   foreach(QXmlStreamAttribute attr, *attrv) {
+-    if (attr.name().compare("Name", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("Name"), Qt::CaseInsensitive) == 0) {
+       route->rte_name = attr.value().toString().trimmed();
+-    } else if (attr.name().compare("Software", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Software"), Qt::CaseInsensitive) == 0) {
+       route->rte_desc = attr.value().toString().trimmed();
+     }
+   }
+@@ -248,20 +248,20 @@ tef_item_start(xg_string args, const QXmlStreamAttributes* attrv)
+     QString attrstr = attr.value().toString();
+     QByteArray attrtext = attrstr.toUtf8();
+ 
+-    if (attr.name().compare("SegDescription", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("SegDescription"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->shortname = attrstr.trimmed();
+-    } else if (attr.name().compare("PointDescription", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("PointDescription"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->description = attrstr.trimmed();
+-    } else if (attr.name().compare("ViaStation", Qt::CaseInsensitive) == 0 &&
+-               attr.value().compare("true", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("ViaStation"), Qt::CaseInsensitive) == 0 &&
++               attr.value().compare(QLatin1String("true"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->wpt_flags.fmt_use = 1;  /* only a flag */
+ 
+       /* new in TEF V2 */
+-    } else if (attr.name().compare("Instruction", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Instruction"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->description = attrstr.trimmed();
+-    } else if (attr.name().compare("Altitude", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Altitude"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->altitude = attrstr.toDouble();
+-    } else if (attr.name().compare("TimeStamp", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("TimeStamp"), Qt::CaseInsensitive) == 0) {
+       /* nothing for the moment */
+     }
+   }

--- a/tools/archive_images/gpsbabel_1_5_2.patch
+++ b/tools/archive_images/gpsbabel_1_5_2.patch
@@ -1,0 +1,79 @@
+diff --git a/gpsbabel/configure.in b/gpsbabel/configure.in
+index e10ee475..71f076d4 100644
+--- a/gpsbabel/configure.in
++++ b/gpsbabel/configure.in
+@@ -325,13 +325,13 @@ case "$target" in
+ 		}])],
+ 		[AC_MSG_RESULT(no)],
+ 		[OCXXFLAGS="$CXXFLAGS"
+-		CXXFLAGS="$CXXFLAGS -fPIE"
++		CXXFLAGS="$CXXFLAGS -fPIC"
+ 		AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+ 			#include <QtCore/QString>
+ 			void f(void) {
+ 			}])],
+ 			[AC_MSG_RESULT(yes)
+-			CFLAGS="$CFLAGS -fPIE"],
++			CFLAGS="$CFLAGS -fPIC"],
+ 			[AC_MSG_RESULT(unknown)
+ 			CXXFLAGS="$OCXXFLAGS"]
+ 			)]
+diff --git a/gpsbabel/tef_xml.cc b/gpsbabel/tef_xml.cc
+index c8a64f8d..134eaa17 100644
+--- a/gpsbabel/tef_xml.cc
++++ b/gpsbabel/tef_xml.cc
+@@ -72,11 +72,11 @@ tef_start(xg_string args, const QXmlStreamAttributes* attrv)
+   bool valid = false;
+ 
+   foreach(QXmlStreamAttribute attr, *attrv) {
+-    if (attr.name().compare("Comment", Qt::CaseInsensitive) == 0) {
+-      if (attr.value().compare("TourExchangeFormat", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("Comment"), Qt::CaseInsensitive) == 0) {
++      if (attr.value().compare(QLatin1String("TourExchangeFormat"), Qt::CaseInsensitive) == 0) {
+         valid = true;
+       }
+-    } else if (attr.name().compare("Version", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Version"), Qt::CaseInsensitive) == 0) {
+       version = attr.value().toString().toDouble();
+     }
+   }
+@@ -95,9 +95,9 @@ tef_header(xg_string args, const QXmlStreamAttributes* attrv)
+ {
+   route = route_head_alloc();
+   foreach(QXmlStreamAttribute attr, *attrv) {
+-    if (attr.name().compare("Name", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("Name"), Qt::CaseInsensitive) == 0) {
+       route->rte_name = attr.value().toString().trimmed();
+-    } else if (attr.name().compare("Software", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Software"), Qt::CaseInsensitive) == 0) {
+       route->rte_desc = attr.value().toString().trimmed();
+     }
+   }
+@@ -248,20 +248,20 @@ tef_item_start(xg_string args, const QXmlStreamAttributes* attrv)
+     QString attrstr = attr.value().toString();
+     QByteArray attrtext = attrstr.toUtf8();
+ 
+-    if (attr.name().compare("SegDescription", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("SegDescription"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->shortname = attrstr.trimmed();
+-    } else if (attr.name().compare("PointDescription", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("PointDescription"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->description = attrstr.trimmed();
+-    } else if (attr.name().compare("ViaStation", Qt::CaseInsensitive) == 0 &&
+-               attr.value().compare("true", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("ViaStation"), Qt::CaseInsensitive) == 0 &&
++               attr.value().compare(QLatin1String("true"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->wpt_flags.fmt_use = 1;  /* only a flag */
+ 
+       /* new in TEF V2 */
+-    } else if (attr.name().compare("Instruction", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Instruction"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->description = attrstr.trimmed();
+-    } else if (attr.name().compare("Altitude", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Altitude"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->altitude = attrstr.toDouble();
+-    } else if (attr.name().compare("TimeStamp", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("TimeStamp"), Qt::CaseInsensitive) == 0) {
+       /* nothing for the moment */
+     }
+   }

--- a/tools/archive_images/gpsbabel_1_5_2.patch
+++ b/tools/archive_images/gpsbabel_1_5_2.patch
@@ -853,6 +853,63 @@ index e10ee475..1aa48807 100644
  AC_CONFIG_FILES([gui/makelinuxdist.sh], [chmod +x gui/makelinuxdist.sh])
  AC_OUTPUT
  
+diff --git a/gpsbabel/gui/makelinuxdist.sh.in b/gpsbabel/gui/makelinuxdist.sh.in
+index 72707f7a..8176d457 100644
+--- a/gpsbabel/gui/makelinuxdist.sh.in
++++ b/gpsbabel/gui/makelinuxdist.sh.in
+@@ -7,32 +7,9 @@ DISTNAME=GPSBabel@PACKAGE_VERSION@@PACKAGE_RELEASE@
+ DISTDIR=$DISTNAME
+ rm -rf $DISTDIR
+ mkdir $DISTDIR
+-mkdir $DISTDIR/plugins
+ mkdir $DISTDIR/translations
+ mkdir $DISTDIR/help
+ 
+-QT_LIBS=`ldd objects/gpsbabelfe-bin | grep libQt | awk '{print $3}'`
+-for lib in $QT_LIBS
+-do
+-	cp $lib $DISTDIR
+-done
+-#cp `ldd objects/gpsbabelfe-bin  | grep libphonon |awk '{print $3}'` $DISTDIR
+-#cp `ldd objects/gpsbabelfe-bin  | grep libaudio   |awk '{print $3}'` $DISTDIR
+-
+-cp -r $QT_INSTALL_PLUGINS/imageformats $DISTDIR/plugins
+-if [ -e $QT_INSTALL_PLUGINS/codecs ]
+-then
+-  cp -r $QT_INSTALL_PLUGINS/codecs $DISTDIR/plugins
+-else
+-  echo "Warning: $QT_INSTALL_PLUGINS/codecs not found, perhaps this is normal for Qt5"
+-fi
+-if [ -e $QT_INSTALL_PLUGINS/platforms ]
+-then
+-#  we need at least platforms/libqxcb.so
+-  cp -r $QT_INSTALL_PLUGINS/platforms $DISTDIR/plugins
+-else
+-  echo "Wanring: $QT_INSTALL_PLUGINS/platforms not found, this is normal for Qt4"
+-fi
+ cp $QT_INSTALL_TRANSLATIONS/qt_*.qm $DISTDIR/translations/
+ 
+ # copy the compiled translations
+@@ -40,10 +17,7 @@ cp *.qm $DISTDIR/translations
+ 
+ # Now our gui
+ cp gmapbase.html $DISTDIR/
+-cp gpsbabelfe $DISTDIR/
+-chmod +x $DISTDIR/gpsbabelfe
+-cp objects/gpsbabelfe-bin $DISTDIR
+-cp qt.conf $DISTDIR/
++cp objects/gpsbabelfe-bin $DISTDIR/gpsbabelfe
+ cp ../gpsbabel $DISTDIR/
+ #
+ cp -r help/*.html $DISTDIR/help
+@@ -53,7 +27,3 @@ cp ../COPYING $DISTDIR/
+ cp ../README* $DISTDIR/
+ 
+ 
+-rm -f $DISTDIR.tar $DISTDIR.tar.bz2
+-tar cvf $DISTDIR.tar $DISTDIR
+-bzip2 $DISTDIR.tar
+-
 diff --git a/gpsbabel/tef_xml.cc b/gpsbabel/tef_xml.cc
 index c8a64f8d..134eaa17 100644
 --- a/gpsbabel/tef_xml.cc

--- a/tools/archive_images/gpsbabel_1_5_3.patch
+++ b/tools/archive_images/gpsbabel_1_5_3.patch
@@ -867,6 +867,63 @@ index e5fa054c..a6fc26be 100644
  
  #include <QtCore/QXmlStreamReader>
  #include <QtCore/QRegExp>
+diff --git a/gui/makelinuxdist.sh.in b/gui/makelinuxdist.sh.in
+index 72707f7a..8176d457 100644
+--- a/gui/makelinuxdist.sh.in
++++ b/gui/makelinuxdist.sh.in
+@@ -7,32 +7,9 @@ DISTNAME=GPSBabel@PACKAGE_VERSION@@PACKAGE_RELEASE@
+ DISTDIR=$DISTNAME
+ rm -rf $DISTDIR
+ mkdir $DISTDIR
+-mkdir $DISTDIR/plugins
+ mkdir $DISTDIR/translations
+ mkdir $DISTDIR/help
+ 
+-QT_LIBS=`ldd objects/gpsbabelfe-bin | grep libQt | awk '{print $3}'`
+-for lib in $QT_LIBS
+-do
+-	cp $lib $DISTDIR
+-done
+-#cp `ldd objects/gpsbabelfe-bin  | grep libphonon |awk '{print $3}'` $DISTDIR
+-#cp `ldd objects/gpsbabelfe-bin  | grep libaudio   |awk '{print $3}'` $DISTDIR
+-
+-cp -r $QT_INSTALL_PLUGINS/imageformats $DISTDIR/plugins
+-if [ -e $QT_INSTALL_PLUGINS/codecs ]
+-then
+-  cp -r $QT_INSTALL_PLUGINS/codecs $DISTDIR/plugins
+-else
+-  echo "Warning: $QT_INSTALL_PLUGINS/codecs not found, perhaps this is normal for Qt5"
+-fi
+-if [ -e $QT_INSTALL_PLUGINS/platforms ]
+-then
+-#  we need at least platforms/libqxcb.so
+-  cp -r $QT_INSTALL_PLUGINS/platforms $DISTDIR/plugins
+-else
+-  echo "Wanring: $QT_INSTALL_PLUGINS/platforms not found, this is normal for Qt4"
+-fi
+ cp $QT_INSTALL_TRANSLATIONS/qt_*.qm $DISTDIR/translations/
+ 
+ # copy the compiled translations
+@@ -40,10 +17,7 @@ cp *.qm $DISTDIR/translations
+ 
+ # Now our gui
+ cp gmapbase.html $DISTDIR/
+-cp gpsbabelfe $DISTDIR/
+-chmod +x $DISTDIR/gpsbabelfe
+-cp objects/gpsbabelfe-bin $DISTDIR
+-cp qt.conf $DISTDIR/
++cp objects/gpsbabelfe-bin $DISTDIR/gpsbabelfe
+ cp ../gpsbabel $DISTDIR/
+ #
+ cp -r help/*.html $DISTDIR/help
+@@ -53,7 +27,3 @@ cp ../COPYING $DISTDIR/
+ cp ../README* $DISTDIR/
+ 
+ 
+-rm -f $DISTDIR.tar $DISTDIR.tar.bz2
+-tar cvf $DISTDIR.tar $DISTDIR
+-bzip2 $DISTDIR.tar
+-
 diff --git a/tef_xml.cc b/tef_xml.cc
 index c8a64f8d..134eaa17 100644
 --- a/tef_xml.cc

--- a/tools/archive_images/gpsbabel_1_5_3.patch
+++ b/tools/archive_images/gpsbabel_1_5_3.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile.in b/Makefile.in
-index 83af6048..ae94a7bd 100644
+index 3752efc1..0ce58112 100644
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -102,9 +102,6 @@ JEEPS=jeeps/gpsapp.o jeeps/gpscom.o \
@@ -20,7 +20,7 @@ index 83af6048..ae94a7bd 100644
  	  $(GARMIN) $(JEEPS) $(SHAPE) @ZLIB@ $(FMTS) $(FILTERS)
  OBJS = main.o globals.o $(LIBOBJS) @FILEINFO@
  
-@@ -435,90 +431,90 @@ toolinfo:
+@@ -432,93 +428,93 @@ toolinfo:
  	-$(QMAKE) -v
  
  # Machine generated from here down. 
@@ -75,6 +75,10 @@ index 83af6048..ae94a7bd 100644
    jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
    jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
    grtcirc.h src/core/logging.h strptime.h xcsv_tokens.gperf
+-delbin.o: delbin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++delbin.o: delbin.cc defs.h config.h queue.h   \
+   gbfile.h cet.h inifile.h session.h src/core/datetime.h \
+   src/core/xmltag.h
 -delgpl.o: delgpl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +delgpl.o: delgpl.cc defs.h config.h queue.h   \
    gbfile.h cet.h inifile.h session.h src/core/datetime.h
@@ -149,7 +153,7 @@ index 83af6048..ae94a7bd 100644
    gbfile.h cet.h inifile.h session.h src/core/datetime.h cet_util.h \
    grtcirc.h jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h \
    jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
-@@ -526,85 +522,85 @@ garmin.o: garmin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
+@@ -526,82 +522,82 @@ garmin.o: garmin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
    jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h \
    jeeps/gpsserial.h garmin_tables.h garmin_fs.h garmin_device_xml.h
  garmin_device_xml.o: garmin_device_xml.cc defs.h config.h queue.h \
@@ -220,9 +224,6 @@ index 83af6048..ae94a7bd 100644
 -geo.o: geo.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
 +geo.o: geo.cc defs.h config.h queue.h   gbfile.h \
    cet.h inifile.h session.h src/core/datetime.h src/core/file.h
--ggv_bin.o: ggv_bin.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
-+ggv_bin.o: ggv_bin.cc defs.h config.h queue.h   \
-   gbfile.h cet.h inifile.h session.h src/core/datetime.h
 -ggv_log.o: ggv_log.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +ggv_log.o: ggv_log.cc defs.h config.h queue.h   \
    gbfile.h cet.h inifile.h session.h src/core/datetime.h grtcirc.h \
@@ -234,11 +235,6 @@ index 83af6048..ae94a7bd 100644
 -globals.o: globals.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +globals.o: globals.cc defs.h config.h queue.h   \
    gbfile.h cet.h inifile.h session.h src/core/datetime.h gbversion.h
--globalsat_sport.o: globalsat_sport.cc defs.h config.h queue.h zlib/zlib.h \
-- zlib/zconf.h config.h gbfile.h cet.h inifile.h session.h \
-+globalsat_sport.o: globalsat_sport.cc defs.h config.h queue.h  \
-+  config.h gbfile.h cet.h inifile.h session.h \
-  src/core/datetime.h gbser.h
 -glogbook.o: glogbook.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +glogbook.o: glogbook.cc defs.h config.h queue.h   \
    gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h \
@@ -246,6 +242,9 @@ index 83af6048..ae94a7bd 100644
 -gnav_trl.o: gnav_trl.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
 +gnav_trl.o: gnav_trl.cc defs.h config.h queue.h   \
    gbfile.h cet.h inifile.h session.h src/core/datetime.h
+-google.o: google.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h \
++google.o: google.cc defs.h config.h queue.h   \
+   gbfile.h cet.h inifile.h session.h src/core/datetime.h xmlgeneric.h
 -googledir.o: googledir.cc defs.h config.h queue.h zlib/zlib.h \
 -  zlib/zconf.h gbfile.h cet.h inifile.h session.h src/core/datetime.h \
 +googledir.o: googledir.cc defs.h config.h queue.h  \
@@ -267,7 +266,7 @@ index 83af6048..ae94a7bd 100644
    cet.h inifile.h session.h src/core/datetime.h cet_util.h garmin_fs.h \
    jeeps/gps.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
    jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
-@@ -612,79 +608,79 @@ gpx.o: gpx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
+@@ -609,79 +605,79 @@ gpx.o: gpx.cc defs.h config.h queue.h zlib/zlib.h zlib/zconf.h gbfile.h \
    jeeps/gpsrqst.h jeeps/gpsinput.h jeeps/gpsproj.h garmin_tables.h \
    src/core/logging.h src/core/file.h src/core/xmlstreamwriter.h \
    src/core/xmltag.h
@@ -372,7 +371,7 @@ index 83af6048..ae94a7bd 100644
    cet.h inifile.h session.h src/core/datetime.h jeeps/gpsport.h \
    jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
    jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
-@@ -692,89 +688,89 @@ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
+@@ -689,89 +685,89 @@ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
    jeeps/gpsproj.h jeeps/garminusb.h jeeps/gpsusbcommon.h \
    jeeps/../garmin_device_xml.h
  jeeps/gpsmath.o: jeeps/gpsmath.cc jeeps/gps.h jeeps/../defs.h config.h \
@@ -481,7 +480,7 @@ index 83af6048..ae94a7bd 100644
  mac/libusb/darwin.o: mac/libusb/darwin.c config.h mac/libusb/usbi.h \
    mac/libusb/usb.h mac/libusb/error.h
  mac/libusb/descriptors.o: mac/libusb/descriptors.c mac/libusb/usbi.h \
-@@ -783,261 +779,233 @@ mac/libusb/error.o: mac/libusb/error.c mac/libusb/usb.h \
+@@ -780,261 +776,233 @@ mac/libusb/error.o: mac/libusb/error.c mac/libusb/usb.h \
    mac/libusb/error.h
  mac/libusb/usb.o: mac/libusb/usb.c mac/libusb/usbi.h mac/libusb/usb.h \
    mac/libusb/error.h
@@ -844,10 +843,10 @@ index 83af6048..ae94a7bd 100644
  internal_styles.cc: mkstyle.sh $(srcdir)/style/*.style
  	$(srcdir)/mkstyle.sh > internal_styles.cc || (rm -f internal_styles.cc ; exit 1)
 diff --git a/configure.in b/configure.in
-index ffa67430..b0e84c42 100644
+index d8fd5d4e..a6afd36a 100644
 --- a/configure.in
 +++ b/configure.in
-@@ -402,7 +402,7 @@ AC_SUBST(QT_INC_OPT)
+@@ -397,7 +397,7 @@ AC_SUBST(QT_INC_OPT)
  AC_SUBST(QT_SYSINC_OPT)
  AC_SUBST(QT_LIBS)
  
@@ -856,8 +855,20 @@ index ffa67430..b0e84c42 100644
  AC_CONFIG_FILES([gui/makelinuxdist.sh], [chmod +x gui/makelinuxdist.sh])
  AC_OUTPUT
  
+diff --git a/gpx.cc b/gpx.cc
+index e5fa054c..a6fc26be 100644
+--- a/gpx.cc
++++ b/gpx.cc
+@@ -28,7 +28,6 @@
+ #include "src/core/file.h"
+ #include "src/core/xmlstreamwriter.h"
+ #include "src/core/xmltag.h"
+-#include "src/core/ziparchive.h"
+ 
+ #include <QtCore/QXmlStreamReader>
+ #include <QtCore/QRegExp>
 diff --git a/tef_xml.cc b/tef_xml.cc
-index b32d69b3..38142961 100644
+index c8a64f8d..134eaa17 100644
 --- a/tef_xml.cc
 +++ b/tef_xml.cc
 @@ -72,11 +72,11 @@ tef_start(xg_string args, const QXmlStreamAttributes* attrv)

--- a/tools/archive_images/gpsbabel_1_5_4.patch
+++ b/tools/archive_images/gpsbabel_1_5_4.patch
@@ -1,0 +1,81 @@
+diff --git a/Makefile.in b/Makefile.in
+index 83af6048..898a30b4 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -102,9 +102,6 @@ JEEPS=jeeps/gpsapp.o jeeps/gpscom.o \
+ 
+ SHAPE=shapelib/shpopen.o shapelib/dbfopen.o shapelib/safileio.o
+ 
+-MINIZIP=zlib/contrib/minizip/zip.o \
+-	zlib/contrib/minizip/ioapi.o
+-
+ ZLIB=zlib/adler32.o zlib/compress.o zlib/crc32.o zlib/deflate.o zlib/inffast.o \
+ 	zlib/inflate.o zlib/infback.o zlib/inftrees.o zlib/trees.o \
+ 	zlib/uncompr.o zlib/gzlib.o zlib/gzclose.o zlib/gzread.o \
+@@ -118,7 +115,6 @@ LIBOBJS = queue.o route.o waypt.o filter_vecs.o util.o vecs.o mkshort.o \
+ 	  gbfile.o parse.o session.o \
+ 	  src/core/xmlstreamwriter.o \
+ 	  src/core/usasciicodec.o\
+-	  src/core/ziparchive.o \
+ 	  $(GARMIN) $(JEEPS) $(SHAPE) @ZLIB@ $(FMTS) $(FILTERS)
+ OBJS = main.o globals.o $(LIBOBJS) @FILEINFO@
+ 
+diff --git a/tef_xml.cc b/tef_xml.cc
+index b32d69b3..38142961 100644
+--- a/tef_xml.cc
++++ b/tef_xml.cc
+@@ -72,11 +72,11 @@ tef_start(xg_string args, const QXmlStreamAttributes* attrv)
+   bool valid = false;
+ 
+   foreach(QXmlStreamAttribute attr, *attrv) {
+-    if (attr.name().compare("Comment", Qt::CaseInsensitive) == 0) {
+-      if (attr.value().compare("TourExchangeFormat", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("Comment"), Qt::CaseInsensitive) == 0) {
++      if (attr.value().compare(QLatin1String("TourExchangeFormat"), Qt::CaseInsensitive) == 0) {
+         valid = true;
+       }
+-    } else if (attr.name().compare("Version", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Version"), Qt::CaseInsensitive) == 0) {
+       version = attr.value().toString().toDouble();
+     }
+   }
+@@ -95,9 +95,9 @@ tef_header(xg_string args, const QXmlStreamAttributes* attrv)
+ {
+   route = route_head_alloc();
+   foreach(QXmlStreamAttribute attr, *attrv) {
+-    if (attr.name().compare("Name", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("Name"), Qt::CaseInsensitive) == 0) {
+       route->rte_name = attr.value().toString().trimmed();
+-    } else if (attr.name().compare("Software", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Software"), Qt::CaseInsensitive) == 0) {
+       route->rte_desc = attr.value().toString().trimmed();
+     }
+   }
+@@ -248,20 +248,20 @@ tef_item_start(xg_string args, const QXmlStreamAttributes* attrv)
+     QString attrstr = attr.value().toString();
+     QByteArray attrtext = attrstr.toUtf8();
+ 
+-    if (attr.name().compare("SegDescription", Qt::CaseInsensitive) == 0) {
++    if (attr.name().compare(QLatin1String("SegDescription"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->shortname = attrstr.trimmed();
+-    } else if (attr.name().compare("PointDescription", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("PointDescription"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->description = attrstr.trimmed();
+-    } else if (attr.name().compare("ViaStation", Qt::CaseInsensitive) == 0 &&
+-               attr.value().compare("true", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("ViaStation"), Qt::CaseInsensitive) == 0 &&
++               attr.value().compare(QLatin1String("true"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->wpt_flags.fmt_use = 1;  /* only a flag */
+ 
+       /* new in TEF V2 */
+-    } else if (attr.name().compare("Instruction", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Instruction"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->description = attrstr.trimmed();
+-    } else if (attr.name().compare("Altitude", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("Altitude"), Qt::CaseInsensitive) == 0) {
+       wpt_tmp->altitude = attrstr.toDouble();
+-    } else if (attr.name().compare("TimeStamp", Qt::CaseInsensitive) == 0) {
++    } else if (attr.name().compare(QLatin1String("TimeStamp"), Qt::CaseInsensitive) == 0) {
+       /* nothing for the moment */
+     }
+   }

--- a/tools/archive_images/gpsbabel_1_5_4.patch
+++ b/tools/archive_images/gpsbabel_1_5_4.patch
@@ -856,6 +856,63 @@ index ffa67430..b0e84c42 100644
  AC_CONFIG_FILES([gui/makelinuxdist.sh], [chmod +x gui/makelinuxdist.sh])
  AC_OUTPUT
  
+diff --git a/gui/makelinuxdist.sh.in b/gui/makelinuxdist.sh.in
+index 72707f7a..8176d457 100644
+--- a/gui/makelinuxdist.sh.in
++++ b/gui/makelinuxdist.sh.in
+@@ -7,32 +7,9 @@ DISTNAME=GPSBabel@PACKAGE_VERSION@@PACKAGE_RELEASE@
+ DISTDIR=$DISTNAME
+ rm -rf $DISTDIR
+ mkdir $DISTDIR
+-mkdir $DISTDIR/plugins
+ mkdir $DISTDIR/translations
+ mkdir $DISTDIR/help
+ 
+-QT_LIBS=`ldd objects/gpsbabelfe-bin | grep libQt | awk '{print $3}'`
+-for lib in $QT_LIBS
+-do
+-	cp $lib $DISTDIR
+-done
+-#cp `ldd objects/gpsbabelfe-bin  | grep libphonon |awk '{print $3}'` $DISTDIR
+-#cp `ldd objects/gpsbabelfe-bin  | grep libaudio   |awk '{print $3}'` $DISTDIR
+-
+-cp -r $QT_INSTALL_PLUGINS/imageformats $DISTDIR/plugins
+-if [ -e $QT_INSTALL_PLUGINS/codecs ]
+-then
+-  cp -r $QT_INSTALL_PLUGINS/codecs $DISTDIR/plugins
+-else
+-  echo "Warning: $QT_INSTALL_PLUGINS/codecs not found, perhaps this is normal for Qt5"
+-fi
+-if [ -e $QT_INSTALL_PLUGINS/platforms ]
+-then
+-#  we need at least platforms/libqxcb.so
+-  cp -r $QT_INSTALL_PLUGINS/platforms $DISTDIR/plugins
+-else
+-  echo "Wanring: $QT_INSTALL_PLUGINS/platforms not found, this is normal for Qt4"
+-fi
+ cp $QT_INSTALL_TRANSLATIONS/qt_*.qm $DISTDIR/translations/
+ 
+ # copy the compiled translations
+@@ -40,10 +17,7 @@ cp *.qm $DISTDIR/translations
+ 
+ # Now our gui
+ cp gmapbase.html $DISTDIR/
+-cp gpsbabelfe $DISTDIR/
+-chmod +x $DISTDIR/gpsbabelfe
+-cp objects/gpsbabelfe-bin $DISTDIR
+-cp qt.conf $DISTDIR/
++cp objects/gpsbabelfe-bin $DISTDIR/gpsbabelfe
+ cp ../gpsbabel $DISTDIR/
+ #
+ cp -r help/*.html $DISTDIR/help
+@@ -53,7 +27,3 @@ cp ../COPYING $DISTDIR/
+ cp ../README* $DISTDIR/
+ 
+ 
+-rm -f $DISTDIR.tar $DISTDIR.tar.bz2
+-tar cvf $DISTDIR.tar $DISTDIR
+-bzip2 $DISTDIR.tar
+-
 diff --git a/tef_xml.cc b/tef_xml.cc
 index b32d69b3..38142961 100644
 --- a/tef_xml.cc

--- a/tools/archive_images/gpsbabel_1_6_0.patch
+++ b/tools/archive_images/gpsbabel_1_6_0.patch
@@ -1,0 +1,843 @@
+diff --git a/Makefile.in b/Makefile.in
+index 6f219438..52337c12 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -422,115 +422,115 @@ toolinfo:
+ 	-$(QMAKE) -v
+ 
+ # Machine generated from here down.
+-alan.o: alan.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++alan.o: alan.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h
+-an1.o: an1.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++an1.o: an1.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h an1sym.h
+-arcdist.o: arcdist.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++arcdist.o: arcdist.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   arcdist.h filter.h filterdefs.h grtcirc.h
+-bcr.o: bcr.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++bcr.o: bcr.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h csv_util.h \
+   garmin_tables.h
+-bend.o: bend.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++bend.o: bend.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h bend.h grtcirc.h
+-brauniger_iq.o: brauniger_iq.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++brauniger_iq.o: brauniger_iq.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h
+-bushnell.o: bushnell.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++bushnell.o: bushnell.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-bushnell_trl.o: bushnell_trl.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++bushnell_trl.o: bushnell_trl.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-cet.o: cet.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++cet.o: cet.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h
+-cet_util.o: cet_util.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++cet_util.o: cet_util.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h src/core/logging.h cet/ansi_x3_4_1968.h cet/cp1252.h \
+   cet/iso_8859_8.h
+-compegps.o: compegps.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++compegps.o: compegps.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
+-cst.o: cst.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++cst.o: cst.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h
+-csv_util.o: csv_util.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++csv_util.o: csv_util.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h src/core/logging.h
+-delgpl.o: delgpl.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++delgpl.o: delgpl.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-destinator.o: destinator.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++destinator.o: destinator.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h cet_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   strptime.h
+-dg-100.o: dg-100.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++dg-100.o: dg-100.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h
+-discard.o: discard.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++discard.o: discard.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   discard.h filter.h filterdefs.h
+-dmtlog.o: dmtlog.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++dmtlog.o: dmtlog.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h xmlgeneric.h
+-duplicate.o: duplicate.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++duplicate.o: duplicate.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h duplicate.h
+-easygps.o: easygps.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++easygps.o: easygps.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-energympro.o: energympro.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++energympro.o: energympro.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-enigma.o: enigma.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++enigma.o: enigma.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-exif.o: exif.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++exif.o: exif.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
+-explorist_ini.o: explorist_ini.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h cet.h inifile.h gbfile.h session.h src/core/datetime.h \
++explorist_ini.o: explorist_ini.cc defs.h config.h  \
++   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h explorist_ini.h
+-f90g_track.o: f90g_track.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++f90g_track.o: f90g_track.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-fatal.o: fatal.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++fatal.o: fatal.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-filter_vecs.o: filter_vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++filter_vecs.o: filter_vecs.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h arcdist.h filter.h bend.h discard.h duplicate.h \
+   filterdefs.h height.h interpolate.h nukedata.h polygon.h position.h \
+   radius.h reverse_route.h smplrout.h sort.h stackfilter.h swapdata.h \
+   trackfilter.h transform.h validate.h gbversion.h
+-formspec.o: formspec.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++formspec.o: formspec.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-g7towin.o: g7towin.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++g7towin.o: g7towin.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   garmin_tables.h strptime.h
+-garmin.o: garmin.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++garmin.o: garmin.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h garmin_device_xml.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   garmin_tables.h grtcirc.h jeeps/gpsserial.h
+-garmin_device_xml.o: garmin_device_xml.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h cet.h inifile.h gbfile.h session.h src/core/datetime.h \
++garmin_device_xml.o: garmin_device_xml.cc defs.h config.h  \
++   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h garmin_device_xml.h xmlgeneric.h
+-garmin_fit.o: garmin_fit.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_fit.o: garmin_fit.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-garmin_fs.o: garmin_fs.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++garmin_fs.o: garmin_fs.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h
+-garmin_gpi.o: garmin_gpi.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_gpi.o: garmin_gpi.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h garmin_gpi.h cet_util.h garmin_fs.h jeeps/gps.h \
+   jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+@@ -538,246 +538,246 @@ garmin_gpi.o: garmin_gpi.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+   jeeps/gpsrqst.h
+ garmin_tables.o: garmin_tables.cc garmin_tables.h defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h session.h \
++    cet.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsmath.h \
+   jeeps/gpsport.h src/core/logging.h
+-garmin_txt.o: garmin_txt.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_txt.o: garmin_txt.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h cet_util.h csv_util.h garmin_fs.h jeeps/gps.h \
+   jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+   jeeps/gpsrqst.h garmin_tables.h grtcirc.h strptime.h
+-garmin_xt.o: garmin_xt.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++garmin_xt.o: garmin_xt.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-gbfile.o: gbfile.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++gbfile.o: gbfile.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/logging.h
+-gbser.o: gbser.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++gbser.o: gbser.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h gbser_private.h
+-gbser_posix.o: gbser_posix.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++gbser_posix.o: gbser_posix.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h gbser_private.h
+-gdb.o: gdb.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++gdb.o: gdb.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h \
+   garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h \
+   grtcirc.h
+-geo.o: geo.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++geo.o: geo.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/file.h
+-geojson.o: geojson.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++geojson.o: geojson.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/file.h
+-ggv_bin.o: ggv_bin.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++ggv_bin.o: ggv_bin.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-ggv_log.o: ggv_log.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++ggv_log.o: ggv_log.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-ggv_ovl.o: ggv_ovl.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++ggv_ovl.o: ggv_ovl.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-globals.o: globals.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++globals.o: globals.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbversion.h
+-globalsat_sport.o: globalsat_sport.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h cet.h inifile.h gbfile.h session.h src/core/datetime.h \
++globalsat_sport.o: globalsat_sport.cc defs.h config.h  \
++   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h
+-glogbook.o: glogbook.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++glogbook.o: glogbook.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/file.h xmlgeneric.h
+-gnav_trl.o: gnav_trl.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++gnav_trl.o: gnav_trl.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-googledir.o: googledir.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++googledir.o: googledir.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-gopal.o: gopal.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++gopal.o: gopal.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h grtcirc.h jeeps/gpsmath.h jeeps/gpsport.h \
+   strptime.h
+-gpssim.o: gpssim.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++gpssim.o: gpssim.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-gpsutil.o: gpsutil.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++gpsutil.o: gpsutil.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h magellan.h
+-gpx.o: gpx.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++gpx.o: gpx.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h garmin_fs.h \
+   jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h src/core/file.h \
+   src/core/logging.h src/core/xmlstreamwriter.h src/core/xmltag.h
+-grtcirc.o: grtcirc.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++grtcirc.o: grtcirc.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-gtm.o: gtm.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++gtm.o: gtm.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-gtrnctr.o: gtrnctr.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++gtrnctr.o: gtrnctr.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-height.o: height.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++height.o: height.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h height.h heightgrid.h
+-hiketech.o: hiketech.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++hiketech.o: hiketech.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/xmlstreamwriter.h xmlgeneric.h
+-holux.o: holux.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++holux.o: holux.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   holux.h
+-html.o: html.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++html.o: html.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
+-humminbird.o: humminbird.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++humminbird.o: humminbird.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-igc.o: igc.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++igc.o: igc.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h
+-ignrando.o: ignrando.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++ignrando.o: ignrando.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-igo8.o: igo8.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++igo8.o: igo8.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h
+-ik3d.o: ik3d.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++ik3d.o: ik3d.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-inifile.o: inifile.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++inifile.o: inifile.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/file.h
+-internal_styles.o: internal_styles.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h cet.h inifile.h gbfile.h session.h src/core/datetime.h \
++internal_styles.o: internal_styles.cc defs.h config.h  \
++   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-interpolate.o: interpolate.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++interpolate.o: interpolate.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h filterdefs.h filter.h interpolate.h grtcirc.h
+-itracku.o: itracku.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++itracku.o: itracku.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h
+ jeeps/gpsapp.o: jeeps/gpsapp.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsserial.h jeeps/gpsusbint.h
+ jeeps/gpscom.o: jeeps/gpscom.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpsdevice.o: jeeps/gpsdevice.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h \
++  config.h   cet.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsdevice_ser.o: jeeps/gpsdevice_ser.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h \
++  config.h   cet.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsdevice_usb.o: jeeps/gpsdevice_usb.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h \
++  config.h   cet.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsusbcommon.h jeeps/gpsusbint.h
+ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/usb.h \
+-  jeeps/gps.h jeeps/../defs.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++  jeeps/gps.h jeeps/../defs.h   cet.h inifile.h \
+   gbfile.h defs.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   jeeps/garminusb.h jeeps/gpsusbcommon.h jeeps/../garmin_device_xml.h
+ jeeps/gpsmath.o: jeeps/gpsmath.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsdatum.h
+ jeeps/gpsmem.o: jeeps/gpsmem.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpsprot.o: jeeps/gpsprot.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpsread.o: jeeps/gpsread.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsrqst.o: jeeps/gpsrqst.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpssend.o: jeeps/gpssend.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsserial.o: jeeps/gpsserial.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h \
++  config.h   cet.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/../gbser.h \
+   jeeps/gpsserial.h gbser_posix.h
+ jeeps/gpsusbcommon.o: jeeps/gpsusbcommon.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h \
++  config.h   cet.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsusbcommon.h
+ jeeps/gpsusbread.o: jeeps/gpsusbread.cc jeeps/garminusb.h \
+-  jeeps/gpsdevice.h jeeps/gps.h jeeps/../defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++  jeeps/gpsdevice.h jeeps/gps.h jeeps/../defs.h config.h  \
++   cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsusbint.h
+ jeeps/gpsusbsend.o: jeeps/gpsusbsend.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h \
++  config.h   cet.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsusbint.h
+ jeeps/jgpsutil.o: jeeps/jgpsutil.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h cet.h inifile.h gbfile.h defs.h session.h \
++    cet.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+-jogmap.o: jogmap.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++jogmap.o: jogmap.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h xmlgeneric.h
+-jtr.o: jtr.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++jtr.o: jtr.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h csv_util.h
+-kml.o: kml.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++kml.o: kml.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h grtcirc.h \
+   src/core/file.h src/core/xmlstreamwriter.h src/core/xmltag.h \
+   xmlgeneric.h
+-lmx.o: lmx.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++lmx.o: lmx.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-lowranceusr.o: lowranceusr.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++lowranceusr.o: lowranceusr.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+ mac/libusb/darwin.o: mac/libusb/darwin.c config.h mac/libusb/usbi.h \
+@@ -788,294 +788,261 @@ mac/libusb/error.o: mac/libusb/error.c mac/libusb/usb.h \
+   mac/libusb/error.h
+ mac/libusb/usb.o: mac/libusb/usb.c mac/libusb/usbi.h mac/libusb/usb.h \
+   mac/libusb/error.h
+-maggeo.o: maggeo.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++maggeo.o: maggeo.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h magellan.h xmlgeneric.h
+-magproto.o: magproto.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++magproto.o: magproto.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   explorist_ini.h gbser.h magellan.h
+-main.o: main.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++main.o: main.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h \
+   csv_util.h filter.h filterdefs.h src/core/file.h \
+   src/core/usasciicodec.h
+-mapasia.o: mapasia.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++mapasia.o: mapasia.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-mapbar_track.o: mapbar_track.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++mapbar_track.o: mapbar_track.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-mapfactor.o: mapfactor.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++mapfactor.o: mapfactor.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/file.h src/core/xmlstreamwriter.h
+-mapsend.o: mapsend.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++mapsend.o: mapsend.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   mapsend.h magellan.h
+-mapsource.o: mapsource.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++mapsource.o: mapsource.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
+-mkshort.o: mkshort.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++mkshort.o: mkshort.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h
+-mmo.o: mmo.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++mmo.o: mmo.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h
+-mtk_locus.o: mtk_locus.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++mtk_locus.o: mtk_locus.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h
+-mtk_logger.o: mtk_logger.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++mtk_logger.o: mtk_logger.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h
+-mynav.o: mynav.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++mynav.o: mynav.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-navicache.o: navicache.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++navicache.o: navicache.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h src/core/file.h
+-naviguide.o: naviguide.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++naviguide.o: naviguide.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
+-navilink.o: navilink.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++navilink.o: navilink.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h jeeps/gpsmath.h jeeps/gpsport.h navilink.h
+-navitel.o: navitel.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++navitel.o: navitel.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-netstumbler.o: netstumbler.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++netstumbler.o: netstumbler.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h cet_util.h csv_util.h
+-nmea.o: nmea.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++nmea.o: nmea.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h \
+   gbser.h jeeps/gpsmath.h jeeps/gpsport.h src/core/logging.h strptime.h
+-nmn4.o: nmn4.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++nmn4.o: nmn4.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h \
+   csv_util.h
+-nukedata.o: nukedata.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++nukedata.o: nukedata.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h nukedata.h
+-osm.o: osm.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++osm.o: osm.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-ozi.o: ozi.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++ozi.o: ozi.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h csv_util.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/textstream.h src/core/file.h
+-parse.o: parse.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++parse.o: parse.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-pcx.o: pcx.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++pcx.o: pcx.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h cet_util.h \
+   csv_util.h garmin_tables.h
+-pocketfms_bc.o: pocketfms_bc.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++pocketfms_bc.o: pocketfms_bc.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-pocketfms_fp.o: pocketfms_fp.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++pocketfms_fp.o: pocketfms_fp.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h xmlgeneric.h
+-pocketfms_wp.o: pocketfms_wp.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++pocketfms_wp.o: pocketfms_wp.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h csv_util.h
+-polygon.o: polygon.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++polygon.o: polygon.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h polygon.h
+-position.o: position.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++position.o: position.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h grtcirc.h position.h
+-psitrex.o: psitrex.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++psitrex.o: psitrex.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h
+-radius.o: radius.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++radius.o: radius.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h radius.h grtcirc.h
+-random.o: random.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++random.o: random.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+-raymarine.o: raymarine.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++raymarine.o: raymarine.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h
+-reverse_route.o: reverse_route.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h cet.h inifile.h gbfile.h session.h src/core/datetime.h \
++reverse_route.o: reverse_route.cc defs.h config.h  \
++   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h filterdefs.h filter.h reverse_route.h
+-rgbcolors.o: rgbcolors.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++rgbcolors.o: rgbcolors.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-route.o: route.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++route.o: route.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-saroute.o: saroute.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++saroute.o: saroute.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-sbn.o: sbn.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++sbn.o: sbn.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h navilink.h
+-sbp.o: sbp.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++sbp.o: sbp.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h navilink.h
+-session.o: session.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++session.o: session.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-shape.o: shape.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++shape.o: shape.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   shapelib/shapefil.h
+ shapelib/dbfopen.o: shapelib/dbfopen.c shapelib/shapefil.h
+ shapelib/safileio.o: shapelib/safileio.c shapelib/shapefil.h
+ shapelib/shpopen.o: shapelib/shpopen.c shapelib/shapefil.h
+-skyforce.o: skyforce.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++skyforce.o: skyforce.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-skytraq.o: skytraq.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++skytraq.o: skytraq.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h
+-smplrout.o: smplrout.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++smplrout.o: smplrout.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h grtcirc.h smplrout.h
+-sort.o: sort.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++sort.o: sort.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h sort.h
+ src/core/textstream.o: src/core/textstream.cc src/core/textstream.h \
+-  src/core/file.h defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++  src/core/file.h defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+ src/core/usasciicodec.o: src/core/usasciicodec.cc src/core/usasciicodec.h
+ src/core/xmlstreamwriter.o: src/core/xmlstreamwriter.cc \
+   src/core/xmlstreamwriter.h
+-stackfilter.o: stackfilter.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++stackfilter.o: stackfilter.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h filterdefs.h filter.h stackfilter.h
+-stmsdf.o: stmsdf.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++stmsdf.o: stmsdf.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h grtcirc.h jeeps/gpsmath.h jeeps/gpsport.h \
+   src/core/logging.h
+-stmwpp.o: stmwpp.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++stmwpp.o: stmwpp.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h cet_util.h
+ strptime.o: strptime.c config.h strptime.h
+-subrip.o: subrip.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++subrip.o: subrip.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-swapdata.o: swapdata.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++swapdata.o: swapdata.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h swapdata.h
+-tef_xml.o: tef_xml.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++tef_xml.o: tef_xml.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-teletype.o: teletype.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++teletype.o: teletype.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-text.o: text.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++text.o: text.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
+-tiger.o: tiger.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++tiger.o: tiger.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h
+-tmpro.o: tmpro.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++tmpro.o: tmpro.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h
+-tomtom.o: tomtom.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++tomtom.o: tomtom.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-tpg.o: tpg.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++tpg.o: tpg.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-tpo.o: tpo.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++tpo.o: tpo.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-trackfilter.o: trackfilter.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++trackfilter.o: trackfilter.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h filterdefs.h filter.h trackfilter.h grtcirc.h
+-transform.o: transform.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++transform.o: transform.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h transform.h
+-unicsv.o: unicsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++unicsv.o: unicsv.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h \
+   src/core/logging.h src/core/textstream.h src/core/file.h
+-units.o: units.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++units.o: units.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-util.o: util.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++util.o: util.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/xmltag.h
+ util_crc.o: util_crc.cc
+-v900.o: v900.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++v900.o: v900.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h
+-validate.o: validate.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++validate.o: validate.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   filterdefs.h filter.h validate.h
+-vcf.o: vcf.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++vcf.o: vcf.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-vecs.o: vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++vecs.o: vecs.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h csv_util.h \
+   gbversion.h xcsv.h src/core/file.h
+-vidaone.o: vidaone.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++vidaone.o: vidaone.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-vitosmt.o: vitosmt.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++vitosmt.o: vitosmt.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-vitovtt.o: vitovtt.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++vitovtt.o: vitovtt.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-vpl.o: vpl.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++vpl.o: vpl.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h
+-waypt.o: waypt.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++waypt.o: waypt.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h grtcirc.h \
+   src/core/logging.h
+-wbt-200.o: wbt-200.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++wbt-200.o: wbt-200.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h grtcirc.h
+-wfff_xml.o: wfff_xml.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++wfff_xml.o: wfff_xml.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-wintec_tes.o: wintec_tes.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++wintec_tes.o: wintec_tes.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-xcsv.o: xcsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++xcsv.o: xcsv.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h csv_util.h \
+   garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h grtcirc.h \
+   src/core/file.h src/core/logging.h strptime.h xcsv.h xcsv_tokens.gperf
+-xmlgeneric.o: xmlgeneric.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++xmlgeneric.o: xmlgeneric.cc defs.h config.h   \
+   cet.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h cet_util.h src/core/file.h xmlgeneric.h
+-xmltag.o: xmltag.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++xmltag.o: xmltag.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h src/core/xmltag.h
+-xol.o: xol.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h inifile.h \
++xol.o: xol.cc defs.h config.h   cet.h inifile.h \
+   gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h src/core/file.h \
+   src/core/xmlstreamwriter.h xmlgeneric.h
+-yahoo.o: yahoo.cc defs.h config.h zlib/zlib.h zlib/zconf.h cet.h \
++yahoo.o: yahoo.cc defs.h config.h   cet.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-zlib/adler32.o: zlib/adler32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/compress.o: zlib/compress.c zlib/zlib.h zlib/zconf.h config.h
+-zlib/contrib/minizip/ioapi.o: zlib/contrib/minizip/ioapi.c \
+-  zlib/contrib/minizip/ioapi.h zlib/zlib.h zlib/zconf.h config.h
+-zlib/contrib/minizip/zip.o: zlib/contrib/minizip/zip.c zlib/zlib.h \
+-  zlib/zconf.h config.h zlib/contrib/minizip/zip.h \
+-  zlib/contrib/minizip/ioapi.h zlib/contrib/minizip/crypt.h
+-zlib/crc32.o: zlib/crc32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h config.h \
+-  zlib/crc32.h
+-zlib/deflate.o: zlib/deflate.c zlib/deflate.h zlib/zutil.h zlib/zlib.h \
+-  zlib/zconf.h config.h
+-zlib/gzclose.o: zlib/gzclose.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzlib.o: zlib/gzlib.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzread.o: zlib/gzread.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzwrite.o: zlib/gzwrite.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/infback.o: zlib/infback.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h zlib/inffixed.h
+-zlib/inffast.o: zlib/inffast.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h
+-zlib/inflate.o: zlib/inflate.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h zlib/inffixed.h
+-zlib/inftrees.o: zlib/inftrees.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h
+-zlib/trees.o: zlib/trees.c zlib/deflate.h zlib/zutil.h zlib/zlib.h \
+-  zlib/zconf.h config.h zlib/trees.h
+-zlib/uncompr.o: zlib/uncompr.c zlib/zlib.h zlib/zconf.h config.h
+-zlib/zutil.o: zlib/zutil.c zlib/zutil.h zlib/zlib.h zlib/zconf.h config.h \
+-  zlib/gzguts.h
+ internal_styles.cc: mkstyle.sh $(srcdir)/style/*.style
+ 	$(srcdir)/mkstyle.sh > internal_styles.cc || (rm -f internal_styles.cc ; exit 1)

--- a/tools/archive_images/gpsbabel_1_7_0.patch
+++ b/tools/archive_images/gpsbabel_1_7_0.patch
@@ -1,0 +1,882 @@
+diff --git a/Makefile.in b/Makefile.in
+index 5ace8da1..60c6bbb4 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -424,86 +424,86 @@ mac/libusb/libusb-1.0.a:
+ 	cd mac/libusb; $(QMAKE) @abs_srcdir@/mac/libusb/libusb.pro && $(MAKE)
+ 
+ # Machine generated from here down.
+-alan.o: alan.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++alan.o: alan.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-an1.o: an1.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++an1.o: an1.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   an1sym.h
+-arcdist.o: arcdist.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++arcdist.o: arcdist.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   arcdist.h filter.h grtcirc.h src/core/logging.h
+-bcr.o: bcr.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++bcr.o: bcr.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h garmin_tables.h
+-bend.o: bend.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++bend.o: bend.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   bend.h filter.h grtcirc.h
+-brauniger_iq.o: brauniger_iq.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++brauniger_iq.o: brauniger_iq.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h
+-bushnell.o: bushnell.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++bushnell.o: bushnell.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-bushnell_trl.o: bushnell_trl.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++bushnell_trl.o: bushnell_trl.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-cet.o: cet.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++cet.o: cet.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet.h
+-cet_util.o: cet_util.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++cet_util.o: cet_util.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h cet_util.h src/core/logging.h
+-compegps.o: compegps.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++compegps.o: compegps.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h cet_util.h csv_util.h jeeps/gpsmath.h \
+   jeeps/gpsport.h
+-cst.o: cst.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++cst.o: cst.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h
+-csv_util.o: csv_util.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++csv_util.o: csv_util.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h csv_util.h src/core/logging.h
+-delgpl.o: delgpl.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++delgpl.o: delgpl.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-destinator.o: destinator.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++destinator.o: destinator.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   strptime.h
+-dg-100.o: dg-100.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++dg-100.o: dg-100.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   dg-100.h format.h gbser.h
+-discard.o: discard.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++discard.o: discard.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   discard.h filter.h
+-dmtlog.o: dmtlog.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++dmtlog.o: dmtlog.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h xmlgeneric.h
+-duplicate.o: duplicate.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++duplicate.o: duplicate.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h duplicate.h filter.h
+-easygps.o: easygps.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++easygps.o: easygps.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-energympro.o: energympro.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++energympro.o: energympro.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h energympro.h format.h
+-enigma.o: enigma.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++enigma.o: enigma.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-exif.o: exif.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++exif.o: exif.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h
+-explorist_ini.o: explorist_ini.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++explorist_ini.o: explorist_ini.cc defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h explorist_ini.h
+-f90g_track.o: f90g_track.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++f90g_track.o: f90g_track.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-fatal.o: fatal.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++fatal.o: fatal.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/logging.h
+-filter_vecs.o: filter_vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++filter_vecs.o: filter_vecs.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h filter_vecs.h arcdist.h filter.h bend.h discard.h \
+   duplicate.h height.h heightgrid.h interpolate.h nukedata.h polygon.h \
+@@ -518,17 +518,17 @@ filter_vecs.o: filter_vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h yahoo.h
+-formspec.o: formspec.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++formspec.o: formspec.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-g7towin.o: g7towin.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++g7towin.o: g7towin.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   garmin_tables.h strptime.h
+-garmin.o: garmin.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++garmin.o: garmin.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h format.h garmin_device_xml.h garmin_fs.h jeeps/gps.h \
+   jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+@@ -540,101 +540,101 @@ garmin.o: garmin.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
+   kml.h xmlgeneric.h legacyformat.h lowranceusr.h mynav.h nmea.h osm.h \
+   qstarz_bl_1000.h random.h shape.h shapelib/shapefil.h subrip.h \
+   unicsv.h src/core/textstream.h xcsv.h yahoo.h
+-garmin_device_xml.o: garmin_device_xml.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++garmin_device_xml.o: garmin_device_xml.cc defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h garmin_device_xml.h \
+   xmlgeneric.h
+-garmin_fit.o: garmin_fit.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_fit.o: garmin_fit.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h garmin_fit.h format.h jeeps/gpsmath.h \
+   jeeps/gpsport.h src/core/logging.h
+-garmin_fs.o: garmin_fs.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_fs.o: garmin_fs.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   garmin_tables.h
+-garmin_gpi.o: garmin_gpi.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_gpi.o: garmin_gpi.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h garmin_gpi.h cet_util.h garmin_fs.h jeeps/gps.h \
+   jeeps/../defs.h jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h \
+   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+   jeeps/gpsrqst.h
+-garmin_tables.o: garmin_tables.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++garmin_tables.o: garmin_tables.cc defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h garmin_tables.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/logging.h \
+   garmin_icon_tables.h
+-garmin_txt.o: garmin_txt.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_txt.o: garmin_txt.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h csv_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   garmin_tables.h src/core/textstream.h src/core/file.h strptime.h
+-garmin_xt.o: garmin_xt.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++garmin_xt.o: garmin_xt.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-gbfile.o: gbfile.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gbfile.o: gbfile.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/logging.h cet.h
+-gbser.o: gbser.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gbser.o: gbser.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h gbser_private.h
+-gbser_posix.o: gbser_posix.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++gbser_posix.o: gbser_posix.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h gbser_private.h
+-gdb.o: gdb.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gdb.o: gdb.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h \
+   grtcirc.h
+-geo.o: geo.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++geo.o: geo.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/file.h
+-geojson.o: geojson.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++geojson.o: geojson.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   geojson.h format.h src/core/file.h src/core/logging.h
+-ggv_bin.o: ggv_bin.cc ggv_bin.h defs.h config.h zlib/zlib.h zlib/zconf.h \
++ggv_bin.o: ggv_bin.cc ggv_bin.h defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h format.h
+-ggv_log.o: ggv_log.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++ggv_log.o: ggv_log.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-ggv_ovl.o: ggv_ovl.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++ggv_ovl.o: ggv_ovl.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-globals.o: globals.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++globals.o: globals.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbversion.h
+-globalsat_sport.o: globalsat_sport.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++globalsat_sport.o: globalsat_sport.cc defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h globalsat_sport.h format.h \
+   gbser.h
+-glogbook.o: glogbook.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++glogbook.o: glogbook.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h src/core/file.h xmlgeneric.h
+-gnav_trl.o: gnav_trl.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++gnav_trl.o: gnav_trl.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-googledir.o: googledir.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++googledir.o: googledir.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h xmlgeneric.h
+-gopal.o: gopal.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gopal.o: gopal.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h grtcirc.h jeeps/gpsmath.h jeeps/gpsport.h \
+   strptime.h
+-gpssim.o: gpssim.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gpssim.o: gpssim.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   nmea.h format.h
+-gpsutil.o: gpsutil.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gpsutil.o: gpsutil.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h magellan.h
+-gpx.o: gpx.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gpx.o: gpx.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gpx.h format.h src/core/file.h src/core/xmlstreamwriter.h \
+   src/core/xmltag.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+@@ -642,88 +642,88 @@ gpx.o: gpx.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h \
+   garmin_tables.h src/core/logging.h
+-grtcirc.o: grtcirc.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++grtcirc.o: grtcirc.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-gtm.o: gtm.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gtm.o: gtm.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-gtrnctr.o: gtrnctr.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++gtrnctr.o: gtrnctr.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-height.o: height.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++height.o: height.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   height.h filter.h heightgrid.h
+-hiketech.o: hiketech.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++hiketech.o: hiketech.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h src/core/xmlstreamwriter.h xmlgeneric.h
+-holux.o: holux.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++holux.o: holux.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   holux.h
+-html.o: html.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++html.o: html.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
+-humminbird.o: humminbird.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++humminbird.o: humminbird.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-igc.o: igc.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++igc.o: igc.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h
+-ignrando.o: ignrando.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++ignrando.o: ignrando.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h xmlgeneric.h
+-igo8.o: igo8.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++igo8.o: igo8.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-ik3d.o: ik3d.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++ik3d.o: ik3d.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-inifile.o: inifile.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++inifile.o: inifile.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/file.h
+-internal_styles.o: internal_styles.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++internal_styles.o: internal_styles.cc defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h
+-interpolate.o: interpolate.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++interpolate.o: interpolate.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h interpolate.h filter.h grtcirc.h \
+   src/core/logging.h
+-itracku.o: itracku.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++itracku.o: itracku.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h
+ jeeps/gpsapp.o: jeeps/gpsapp.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsserial.h jeeps/gpsusbint.h
+ jeeps/gpscom.o: jeeps/gpscom.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpsdevice.o: jeeps/gpsdevice.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++  config.h   formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsdevice_ser.o: jeeps/gpsdevice_ser.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++  config.h   formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsdevice_usb.o: jeeps/gpsdevice_usb.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++  config.h   formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsusbcommon.h jeeps/gpsusbint.h
+ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/libusb.h \
+-  jeeps/../defs.h zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h \
++  jeeps/../defs.h   formspec.h inifile.h gbfile.h \
+   defs.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/garminusb.h jeeps/gpsdevice.h jeeps/gps.h jeeps/gpsport.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+@@ -731,95 +731,95 @@ jeeps/gpslibusb.o: jeeps/gpslibusb.cc config.h mac/libusb/libusb.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsusbcommon.h \
+   jeeps/../garmin_device_xml.h
+ jeeps/gpsmath.o: jeeps/gpsmath.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsdatum.h
+ jeeps/gpsmem.o: jeeps/gpsmem.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpsprot.o: jeeps/gpsprot.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpsread.o: jeeps/gpsread.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsrqst.o: jeeps/gpsrqst.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+ jeeps/gpssend.o: jeeps/gpssend.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsserial.h
+ jeeps/gpsserial.o: jeeps/gpsserial.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++  config.h   formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/../gbser.h \
+   jeeps/gpsserial.h gbser_posix.h
+ jeeps/gpsusbcommon.o: jeeps/gpsusbcommon.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++  config.h   formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsusbcommon.h
+ jeeps/gpsusbread.o: jeeps/gpsusbread.cc jeeps/garminusb.h \
+-  jeeps/gpsdevice.h jeeps/gps.h jeeps/../defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h defs.h session.h \
++  jeeps/gpsdevice.h jeeps/gps.h jeeps/../defs.h config.h  \
++   formspec.h inifile.h gbfile.h defs.h session.h \
+   src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h \
+   jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h \
+   jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/gpsusbint.h
+ jeeps/gpsusbsend.o: jeeps/gpsusbsend.cc jeeps/gps.h jeeps/../defs.h \
+-  config.h zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++  config.h   formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h jeeps/garminusb.h \
+   jeeps/gpsusbint.h
+ jeeps/jgpsutil.o: jeeps/jgpsutil.cc jeeps/gps.h jeeps/../defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h defs.h \
++    formspec.h inifile.h gbfile.h defs.h \
+   session.h src/core/datetime.h src/core/optional.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+-jogmap.o: jogmap.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++jogmap.o: jogmap.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h xmlgeneric.h
+-jtr.o: jtr.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++jtr.o: jtr.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h nmea.h format.h
+-kml.o: kml.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++kml.o: kml.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   kml.h format.h src/core/file.h src/core/xmlstreamwriter.h xmlgeneric.h \
+   grtcirc.h src/core/logging.h src/core/xmltag.h units.h
+-lmx.o: lmx.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++lmx.o: lmx.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-lowranceusr.o: lowranceusr.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++lowranceusr.o: lowranceusr.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h lowranceusr.h format.h src/core/logging.h
+-maggeo.o: maggeo.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++maggeo.o: maggeo.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h magellan.h
+-magproto.o: magproto.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++magproto.o: magproto.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h explorist_ini.h format.h gbser.h magellan.h vecs.h \
+   dg-100.h energympro.h garmin_fit.h geojson.h src/core/file.h ggv_bin.h \
+@@ -831,7 +831,7 @@ magproto.o: magproto.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
+   jeeps/gpsread.h jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h \
+   jeeps/gpscom.h jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h \
+   jeeps/gpsrqst.h yahoo.h
+-main.o: main.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++main.o: main.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h filter.h filter_vecs.h arcdist.h bend.h \
+   discard.h duplicate.h height.h heightgrid.h interpolate.h nukedata.h \
+@@ -846,191 +846,191 @@ main.o: main.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h yahoo.h
+-mapasia.o: mapasia.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++mapasia.o: mapasia.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-mapbar_track.o: mapbar_track.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++mapbar_track.o: mapbar_track.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-mapfactor.o: mapfactor.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++mapfactor.o: mapfactor.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h src/core/file.h src/core/xmlstreamwriter.h
+-mapsend.o: mapsend.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++mapsend.o: mapsend.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   mapsend.h magellan.h
+-mkshort.o: mkshort.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++mkshort.o: mkshort.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet.h
+-mmo.o: mmo.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++mmo.o: mmo.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-mtk_locus.o: mtk_locus.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++mtk_locus.o: mtk_locus.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h
+-mtk_logger.o: mtk_logger.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++mtk_logger.o: mtk_logger.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h
+ mynav.o: mynav.cc src/core/textstream.h src/core/file.h defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++    formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h mynav.h format.h
+-navicache.o: navicache.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++navicache.o: navicache.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h cet_util.h src/core/file.h
+-naviguide.o: naviguide.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++naviguide.o: naviguide.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h csv_util.h jeeps/gpsmath.h jeeps/gpsport.h
+-navilink.o: navilink.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++navilink.o: navilink.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h gbser.h jeeps/gpsmath.h jeeps/gpsport.h navilink.h
+-navitel.o: navitel.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++navitel.o: navitel.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-netstumbler.o: netstumbler.cc cet_util.h defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++netstumbler.o: netstumbler.cc cet_util.h defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h csv_util.h
+-nmea.o: nmea.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++nmea.o: nmea.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   nmea.h format.h cet_util.h gbser.h jeeps/gpsmath.h jeeps/gpsport.h \
+   src/core/logging.h strptime.h
+-nmn4.o: nmn4.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++nmn4.o: nmn4.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h
+-nukedata.o: nukedata.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++nukedata.o: nukedata.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h nukedata.h filter.h
+-osm.o: osm.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++osm.o: osm.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   osm.h format.h xmlgeneric.h
+-ozi.o: ozi.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++ozi.o: ozi.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h jeeps/gpsmath.h jeeps/gpsport.h src/core/textstream.h \
+   src/core/file.h
+-parse.o: parse.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++parse.o: parse.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-pcx.o: pcx.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++pcx.o: pcx.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h garmin_tables.h
+-pocketfms_bc.o: pocketfms_bc.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++pocketfms_bc.o: pocketfms_bc.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-pocketfms_fp.o: pocketfms_fp.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++pocketfms_fp.o: pocketfms_fp.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h xmlgeneric.h
+-pocketfms_wp.o: pocketfms_wp.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++pocketfms_wp.o: pocketfms_wp.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h csv_util.h
+-polygon.o: polygon.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++polygon.o: polygon.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   polygon.h filter.h
+-position.o: position.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++position.o: position.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h grtcirc.h position.h filter.h
+ qstarz_bl_1000.o: qstarz_bl_1000.cc qstarz_bl_1000.h defs.h config.h \
+-  zlib/zlib.h zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++    formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h format.h src/core/logging.h
+-radius.o: radius.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++radius.o: radius.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   radius.h filter.h grtcirc.h
+-random.o: random.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++random.o: random.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   random.h format.h garmin_fs.h jeeps/gps.h jeeps/../defs.h \
+   jeeps/gpsport.h jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h
+-raymarine.o: raymarine.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++raymarine.o: raymarine.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h csv_util.h
+-reverse_route.o: reverse_route.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++reverse_route.o: reverse_route.cc defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h reverse_route.h filter.h
+-rgbcolors.o: rgbcolors.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++rgbcolors.o: rgbcolors.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-route.o: route.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++route.o: route.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-saroute.o: saroute.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++saroute.o: saroute.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-sbn.o: sbn.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++sbn.o: sbn.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   navilink.h
+-sbp.o: sbp.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++sbp.o: sbp.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   navilink.h
+-session.o: session.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++session.o: session.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-shape.o: shape.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++shape.o: shape.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   shape.h format.h shapelib/shapefil.h
+ shapelib/dbfopen.o: shapelib/dbfopen.c shapelib/shapefil.h
+ shapelib/safileio.o: shapelib/safileio.c shapelib/shapefil.h
+ shapelib/shpopen.o: shapelib/shpopen.c shapelib/shapefil.h
+-skyforce.o: skyforce.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++skyforce.o: skyforce.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-skytraq.o: skytraq.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++skytraq.o: skytraq.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h
+-smplrout.o: smplrout.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++smplrout.o: smplrout.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h smplrout.h filter.h grtcirc.h
+-sort.o: sort.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++sort.o: sort.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   sort.h filter.h
+-src/core/textstream.o: src/core/textstream.cc defs.h config.h zlib/zlib.h \
+-  zlib/zconf.h formspec.h inifile.h gbfile.h session.h \
++src/core/textstream.o: src/core/textstream.cc defs.h config.h  \
++   formspec.h inifile.h gbfile.h session.h \
+   src/core/datetime.h src/core/optional.h src/core/textstream.h \
+   src/core/file.h
+ src/core/usasciicodec.o: src/core/usasciicodec.cc src/core/usasciicodec.h
+ src/core/xmlstreamwriter.o: src/core/xmlstreamwriter.cc \
+   src/core/xmlstreamwriter.h
+-stackfilter.o: stackfilter.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++stackfilter.o: stackfilter.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h stackfilter.h filter.h
+-stmsdf.o: stmsdf.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++stmsdf.o: stmsdf.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h grtcirc.h jeeps/gpsmath.h jeeps/gpsport.h \
+   src/core/logging.h
+-stmwpp.o: stmwpp.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++stmwpp.o: stmwpp.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h
+ strptime.o: strptime.c config.h strptime.h
+-subrip.o: subrip.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++subrip.o: subrip.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   subrip.h format.h src/core/logging.h
+-swapdata.o: swapdata.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++swapdata.o: swapdata.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h swapdata.h filter.h
+-tef_xml.o: tef_xml.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++tef_xml.o: tef_xml.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   xmlgeneric.h
+-teletype.o: teletype.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++teletype.o: teletype.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-text.o: text.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++text.o: text.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h src/core/xmltag.h
+-tiger.o: tiger.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++tiger.o: tiger.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h
+-tmpro.o: tmpro.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++tmpro.o: tmpro.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet_util.h csv_util.h
+-tomtom.o: tomtom.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++tomtom.o: tomtom.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-tpg.o: tpg.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++tpg.o: tpg.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-tpo.o: tpo.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++tpo.o: tpo.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-trackfilter.o: trackfilter.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++trackfilter.o: trackfilter.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h trackfilter.h filter.h grtcirc.h
+-transform.o: transform.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++transform.o: transform.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h transform.h filter.h
+-unicsv.o: unicsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++unicsv.o: unicsv.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   unicsv.h format.h src/core/textstream.h src/core/file.h csv_util.h \
+   garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+@@ -1038,22 +1038,22 @@ unicsv.o: unicsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h garmin_tables.h \
+   src/core/logging.h
+-units.o: units.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++units.o: units.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   units.h
+-util.o: util.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++util.o: util.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   cet.h src/core/logging.h src/core/xmltag.h
+ util_crc.o: util_crc.cc
+-v900.o: v900.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++v900.o: v900.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-validate.o: validate.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++validate.o: validate.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h validate.h filter.h
+-vcf.o: vcf.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++vcf.o: vcf.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   jeeps/gpsmath.h jeeps/gpsport.h
+-vecs.o: vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++vecs.o: vecs.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   vecs.h dg-100.h format.h energympro.h garmin_fit.h geojson.h \
+   src/core/file.h ggv_bin.h globalsat_sport.h gpx.h \
+@@ -1065,32 +1065,32 @@ vecs.o: vecs.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
+   jeeps/gpsutil.h jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h \
+   jeeps/gpsfmt.h jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h yahoo.h \
+   gbversion.h src/core/logging.h
+-vidaone.o: vidaone.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++vidaone.o: vidaone.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-vitosmt.o: vitosmt.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++vitosmt.o: vitosmt.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   grtcirc.h
+-vitovtt.o: vitovtt.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++vitovtt.o: vitovtt.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-vpl.o: vpl.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++vpl.o: vpl.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h
+-waypt.o: waypt.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++waypt.o: waypt.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+   jeeps/gpsapp.h jeeps/gpsprot.h jeeps/gpscom.h jeeps/gpsfmt.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h grtcirc.h \
+   src/core/logging.h
+-wbt-200.o: wbt-200.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++wbt-200.o: wbt-200.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   gbser.h grtcirc.h
+-wfff_xml.o: wfff_xml.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++wfff_xml.o: wfff_xml.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h xmlgeneric.h
+-wintec_tes.o: wintec_tes.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++wintec_tes.o: wintec_tes.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h
+-xcsv.o: xcsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++xcsv.o: xcsv.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   csv_util.h garmin_fs.h jeeps/gps.h jeeps/../defs.h jeeps/gpsport.h \
+   jeeps/gpsdevice.h jeeps/gpssend.h jeeps/gpsread.h jeeps/gpsutil.h \
+@@ -1098,46 +1098,18 @@ xcsv.o: xcsv.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
+   jeeps/gpsmath.h jeeps/gpsmem.h jeeps/gpsrqst.h grtcirc.h \
+   src/core/logging.h src/core/textstream.h src/core/file.h strptime.h \
+   xcsv.h format.h xcsv_tokens.gperf
+-xmlgeneric.o: xmlgeneric.cc defs.h config.h zlib/zlib.h zlib/zconf.h \
++xmlgeneric.o: xmlgeneric.cc defs.h config.h   \
+   formspec.h inifile.h gbfile.h session.h src/core/datetime.h \
+   src/core/optional.h xmlgeneric.h src/core/file.h
+-xmltag.o: xmltag.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++xmltag.o: xmltag.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   src/core/xmltag.h
+-xol.o: xol.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++xol.o: xol.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   garmin_tables.h jeeps/gpsmath.h jeeps/gpsport.h src/core/file.h \
+   src/core/xmlstreamwriter.h xmlgeneric.h
+-yahoo.o: yahoo.cc defs.h config.h zlib/zlib.h zlib/zconf.h formspec.h \
++yahoo.o: yahoo.cc defs.h config.h   formspec.h \
+   inifile.h gbfile.h session.h src/core/datetime.h src/core/optional.h \
+   yahoo.h format.h xmlgeneric.h
+-zlib/adler32.o: zlib/adler32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/compress.o: zlib/compress.c zlib/zlib.h zlib/zconf.h config.h
+-zlib/crc32.o: zlib/crc32.c zlib/zutil.h zlib/zlib.h zlib/zconf.h config.h \
+-  zlib/crc32.h
+-zlib/deflate.o: zlib/deflate.c zlib/deflate.h zlib/zutil.h zlib/zlib.h \
+-  zlib/zconf.h config.h
+-zlib/gzclose.o: zlib/gzclose.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzlib.o: zlib/gzlib.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzread.o: zlib/gzread.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/gzwrite.o: zlib/gzwrite.c zlib/gzguts.h zlib/zlib.h zlib/zconf.h \
+-  config.h
+-zlib/infback.o: zlib/infback.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h zlib/inffixed.h
+-zlib/inffast.o: zlib/inffast.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h
+-zlib/inflate.o: zlib/inflate.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h zlib/inflate.h zlib/inffast.h zlib/inffixed.h
+-zlib/inftrees.o: zlib/inftrees.c zlib/zutil.h zlib/zlib.h zlib/zconf.h \
+-  config.h zlib/inftrees.h
+-zlib/trees.o: zlib/trees.c zlib/deflate.h zlib/zutil.h zlib/zlib.h \
+-  zlib/zconf.h config.h zlib/trees.h
+-zlib/uncompr.o: zlib/uncompr.c zlib/zlib.h zlib/zconf.h config.h
+-zlib/zutil.o: zlib/zutil.c zlib/zutil.h zlib/zlib.h zlib/zconf.h config.h \
+-  zlib/gzguts.h
+ internal_styles.cc: mkstyle.sh $(srcdir)/style/*.style
+ 	$(srcdir)/mkstyle.sh > internal_styles.cc || (rm -f internal_styles.cc ; exit 1)

--- a/tools/archive_images/gpsbabel_dev.patch
+++ b/tools/archive_images/gpsbabel_dev.patch
@@ -1,0 +1,13 @@
+diff --git a/gui/babeldata.h b/gui/babeldata.h
+index 9adb4dcd..00392f64 100644
+--- a/gui/babeldata.h
++++ b/gui/babeldata.h
+@@ -63,7 +63,7 @@ public:
+     upgradeErrors_(0),
+     upgradeOffers_(0),
+     runCount_(0),
+-    startupVersionCheck_(true),
++    startupVersionCheck_(false),
+     reportStatistics_(true),
+     allowBetaUpgrades_(false),
+     ignoreVersionMismatch_(false),

--- a/tools/archive_images/make_docker_image_gpsbabel.sh
+++ b/tools/archive_images/make_docker_image_gpsbabel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+# you must be logged into docker for the push to succeed.
+
+versuffix=${1:+$1} # tag name must be lower case
+TMPDIR=$(mktemp -d)
+
+cp "Dockerfile_gpsbabel_${versuffix}" "$TMPDIR"
+cp setup_user.sh "$TMPDIR"
+cp ./*.patch "$TMPDIR"
+
+docker build --pull --file "Dockerfile_gpsbabel_${versuffix}" \
+             --tag "tsteven4/gpsbabel:${versuffix}" \
+             --progress=plain \
+             "$TMPDIR"
+
+/bin/rm -fr "$TMPDIR"
+#docker push tsteven4/gpsbabel:latest
+docker image ls

--- a/tools/archive_images/push.sh
+++ b/tools/archive_images/push.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+docker push tsteven4/gpsbabel:1.5.0
+docker push tsteven4/gpsbabel:1.5.1
+docker push tsteven4/gpsbabel:1.5.2
+docker push tsteven4/gpsbabel:1.5.3
+docker push tsteven4/gpsbabel:1.5.4
+docker push tsteven4/gpsbabel:1.6.0
+docker push tsteven4/gpsbabel:1.7.0
+docker push tsteven4/gpsbabel:1.8.0
+docker push tsteven4/gpsbabel:1.9.0

--- a/tools/archive_images/push.sh
+++ b/tools/archive_images/push.sh
@@ -9,3 +9,4 @@ docker push tsteven4/gpsbabel:1.7.0
 docker push tsteven4/gpsbabel:1.8.0
 docker push tsteven4/gpsbabel:1.9.0
 docker push tsteven4/gpsbabel:latest
+docker push tsteven4/gpsbabel:dev

--- a/tools/archive_images/push.sh
+++ b/tools/archive_images/push.sh
@@ -8,3 +8,4 @@ docker push tsteven4/gpsbabel:1.6.0
 docker push tsteven4/gpsbabel:1.7.0
 docker push tsteven4/gpsbabel:1.8.0
 docker push tsteven4/gpsbabel:1.9.0
+docker push tsteven4/gpsbabel:latest

--- a/tools/archive_images/rebuild.sh
+++ b/tools/archive_images/rebuild.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+./make_docker_image_gpsbabel.sh 1.5.0
+./make_docker_image_gpsbabel.sh 1.5.1
+./make_docker_image_gpsbabel.sh 1.5.2
+./make_docker_image_gpsbabel.sh 1.5.3
+./make_docker_image_gpsbabel.sh 1.5.4
+./make_docker_image_gpsbabel.sh 1.6.0
+./make_docker_image_gpsbabel.sh 1.7.0
+./make_docker_image_gpsbabel.sh 1.8.0
+./make_docker_image_gpsbabel.sh 1.9.0

--- a/tools/archive_images/run_gpsbabel.sh
+++ b/tools/archive_images/run_gpsbabel.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+VERSION=latest
+while getopts "v:" opt; do
+  case $opt in
+    v) VERSION=$OPTARG;;
+  esac
+done
+shift $(($OPTIND -1))
+
+container=$(docker create -q -i -t -w /app -v "$(pwd):/app" "tsteven4/gpsbabel:${VERSION}")
+docker start "${container}" >/dev/null
+docker exec -i -t "${container}" setup_user.sh "$(id -u)" "$(id -g)"
+docker exec -i -t -u "$(id -u):$(id -g)" "${container}" gpsbabel "$@"
+docker rm -f "${container}" >/dev/null
+
+

--- a/tools/archive_images/run_gpsbabel.sh
+++ b/tools/archive_images/run_gpsbabel.sh
@@ -3,12 +3,13 @@ VERSION=latest
 while getopts "v:" opt; do
   case $opt in
     v) VERSION=$OPTARG;;
+    *) exit 1;;
   esac
 done
 shift $(($OPTIND -1))
 
 container=$(docker create -q -i -t -w /app -v "$(pwd):/app" "tsteven4/gpsbabel:${VERSION}")
-trap "docker rm -f ${container} >/dev/null" 0 1 2 3 15
+trap 'docker rm -f "${container}" >/dev/null' 0 1 2 3 15
 docker start "${container}" >/dev/null
 docker exec -i -t "${container}" setup_user.sh "$(id -u)" "$(id -g)"
 docker exec -i -t -u "$(id -u):$(id -g)" "${container}" gpsbabel "$@"

--- a/tools/archive_images/run_gpsbabel.sh
+++ b/tools/archive_images/run_gpsbabel.sh
@@ -8,9 +8,9 @@ done
 shift $(($OPTIND -1))
 
 container=$(docker create -q -i -t -w /app -v "$(pwd):/app" "tsteven4/gpsbabel:${VERSION}")
+trap "docker rm -f ${container} >/dev/null" 0 1 2 3 15
 docker start "${container}" >/dev/null
 docker exec -i -t "${container}" setup_user.sh "$(id -u)" "$(id -g)"
 docker exec -i -t -u "$(id -u):$(id -g)" "${container}" gpsbabel "$@"
-docker rm -f "${container}" >/dev/null
 
 

--- a/tools/archive_images/run_gpsbabel.sh
+++ b/tools/archive_images/run_gpsbabel.sh
@@ -6,7 +6,7 @@ while getopts "v:" opt; do
     *) exit 1;;
   esac
 done
-shift $(($OPTIND -1))
+shift $((OPTIND -1))
 
 container=$(docker create -q -i -t -w /app -v "$(pwd):/app" "tsteven4/gpsbabel:${VERSION}")
 trap 'docker rm -f "${container}" >/dev/null' 0 1 2 3 15

--- a/tools/archive_images/run_gpsbabelfe.sh
+++ b/tools/archive_images/run_gpsbabelfe.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+VERSION=latest
+while getopts "v:" opt; do
+  case $opt in
+    v) VERSION=$OPTARG;;
+    *) exit 1;;
+  esac
+done
+shift $((OPTIND -1))
+
+container=$(docker create -q -i -t -w /app -v "$(pwd):/app" --net=host -v $HOME/.Xauthority:/root/.Xauthority -v /tmp/.X11-unix:/tmp/.X11-unix --env DISPLAY=$DISPLAY "tsteven4/gpsbabel:${VERSION}")
+trap 'docker rm -f "${container}" >/dev/null' 0 1 2 3 15
+docker start "${container}" >/dev/null
+docker exec -i -t "${container}" setup_user.sh "$(id -u)" "$(id -g)"
+docker exec -i -t -u "$(id -u):$(id -g)" "${container}" gpsbabelfe "$@"
+
+

--- a/tools/archive_images/run_gpsbabelfe.sh
+++ b/tools/archive_images/run_gpsbabelfe.sh
@@ -8,7 +8,7 @@ while getopts "v:" opt; do
 done
 shift $((OPTIND -1))
 
-container=$(docker create -q -i -t -w /app -v "$(pwd):/app" --net=host -v $HOME/.Xauthority:/root/.Xauthority -v /tmp/.X11-unix:/tmp/.X11-unix --env DISPLAY=$DISPLAY "tsteven4/gpsbabel:${VERSION}")
+container=$(docker create -q -i -t -w /app -v "$(pwd):/app" --net=host -v "$HOME/.Xauthority:/root/.Xauthority" -v /tmp/.X11-unix:/tmp/.X11-unix --env "DISPLAY=$DISPLAY" "tsteven4/gpsbabel:${VERSION}")
 trap 'docker rm -f "${container}" >/dev/null' 0 1 2 3 15
 docker start "${container}" >/dev/null
 docker exec -i -t "${container}" setup_user.sh "$(id -u)" "$(id -g)"

--- a/tools/archive_images/run_gpsbabelfe.sh
+++ b/tools/archive_images/run_gpsbabelfe.sh
@@ -8,7 +8,11 @@ while getopts "v:" opt; do
 done
 shift $((OPTIND -1))
 
-container=$(docker create -q -i -t -w /app -v "$(pwd):/app" --net=host -v "$HOME/.Xauthority:/root/.Xauthority" -v /tmp/.X11-unix:/tmp/.X11-unix --env "DISPLAY=$DISPLAY" "tsteven4/gpsbabel:${VERSION}")
+if [ -n "$LANG" ]; then
+  OPTIONS+=(-e "LANG=$LANG")
+fi
+
+container=$(docker create -q -i -t -w /app -v "$(pwd):/app" --network=host -v "$HOME/.Xauthority:/root/.Xauthority" -v /tmp/.X11-unix:/tmp/.X11-unix -e "DISPLAY=$DISPLAY"  "${OPTIONS[@]}" "tsteven4/gpsbabel:${VERSION}")
 trap 'docker rm -f "${container}" >/dev/null' 0 1 2 3 15
 docker start "${container}" >/dev/null
 docker exec -i -t "${container}" setup_user.sh "$(id -u)" "$(id -g)"

--- a/tools/archive_images/setup_user.sh
+++ b/tools/archive_images/setup_user.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if ! getent group "$2" >/dev/null 2>&1; then
+  groupadd -g "$2" gpsbabel_user
+fi
+if ! getent passwd "$1" >/dev/null 2>&1; then
+  useradd -g "$2" -u "$1" -m gpsbabel_user
+fi

--- a/tools/archive_images/test.sh
+++ b/tools/archive_images/test.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -x
-./tools/archive_images/run_gpsbabel.sh -v 1.5.0 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.5.1 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.5.2 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.5.3 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.5.4 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.6.0 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.7.0 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.8.0 -- -D1
-./tools/archive_images/run_gpsbabel.sh -v 1.9.0 -- -D1
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.0 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.1 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.2 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.3 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.4 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.6.0 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.7.0 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.8.0 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.9.0 -- -D1

--- a/tools/archive_images/test.sh
+++ b/tools/archive_images/test.sh
@@ -10,3 +10,5 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
 "${SOURCE_DIR}/run_gpsbabel.sh" -v 1.7.0 -- -D1
 "${SOURCE_DIR}/run_gpsbabel.sh" -v 1.8.0 -- -D1
 "${SOURCE_DIR}/run_gpsbabel.sh" -v 1.9.0 -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -- -D1
+"${SOURCE_DIR}/run_gpsbabel.sh" -v dev -- -D1

--- a/tools/archive_images/test.sh
+++ b/tools/archive_images/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+./tools/archive_images/run_gpsbabel.sh -v 1.5.0 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.5.1 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.5.2 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.5.3 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.5.4 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.6.0 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.7.0 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.8.0 -- -D1
+./tools/archive_images/run_gpsbabel.sh -v 1.9.0 -- -D1


### PR DESCRIPTION
Releases 1.5.0, 1.5.1, 1.5.2, 1.5.3, 1.5.4, 1.6.0, 1.7.0, 1.8.0, 1.9.0 can be run on linux/amd64 by:

> $ ./tools/archive_images/run_gpsbabel.sh -v 1.8.0 -- -D1 -i gpx -f reference/bounds-test.gpx -o
 unicsv -F -
GPSBabel Version: 1.8.0
main: Compiled with Qt 5.15.3 for architecture x86_64-little_endian-lp64
main: Running with Qt 5.15.3 on Ubuntu 22.04.4 LTS, x86_64
main: QLocale::system() is C
main: QLocale() is C
main: QTextCodec::codecForLocale() is UTF-8, mib 106
options: module/option=value: gpx/snlen="32" (=default)
options: module/option=value: gpx/elevprec="3" (=default)
options: module/option=value: unicsv/datum="WGS 84" (=default)
options: module/option=value: unicsv/prec="6" (=default)
options: module/option=value: unicsv/codec="UTF-8" (=default)
No,Latitude,Longitude,Name,Altitude,Description
1,36.339560,-117.422570,"Head east on CA-190 E/Nadeau Trail Continue to follow CA-190 E",479.3,"go 52.3&#160;mi"
2,36.460850,-116.865460,"Turn right at Airport Rd",-55.6,"go 0.8&#160;mi"
3,36.463640,-116.879200,"Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328",-67.3,"Arrive at: Furnace Creek Airport-L06, Death Valley National Park, Death Valley, CA 92328"
4,36.236600,-117.072030,"Head northwest",2272.3,"go 3.0&#160;mi"
5,36.253260,-117.113260,"Continue straight onto Charcoal Kiln Rd",1734.2,"go 4.2&#160;mi"
6,36.264610,-117.179860,"Continue onto Wood Canyon Rd",1304.1,"go 0.7&#160;mi"
7,36.265430,-117.192050,"Continue onto Wildrose Rd",1226.4,"go 7.9&#160;mi"
8,36.335600,-117.135520,"Slight left to stay on Wildrose Rd",1595.8,"go 13.2&#160;mi"
9,36.494947,-117.226936,"Arrive at: Wildrose Rd",669.8,"Arrive at: Wildrose Rd"
10,36.463670,-116.879080,"Head east on Airport Rd",,"go 0.8&#160;mi"
11,36.460860,-116.865720,"Arrive at: Airport Rd",,"Arrive at: Airport Rd"