### PR TITLE
Revert "fix an annoying Wstringop-truncation warning. (#1348)"

### DIFF
--- a/jeeps/gpsapp.cc
+++ b/jeeps/gpsapp.cc
@@ -88,7 +88,7 @@ static void   GPS_D152_Send(UC* data, GPS_PWay way, int32_t* len);
 static void   GPS_D154_Send(UC* data, GPS_PWay way, int32_t* len);
 static void   GPS_D155_Send(UC* data, GPS_PWay way, int32_t* len);
 
-static void   GPS_D120_Get(US cat_num, char*s);
+static void   GPS_D120_Get(int cat_num, char*s);
 
 static void   GPS_D200_Get(GPS_PWay* way, const UC* s);
 static void   GPS_D201_Get(GPS_PWay* way, UC* s);
@@ -1137,8 +1137,8 @@ int32_t GPS_A101_Get(const char* port)
   gpsdevh* fd;
   GPS_Packet tra;
   GPS_Packet rec;
-  US n;
-  US i;
+  int32_t n;
+  int32_t i;
 
 
   if (!GPS_Device_On(port,&fd)) {
@@ -2021,7 +2021,7 @@ char gps_categories[16][17];
  * Read descriptor s into category number N;
  */
 static
-void GPS_D120_Get(US cat_num, char* s)
+void GPS_D120_Get(int cat_num, char* s)
 {
   /* we're guaranteed to have no more than 16 chars plus a
    * null terminator.
@@ -2030,15 +2030,11 @@ void GPS_D120_Get(US cat_num, char* s)
    * so mimic the behaviour of the 276/296.
    */
 
-  if (cat_num < 16) {
-    if (*s) {
-      strncpy(gps_categories[cat_num], s, sizeof(gps_categories[0]));
-    } else {
-      snprintf(gps_categories[cat_num], sizeof(gps_categories[0]),
-               "Category %d", cat_num+1);
-    }
+  if (*s) {
+    strncpy(gps_categories[cat_num], s, sizeof(gps_categories[0]));
   } else {
-    GPS_Warning("GPS_D120_Get: assumption (1 <= category number <= 16) violated");
+    snprintf(gps_categories[cat_num], sizeof(gps_categories[0]),
+             "Category %d", cat_num+1);
   }
 }
 


### PR DESCRIPTION
This reverts commit a4dec0acfbeb6d93a9a73e3673da983bfdd7511b.

The compiler is smart enough to figure out there isn't a Wformat-truncation issue, and the changes didn't related to the Wstringop-truncation  warning.