### PR TITLE
hide logging member variables, use references for stream op.

### DIFF
--- a/src/core/logging.cc
+++ b/src/core/logging.cc
@@ -22,9 +22,9 @@
 #include "src/core/logging.h"
 
 
-QDebug operator<< (QDebug debug, const DebugIndent& indent)
+QDebug& operator<< (QDebug& debug, const DebugIndent& indent)
 {
-  for (int i = 1; i<indent.level; i++) {
+  for (int i = 1; i<indent.level_; i++) {
     debug << '.';
   }
   return debug;

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -52,18 +52,20 @@ public:
 class DebugIndent
 {
 public:
-  explicit DebugIndent(int l) : level(l) {}
+  explicit DebugIndent(int l) : level_(l) {}
+  friend QDebug& operator<<(QDebug& out, const DebugIndent& indent);
 
-  int level;
+private:
+  int level_;
 };
 
-QDebug operator<< (QDebug debug, const DebugIndent& indent);
+QDebug& operator<< (QDebug& debug, const DebugIndent& indent);
 
 class Debug : public QDebug
 {
 public:
   Debug() : QDebug(QtDebugMsg) {nospace().noquote();}
-  explicit Debug(int l) : QDebug(QtDebugMsg) {nospace().noquote() << DebugIndent(l);}
+  explicit Debug(int level) : QDebug(QtDebugMsg) {nospace().noquote() << DebugIndent(level);}
 };
 
 #endif //  SRC_CORE_LOGGING_H_

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -53,7 +53,7 @@ class DebugIndent
 {
 public:
   explicit DebugIndent(int l) : level_(l) {}
-  friend QDebug& operator<<(QDebug& out, const DebugIndent& indent);
+  friend QDebug& operator<<(QDebug& debug, const DebugIndent& indent);
 
 private:
   int level_;

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -52,7 +52,7 @@ public:
 class DebugIndent
 {
 public:
-  explicit DebugIndent(int l) : level_(l) {}
+  explicit DebugIndent(int level) : level_(level) {}
   friend QDebug& operator<<(QDebug& debug, const DebugIndent& indent);
 
 private:


### PR DESCRIPTION
This resolves tidy the related misc-non-private-member-variables-in-classes warning, as well as using the standard signature for output stream operator to avoid unnecessary copies.