### PR TITLE
Refactor GUI map preview

### DIFF
--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -214,6 +214,27 @@ GMapDialog::GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te):
 }
 
 //------------------------------------------------------------------------
+void GMapDialog::trace(const QString& label, const QStandardItem* it)
+{
+  if constexpr(debug_) {
+    QDebug qdb(QtDebugMsg);
+    qdb.nospace().noquote() << label + ": ";
+    qdb.quote();
+    if (it == nullptr) {
+      qdb << "null item";
+    } else {
+      QStandardItem* parent = it->parent();
+      if (parent == nullptr) {
+        qdb << "parent: none";
+      } else {
+        qdb << "parent: " << parent->text();
+      }
+      qdb << " item: " << it->text() << " (row: " << it->row() << ")";
+    }
+  }
+}
+  
+//------------------------------------------------------------------------
 void GMapDialog::showHideChild(const QStandardItem* child)
 {
   const QStandardItem* top = child->parent();
@@ -241,11 +262,7 @@ void GMapDialog::showHideChildren(const QStandardItem* top)
 //-------------------------------------------------------------------------
 void GMapDialog::itemChangedX(QStandardItem* it)
 {
-  if constexpr(debug_) {
-    qDebug() << "item X changed parent" <<
-             ((it->parent() == nullptr)? "none" : it->parent()->text()) <<
-             "row" << it->row();
-  }
+  trace("itemChangedX", it);
   if ((it == wptItem_) || (it == trkItem_) || (it == rteItem_)) {
     showHideChildren(it);
   } else {
@@ -260,11 +277,9 @@ void GMapDialog::itemChangedX(QStandardItem* it)
 void GMapDialog::treeDoubleClicked(const QModelIndex& idx)
 {
   QStandardItem* it = model_->itemFromIndex(idx);
+  trace("treeDoubleClicked", it);
   QStandardItem* parent = it->parent();
   int row = it->row();
-  if constexpr(debug_) {
-    qDebug() << "tree dbl click" << ((parent == nullptr)? "none": parent->text()) << "row" << row;
-  }
   if (parent == wptItem_) {
     parent->setCheckState(Qt::Checked);
     it->setCheckState(Qt::Checked);
@@ -283,6 +298,7 @@ void GMapDialog::treeDoubleClicked(const QModelIndex& idx)
 //-------------------------------------------------------------------------
 void GMapDialog::itemClickedX(const QStandardItem* it)
 {
+  trace("itemXClicked", it);
   if (it != nullptr) {
     QModelIndex idx = model_->indexFromItem(it);
     ui_.treeView->scrollTo(idx, QAbstractItemView::PositionAtCenter);
@@ -377,7 +393,7 @@ void GMapDialog::showChildContextMenu(const QString& text, const QStandardItem* 
 void GMapDialog::showContextMenu(const QPoint& pt)
 {
   if constexpr(debug_) {
-    qDebug() << "show context menu";
+    qDebug() << "showContextMenu";
   }
   QModelIndex idx = ui_.treeView->indexAt(pt);
   if (idx.isValid()) {

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -193,7 +193,7 @@ GMapDialog::GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te):
   ui_.treeView->setModel(model_);
   ui_.treeView->setExpandsOnDoubleClick(false);
   connect(model_, &QStandardItemModel::itemChanged,
-          this,  &GMapDialog::itemChangedX);
+          this, &GMapDialog::itemChangedX);
   connect(mapWidget_, &Map::waypointClicked, this, [this](int i)->void {
     itemClickedX(wptItem_->child(i));
   });
@@ -222,7 +222,7 @@ void GMapDialog::showHideChild(const QStandardItem* child)
   int row = child->row();
   if (top == wptItem_) {
     mapWidget_->setWaypointVisibility(row, show);
-  } else if (top ==  trkItem_) {
+  } else if (top == trkItem_) {
     mapWidget_->setTrackVisibility(row, show);
   } else if (top == rteItem_) {
     mapWidget_->setRouteVisibility(row, show);
@@ -291,7 +291,7 @@ void GMapDialog::itemClickedX(const QStandardItem* it)
 }
 
 //-------------------------------------------------------------------------
-void GMapDialog::selectionChangedX(const QItemSelection& sel,  const QItemSelection& desel)
+void GMapDialog::selectionChangedX(const QItemSelection& sel, const QItemSelection& desel)
 {
   if constexpr(debug_) {
     qDebug() << "selectionChangedX";
@@ -403,7 +403,7 @@ void GMapDialog::showContextMenu(const QPoint& pt)
                                   tr("Collapse All")
                                  };
       showTopContextMenu(labels, it, pt);
-    } else if (it !=  nullptr) {
+    } else if (it != nullptr) {
       QStandardItem* parent = it->parent();
       if (parent == wptItem_) {
         showChildContextMenu(tr("Show Only This Waypoint"), it, pt);

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -140,11 +140,10 @@ void GMapDialog::appendRouteInfo(QStandardItem* it, const GpxRoute& rte)
 }
 
 //------------------------------------------------------------------------
-GMapDialog::GMapDialog(QWidget* parent, const QString& gpxFileName, QPlainTextEdit* te): QDialog(parent)
+GMapDialog::GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te): QDialog(parent), gpx_(mapData)
 {
   ui_.setupUi(this);
   this->setWindowTitle(QString(appName) + " " + QString("Google Maps"));
-  gpx_.read(gpxFileName);
 
   mapWidget_ = new Map(this, gpx_, te);
   auto* lay = new QHBoxLayout(ui_.frame);

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -194,9 +194,15 @@ GMapDialog::GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te):
   ui_.treeView->setExpandsOnDoubleClick(false);
   connect(model_, &QStandardItemModel::itemChanged,
           this,  &GMapDialog::itemChangedX);
-  connect(mapWidget_, &Map::waypointClicked, this, &GMapDialog::waypointClickedX);
-  connect(mapWidget_, &Map::routeClicked, this, &GMapDialog::routeClickedX);
-  connect(mapWidget_, &Map::trackClicked, this, &GMapDialog::trackClickedX);
+  connect(mapWidget_, &Map::waypointClicked, this, [this](int i)->void {
+    itemClickedX(wptItem_->child(i));
+  });
+  connect(mapWidget_, &Map::routeClicked, this, [this](int i)->void {
+    itemClickedX(rteItem_->child(i));
+  });
+  connect(mapWidget_, &Map::trackClicked, this, [this](int i)->void {
+    itemClickedX(trkItem_->child(i));
+  });
   connect(ui_.treeView, &QAbstractItemView::doubleClicked,
           this, &GMapDialog::treeDoubleClicked);
   connect(ui_.treeView->selectionModel(), &QItemSelectionModel::selectionChanged,
@@ -275,30 +281,8 @@ void GMapDialog::treeDoubleClicked(const QModelIndex& idx)
 }
 
 //-------------------------------------------------------------------------
-void GMapDialog::waypointClickedX(int i)
+void GMapDialog::itemClickedX(const QStandardItem* it)
 {
-  const QStandardItem* it = wptItem_->child(i);
-  if (it != nullptr) {
-    QModelIndex idx = model_->indexFromItem(it);
-    ui_.treeView->scrollTo(idx, QAbstractItemView::PositionAtCenter);
-    ui_.treeView->selectionModel()->select(idx, QItemSelectionModel::ClearAndSelect);
-  }
-}
-//-------------------------------------------------------------------------
-void GMapDialog::trackClickedX(int i)
-{
-  const QStandardItem* it = trkItem_->child(i);
-  if (it != nullptr) {
-    QModelIndex idx = model_->indexFromItem(it);
-    ui_.treeView->scrollTo(idx, QAbstractItemView::PositionAtCenter);
-    ui_.treeView->selectionModel()->select(idx, QItemSelectionModel::ClearAndSelect);
-  }
-}
-
-//-------------------------------------------------------------------------
-void GMapDialog::routeClickedX(int i)
-{
-  const QStandardItem* it = rteItem_->child(i);
   if (it != nullptr) {
     QModelIndex idx = model_->indexFromItem(it);
     ui_.treeView->scrollTo(idx, QAbstractItemView::PositionAtCenter);

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -34,7 +34,6 @@
 #include <QStandardItemModel>   // for QStandardItemModel
 #include <QTreeView>            // for QTreeView
 #include <Qt>                   // for CheckState, ContextMenuPolicy
-#include <utility>              // for as_const
 #include "appname.h"            // for appName
 #include "gpx.h"                // for GpxWaypoint, GpxTrack, GpxRoute, Gpx, GpxItem, GpxTrackPoint, GpxTrackSegment
 #include "latlng.h"             // for LatLn
@@ -157,7 +156,7 @@ GMapDialog::GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te):
   wptItem_->setCheckable(true);
   wptItem_->setCheckState(Qt::Checked);
   model_->appendRow(wptItem_);
-  for (const auto& wpt : std::as_const(gpx_.getWaypoints())) {
+  for (const auto& wpt : gpx_.getWaypoints()) {
     QStandardItem* it = new StandardItem(wpt.getName());
     wptItem_->appendRow(it);
     it->setCheckable(true);
@@ -169,7 +168,7 @@ GMapDialog::GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te):
   trkItem_->setCheckable(true);
   trkItem_->setCheckState(Qt::Checked);
   model_->appendRow(trkItem_);
-  for (const auto& trk : std::as_const(gpx_.getTracks())) {
+  for (const auto& trk : gpx_.getTracks()) {
     QStandardItem* it = new StandardItem(trk.getName());
     trkItem_->appendRow(it);
     it->setCheckable(true);
@@ -181,7 +180,7 @@ GMapDialog::GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te):
   rteItem_->setCheckable(true);
   rteItem_->setCheckState(Qt::Checked);
   model_->appendRow(rteItem_);
-  for (const auto& rte : std::as_const(gpx_.getRoutes())) {
+  for (const auto& rte : gpx_.getRoutes()) {
     QStandardItem* it = new StandardItem(rte.getName());
     rteItem_->appendRow(it);
     it->setCheckable(true);

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -24,6 +24,7 @@
 #include "gmapdlg.h"
 #include <QAbstractItemView>    // for QAbstractItemView
 #include <QDateTime>            // for QDateTime, operator<, operator>
+#include <QDebug>               // for QDebug
 #include <QFrame>               // for QFrame
 #include <QHBoxLayout>          // for QHBoxLayout
 #include <QHeaderView>          // for QHeaderView
@@ -34,6 +35,7 @@
 #include <QStandardItemModel>   // for QStandardItemModel
 #include <QTreeView>            // for QTreeView
 #include <Qt>                   // for CheckState, ContextMenuPolicy
+#include <QtGlobal>             // for qDebug
 #include "appname.h"            // for appName
 #include "gpx.h"                // for GpxWaypoint, GpxTrack, GpxRoute, Gpx, GpxItem, GpxTrackPoint, GpxTrackSegment
 #include "latlng.h"             // for LatLn
@@ -234,9 +236,11 @@ void GMapDialog::showHideChildren(const QStandardItem* top)
 //-------------------------------------------------------------------------
 void GMapDialog::itemChangedX(QStandardItem* it)
 {
-  qDebug() << "item X changed parent" <<
-           ((it->parent() == nullptr)? "none" : it->parent()->text()) <<
-           "row" << it->row();
+  if constexpr(debug_) {
+    qDebug() << "item X changed parent" <<
+             ((it->parent() == nullptr)? "none" : it->parent()->text()) <<
+             "row" << it->row();
+  }
   if ((it == wptItem_) || (it == trkItem_) || (it == rteItem_)) {
     showHideChildren(it);
   } else {
@@ -253,7 +257,9 @@ void GMapDialog::treeDoubleClicked(const QModelIndex& idx)
   QStandardItem* it = model_->itemFromIndex(idx);
   QStandardItem* parent = it->parent();
   int row = it->row();
-  qDebug() << "tree dbl click" << ((parent == nullptr)? "none": parent->text()) << "row" << row;
+  if constexpr(debug_) {
+    qDebug() << "tree dbl click" << ((parent == nullptr)? "none": parent->text()) << "row" << row;
+  }
   if (parent == wptItem_) {
     parent->setCheckState(Qt::Checked);
     it->setCheckState(Qt::Checked);
@@ -304,7 +310,9 @@ void GMapDialog::routeClickedX(int i)
 //-------------------------------------------------------------------------
 void GMapDialog::selectionChangedX(const QItemSelection& sel,  const QItemSelection& desel)
 {
-  qDebug() << "selectionChangedX";
+  if constexpr(debug_) {
+    qDebug() << "selectionChangedX";
+  }
   for (const QModelIndexList idxs = desel.indexes(); const auto& idx : idxs) {
     const QStandardItem* it = model_->itemFromIndex(idx);
     const QStandardItem* parent = it->parent();
@@ -435,7 +443,9 @@ void GMapDialog::showOnlyThisRoute()
 //------------------------------------------------------------------------
 void GMapDialog::showContextMenu(const QPoint& pt)
 {
-  qDebug() << "show context menu";
+  if constexpr(debug_) {
+    qDebug() << "show context menu";
+  }
   QModelIndex idx = ui_.treeView->indexAt(pt);
   if (idx.isValid()) {
     const QStandardItem* it = model_->itemFromIndex(idx);

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -341,8 +341,12 @@ void GMapDialog::expandCollapseAll(QStandardItem* top, bool exp)
 }
 
 //------------------------------------------------------------------------
-void GMapDialog::checkUncheckAll(QStandardItem* top, bool ck)
+void GMapDialog::showHideAll(QStandardItem* top, bool ck)
 {
+  trace("showHideAll", top);
+  if (ck) {
+    mapWidget_->resetBounds();
+  }
   top->setCheckState(ck ? Qt::Checked: Qt::Unchecked);
   for (int row = 0; row < top->rowCount(); ++row) {
     QStandardItem* child = top->child(row);
@@ -353,6 +357,14 @@ void GMapDialog::checkUncheckAll(QStandardItem* top, bool ck)
 //------------------------------------------------------------------------
 void GMapDialog::showOnlyThis(QStandardItem* top, int menuRow)
 {
+  trace("showOnlyThis", top->child(menuRow));
+  if (top == wptItem_) {
+    mapWidget_->panTo(gpx_.getWaypoints().at(menuRow).getLocation());
+  } else if (top == trkItem_) {
+    mapWidget_->frameTrack(menuRow);
+  } else if (top = rteItem_) {
+    mapWidget_->frameRoute(menuRow);
+  }
   for (int row = 0; row < top->rowCount(); ++row) {
     QStandardItem* child = top->child(row);
     child->setCheckState(row == menuRow? Qt::Checked: Qt::Unchecked);
@@ -363,11 +375,11 @@ void GMapDialog::showOnlyThis(QStandardItem* top, int menuRow)
 void GMapDialog::showTopContextMenu(const QStringList& text, QStandardItem* top, const QPoint& pt)
 {
   QMenu menu(this);
-  menu.addAction(text.at(0), this, [&top]()->void {
-    checkUncheckAll(top, true);
+  menu.addAction(text.at(0), this, [this, &top]()->void {
+    showHideAll(top, true);
   });
-  menu.addAction(text.at(1), this, [&top]()->void {
-    checkUncheckAll(top, false);
+  menu.addAction(text.at(1), this, [this, &top]()->void {
+    showHideAll(top, false);
   });
   menu.addAction(text.at(2), this, [this, &top]()->void {
     expandCollapseAll(top, true);
@@ -383,7 +395,7 @@ void GMapDialog::showChildContextMenu(const QString& text, const QStandardItem* 
   QStandardItem* parent = child->parent();
   int row = child->row();
   QMenu menu(this);
-  menu.addAction(text, this, [&row, &parent]()->void {
+  menu.addAction(text, this, [this, &row, &parent]()->void {
     showOnlyThis(parent, row);
   });
   menu.exec(ui_.treeView->mapToGlobal(pt));

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -44,7 +44,7 @@ public:
   GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te);
 
 private:
-  static constexpr bool debug_ = true;
+  static constexpr bool debug_ = false;
 
   Ui_GMapDlg ui_;
   Map* mapWidget_;

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -62,11 +62,11 @@ private:
 
   static void trace(const QString& label, const QStandardItem* it);
   void expandCollapseAll(QStandardItem* top, bool exp);
-  static void checkUncheckAll(QStandardItem* top, bool ck);
+  void showHideAll(QStandardItem* top, bool ck);
   void showHideChild(const QStandardItem* child);
   void showHideChildren(const QStandardItem* top);
   void itemClickedX(const QStandardItem* it);
-  static void showOnlyThis(QStandardItem* top, int menuRow);
+  void showOnlyThis(QStandardItem* top, int menuRow);
   void showTopContextMenu(const QStringList& text, QStandardItem* top, const QPoint& pt);
   void showChildContextMenu(const QString& text, const QStandardItem* child, const QPoint& pt);
 

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -34,6 +34,7 @@
 #include <QStandardItemModel>  // for QStandardItemModel
 #include <QString>             // for QString
 #include <QWidget>             // for QWidget
+#include <concepts>            // for derived_from
 #include "gpx.h"               // for Gpx, GpxRoute, GpxTrack, GpxWaypoint
 #include "map.h"               // for Map
 #include "ui_gmapui.h"         // for Ui_GMapDlg
@@ -62,7 +63,7 @@ private:
 
   void expandCollapseAll(QStandardItem* top, bool exp);
   static void checkUncheckAll(QStandardItem* top, bool ck);
-  template<typename GpxItemType>
+  template<typename GpxItemType> requires std::derived_from<GpxItemType, GpxItem>
   void showOnlyThis(QList<GpxItemType>& list, QStandardItem* top);
 
   //

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -53,7 +53,6 @@ private:
   QStandardItem* trkItem_;
   QStandardItem* rteItem_;
   const Gpx& gpx_;
-  int menuIndex_;
 
   static void appendWaypointInfo(QStandardItem* it, const GpxWaypoint& wpt);
   static void appendTrackInfo(QStandardItem* it, const GpxTrack& trk);
@@ -65,7 +64,9 @@ private:
   static void checkUncheckAll(QStandardItem* top, bool ck);
   void showHideChild(const QStandardItem* child);
   void showHideChildren(const QStandardItem* top);
-  void showOnlyThis(QStandardItem* top);
+  static void showOnlyThis(QStandardItem* top, int menuRow);
+  void showTopContextMenu(const QStringList& text, QStandardItem* top, const QPoint& pt);
+  void showChildContextMenu(const QString& text, const QStandardItem* child, const QPoint& pt);
 
   //
 private slots:
@@ -76,26 +77,6 @@ private slots:
   void treeDoubleClicked(const QModelIndex& idx);
   void selectionChangedX(const QItemSelection& sel,  const QItemSelection& desel);
   void showContextMenu(const QPoint& pt);
-
-  void expandAllWaypoints();
-  void expandAllTracks();
-  void expandAllRoutes();
-
-  void collapseAllWaypoints();
-  void collapseAllTracks();
-  void collapseAllRoutes();
-
-  void hideAllWaypoints();
-  void hideAllTracks();
-  void hideAllRoutes();
-
-  void showAllWaypoints();
-  void showAllTracks();
-  void showAllRoutes();
-
-  void showOnlyThisWaypoint();
-  void showOnlyThisTrack();
-  void showOnlyThisRoute();
 };
 
 #endif

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -41,7 +41,7 @@ class GMapDialog: public QDialog
 {
   Q_OBJECT
 public:
-  GMapDialog(QWidget* parent, const QString& gpxFileName, QPlainTextEdit* te);
+  GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te);
 
 private:
   Ui_GMapDlg ui_;
@@ -50,7 +50,7 @@ private:
   QStandardItem* wptItem_;
   QStandardItem* trkItem_;
   QStandardItem* rteItem_;
-  Gpx gpx_;
+  const Gpx& gpx_;
   int menuIndex_;
 
   static void appendWaypointInfo(QStandardItem* it, const GpxWaypoint& wpt);

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -25,7 +25,6 @@
 
 #include <QDialog>             // for QDialog
 #include <QItemSelection>      // for QItemSelection
-#include <QList>               // for QList
 #include <QModelIndex>         // for QModelIndex
 #include <QObject>             // for Q_OBJECT, slots
 #include <QPlainTextEdit>      // for QPlainTextEdit
@@ -34,7 +33,6 @@
 #include <QStandardItemModel>  // for QStandardItemModel
 #include <QString>             // for QString
 #include <QWidget>             // for QWidget
-#include <concepts>            // for derived_from
 #include "gpx.h"               // for Gpx, GpxRoute, GpxTrack, GpxWaypoint
 #include "map.h"               // for Map
 #include "ui_gmapui.h"         // for Ui_GMapDlg
@@ -63,8 +61,9 @@ private:
 
   void expandCollapseAll(QStandardItem* top, bool exp);
   static void checkUncheckAll(QStandardItem* top, bool ck);
-  template<typename GpxItemType> requires std::derived_from<GpxItemType, GpxItem>
-  void showOnlyThis(QList<GpxItemType>& list, QStandardItem* top);
+  void showHideChild(const QStandardItem* child);
+  void showHideChildren(const QStandardItem* top);
+  void showOnlyThis(QStandardItem* top);
 
   //
 private slots:

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -44,6 +44,8 @@ public:
   GMapDialog(QWidget* parent, const Gpx& mapData, QPlainTextEdit* te);
 
 private:
+  static constexpr bool debug_ = true;
+
   Ui_GMapDlg ui_;
   Map* mapWidget_;
   QStandardItemModel* model_;

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -48,35 +48,33 @@ private:
   Ui_GMapDlg ui_;
   Map* mapWidget_;
   QStandardItemModel* model_;
-  QStandardItem* wptItem_, *trkItem_, *rteItem_;
-  QList<QStandardItem*> wptList_, trkList_, rteList_;
+  QStandardItem* wptItem_;
+  QStandardItem* trkItem_;
+  QStandardItem* rteItem_;
   Gpx gpx_;
   int menuIndex_;
 
-  void appendWaypointInfo(QStandardItem* it, const GpxWaypoint& wpt);
-  void appendTrackInfo(QStandardItem* it, const GpxTrack& trk);
-  void appendRouteInfo(QStandardItem* it, const GpxRoute& rte);
+  static void appendWaypointInfo(QStandardItem* it, const GpxWaypoint& wpt);
+  static void appendTrackInfo(QStandardItem* it, const GpxTrack& trk);
+  static void appendRouteInfo(QStandardItem* it, const GpxRoute& rte);
 
-  int waypointIndex(QStandardItem* it);
-  int trackIndex(QStandardItem* it);
-  int routeIndex(QStandardItem* it);
-  QString formatLength(double l);
+  static QString formatLength(double l);
+
+  void expandCollapseAll(QStandardItem* top, bool exp);
+  static void checkUncheckAll(QStandardItem* top, bool ck);
+  template<typename GpxItemType>
+  void showOnlyThis(QList<GpxItemType>& list, QStandardItem* top);
 
   //
 private slots:
-  void itemChangedX(QStandardItem*);
+  void itemChangedX(QStandardItem* it);
   void waypointClickedX(int i);
   void trackClickedX(int i);
   void routeClickedX(int i);
   void treeDoubleClicked(const QModelIndex& idx);
-  void selectionChangedX(const QItemSelection&,  const QItemSelection&);
-  void showContextMenu(const QPoint&);
+  void selectionChangedX(const QItemSelection& sel,  const QItemSelection& desel);
+  void showContextMenu(const QPoint& pt);
 
-
-  void expandCollapseAll(const QList<QStandardItem*>& li,
-                         QStandardItem* it, bool exp);
-  void checkUncheckAll(const QList<QStandardItem*>& li,
-                       QStandardItem* it, bool exp);
   void expandAllWaypoints();
   void expandAllTracks();
   void expandAllRoutes();

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -60,6 +60,7 @@ private:
 
   static QString formatLength(double l);
 
+  static void trace(const QString& label, const QStandardItem* it);
   void expandCollapseAll(QStandardItem* top, bool exp);
   static void checkUncheckAll(QStandardItem* top, bool ck);
   void showHideChild(const QStandardItem* child);

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -64,6 +64,7 @@ private:
   static void checkUncheckAll(QStandardItem* top, bool ck);
   void showHideChild(const QStandardItem* child);
   void showHideChildren(const QStandardItem* top);
+  void itemClickedX(const QStandardItem* it);
   static void showOnlyThis(QStandardItem* top, int menuRow);
   void showTopContextMenu(const QStringList& text, QStandardItem* top, const QPoint& pt);
   void showChildContextMenu(const QString& text, const QStandardItem* child, const QPoint& pt);
@@ -71,9 +72,6 @@ private:
   //
 private slots:
   void itemChangedX(QStandardItem* it);
-  void waypointClickedX(int i);
-  void trackClickedX(int i);
-  void routeClickedX(int i);
   void treeDoubleClicked(const QModelIndex& idx);
   void selectionChangedX(const QItemSelection& sel,  const QItemSelection& desel);
   void showContextMenu(const QPoint& pt);

--- a/gui/gmapdlg.h
+++ b/gui/gmapdlg.h
@@ -73,8 +73,7 @@ private:
 private slots:
   void itemChangedX(QStandardItem* it);
   void treeDoubleClicked(const QModelIndex& idx);
-  void selectionChangedX(const QItemSelection& sel,  const QItemSelection& desel);
+  void selectionChangedX(const QItemSelection& sel, const QItemSelection& desel);
   void showContextMenu(const QPoint& pt);
 };
-
 #endif

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -47,30 +47,7 @@ static bool trackIsEmpty(const GpxTrack& trk)
 class GpxHandler
 {
 public:
-  GpxHandler()
-
-  {
-    state = e_noop;
-  }
-
-  enum elementState {e_noop, e_wpt, e_trk,
-                     e_trkpt, e_trkseg, e_rte, e_rtept
-                    };
-  QString textChars;
-  GpxWaypoint currentWpt;
-  QList <GpxWaypoint> wptList;
-
-  QList <GpxTrack> trkList;
-  GpxTrack currentTrk;
-  GpxTrackPoint currentTrkPt;
-  GpxTrackSegment currentTrkSeg;
-
-  QList <GpxRoute> rteList;
-  GpxRoute currentRte;
-  GpxRoutePoint currentRtePt;
-
-  elementState state;
-  QList <elementState> stateStack;
+  /* Member Functions */
 
   void startElement(QStringView localName,
                     const QXmlStreamAttributes& atts)
@@ -204,6 +181,34 @@ public:
   {
     textChars = x;
   }
+
+  /* Data Members */
+
+  QList <GpxWaypoint> wptList;
+  QList <GpxTrack> trkList;
+  QList <GpxRoute> rteList;
+
+private:
+  /* Types */
+
+  enum elementState {e_noop, e_wpt, e_trk,
+                     e_trkpt, e_trkseg, e_rte, e_rtept
+                    };
+
+  /* Data Memebers */
+
+  QString textChars;
+  GpxWaypoint currentWpt;
+
+  GpxTrack currentTrk;
+  GpxTrackPoint currentTrkPt;
+  GpxTrackSegment currentTrkSeg;
+
+  GpxRoute currentRte;
+  GpxRoutePoint currentRtePt;
+
+  elementState state{e_noop};
+  QList <elementState> stateStack;
 };
 
 

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -209,11 +209,11 @@ public:
 
 //------------------------------------------------------------------------
 
-bool Gpx::read(const QString& fileName)
+QString Gpx::read(const QString& fileName)
 {
   QFile file(fileName);
   if (!file.open(QIODevice::ReadOnly)) {
-    return false;
+    return QStringLiteral("Error opening file %1").arg(fileName);
   }
 
   QXmlStreamReader reader(&file);
@@ -249,8 +249,8 @@ bool Gpx::read(const QString& fileName)
     wayPoints = gpxHandler.wptList;
     tracks = gpxHandler.trkList;
     routes = gpxHandler.rteList;
-    return true;
+    return {};
   }
-  return false;
+  return QStringLiteral("Error parsing map file: %1").arg(reader.errorString());
 
 }

--- a/gui/gpx.cc
+++ b/gui/gpx.cc
@@ -224,7 +224,7 @@ QString Gpx::read(const QString& fileName)
   QXmlStreamReader reader(&file);
   GpxHandler gpxHandler;
 
-  for (bool atEnd = false; !reader.atEnd() && !atEnd;)  {
+  for (bool atEnd = false; !reader.atEnd() && !atEnd;) {
     reader.readNext();
     // do processing
     switch (reader.tokenType()) {

--- a/gui/gpx.h
+++ b/gui/gpx.h
@@ -345,32 +345,17 @@ class Gpx
 public:
   QString read(const QString& fileName);
 
-  QList <GpxWaypoint>& getWaypoints()
-  {
-    return wayPoints;
-  } // nonconst
-
-  QList <GpxTrack>&    getTracks()
-  {
-    return tracks;
-  }
-
-  QList <GpxRoute>&    getRoutes()
-  {
-    return routes;
-  }
-
-  const QList <GpxWaypoint>& getWaypoints() const
+  const QList<GpxWaypoint>& getWaypoints() const
   {
     return wayPoints;
   }
 
-  const QList <GpxTrack>& getTracks()       const
+  const QList<GpxTrack>& getTracks() const
   {
     return tracks;
   }
 
-  const QList <GpxRoute>& getRoutes()       const
+  const QList<GpxRoute>& getRoutes() const
   {
     return routes;
   }

--- a/gui/gpx.h
+++ b/gui/gpx.h
@@ -26,7 +26,6 @@
 #include <QDateTime>         // for QDateTime
 #include <QList>             // for QList
 #include <QString>           // for QString
-#include <QtGlobal>          // for QForeachContainer, qMakeForeachContainer, foreach
 #include "latlng.h"          // for LatLng
 
 
@@ -55,10 +54,6 @@ protected:
 class GpxRoutePoint: public GpxItem
 {
 public:
-  GpxRoutePoint():  location(LatLng()), name(QString())
-  {
-  }
-
   void setLocation(const LatLng& pt)
   {
     location = pt;
@@ -88,29 +83,6 @@ private:
 class GpxRoute: public GpxItem
 {
 public:
-  GpxRoute(): name(QString()), cachedLength(-1) {}
-
-  GpxRoute(const GpxRoute& c)
-    :GpxItem(c.visible),
-     name(c.name), cachedLength(c.cachedLength)
-  {
-    routePoints.clear();
-    foreach (GpxRoutePoint sg, c.routePoints) {
-      routePoints << sg;
-    }
-  }
-  GpxRoute& operator = (const GpxRoute& c)
-  {
-    visible = c.visible;
-    name = c.name;
-    cachedLength = c.cachedLength;
-    routePoints.clear();
-    foreach (GpxRoutePoint sg, c.routePoints) {
-      routePoints << sg;
-    }
-    return *this;
-  }
-
   double length() const
   {
     if (cachedLength >=0.0) {
@@ -119,7 +91,7 @@ public:
     LatLng prevPt;
     bool first = true;
     double dist = 0.0;
-    foreach (GpxRoutePoint pt, routePoints) {
+    for (const GpxRoutePoint& pt : routePoints) {
       if (first) {
         prevPt = pt.getLocation();
         first = false;
@@ -160,17 +132,13 @@ public:
 private:
   QString name;
   QList <GpxRoutePoint> routePoints;
-  double cachedLength;
+  double cachedLength{-1.0};
 };
 
 //------------------------------------------------------------------------
 class GpxTrackPoint: public GpxItem
 {
 public:
-  GpxTrackPoint():  location(LatLng()), elevation(0), dateTime(QDateTime())
-  {
-  }
-
   void setLocation(const LatLng& pt)
   {
     location = pt;
@@ -203,7 +171,7 @@ public:
 
 private:
   LatLng location;
-  double  elevation;
+  double  elevation{0.0};
   QDateTime dateTime;
 };
 
@@ -211,24 +179,6 @@ private:
 class GpxTrackSegment: public GpxItem
 {
 public:
-  GpxTrackSegment() {}
-
-  GpxTrackSegment(const GpxTrackSegment& c): GpxItem(c.visible)
-  {
-    trackPoints.clear();
-    foreach (GpxTrackPoint pt, c.trackPoints) {
-      trackPoints << pt;
-    }
-  }
-  GpxTrackSegment& operator = (const GpxTrackSegment& c)
-  {
-    visible = c.visible;
-    trackPoints.clear();
-    foreach (GpxTrackPoint pt, c.trackPoints) {
-      trackPoints << pt;
-    }
-    return *this;
-  }
   void addPoint(const GpxTrackPoint& pt)
   {
     trackPoints << pt;
@@ -250,36 +200,6 @@ private:
 class GpxTrack: public GpxItem
 {
 public:
-  GpxTrack():  number(1), name(QString()), comment(QString()), description(QString()), cachedLength(-1.0) {}
-
-  GpxTrack(const GpxTrack& c)
-    :GpxItem(c.visible),
-     number(c.number),
-     name(c.name),
-     comment(c.comment),
-     description(c.description),
-     cachedLength(c.cachedLength)
-  {
-    trackSegments.clear();
-    foreach (GpxTrackSegment sg, c.trackSegments) {
-      trackSegments << sg;
-    }
-  }
-  GpxTrack& operator = (const GpxTrack& c)
-  {
-    visible = c.visible;
-    number = c.number;
-    name = c.name;
-    comment = c.comment;
-    description = c.description;
-    cachedLength = c.cachedLength;
-    trackSegments.clear();
-    foreach (GpxTrackSegment sg, c.trackSegments) {
-      trackSegments << sg;
-    }
-    return *this;
-  }
-
   void setNumber(int n)
   {
     number = n;
@@ -342,8 +262,8 @@ public:
     LatLng prevPt;
     bool first = true;
     double dist = 0.0;
-    foreach (GpxTrackSegment seg, trackSegments) {
-      foreach (GpxTrackPoint pt, seg.getTrackPoints()) {
+    for (const GpxTrackSegment& seg : trackSegments) {
+      for (const GpxTrackPoint& pt : seg.getTrackPoints()) {
         if (first) {
           prevPt = pt.getLocation();
           first = false;
@@ -359,27 +279,18 @@ public:
   }
 
 private:
-  int     number;
+  int     number{1};
   QString name;
   QString comment;
   QString description;
   QList <GpxTrackSegment> trackSegments;
-  double cachedLength;
+  double cachedLength{-1.0};
 };
 
 //------------------------------------------------------------------------
 class GpxWaypoint: public GpxItem
 {
 public:
-  GpxWaypoint():
-    location_(LatLng(0, 0)),
-    elevation_(-1.0E-100),
-    name_(QString()),
-    comment_(QString()),
-    description_(QString()),
-    symbol_(QString())
-  {}
-
   void setLocation(const LatLng& pt)
   {
     location_ = pt;
@@ -442,7 +353,7 @@ public:
 
 private:
   LatLng location_;
-  double  elevation_;
+  double  elevation_{-1.0E-100};
   QString name_;
   QString comment_;
   QString description_;
@@ -453,7 +364,6 @@ private:
 class Gpx
 {
 public:
-  Gpx() {}
   bool read(const QString& fileName);
 
   QList <GpxWaypoint>& getWaypoints()

--- a/gui/gpx.h
+++ b/gui/gpx.h
@@ -343,7 +343,7 @@ private:
 class Gpx
 {
 public:
-  bool read(const QString& fileName);
+  QString read(const QString& fileName);
 
   QList <GpxWaypoint>& getWaypoints()
   {

--- a/gui/gpx.h
+++ b/gui/gpx.h
@@ -150,7 +150,7 @@ public:
 
 private:
   LatLng location;
-  double  elevation{0.0};
+  double elevation{0.0};
   QDateTime dateTime;
 };
 
@@ -258,7 +258,7 @@ public:
   }
 
 private:
-  int     number{1};
+  int number{1};
   QString name;
   QString comment;
   QString description;
@@ -332,7 +332,7 @@ public:
 
 private:
   LatLng location_;
-  double  elevation_{-1.0E-100};
+  double elevation_{-1.0E-100};
   QString name_;
   QString comment_;
   QString description_;
@@ -362,9 +362,7 @@ public:
 
 private:
   QList <GpxWaypoint> wayPoints;
-  QList <GpxTrack>    tracks;
-  QList <GpxRoute>    routes;
+  QList <GpxTrack> tracks;
+  QList <GpxRoute> routes;
 };
-
-
 #endif

--- a/gui/gpx.h
+++ b/gui/gpx.h
@@ -30,28 +30,7 @@
 
 
 //------------------------------------------------------------------------
-class GpxItem
-{
-public:
-  GpxItem(): visible(true) {}
-  GpxItem(bool visible): visible(visible) {}
-
-  void setVisible(bool b)
-  {
-    visible = b;
-  }
-
-  bool getVisible() const
-  {
-    return visible;
-  }
-
-protected:
-  bool visible;
-};
-
-//------------------------------------------------------------------------
-class GpxRoutePoint: public GpxItem
+class GpxRoutePoint
 {
 public:
   void setLocation(const LatLng& pt)
@@ -80,7 +59,7 @@ private:
 };
 
 //------------------------------------------------------------------------
-class GpxRoute: public GpxItem
+class GpxRoute
 {
 public:
   double length() const
@@ -136,7 +115,7 @@ private:
 };
 
 //------------------------------------------------------------------------
-class GpxTrackPoint: public GpxItem
+class GpxTrackPoint
 {
 public:
   void setLocation(const LatLng& pt)
@@ -176,7 +155,7 @@ private:
 };
 
 //------------------------------------------------------------------------
-class GpxTrackSegment: public GpxItem
+class GpxTrackSegment
 {
 public:
   void addPoint(const GpxTrackPoint& pt)
@@ -197,7 +176,7 @@ private:
   QList <GpxTrackPoint> trackPoints;
 };
 //------------------------------------------------------------------------
-class GpxTrack: public GpxItem
+class GpxTrack
 {
 public:
   void setNumber(int n)
@@ -288,7 +267,7 @@ private:
 };
 
 //------------------------------------------------------------------------
-class GpxWaypoint: public GpxItem
+class GpxWaypoint
 {
 public:
   void setLocation(const LatLng& pt)

--- a/gui/latlng.h
+++ b/gui/latlng.h
@@ -28,7 +28,7 @@
 class LatLng
 {
 public:
-  LatLng(): _lat(0), _lng(0) {}
+  LatLng() = default;
   LatLng(double lat, double lng): _lat(lat), _lng(lng) {}
   double lat() const
   {
@@ -41,8 +41,8 @@ public:
   double haversineDistance(const LatLng& other) const;
 
 private:
-  double _lat;
-  double _lng;
+  double _lat{0.0};
+  double _lng{0.0};
 };
 
 

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -37,7 +37,6 @@
 #include <QWebEngineSettings>     // for QWebEngineSettings
 #include <QWebEngineView>         // for QWebEngineView
 #include <Qt>                     // for CursorShape
-#include <QtGlobal>               // for QForeachContainer, qMakeForeachContainer, foreach
 
 #include <string>                 // for string
 #include <vector>                 // for vector
@@ -53,13 +52,8 @@ using std::vector;
 //------------------------------------------------------------------------
 static QString stripDoubleQuotes(const QString& s)
 {
-  QString out;
-  foreach (QChar c, s) {
-    if (c != QChar('"')) {
-      out += c;
-    }
-  }
-  return out;
+  QString out = s;
+  return out.remove('"');
 }
 
 //------------------------------------------------------------------------
@@ -67,8 +61,6 @@ Map::Map(QWidget* parent,
          const Gpx&  gpx, QPlainTextEdit* te):
   QWebEngineView(parent),
   gpx_(gpx),
-  mapPresent_(false),
-  busyCursor_(false),
   textEdit_(te)
 {
   busyCursor_ = true;
@@ -239,7 +231,7 @@ void Map::showGpxData()
 
   // Waypoints.
   int num=0;
-  foreach (const  GpxWaypoint& pt, gpx_.getWaypoints()) {
+  for (const GpxWaypoint& pt : gpx_.getWaypoints()) {
     scriptStr
         << QString("waypts[%1] = new google.maps.Marker({map: map, position: %2, "
                    "title: \"%3\", icon: blueIcon});")
@@ -258,10 +250,10 @@ void Map::showGpxData()
 
   // Tracks
   num = 0;
-  foreach (const GpxTrack& trk, gpx_.getTracks()) {
+  for (const GpxTrack& trk : gpx_.getTracks()) {
     vector <LatLng> pts;
-    foreach (const GpxTrackSegment seg, trk.getTrackSegments()) {
-      foreach (const GpxTrackPoint pt, seg.getTrackPoints()) {
+    for (const GpxTrackSegment& seg : trk.getTrackSegments()) {
+      for (const GpxTrackPoint& pt : seg.getTrackPoints()) {
         pts.push_back(pt.getLocation());
       }
     }
@@ -287,9 +279,9 @@ void Map::showGpxData()
 
   // Routes
   num = 0;
-  foreach (const GpxRoute& rte, gpx_.getRoutes()) {
+  for (const GpxRoute& rte : gpx_.getRoutes()) {
     vector <LatLng> pts;
-    foreach (const GpxRoutePoint& pt, rte.getRoutePoints()) {
+    for (const GpxRoutePoint& pt : rte.getRoutePoints()) {
       pts.push_back(pt.getLocation());
     }
     QString path = makePath(pts);
@@ -350,7 +342,7 @@ void Map::showTracks(const QList<GpxTrack>& tracks)
 {
   QStringList scriptStr;
   int i=0;
-  foreach (const GpxTrack& trk, tracks) {
+  for (const GpxTrack& trk : tracks) {
     scriptStr << QString("trks[%1].%2();").arg(i).arg(trk.getVisible()?"show":"hide");
     i++;
   }
@@ -375,7 +367,7 @@ void Map::showWaypoints(const QList<GpxWaypoint>& waypoints)
 {
   QStringList scriptStr;
   int i=0;
-  foreach (const GpxWaypoint& pt, waypoints) {
+  for (const GpxWaypoint& pt : waypoints) {
     scriptStr << QString("waypts[%1].setVisible(%2);").arg(i++).arg(pt.getVisible()?"true":"false");
   }
   evaluateJS(scriptStr);
@@ -397,7 +389,7 @@ void Map::showRoutes(const QList<GpxRoute>& routes)
 {
   QStringList scriptStr;
   int i=0;
-  foreach (const GpxRoute& rt, routes) {
+  for (const GpxRoute& rt : routes) {
     scriptStr << QString("rtes[%1].%2();").arg(i).arg(rt.getVisible()?"show":"hide");
     i++;
   }

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -326,7 +326,6 @@ void Map::markerClicked(int t, int i)
   } else if (t == 2) {
     emit routeClicked(i);
   }
-
 }
 
 //------------------------------------------------------------------------
@@ -392,7 +391,6 @@ void Map::frameTrack(int i)
   scriptStr
       << QString("map.setCenter(trks[%1].getBounds().getCenter());").arg(i)
       << QString("map.fitBounds(trks[%1].getBounds());").arg(i)
-
       ;
   evaluateJS(scriptStr);
 }

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -28,6 +28,7 @@
 #include <QFile>                  // for QFile
 #include <QIODevice>              // for QIODevice
 #include <QLatin1String>          // for QLatin1String
+#include <QList>                  // for QList
 #include <QMessageBox>            // for QMessageBox
 #include <QNetworkAccessManager>  // for QNetworkAccessManager
 #include <QStringLiteral>         // for qMakeStringPrivate, QStringLiteral
@@ -336,75 +337,6 @@ void Map::logTime(const QString& s)
     textEdit_->appendPlainText(QString("%1: %2 ms").arg(s).arg(stopWatch_.elapsed()));
   }
   stopWatch_.start();
-}
-//------------------------------------------------------------------------
-void Map::showTracks(const QList<GpxTrack>& tracks)
-{
-  QStringList scriptStr;
-  int i=0;
-  for (const GpxTrack& trk : tracks) {
-    scriptStr << QString("trks[%1].%2();").arg(i).arg(trk.getVisible()?"show":"hide");
-    i++;
-  }
-  evaluateJS(scriptStr);
-}
-
-//------------------------------------------------------------------------
-void Map::hideAllTracks()
-{
-  QStringList scriptStr;
-  scriptStr
-      << "for (idx = 0; idx < trks.length; idx += 1) {"
-      << "    trks[idx].hide();"
-      << "}"
-      ;
-  evaluateJS(scriptStr);
-}
-
-//------------------------------------------------------------------------
-// TACKY: we assume the waypoints list and JS waypts[] are parallel.
-void Map::showWaypoints(const QList<GpxWaypoint>& waypoints)
-{
-  QStringList scriptStr;
-  int i=0;
-  for (const GpxWaypoint& pt : waypoints) {
-    scriptStr << QString("waypts[%1].setVisible(%2);").arg(i++).arg(pt.getVisible()?"true":"false");
-  }
-  evaluateJS(scriptStr);
-}
-//------------------------------------------------------------------------
-void Map::hideAllWaypoints()
-{
-  QStringList scriptStr;
-  scriptStr
-      << "for (idx = 0; idx < waypts.length; idx += 1) {"
-      << "    waypts[idx].setVisible(false);"
-      << "}"
-      ;
-  evaluateJS(scriptStr);
-}
-
-//------------------------------------------------------------------------
-void Map::showRoutes(const QList<GpxRoute>& routes)
-{
-  QStringList scriptStr;
-  int i=0;
-  for (const GpxRoute& rt : routes) {
-    scriptStr << QString("rtes[%1].%2();").arg(i).arg(rt.getVisible()?"show":"hide");
-    i++;
-  }
-  evaluateJS(scriptStr);
-}
-//------------------------------------------------------------------------
-void Map::hideAllRoutes()
-{
-  QStringList scriptStr;
-  scriptStr
-      << "for (idx = 0; idx < rtes.length; idx += 1) {"
-      << "    rtes[idx].hide();"
-      << "}"
-      ;
-  evaluateJS(scriptStr);
 }
 //------------------------------------------------------------------------
 void Map::setWaypointVisibility(int i, bool show)

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -59,7 +59,7 @@ static QString stripDoubleQuotes(const QString& s)
 
 //------------------------------------------------------------------------
 Map::Map(QWidget* parent,
-         const Gpx&  gpx, QPlainTextEdit* te):
+         const Gpx& gpx, QPlainTextEdit* te):
   QWebEngineView(parent),
   gpx_(gpx),
   textEdit_(te)
@@ -83,7 +83,7 @@ Map::Map(QWidget* parent,
   // 1. In the file system in the same directory as the executable.
   // 2. In the Qt resource system.  This is useful if the resource was compiled
   //    into the executable.
-  QString baseFile =  QApplication::applicationDirPath() + "/gmapbase.html";
+  QString baseFile = QApplication::applicationDirPath() + "/gmapbase.html";
   QString fileName;
   QUrl baseUrl;
   if (QFile(baseFile).exists()) {
@@ -186,7 +186,7 @@ void Map::loadFinishedX(bool f)
 //------------------------------------------------------------------------
 static QString fmtLatLng(const LatLng& l)
 {
-  return  QString("{lat: %1, lng: %3}").arg(l.lat(), 0, 'f', 5) .arg(l.lng(), 0, 'f', 5);
+  return QString("{lat: %1, lng: %3}").arg(l.lat(), 0, 'f', 5) .arg(l.lng(), 0, 'f', 5);
 }
 
 //------------------------------------------------------------------------

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -357,6 +357,15 @@ void Map::setRouteVisibility(int i, bool show)
 }
 
 //------------------------------------------------------------------------
+void Map::resetBounds()
+{
+  evaluateJS(QStringList{
+    "map.setCenter(bounds.getCenter());",
+    "map.fitBounds(bounds);",
+  });
+}
+
+//------------------------------------------------------------------------
 void Map::panTo(const LatLng& loc)
 {
   evaluateJS(QString("map.panTo(new google.maps.LatLng(%1));").arg(fmtLatLng(loc)));
@@ -386,27 +395,20 @@ void Map::setWaypointColorBlue(int i)
 //------------------------------------------------------------------------
 void Map::frameTrack(int i)
 {
-  QStringList scriptStr;
-
-  scriptStr
-      << QString("map.setCenter(trks[%1].getBounds().getCenter());").arg(i)
-      << QString("map.fitBounds(trks[%1].getBounds());").arg(i)
-      ;
-  evaluateJS(scriptStr);
+  evaluateJS(QStringList{
+    QString("map.setCenter(trks[%1].getBounds().getCenter());").arg(i),
+    QString("map.fitBounds(trks[%1].getBounds());").arg(i),
+  });
 }
-
 
 //------------------------------------------------------------------------
 void Map::frameRoute(int i)
 {
-  QStringList scriptStr;
-  scriptStr
-      << QString("map.setCenter(rtes[%1].getBounds().getCenter());").arg(i)
-      << QString("map.fitBounds(rtes[%1].getBounds());").arg(i)
-      ;
-  evaluateJS(scriptStr);
+  evaluateJS(QStringList{
+    QString("map.setCenter(rtes[%1].getBounds().getCenter());").arg(i),
+    QString("map.fitBounds(rtes[%1].getBounds());").arg(i),
+  });
 }
-
 
 //------------------------------------------------------------------------
 void Map::evaluateJS(const QString& s, bool upd)

--- a/gui/map.h
+++ b/gui/map.h
@@ -81,6 +81,7 @@ public:
   void setTrackVisibility(int i, bool show);
   void setWaypointVisibility(int i, bool show);
   void setRouteVisibility(int i, bool show);
+  void resetBounds();
   void panTo(const LatLng& loc);
   void setWaypointColorRed(int i);
   void setWaypointColorBlue(int i);

--- a/gui/map.h
+++ b/gui/map.h
@@ -94,7 +94,7 @@ public slots:
   void hideAllRoutes();
   void setRouteVisibility(int i, bool show);
 
-  void loadFinishedX(bool);
+  void loadFinishedX(bool f);
   void markerClicked(int t, int i);
   void panTo(const LatLng& loc);
   void setWaypointColorRed(int i);
@@ -102,11 +102,11 @@ public slots:
   void frameTrack(int i);
   void frameRoute(int i);
 
-  void logTime(const QString&);
+  void logTime(const QString& s);
 
 private:
-  QByteArray encodeKey(const QByteArray& key);
-  QByteArray decodeKey(const QByteArray& key);
+  static QByteArray encodeKey(const QByteArray& key);
+  static QByteArray decodeKey(const QByteArray& key);
 
 signals:
   void waypointClicked(int i);
@@ -115,15 +115,15 @@ signals:
 
 private:
 #ifdef DEBUG_JS_GENERATION
-  QFile* dbgdata_;
-  QTextStream* dbgout_;
+  QFile* dbgdata_{nullptr};
+  QTextStream* dbgout_{nullptr};
 #endif
-  QNetworkAccessManager* manager_;
+  QNetworkAccessManager* manager_{nullptr};
   const Gpx& gpx_;
-  bool mapPresent_;
-  bool busyCursor_;
+  bool mapPresent_{false};
+  bool busyCursor_{false};
   QElapsedTimer stopWatch_;
-  QPlainTextEdit* textEdit_;
+  QPlainTextEdit* textEdit_{nullptr};
 
   void evaluateJS(const QString& s, bool update = true);
   void evaluateJS(const QStringList& s, bool update = true);

--- a/gui/map.h
+++ b/gui/map.h
@@ -74,7 +74,7 @@ class Map : public QWebEngineView
   Q_OBJECT
 public:
   Map(QWidget* parent,
-      const Gpx&  gpx_, QPlainTextEdit* textEdit_);
+      const Gpx& gpx_, QPlainTextEdit* textEdit_);
   ~Map();
 
   void showGpxData();

--- a/gui/map.h
+++ b/gui/map.h
@@ -69,7 +69,6 @@ signals:
 };
 
 
-
 class Map : public QWebEngineView
 {
   Q_OBJECT
@@ -117,11 +116,7 @@ private:
   void evaluateJS(const QString& s, bool update = true);
   void evaluateJS(const QStringList& s, bool update = true);
 
-
 protected:
   void resizeEvent(QResizeEvent* event) override;
-
 };
-
-
 #endif // HEADER_H

--- a/gui/map.h
+++ b/gui/map.h
@@ -25,7 +25,6 @@
 
 #include <QByteArray>             // for QByteArray
 #include <QElapsedTimer>          // for QElapsedTimer
-#include <QList>                  // for QList
 #include <QNetworkAccessManager>  // for QNetworkAccessManager
 #include <QObject>                // for QObject, emit, Q_OBJECT, signals, slots
 #include <QPlainTextEdit>         // for QPlainTextEdit
@@ -79,29 +78,19 @@ public:
       const Gpx&  gpx_, QPlainTextEdit* textEdit_);
   ~Map();
 
-public slots:
   void showGpxData();
-
-  void showTracks(const QList<GpxTrack>& tracks);
-  void hideAllTracks();
   void setTrackVisibility(int i, bool show);
-
-  void showWaypoints(const QList<GpxWaypoint>& waypoints);
-  void hideAllWaypoints();
   void setWaypointVisibility(int i, bool show);
-
-  void showRoutes(const QList<GpxRoute>& routes);
-  void hideAllRoutes();
   void setRouteVisibility(int i, bool show);
-
-  void loadFinishedX(bool f);
-  void markerClicked(int t, int i);
   void panTo(const LatLng& loc);
   void setWaypointColorRed(int i);
   void setWaypointColorBlue(int i);
   void frameTrack(int i);
   void frameRoute(int i);
 
+public slots:
+  void loadFinishedX(bool f);
+  void markerClicked(int t, int i);
   void logTime(const QString& s);
 
 private:


### PR DESCRIPTION
Among other cleanups this enforces storage of which map items are visible to GMapDlg::model_.  Duplication of this information, for example in GpxItem::visible, has been eliminated.  This allows simplification as we can often use common routines passing a parent or child of the model instead of separate routine for wayoints/tracks/routes. It also improves maintainability and correctness as the possibility of disagreement is eliminated (which could occur previously).   It allows GMapDlg::gpx_ to be const, which ensures we aren't operating on copies of information, as we were in GMapDialog::[show|hide[All[Waypoints|Track|Routes]() (although the code worked anyway, the operation on the temporary copy was just obfuscation.  Overall we are down 347 LOCs.

This started as remove of foreach.  That is readily achievable in the GUI, but fraught with peril in the CLI due to routines that operate on global lists that you may be iterating over.

I still need to turn debug off before merging.