### PR TITLE
String handling in gbfile

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -921,10 +921,9 @@ void* xcalloc(size_t nmemb, size_t size);
 void* xmalloc(size_t size);
 void* xrealloc(void* p, size_t s);
 void xfree(const void* mem);
-char* xstrdup(const QString& s);
 char* xstrdup(const char* s);
 
-FILE* xfopen(const char* fname, const char* type, const char* errtxt);
+FILE* xfopen(const QString& fname, const char* type, const QString& errtxt);
 
 // Thin wrapper around fopen() that supports Unicode fname on all platforms.
 FILE* ufopen(const QString& fname, const char* mode);

--- a/exif.cc
+++ b/exif.cc
@@ -1442,7 +1442,7 @@ ExifFormat::read()
 
   exif_app_ = exif_load_apps();
   if (exif_app_ == nullptr) {
-    fatal(MYNAME ": No EXIF header in source file \"%s\".", fin_->name);
+    fatal(MYNAME ": No EXIF header in source file \"%s\".", qPrintable(fin_->name));
   }
 
   exif_examine_app(exif_app_);
@@ -1471,7 +1471,7 @@ ExifFormat::wr_init(const QString& fname)
   }
   exif_app_ = exif_load_apps();
   if (exif_app_ == nullptr) {
-    fatal(MYNAME ": No EXIF header found in source file \"%s\".", fin_->name);
+    fatal(MYNAME ": No EXIF header found in source file \"%s\".", qPrintable(fin_->name));
   }
   exif_examine_app(exif_app_);
   gbfclose(fin_);

--- a/garmin_fit.cc
+++ b/garmin_fit.cc
@@ -129,7 +129,7 @@ GarminFitFormat::fit_parse_header()
       for (unsigned int i = 0; i < kReadHeaderCrcLen; ++i) {
         int data = gbfgetc(fin);
         if (data == EOF) {
-          fatal(MYNAME ": File %s truncated\n", fin->name);
+          fatal(MYNAME ": File %s truncated\n", qPrintable(fin->name));
         }
         crc = fit_crc16(data, crc);
       }
@@ -1096,7 +1096,7 @@ GarminFitFormat::fit_write_file_finish() const
   // Update data records size in file header
   gbsize_t file_size = gbftell(fout);
   if (file_size < kWriteHeaderCrcLen) {
-    fatal(MYNAME ": File %s truncated\n", fout->name);
+    fatal(MYNAME ": File %s truncated\n", qPrintable(fout->name));
   }
   gbfseek(fout, 0, SEEK_SET);
   fit_write_file_header(file_size - kWriteHeaderCrcLen, 0);
@@ -1107,7 +1107,7 @@ GarminFitFormat::fit_write_file_finish() const
   for (unsigned int i = 0; i < kWriteHeaderLen; ++i) {
     int data = gbfgetc(fout);
     if (data == EOF) {
-      fatal(MYNAME ": File %s truncated\n", fout->name);
+      fatal(MYNAME ": File %s truncated\n", qPrintable(fout->name));
     }
     crc = fit_crc16(data, crc);
   }

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -24,6 +24,7 @@
 #include <QChar>               // for QChar, operator==, operator!=
 #include <QDebug>              // for QDebug
 #include <QString>             // for QString
+#include <Qt>                  // for CaseInsensitive
 #include <QtGlobal>            // for qPrintable
 
 #include <cassert>             // for assert
@@ -93,20 +94,19 @@ gzapi_open(gbfile* self, const char* mode)
     self->handle.gz = gzdopen(fileno(fd), openmode);
   } else {
 #if __WIN32__
-    // On Windows, convert UTF-8 to wchar_t[] and use gzopen_w().
-    QString name(self->name);
-    self->handle.gz = gzopen_w((const wchar_t*) name.utf16(), openmode);
+    // On Windows, convert to wchar_t[] and use gzopen_w().
+    self->handle.gz = gzopen_w((const wchar_t*) self->name.utf16(), openmode);
 #else
     // On other platforms, convert to native locale (UTF-8 or other 8-bit).
-    self->handle.gz = gzopen(qPrintable(QString(self->name)), openmode);
+    self->handle.gz = gzopen(qPrintable(self->name), openmode);
 #endif
   }
 
   if (self->handle.gz == nullptr) {
     fatal("%s: Cannot %s file '%s'!\n",
-          self->module,
+          qPrintable(self->module),
           (self->mode == 'r') ? "open" : "create",
-          self->name);
+          qPrintable(self->name));
   }
 
   return self;
@@ -131,9 +131,9 @@ gzapi_seek(gbfile* self, int32_t offset, int whence)
 
   if (result < 0) {
     if (self->is_pipe) {
-      fatal("%s: This format cannot be used in piped commands!\n", self->module);
+      fatal("%s: This format cannot be used in piped commands!\n", qPrintable(self->module));
     }
-    fatal("%s: online compression not yet supported for this format!", self->module);
+    fatal("%s: online compression not yet supported for this format!", qPrintable(self->module));
   }
   return 0;
 }
@@ -155,7 +155,7 @@ gzapi_read(void* buf, const gbsize_t size, const gbsize_t members, gbfile* self)
 
   /* Check for an incomplete READ */
   if ((members == 1) && (size > 1) && (result > 0) && (result < (int)size)) {
-    fatal("%s: Unexpected end of file (EOF)!\n", self->module);
+    fatal("%s: Unexpected end of file (EOF)!\n", qPrintable(self->module));
   }
 
   result /= size;
@@ -171,7 +171,7 @@ gzapi_read(void* buf, const gbsize_t size, const gbsize_t members, gbfile* self)
     }
     if ((errnum != Z_STREAM_END) && (errnum != 0))
       fatal("%s: zlib returned error %d ('%s')!\n",
-            self->module, errnum, errtxt);
+            qPrintable(self->module), errnum, errtxt);
   }
   return (gbsize_t) result;
 }
@@ -296,10 +296,10 @@ stdapi_seek(gbfile* self, int32_t offset, int whence)
       break;
     default:
       fatal("%s: Unknown seek operation (%d) for file %s!\n",
-            self->module, whence, self->name);
+            qPrintable(self->module), whence, qPrintable(self->name));
     }
     fatal("%s: Unable to set file (%s) to position (%llu)!\n",
-          self->module, self->name, (long long unsigned) pos);
+          qPrintable(self->module), qPrintable(self->name), (long long unsigned) pos);
   }
   return 0;
 }
@@ -312,7 +312,7 @@ stdapi_read(void* buf, const gbsize_t size, const gbsize_t members, gbfile* self
 
   if ((result < members) && (error_number = ferror(self->handle.std))) {
     fatal("%s: Error %d occurred during read of file '%s'!\n",
-          self->module, error_number, self->name);
+          qPrintable(self->module), error_number, qPrintable(self->name));
   }
   return result;
 }
@@ -501,15 +501,15 @@ memapi_error(gbfile* self)
  */
 
 gbfile*
-gbfopen(const QString& filename, const char* mode, const char* module)
+gbfopen(const QString& filename, const char* mode, const QString& module)
 {
-  auto* file = (gbfile*) xcalloc(1, sizeof(gbfile));
+  auto* file = new gbfile;
 
-  file->module = xstrdup(module);
+  file->module = module;
   file->mode = 'r'; // default
   file->binary = (strchr(mode, 'b') != nullptr);
   file->back = -1;
-  file->memapi = (filename == nullptr);
+  file->memapi = filename.isNull();
 
   for (const char* m = mode; *m; m++) {
     switch (tolower(*m)) {
@@ -527,7 +527,7 @@ gbfopen(const QString& filename, const char* mode, const char* module)
 
   if (file->memapi) {
     file->gzapi = 0;
-    file->name = xstrdup("(Memory stream)");
+    file->name = "(Memory stream)";
 
     file->fileclearerr = memapi_clearerr;
     file->fileclose = memapi_close;
@@ -541,12 +541,11 @@ gbfopen(const QString& filename, const char* mode, const char* module)
     file->fileungetc = memapi_ungetc;
     file->filewrite = memapi_write;
   } else {
-    file->name = xstrdup(filename);
+    file->name = filename;
     file->is_pipe = (filename == '-');
 
     /* Do we have a '.gz' extension in the filename ? */
-    int len = strlen(file->name);
-    if ((len > 3) && (case_ignore_strcmp(&file->name[len-3], ".gz") == 0)) {
+    if ((file->name.size() > 3) && (file->name.endsWith(".gz", Qt::CaseInsensitive))) {
 #if !ZLIB_INHIBITED
       /* force gzipped files on output */
       file->gzapi = 1;
@@ -571,7 +570,7 @@ gbfopen(const QString& filename, const char* mode, const char* module)
       file->filewrite = gzapi_write;
 #else
       /* This is the only runtime test we make */
-      fatal("%s: Zlib was not included in this build.\n", file->module);
+      fatal("%s: Zlib was not included in this build.\n", qPrintable(file->module));
 #endif
     } else {
       file->fileclearerr = stdapi_clearerr;
@@ -601,7 +600,7 @@ gbfopen(const QString& filename, const char* mode, const char* module)
  */
 
 gbfile*
-gbfopen_be(const QString& filename, const char* mode, const char* module)
+gbfopen_be(const QString& filename, const char* mode, const QString& module)
 {
   gbfile* result = gbfopen(filename, mode, module);
   result->big_endian = 1;
@@ -622,10 +621,8 @@ gbfclose(gbfile* file)
 
   file->fileclose(file);
 
-  xfree(file->name);
-  xfree(file->module);
   xfree(file->buff);
-  xfree(file);
+  delete file;
 }
 
 /*
@@ -815,9 +812,9 @@ gbfwrite(const void* buf, const gbsize_t size, const gbsize_t members, gbfile* f
   unsigned int result = file->filewrite(buf, size, members, file);
   if (result != members) {
     fatal("%s: Could not write %lld bytes to %s (result %d)!\n",
-          file->module,
+          qPrintable(file->module),
           (long long int)(members - result) * size,
-          file->name,
+          qPrintable(file->name),
           result);
   }
 
@@ -885,7 +882,7 @@ gbftell(gbfile* file)
   gbsize_t result = file->filetell(file);
   if ((signed) result == -1)
     fatal("%s: Could not determine position of file '%s'!\n",
-          file->module, file->name);
+          qPrintable(file->module), qPrintable(file->name));
   return result;
 }
 
@@ -921,7 +918,7 @@ gbfgetint32(gbfile* file)
   char buf[4];
 
   if (gbfread(&buf, 1, sizeof(buf), file) != sizeof(buf)) {
-    fatal("%s: Unexpected end of file (%s)!\n", file->module, file->name);
+    fatal("%s: Unexpected end of file (%s)!\n", qPrintable(file->module), qPrintable(file->name));
   }
 
   if (file->big_endian) {
@@ -941,7 +938,7 @@ gbfgetint16(gbfile* file)
   char buf[2];
 
   if (gbfread(&buf, 1, sizeof(buf), file) != sizeof(buf)) {
-    fatal("%s: Unexpected end of file (%s)!\n", file->module, file->name);
+    fatal("%s: Unexpected end of file (%s)!\n", qPrintable(file->module), qPrintable(file->name));
   }
 
   if (file->big_endian) {
@@ -961,7 +958,7 @@ gbfgetdbl(gbfile* file)
   char buf[8];
 
   if (gbfread(&buf, 1, sizeof(buf), file) != sizeof(buf)) {
-    fatal("%s: Unexpected end of file (%s)!\n", file->module, file->name);
+    fatal("%s: Unexpected end of file (%s)!\n", qPrintable(file->module), qPrintable(file->name));
   }
 
   return endian_read_double(buf, ! file->big_endian);
@@ -977,7 +974,7 @@ gbfgetflt(gbfile* file)
   char buf[4];
 
   if (gbfread(&buf, 1, sizeof(buf), file) != sizeof(buf)) {
-    fatal("%s: Unexpected end of file (%s)!\n", file->module, file->name);
+    fatal("%s: Unexpected end of file (%s)!\n", qPrintable(file->module), qPrintable(file->name));
   }
 
   return endian_read_float(buf, ! file->big_endian);
@@ -1002,7 +999,7 @@ gbfgetcstr_old(gbfile* file)
     }
 
     if (c == EOF) {
-      fatal("%s: Unexpected end of file (%s)!\n", file->module, file->name);
+      fatal("%s: Unexpected end of file (%s)!\n", qPrintable(file->module), qPrintable(file->name));
     }
 
     if (len == file->buffsz) {
@@ -1049,12 +1046,12 @@ gbfgetpstr(gbfile* file)
 {
   int len = gbfgetc(file);
   if (len == EOF) {
-    fatal("%s: Unexpected end of file (%s)!\n", file->module, file->name);
+    fatal("%s: Unexpected end of file (%s)!\n", qPrintable(file->module), qPrintable(file->name));
   }
   QByteArray ba;
   ba.resize(len);
   if (gbfread(ba.data(), 1, len, file) != (gbsize_t) len) {
-    fatal("%s: Unexpected end of file (%s)!\n", file->module, file->name);
+    fatal("%s: Unexpected end of file (%s)!\n", qPrintable(file->module), qPrintable(file->name));
   }
 
   return QString(ba);
@@ -1072,7 +1069,7 @@ gbfgetutf16char(gbfile* file)
 
     if (c1 == EOF) {
         fatal("%s: Incomplete unicode (UTF-16%cE) character at EOF!\n",
-              file->module,
+              qPrintable(file->module),
               file->big_endian ? 'B' : 'L');
     }
 
@@ -1121,7 +1118,7 @@ gbfgetutf16str(gbfile* file)
       if (qch2 != u'\n') {  // including qch2.isNull()
         // Putting back two chars may not be supported, e.g. with gzapi_ungetc.
         fatal("%s: Invalid unicode (UTF-16%cE) line break!\n",
-              file->module,
+              qPrintable(file->module),
               file->big_endian ? 'B' : 'L');
       }
       break;
@@ -1131,7 +1128,7 @@ gbfgetutf16str(gbfile* file)
 
     if (qch.isLowSurrogate()) {
       fatal("%s: Leading unicode (UTF-16%cE) low surrogate!\n",
-            file->module,
+            qPrintable(file->module),
             file->big_endian ? 'B' : 'L');
     }
 
@@ -1140,7 +1137,7 @@ gbfgetutf16str(gbfile* file)
       QChar qch2 = gbfgetutf16char(file);
       if (!qch2.isLowSurrogate()) { // including qch2.isNull()
         fatal("%s: Missing unicode (UTF-16%cE) low surrogate!\n",
-              file->module,
+              qPrintable(file->module),
               file->big_endian ? 'B' : 'L');
       }
       str.append(qch2);

--- a/gbfile.h
+++ b/gbfile.h
@@ -58,40 +58,40 @@ struct gbfile {
 #if !ZLIB_INHIBITED
     gzFile gz;
 #endif
-  } handle;
-  char*   name;
-  char*   module;
-  char*   buff;	/* static growing buffer, primary used by gbprintf */
-  int    buffsz;
-  char   mode;
-  int    back;
-  gbsize_t mempos;	/* curr. position in memory */
-  gbsize_t memlen;	/* max. number of written bytes to memory */
-  gbsize_t memsz;		/* curr. size of allocated memory */
-  unsigned char big_endian:1;
-  unsigned char binary:1;
-  unsigned char gzapi:1;
-  unsigned char memapi:1;
-  unsigned char unicode:1;
-  unsigned char unicode_checked:1;
-  unsigned char is_pipe:1;
-  gbfclearerr_cb fileclearerr;
-  gbfclose_cb fileclose;
-  gbfeof_cb fileeof;
-  gbferror_cb fileerror;
-  gbfflush_cb fileflush;
-  gbfopen_cb fileopen;
-  gbfread_cb fileread;
-  gbfseek_cb fileseek;
-  gbftell_cb filetell;
-  gbfungetc_cb fileungetc;
-  gbfwrite_cb filewrite;
+  } handle{nullptr};
+  QString   name;
+  QString   module;
+  char*   buff{nullptr};	/* static growing buffer, primary used by gbprintf */
+  int    buffsz{0};
+  char   mode{0};
+  int    back{0};
+  gbsize_t mempos{0};	/* curr. position in memory */
+  gbsize_t memlen{0};	/* max. number of written bytes to memory */
+  gbsize_t memsz{0};	/* curr. size of allocated memory */
+  unsigned char big_endian:1{0};
+  unsigned char binary:1{0};
+  unsigned char gzapi:1{0};
+  unsigned char memapi:1{0};
+  unsigned char unicode:1{0};
+  unsigned char unicode_checked:1{0};
+  unsigned char is_pipe:1{0};
+  gbfclearerr_cb fileclearerr{nullptr};
+  gbfclose_cb fileclose{nullptr};
+  gbfeof_cb fileeof{nullptr};
+  gbferror_cb fileerror{nullptr};
+  gbfflush_cb fileflush{nullptr};
+  gbfopen_cb fileopen{nullptr};
+  gbfread_cb fileread{nullptr};
+  gbfseek_cb fileseek{nullptr};
+  gbftell_cb filetell{nullptr};
+  gbfungetc_cb fileungetc{nullptr};
+  gbfwrite_cb filewrite{nullptr};
 };
 
 
-gbfile* gbfopen(const QString& filename, const char* mode, const char* module);
-gbfile* gbfopen_be(const QString& filename, const char* mode, const char* module);
-inline gbfile* gbfopen_le(const QString& filename, const char* mode, const char* module)
+gbfile* gbfopen(const QString& filename, const char* mode, const QString& module);
+gbfile* gbfopen_be(const QString& filename, const char* mode, const QString& module);
+inline gbfile* gbfopen_le(const QString& filename, const char* mode, const QString& module)
 {
   return gbfopen(filename, mode, module);
 }

--- a/gdb.cc
+++ b/gdb.cc
@@ -383,14 +383,14 @@ GdbFormat::read_file_header()
   	misinterpreted.
   */
   if (strcmp(buf, "MsRcf") != 0) {
-    fatal(MYNAME ": Invalid file \"%s\"!", fin->name);
+    fatal(MYNAME ": Invalid file \"%s\"!", qPrintable(fin->name));
   }
 
   int reclen = FREAD_i32;
   Q_UNUSED(reclen);
   QByteArray drec = FREAD_STR();
   if (drec.at(0) != 'D') {
-    fatal(MYNAME ": Invalid file \"%s\"!", fin->name);
+    fatal(MYNAME ": Invalid file \"%s\"!", qPrintable(fin->name));
   }
 
   gdb_ver = drec.at(1) - 'k' + 1;
@@ -1081,7 +1081,7 @@ GdbFormat::read()
 
   if (incomplete) {
     warning(MYNAME ":------------------------------------------\n");
-    warning(MYNAME ": \"%s\"\n", fin->name);
+    warning(MYNAME ": \"%s\"\n", qPrintable(fin->name));
     warning(MYNAME ":------------------------------------------\n");
     warning(MYNAME ":       Please mail this information\n");
     warning(MYNAME "     and, if you can, the used GDB file\n");

--- a/util.cc
+++ b/util.cc
@@ -102,11 +102,6 @@ xstrdup(const char* s)
   return o;
 }
 
-char* xstrdup(const QString& s)
-{
-  return xstrdup(CSTR(s));
-}
-
 void*
 xrealloc(void* p, size_t s)
 {
@@ -123,26 +118,26 @@ xrealloc(void* p, size_t s)
  * Wrapper for open that honours - for stdin, stdout, unifies error text.
  */
 FILE*
-xfopen(const char* fname, const char* type, const char* errtxt)
+xfopen(const QString& fname, const char* type, const QString& errtxt)
 {
   bool am_writing = strchr(type, 'w') != nullptr;
 
-  if (fname == nullptr) {
+  if (fname.isEmpty()) {
     fatal("%s must have a filename specified for %s.\n",
-          errtxt, am_writing ? "write" : "read");
+          qPrintable(errtxt), am_writing ? "write" : "read");
   }
 
-  if (0 == strcmp(fname, "-")) {
+  if (fname == "-") {
     return am_writing ? stdout : stdin;
   }
-  FILE* f = ufopen(QString::fromUtf8(fname), type);
+  FILE* f = ufopen(fname, type);
   if (nullptr == f) {
     // There are some possible vagaries of using Qt for the full pathname
     // vs. the STD C library used for the actual file I/O. It's worth it
     // to get a better error message.
     QFileInfo info(fname);
     fatal("%s cannot open '%s' for %s.  Error was '%s'.\n",
-          errtxt, qPrintable(info.absoluteFilePath()),
+          qPrintable(errtxt), qPrintable(info.absoluteFilePath()),
           am_writing ? "write" : "read",
           strerror(errno));
   }

--- a/vecs.cc
+++ b/vecs.cc
@@ -685,7 +685,7 @@ void Vecs::assign_option(const QString& module, arglist_t* arg, const QString& v
       rval.startsWith('0') && (arg->defaultvalue == nullptr)) {
     return;
   }
-  *arg->argval = arg->argvalptr = xstrdup(rval);
+  *arg->argval = arg->argvalptr = xstrdup(CSTR(rval));
 }
 
 void Vecs::disp_vec_options(const QString& vecname, const QVector<arglist_t>* args)


### PR DESCRIPTION
Keep the file name and module name in QStrings, converting to 8 bit on use when necessary.  This eliminates usage of xstrdup by gbfile.

supply default initializers for gbfile, and use new/delete instead of xcalloc/xfree.

retire char* xstrdup(const QString& s);.