### PR TITLE
manually trigger attestations

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -105,7 +105,7 @@ jobs:
         ./tools/ci_script_osx.sh . ${{ matrix.QT_VERSION }} ${{ matrix.GENERATOR }}
 
     - name: Generate artifact attestation
-      if: ${{ inputs.attestation }}
+      if: ${{ inputs.attestation && matrix.RELEASE }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: 'gui/GPSBabel-*.dmg'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,13 @@ on:
     branches: [ master ]
   schedule:
     - cron: '27 4 * * 2'
-  workflow_dispatch: ~
+  workflow_dispatch:
+    inputs:
+      attestation:
+        description: 'Generate attestation for binary artifacts'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   macos:
@@ -99,7 +105,7 @@ jobs:
         ./tools/ci_script_osx.sh . ${{ matrix.QT_VERSION }} ${{ matrix.GENERATOR }}
 
     - name: Generate artifact attestation
-      if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' ) && matrix.RELEASE
+      if: ${{ inputs.attestation }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: 'gui/GPSBabel-*.dmg'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,7 +8,13 @@ on:
     branches: [ master ]
   schedule:
     - cron: '27 4 * * 2'
-  workflow_dispatch: ~
+  workflow_dispatch:
+    inputs:
+      attestation:
+        description: 'Generate attestation for binary artifacts'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   ubuntu:
@@ -111,7 +117,7 @@ jobs:
         ./testo -p /snap/bin/gpsbabel 
 
     - name: Generate artifact attestation
-      if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
+      if: ${{ inputs.attestation }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,13 @@ on:
     branches: [ master ]
   schedule:
     - cron: '27 4 * * 2'
-  workflow_dispatch: ~
+  workflow_dispatch:
+    inputs:
+      attestation:
+        description: 'Generate attestation for binary artifacts'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
 
@@ -103,7 +109,7 @@ jobs:
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
 
     - name: Generate artifact attestation
-      if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' ) && matrix.RELEASE
+      if: ${{ inputs.attestation }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: 'bld/gui/GPSBabel-*-Setup.exe'
@@ -124,6 +130,6 @@ jobs:
       with:
         name: Windows_Installer ${{ join(matrix.*) }}
         path: |
-          ./bld/gui/GPSBabel-*-Setup.exe
-          ./bld/gui/GPSBabel-*-Manifest.txt
+          bld/gui/GPSBabel-*-Setup.exe
+          bld/gui/GPSBabel-*-Manifest.txt
         retention-days: 7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,7 +109,7 @@ jobs:
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
 
     - name: Generate artifact attestation
-      if: ${{ inputs.attestation }}
+      if: ${{ inputs.attestation && matrix.RELEASE }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: 'bld/gui/GPSBabel-*-Setup.exe'


### PR DESCRIPTION
This removes automatic generation of attestations for continuous releases.  Attestations are only generated

1. for manually triggered workflow runs AND
2. if the "Generate attestation for binary artifacts" box is checked AND
3. for the RELEASE job in a matrix

So it's possible to get one attestation for a windows workflow run (the setup installer), one for a macos workflow run (the dmg), and one for a ubuntu workflow run (the snap).

Note when manually triggering a workflow you can select the branch or tag.

There doesn't seem to be a limit on attestations, but it doesn't seem possible to delete one.

When you download the artifacts they are zipped.  You must unzip them and verify the attestation on the setup installer, dmg or snap.  For example:
```
$ unzip Windows_Installer\ 6.5.3\,amd64\,amd64\,msvc2019_64\,aqt\,true\,Ninja\,windows-latest\ \(2\).zip
Archive:  Windows_Installer 6.5.3,amd64,amd64,msvc2019_64,aqt,true,Ninja,windows-latest (2).zip
  inflating: GPSBabel-20241111T1330Z-8424347-Manifest.txt
  inflating: GPSBabel-20241111T1330Z-8424347-Setup.exe
$ ~/local/bin/gh attestation verify  GPSBabel-20241111T1330Z-8424347-Setup.exe -R tsteven4/gpsbabel_test
Loaded digest sha256:ea0b02b33210f1be9adc6b2a0e008eb6854b47b28cb6539641a0d4c757b868c8 for file://GPSBabel-20241111T1330Z-8424347-Setup.exe
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:ea0b02b33210f1be9adc6b2a0e008eb6854b47b28cb6539641a0d4c757b868c8 was attested by:
REPO                    PREDICATE_TYPE                  WORKFLOW
tsteven4/gpsbabel_test  https://slsa.dev/provenance/v1  .github/workflows/windows.yml@refs/heads/master
```
