### PR TITLE
remove obsolete comparison to option name

### DIFF
--- a/trackfilter.cc
+++ b/trackfilter.cc
@@ -239,7 +239,7 @@ void TrackFilter::trackfilter_split_init_rte_name(route_head* track, const gpsba
 {
   QString datetimestring;
 
-  if (opt_interval != 0) {
+  if (opt_interval) {
     datetimestring = dt.toUTC().toString(u"yyyyMMddhhmmss");
   } else {
     datetimestring = dt.toUTC().toString(u"yyyyMMdd");
@@ -434,8 +434,8 @@ void TrackFilter::trackfilter_split()
 
     /* check additional options */
 
-    opt_interval = (!opt_split.isEmpty() && (opt_split.get() != TRACKFILTER_SPLIT_OPTION));
-    if (opt_interval != 0) {
+    opt_interval = !opt_split.isEmpty();
+    if (opt_interval) {
       static const QRegularExpression re(R"(^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([dhms])$)", QRegularExpression::CaseInsensitiveOption);
       assert(re.isValid());
       QRegularExpressionMatch match = re.match(opt_split);
@@ -470,8 +470,8 @@ void TrackFilter::trackfilter_split()
       }
     }
 
-    opt_distance = (!opt_sdistance.isEmpty() && (opt_sdistance.get() != TRACKFILTER_SDIST_OPTION));
-    if (opt_distance != 0) {
+    opt_distance = !opt_sdistance.isEmpty();
+    if (opt_distance) {
       static const QRegularExpression re(R"(^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([km])$)", QRegularExpression::CaseInsensitiveOption);
       assert(re.isValid());
       QRegularExpressionMatch match = re.match(opt_sdistance);
@@ -519,7 +519,7 @@ void TrackFilter::trackfilter_split()
 
       bool new_track_flag;
 
-      if ((opt_interval == 0) && (opt_distance == 0)) {
+      if (!opt_interval && !opt_distance) {
 //      FIXME: This whole function needs to be reconsidered for arbitrary time.
         new_track_flag = prev_wpt->GetCreationTime().toLocalTime().date() !=
                          wpt->GetCreationTime().toLocalTime().date();
@@ -636,7 +636,7 @@ void TrackFilter::trackfilter_synth()
         }
         if (opt_speed) {
           if (last_speed_time.msecsTo(wpt->GetCreationTime()) != 0) {
-            // If we have multiple points with the same time and
+            // If we have multiple points with the same time, and
             // we use the pair of points about which the time ticks then we will
             // underestimate the distance and compute low speeds on average.
             // Therefore, if we have multiple points with the same time use the

--- a/trackfilter.h
+++ b/trackfilter.h
@@ -59,24 +59,6 @@ private:
   /* Constants */
 
   static constexpr double kDistanceLimit = 1.11319; // for points to be considered the same, meters.
-  static constexpr char TRACKFILTER_PACK_OPTION[] = "pack";
-  static constexpr char TRACKFILTER_SPLIT_OPTION[] = "split";
-  static constexpr char TRACKFILTER_SDIST_OPTION[] = "sdistance";
-  static constexpr char TRACKFILTER_TITLE_OPTION[] = "title";
-  static constexpr char TRACKFILTER_MERGE_OPTION[] = "merge";
-  static constexpr char TRACKFILTER_NAME_OPTION[] = "name";
-  static constexpr char TRACKFILTER_STOP_OPTION[] = "stop";
-  static constexpr char TRACKFILTER_START_OPTION[] = "start";
-  static constexpr char TRACKFILTER_MOVE_OPTION[] = "move";
-  static constexpr char TRACKFILTER_FIX_OPTION[] = "fix";
-  static constexpr char TRACKFILTER_COURSE_OPTION[] = "course";
-  static constexpr char TRACKFILTER_SPEED_OPTION[] = "speed";
-  static constexpr char TRACKFILTER_SEG2TRK_OPTION[] = "seg2trk";
-  static constexpr char TRACKFILTER_TRK2SEG_OPTION[] = "trk2seg";
-  static constexpr char TRACKFILTER_SEGMENT_OPTION[] = "segment";
-  static constexpr char TRACKFILTER_FAKETIME_OPTION[] = "faketime";
-  static constexpr char TRACKFILTER_DISCARD_OPTION[] = "discard";
-  static constexpr char TRACKFILTER_MINPOINTS_OPTION[] = "minimum_points";
 
   /* Member Functions */
 
@@ -130,96 +112,96 @@ private:
 
   QVector<arglist_t> args = {
     {
-      TRACKFILTER_MOVE_OPTION, &opt_move,
+      "move", &opt_move,
       "Correct trackpoint timestamps by a delta", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_PACK_OPTION, &opt_pack,
+      "pack", &opt_pack,
       "Pack all tracks into one", nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_SPLIT_OPTION, &opt_split,
+      "split", &opt_split,
       "Split by date or time interval", nullptr,
       ARGTYPE_STRING, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_SDIST_OPTION, &opt_sdistance,
+      "sdistance", &opt_sdistance,
       "Split by distance", nullptr,
       ARGTYPE_STRING, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_MERGE_OPTION, &opt_merge,
+      "merge", &opt_merge,
       "Merge multiple tracks for the same way", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_NAME_OPTION, &opt_name,
+      "name", &opt_name,
       "Use only track(s) where title matches given name", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_START_OPTION, &opt_start,
+      "start", &opt_start,
       "Use only track points after or at this timestamp", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_STOP_OPTION, &opt_stop,
+      "stop", &opt_stop,
       "Use only track points before or at this timestamp", nullptr, ARGTYPE_STRING,
       ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_TITLE_OPTION, &opt_title,
+      "title", &opt_title,
       "Basic title for new track(s)", nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_FIX_OPTION, &opt_fix,
+      "fix", &opt_fix,
       "Synthesize GPS fixes (PPS, DGPS, 3D, 2D, NONE)", nullptr,
       ARGTYPE_STRING, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_COURSE_OPTION, &opt_course, "Synthesize course",
+      "course", &opt_course, "Synthesize course",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_SPEED_OPTION, &opt_speed, "Synthesize speed",
+      "speed", &opt_speed, "Synthesize speed",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_SEG2TRK_OPTION, &opt_seg2trk,
+      "seg2trk", &opt_seg2trk,
       "Split track at segment boundaries into multiple tracks",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_TRK2SEG_OPTION, &opt_trk2seg,
+      "trk2seg", &opt_trk2seg,
       "Merge tracks inserting segment separators at boundaries",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_SEGMENT_OPTION, &opt_segment,
+      "segment", &opt_segment,
       "segment tracks with abnormally long gaps",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_FAKETIME_OPTION, &opt_faketime,
+      "faketime", &opt_faketime,
       "Add specified timestamp to each trackpoint",
       nullptr, ARGTYPE_STRING, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_DISCARD_OPTION, &opt_discard,
+      "discard", &opt_discard,
       "Discard track points without timestamps during merge",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
     },
     {
-      TRACKFILTER_MINPOINTS_OPTION, &opt_minpoints,
+      "minimum_points", &opt_minpoints,
       "Discard tracks with fewer than these points",
       nullptr, ARGTYPE_INT, "0", "50", nullptr
     },
   };
 
   QList<route_head*> track_list;
-  int opt_interval = 0;
-  int opt_distance = 0;
+  bool opt_interval = false;
+  bool opt_distance = false;
   bool need_time{};		/* initialized within trackfilter_init */
 
 };


### PR DESCRIPTION
We haven't assigned the option name to indicate an option was given without a value since #913.