### PR TITLE
clang tidy fixes

### DIFF
--- a/bend.h
+++ b/bend.h
@@ -64,7 +64,7 @@ private:
     },
   };
 
-  Waypoint* create_wpt_dest(const Waypoint* wpt_orig, const Waypoint* wpt_adj) const;
+  Waypoint* create_wpt_dest(const Waypoint* wpt_orig, const Waypoint* wpt_orig_adj) const;
   int is_small_angle(const Waypoint* wpt_orig,
                      const Waypoint* wpt_orig_prev,
                      const Waypoint* wpt_orig_next) const;

--- a/garmin_tables.cc
+++ b/garmin_tables.cc
@@ -730,9 +730,9 @@ gt_color_value(const unsigned int garmin_index)
 uint32_t
 gt_color_value_by_name(const QString& name)
 {
-  for (int i = 0; i < gt_colors.size(); ++i) {
-    if (QString::compare(gt_colors[i].name, name, Qt::CaseInsensitive) == 0) {
-      return gt_colors[i].rgb;
+  for (const auto& gt_color : gt_colors) {
+    if (QString::compare(gt_color.name, name, Qt::CaseInsensitive) == 0) {
+      return gt_color.rgb;
     }
   }
 

--- a/humminbird.h
+++ b/humminbird.h
@@ -165,7 +165,7 @@ private:
 
   void humminbird_rte_head(const route_head* rte);
   void humminbird_rte_tail(const route_head* rte);
-  static QString wpt_to_id(const Waypoint*);
+  static QString wpt_to_id(const Waypoint* wpt);
   void humminbird_write_rtept(const Waypoint* wpt) const;
   void humminbird_write_waypoint(const Waypoint* wpt);
   void humminbird_write_waypoint_wrapper(const Waypoint* wpt);

--- a/humminbird.h
+++ b/humminbird.h
@@ -172,8 +172,7 @@ private:
 
   /* Data Members */
 
-  QVector<arglist_t> humminbird_args = {
-  };
+  QVector<arglist_t> humminbird_args;
 };
 
 class HumminbirdHTFormat : public Format, private HumminbirdBase
@@ -214,8 +213,7 @@ private:
 
   /* Data Members */
 
-  QVector<arglist_t> humminbirdht_args = {
-  };
+  QVector<arglist_t> humminbirdht_args;
 };
 
 #endif // HUMMINBIRD_H_INCLUDED_

--- a/igc.h
+++ b/igc.h
@@ -87,7 +87,7 @@ public:
   // Qt6 falls back to std::hash, but it may not use the seed.
   friend size_t qHash(const igc_ext_type_t& key, size_t seed = 0) noexcept
   {
-    return qHash(static_cast<std::underlying_type<igc_ext_type_t>::type>(key), seed);
+    return qHash(static_cast<std::underlying_type_t<igc_ext_type_t>>(key), seed);
   }
 
   QVector<arglist_t>* get_args() override

--- a/reverse_route.h
+++ b/reverse_route.h
@@ -40,8 +40,7 @@ public:
 
 private:
   int prev_new_trkseg{};
-  QVector<arglist_t> args = {
-  };
+  QVector<arglist_t> args;
 
   void reverse_route_wpt(const Waypoint* waypointp);
   void reverse_route_head(const route_head* rte);

--- a/src/core/nvector.cc
+++ b/src/core/nvector.cc
@@ -31,10 +31,10 @@
 namespace gpsbabel
 {
 
-LatLon::LatLon(double latitude, double longitude)
+LatLon::LatLon(double latitude, double longitude) : lat(latitude), lon(longitude)
 {
-  lat = latitude;
-  lon = longitude;
+  
+  
 }
 
 NVector::NVector(double latitude_degrees, double longitude_degrees)

--- a/swapdata.h
+++ b/swapdata.h
@@ -40,8 +40,7 @@ public:
   void process() override;
 
 private:
-  QVector<arglist_t> args = {
-  };
+  QVector<arglist_t> args;
 
   static void swapdata_cb(const Waypoint* ref);
 

--- a/xmlgeneric.cc
+++ b/xmlgeneric.cc
@@ -67,7 +67,7 @@ XmlGenericReader::xml_tbl_lookup(const QString& tag, xg_cb_type cb_type)
 
 void
 XmlGenericReader::xml_common_init(const QString& fname, const char* encoding,
-         const QStringList ignorelist, const QStringList skiplist)
+         const QStringList& ignorelist, const QStringList& skiplist)
 {
   rd_fname = fname;
 

--- a/xmlgeneric.h
+++ b/xmlgeneric.h
@@ -89,8 +89,8 @@ public:
   template<class MyFormat>
   void xml_init(const QString& fname, MyFormat* instance, const QList<xg_fmt_map_entry<MyFormat>>& tbl,
                 const char* encoding = nullptr,
-                const QStringList ignorelist = QStringList(),
-                const QStringList skiplist = QStringList())
+                const QStringList& ignorelist = QStringList(),
+                const QStringList& skiplist = QStringList())
   {
     build_xg_tag_map(instance, tbl);
 
@@ -165,7 +165,7 @@ private:
 
   XgCallbackBase* xml_tbl_lookup(const QString& tag, xg_cb_type cb_type);
   void xml_common_init(const QString& fname, const char* encoding,
-                       const QStringList ignorelist, const QStringList skiplist);
+                       const QStringList& ignorelist, const QStringList& skiplist);
   xg_shortcut xml_shortcut(QStringView name);
   void xml_run_parser(QXmlStreamReader& reader);
 


### PR DESCRIPTION
readability-avoid-const-params-in-decls
performance-unnecessary-value-param
readability-inconsistent-declaration-parameter-name
cppcoreguidelines-prefer-member-initializer
readability-redundant-member-init
modernize-loop-convert
modernize-type-traits
readability-named-parameter