### PR TITLE
cleanup GUI special member functions

### DIFF
--- a/gui/babeldata.h
+++ b/gui/babeldata.h
@@ -29,53 +29,31 @@
 #include <QSettings>    // for QSettings
 #include <QString>      // for QString
 #include <QStringList>  // for QStringList
-#include <QTime>        // for QTime
 #include <QUuid>        // for QUuid
+#include <memory>       // for make_unique, unique_ptr
 #include "setting.h"    // for SettingGroup, BoolSetting, StringSetting, IntSetting, DateTimeSetting
-
 
 class BabelData
 {
 public:
+  /* Constants */
+
+  static constexpr int noType_ = -1;
+  static constexpr int fileType_ = 0;
+  static constexpr int deviceType_ = 1;
+
+  /* Special Member Functions */
+
   BabelData():
     inputType_(fileType_),
-    inputFileFormat_(QString()),
-    inputDeviceFormat_(QString()),
-    inputFileNames_(QStringList()),
-    inputDeviceName_(QString()),
-    inputCharSet_(QString()),
-    xlateWayPts_(true),
-    xlateRoutes_(true),
-    xlateTracks_(true),
     outputType_(fileType_),
-    outputFileFormat_(QString()),
-    outputDeviceFormat_(QString()),
-    outputFileName_(QString()),
-    outputDeviceName_(QString()),
-    outputCharSet_(QString()),
-    synthShortNames_(false),
-    forceGPSTypes_(false),
-    debugLevel_(-1),
-    inputBrowse_(QString()),
-    outputBrowse_(QString()),
-    previewGmap_(false),
-    upgradeCheckMethod_(0),
-    upgradeCheckTime_(QDateTime(QDate(2001, 1, 1), QTime(0, 0))),
+    upgradeCheckTime_(QDate(2001, 1, 1).startOfDay()),
     installationUuid_(QUuid::createUuid().toString()),
-    upgradeCallbacks_(0),
-    upgradeAccept_(0),
-    upgradeDeclines_(0),
-    upgradeErrors_(0),
-    upgradeOffers_(0),
-    runCount_(0),
-    startupVersionCheck_(true),
-    reportStatistics_(true),
-    allowBetaUpgrades_(false),
-    ignoreVersionMismatch_(false),
-    disableDonateDialog_(false),
-    donateSplashed_(QDateTime(QDate(2010, 1, 1), QTime(0, 0, 0)))
+    donateSplashed_(QDate(2010, 1, 1).startOfDay())
   {
   }
+
+  /* Member Functions */
 
   void saveSettings(QSettings& st)
   {
@@ -92,52 +70,49 @@ public:
 
   void makeSettingGroup(SettingGroup& sg)
   {
-    sg.addVarSetting(new IntSetting("app.inputType", inputType_));
-    sg.addVarSetting(new StringSetting("app.inputFileFormat", inputFileFormat_));
-    sg.addVarSetting(new StringSetting("app.inputDeviceFormat", inputDeviceFormat_));
-    sg.addVarSetting(new StringSetting("app.inputCharSet", inputCharSet_));
-    sg.addVarSetting(new StringSetting("app.inputDeviceName", inputDeviceName_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.inputType", inputType_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.inputFileFormat", inputFileFormat_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.inputDeviceFormat", inputDeviceFormat_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.inputCharSet", inputCharSet_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.inputDeviceName", inputDeviceName_));
 
-    sg.addVarSetting(new BoolSetting("app.xlateWayPts", xlateWayPts_));
-    sg.addVarSetting(new BoolSetting("app.xlateRoutes", xlateRoutes_));
-    sg.addVarSetting(new BoolSetting("app.xlateTracks", xlateTracks_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.xlateWayPts", xlateWayPts_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.xlateRoutes", xlateRoutes_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.xlateTracks", xlateTracks_));
 
-    sg.addVarSetting(new IntSetting("app.outputType", outputType_));
-    sg.addVarSetting(new StringSetting("app.outputFileFormat", outputFileFormat_));
-    sg.addVarSetting(new StringSetting("app.outputDeviceFormat", outputDeviceFormat_));
-    sg.addVarSetting(new StringSetting("app.outputCharSet", outputCharSet_));
-    sg.addVarSetting(new StringSetting("app.outputDeviceName", outputDeviceName_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.outputType", outputType_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.outputFileFormat", outputFileFormat_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.outputDeviceFormat", outputDeviceFormat_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.outputCharSet", outputCharSet_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.outputDeviceName", outputDeviceName_));
 
-    sg.addVarSetting(new BoolSetting("app.synthShortNames", synthShortNames_));
-    sg.addVarSetting(new BoolSetting("app.forceGPSTypes", forceGPSTypes_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.synthShortNames", synthShortNames_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.forceGPSTypes", forceGPSTypes_));
 
-    sg.addVarSetting(new StringSetting("app.inputBrowse", inputBrowse_));
-    sg.addVarSetting(new StringSetting("app.outputBrowse", outputBrowse_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.inputBrowse", inputBrowse_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.outputBrowse", outputBrowse_));
 
-    sg.addVarSetting(new BoolSetting("app.previewGmap", previewGmap_));
-    sg.addVarSetting(new IntSetting("app.upgradeCheckMethod", upgradeCheckMethod_));
-    sg.addVarSetting(new DateTimeSetting("app.upgradeCheckTime", upgradeCheckTime_));
-    sg.addVarSetting(new DateTimeSetting("app.donateSplashed", donateSplashed_));
-    sg.addVarSetting(new StringSetting("app.installationUuid", installationUuid_));
-    sg.addVarSetting(new IntSetting("app.upgradeCallbacks", upgradeCallbacks_));
-    sg.addVarSetting(new IntSetting("app.upgradeAccept", upgradeAccept_));
-    sg.addVarSetting(new IntSetting("app.upgradeDeclines", upgradeDeclines_));
-    sg.addVarSetting(new IntSetting("app.upgradeErrors", upgradeErrors_));
-    sg.addVarSetting(new IntSetting("app.upgradeOffers", upgradeOffers_));
-    sg.addVarSetting(new IntSetting("app.runCount", runCount_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.previewGmap", previewGmap_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.upgradeCheckMethod", upgradeCheckMethod_));
+    sg.addVarSetting(std::make_unique<DateTimeSetting>("app.upgradeCheckTime", upgradeCheckTime_));
+    sg.addVarSetting(std::make_unique<DateTimeSetting>("app.donateSplashed", donateSplashed_));
+    sg.addVarSetting(std::make_unique<StringSetting>("app.installationUuid", installationUuid_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.upgradeCallbacks", upgradeCallbacks_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.upgradeAccept", upgradeAccept_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.upgradeDeclines", upgradeDeclines_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.upgradeErrors", upgradeErrors_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.upgradeOffers", upgradeOffers_));
+    sg.addVarSetting(std::make_unique<IntSetting>("app.runCount", runCount_));
 
     // Global preferences.
-    sg.addVarSetting(new BoolSetting("app.startupVersionCheck", startupVersionCheck_));
-    sg.addVarSetting(new BoolSetting("app.reportStatistics", reportStatistics_));
-    sg.addVarSetting(new BoolSetting("app.allowBetaUpgrades", allowBetaUpgrades_));
-    sg.addVarSetting(new BoolSetting("app.ignoreVersionMismatch", ignoreVersionMismatch_));
-    sg.addVarSetting(new BoolSetting("app.disableDonateDialog", disableDonateDialog_));
-
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.startupVersionCheck", startupVersionCheck_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.reportStatistics", reportStatistics_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.allowBetaUpgrades", allowBetaUpgrades_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.ignoreVersionMismatch", ignoreVersionMismatch_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.disableDonateDialog", disableDonateDialog_));
   }
 
-  static const int noType_;
-  static const int fileType_;
-  static const int deviceType_;
+  /* Data Members */
 
   int inputType_;
   QString inputFileFormat_;
@@ -146,9 +121,9 @@ public:
   QString inputDeviceName_;
   QString inputCharSet_;
 
-  bool xlateWayPts_;
-  bool xlateRoutes_;
-  bool xlateTracks_;
+  bool xlateWayPts_{true};
+  bool xlateRoutes_{true};
+  bool xlateTracks_{true};
 
   int outputType_;
   QString outputFileFormat_;
@@ -157,31 +132,29 @@ public:
   QString outputDeviceName_;
   QString outputCharSet_;
 
-  bool synthShortNames_;
-  bool forceGPSTypes_;
-  int  debugLevel_;
+  bool synthShortNames_{false};
+  bool forceGPSTypes_{false};
+  int  debugLevel_{-1};
 
   QString inputBrowse_, outputBrowse_;
 
-  bool  previewGmap_;
-  int   upgradeCheckMethod_;
+  bool  previewGmap_{false};
+  int   upgradeCheckMethod_{0};
   QDateTime upgradeCheckTime_;
   QString installationUuid_;
-  int upgradeCallbacks_;
-  int upgradeAccept_;
-  int upgradeDeclines_;
-  int upgradeErrors_;
-  int upgradeOffers_;
-  int runCount_;
+  int upgradeCallbacks_{0};
+  int upgradeAccept_{0};
+  int upgradeDeclines_{0};
+  int upgradeErrors_{0};
+  int upgradeOffers_{0};
+  int runCount_{0};
 
   // Global preferences.
-  bool startupVersionCheck_;
-  bool reportStatistics_;
-  bool allowBetaUpgrades_;
-  bool ignoreVersionMismatch_;
-  bool disableDonateDialog_;
+  bool startupVersionCheck_{true};
+  bool reportStatistics_{true};
+  bool allowBetaUpgrades_{false};
+  bool ignoreVersionMismatch_{false};
+  bool disableDonateDialog_{false};
   QDateTime donateSplashed_;
-
 };
-
 #endif

--- a/gui/filterdata.cc
+++ b/gui/filterdata.cc
@@ -24,9 +24,10 @@
 #include "filterdata.h"
 #include <QChar>    // for QChar
 #include <QDate>    // for QDate
+#include <QTime>    // for QTime
 #include <QVector>  // for QVector
 
-QStringList WayPtsFilterData::makeOptionString()
+QStringList WayPtsFilterData::makeOptionString() const
 {
   QStringList args;
   if (!inUse_) {
@@ -77,7 +78,7 @@ static QString optionDate(const QDateTime& dt)
 }
 
 //------------------------------------------------------------------------
-QStringList TrackFilterData::makeOptionString()
+QStringList TrackFilterData::makeOptionString() const
 {
   QStringList args;
   if (!inUse_) {
@@ -150,7 +151,7 @@ QStringList TrackFilterData::makeOptionString()
 }
 
 //------------------------------------------------------------------------
-QStringList RtTrkFilterData::makeOptionString()
+QStringList RtTrkFilterData::makeOptionString() const
 {
   QStringList args;
   if (!inUse_) {
@@ -168,7 +169,7 @@ QStringList RtTrkFilterData::makeOptionString()
 }
 
 //------------------------------------------------------------------------
-QStringList MiscFltFilterData::makeOptionString()
+QStringList MiscFltFilterData::makeOptionString() const
 {
   QStringList args;
   if (!inUse_) {

--- a/gui/filterdata.h
+++ b/gui/filterdata.h
@@ -23,21 +23,31 @@
 #ifndef FILTERDATA_H
 #define FILTERDATA_H
 
+#include <QDate>        // for QDate
 #include <QDateTime>    // for QDateTime
 #include <QList>        // for QList
 #include <QSettings>    // for QSettings
 #include <QString>      // for QString
 #include <QStringList>  // for QStringList
-#include <QTime>        // for QTime
-#include "setting.h"    // for BoolSetting, SettingGroup, IntSetting, DoubleSetting, DateTimeSetting, StringSetting
+#include <memory>       // for make_unique, unique_ptr
+#include <utility>      // for as_const
+#include "setting.h"    // for BoolSetting, IntSetting, SettingGroup, VarSetting, DoubleSetting, DateTimeSetting, StringSetting
 
 //------------------------------------------------------------------------
 
 class FilterData
 {
 public:
-  FilterData(): inUse_(true) {}
-  virtual ~FilterData() {}
+  /* Special Member Functions */
+
+  FilterData() = default;
+  FilterData(const FilterData &) = default;
+  FilterData &operator=(const FilterData &) = default;
+  FilterData(FilterData &&) = default;
+  FilterData &operator=(FilterData &&) = default;
+  virtual ~FilterData() = default;
+
+  /* Member Functions */
 
   void saveSettings(QSettings& st)
   {
@@ -52,87 +62,80 @@ public:
     sg.restoreSettings(st);
   }
   virtual void makeSettingGroup(SettingGroup& sg) = 0;
-  virtual QStringList makeOptionString() = 0;
+  virtual QStringList makeOptionString() const = 0;
 
-public:
-  bool inUse_;
+  /* Member Data */
+
+  bool inUse_{true};
 };
 //------------------------------------------------------------------------
 
 class TrackFilterData: public FilterData
 {
 public:
-  TrackFilterData():  title(false), titleString(QString()),
-    move(false),  weeks(0), days(0), hours(0), mins(0), secs(0),
-    localTime(true), utc(false),
-    start(false),
-    stop(false),
-    pack(false), merge(false), split(false),
-    GPSFixes(false), GPSFixesVal(0),
-    splitByDate(false),
-    splitByTime(false),
-    splitByDistance(false),
-    course(false), speed(false),
-    splitTime(0), splitTimeUnit(0),
-    splitDist(0), splitDistUnit(0)
+  /* Special Member Functions */
+
+  TrackFilterData() : titleString("ACTIVE LOG #%Y%m%d")   
   {
-    titleString = "ACTIVE LOG #%Y%m%d";
-    stopTime = QDateTime::currentDateTime();
-    stopTime.setTime(QTime(23, 59, 59));
-    startTime = stopTime.addMonths(-6);
-    startTime.setTime(QTime(0, 0, 1));
+    QDate today = QDate::currentDate();
+    stopTime = today.endOfDay();
+    startTime = today.addMonths(-6).startOfDay();
   }
+
+  /* Member Functions */
+
+  QStringList makeOptionString() const override;
   void makeSettingGroup(SettingGroup& sg) override
   {
-    sg.addVarSetting(new BoolSetting("trks.inUse", inUse_));
-    sg.addVarSetting(new BoolSetting("trks.GPSFixes", GPSFixes));
-    sg.addVarSetting(new IntSetting("trks.GPSFixesVal", GPSFixesVal));
-    sg.addVarSetting(new BoolSetting("trks.course", course));
-    sg.addVarSetting(new BoolSetting("trks.speed", speed));
-    sg.addVarSetting(new BoolSetting("trks.pack", pack));
-    sg.addVarSetting(new BoolSetting("trks.merge", merge));
-    sg.addVarSetting(new BoolSetting("trks.split", split));
-    sg.addVarSetting(new BoolSetting("trks.splitByDate", splitByDate));
-    sg.addVarSetting(new BoolSetting("trks.splitByTime", splitByTime));
-    sg.addVarSetting(new BoolSetting("trks.splitByDistance", splitByDistance));
-    sg.addVarSetting(new BoolSetting("trks.start", start));
-    sg.addVarSetting(new DateTimeSetting("trks.startTime", startTime));
-    sg.addVarSetting(new BoolSetting("trks.stop", stop));
-    sg.addVarSetting(new DateTimeSetting("trks.stopTime", stopTime));
-    sg.addVarSetting(new BoolSetting("trks.localTime", localTime));
-    sg.addVarSetting(new BoolSetting("trks.utc", utc));
-    sg.addVarSetting(new BoolSetting("trks.move", move));
-    sg.addVarSetting(new IntSetting("trks.weeks", weeks));
-    sg.addVarSetting(new IntSetting("trks.days", days));
-    sg.addVarSetting(new IntSetting("trks.mins", mins));
-    sg.addVarSetting(new IntSetting("trks.hours", hours));
-    sg.addVarSetting(new IntSetting("trks.secs", secs));
-    sg.addVarSetting(new BoolSetting("trks.title", title));
-    sg.addVarSetting(new StringSetting("trks.titleString", titleString));
-    sg.addVarSetting(new IntSetting("trks.splitTime", splitTime));
-    sg.addVarSetting(new IntSetting("trks.splitTimeUnit", splitTimeUnit));
-    sg.addVarSetting(new IntSetting("trks.splitDist", splitDist));
-    sg.addVarSetting(new IntSetting("trks.splitDistUnit", splitDistUnit));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.inUse", inUse_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.GPSFixes", GPSFixes));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.GPSFixesVal", GPSFixesVal));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.course", course));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.speed", speed));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.pack", pack));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.merge", merge));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.split", split));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.splitByDate", splitByDate));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.splitByTime", splitByTime));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.splitByDistance", splitByDistance));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.start", start));
+    sg.addVarSetting(std::make_unique<DateTimeSetting>("trks.startTime", startTime));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.stop", stop));
+    sg.addVarSetting(std::make_unique<DateTimeSetting>("trks.stopTime", stopTime));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.localTime", localTime));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.utc", utc));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.move", move));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.weeks", weeks));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.days", days));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.mins", mins));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.hours", hours));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.secs", secs));
+    sg.addVarSetting(std::make_unique<BoolSetting>("trks.title", title));
+    sg.addVarSetting(std::make_unique<StringSetting>("trks.titleString", titleString));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.splitTime", splitTime));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.splitTimeUnit", splitTimeUnit));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.splitDist", splitDist));
+    sg.addVarSetting(std::make_unique<IntSetting>("trks.splitDistUnit", splitDistUnit));
   }
-  QStringList makeOptionString() override;
 
-public:
-  bool title;
+  /* Data Members */
+
+  bool title{false};
   QString titleString;
-  bool move;
-  int  weeks, days, hours, mins, secs;
-  bool localTime, utc;
+  bool move{false};
+  int  weeks{0}, days{0}, hours{0}, mins{0}, secs{0};
+  bool localTime{true}, utc{false};
 
-  bool start;
+  bool start{false};
   QDateTime startTime;
-  bool stop;
+  bool stop{false};
   QDateTime stopTime;
-  bool pack, merge, split, GPSFixes;
-  int  GPSFixesVal;
-  bool splitByDate, splitByTime, splitByDistance;
-  bool course, speed;
-  int  splitTime, splitTimeUnit;
-  int  splitDist, splitDistUnit;
+  bool pack{false}, merge{false}, split{false}, GPSFixes{false};
+  int  GPSFixesVal{0};
+  bool splitByDate{false}, splitByTime{false}, splitByDistance{false};
+  bool course{false}, speed{false};
+  int  splitTime{0}, splitTimeUnit{0};
+  int  splitDist{0}, splitDistUnit{0};
 };
 
 //------------------------------------------------------------------------
@@ -140,112 +143,87 @@ public:
 class WayPtsFilterData: public FilterData
 {
 public:
-  WayPtsFilterData():
-    duplicates(false), shortNames(true), locations(false),
-    position(false), radius(false),
-    positionVal(0.0), radiusVal(0.0),
-    longVal(0.0), latVal(0.0),
-    positionUnit(0), radiusUnit(0)
-  {
-  }
+  /* Member Functions */
 
-  QStringList makeOptionString() override;
+  QStringList makeOptionString() const override;
   void makeSettingGroup(SettingGroup& sg) override
   {
-    sg.addVarSetting(new BoolSetting("wpts.inUse", inUse_));
-    sg.addVarSetting(new BoolSetting("wpts.radius", radius));
-    sg.addVarSetting(new DoubleSetting("wpts.radiusVal", radiusVal));
-    sg.addVarSetting(new IntSetting("wpts.radiusUnit", radiusUnit));
-    sg.addVarSetting(new DoubleSetting("wpts.latVal", latVal));
-    sg.addVarSetting(new DoubleSetting("wpts.longVal", longVal));
-    sg.addVarSetting(new BoolSetting("wpts.duplicates", duplicates));
-    sg.addVarSetting(new BoolSetting("wpts.shortNames", shortNames));
-    sg.addVarSetting(new BoolSetting("wpts.locations", locations));
-    sg.addVarSetting(new BoolSetting("wpts.position", position));
-    sg.addVarSetting(new DoubleSetting("wpts.positionVal", positionVal));
-    sg.addVarSetting(new IntSetting("wpts.positionUnit", positionUnit));
+    sg.addVarSetting(std::make_unique<BoolSetting>("wpts.inUse", inUse_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("wpts.radius", radius));
+    sg.addVarSetting(std::make_unique<DoubleSetting>("wpts.radiusVal", radiusVal));
+    sg.addVarSetting(std::make_unique<IntSetting>("wpts.radiusUnit", radiusUnit));
+    sg.addVarSetting(std::make_unique<DoubleSetting>("wpts.latVal", latVal));
+    sg.addVarSetting(std::make_unique<DoubleSetting>("wpts.longVal", longVal));
+    sg.addVarSetting(std::make_unique<BoolSetting>("wpts.duplicates", duplicates));
+    sg.addVarSetting(std::make_unique<BoolSetting>("wpts.shortNames", shortNames));
+    sg.addVarSetting(std::make_unique<BoolSetting>("wpts.locations", locations));
+    sg.addVarSetting(std::make_unique<BoolSetting>("wpts.position", position));
+    sg.addVarSetting(std::make_unique<DoubleSetting>("wpts.positionVal", positionVal));
+    sg.addVarSetting(std::make_unique<IntSetting>("wpts.positionUnit", positionUnit));
   }
 
+  /* Data Members */
 
-public:
-  bool duplicates, shortNames, locations, position, radius;
-  double positionVal;
-  double radiusVal;
-  double longVal, latVal;
-  int positionUnit, radiusUnit;
+  bool duplicates{false}, shortNames{true}, locations{false}, position{false}, radius{false};
+  double positionVal{0.0};
+  double radiusVal{0.0};
+  double longVal{0.0}, latVal{0.0};
+  int positionUnit{0}, radiusUnit{0};
 };
 
 //------------------------------------------------------------------------
 class RtTrkFilterData: public FilterData
 {
 public:
-  RtTrkFilterData():
-    simplify_(false),
-    reverse_(false),
-    limitTo_(100)
-  {
-  }
+  /* Member Functions */
 
-  QStringList makeOptionString() override;
+  QStringList makeOptionString() const override;
   void makeSettingGroup(SettingGroup& sg) override
   {
-    sg.addVarSetting(new BoolSetting("rttrk.inUse", inUse_));
-    sg.addVarSetting(new BoolSetting("rttrk.reverse", reverse_));
-    sg.addVarSetting(new BoolSetting("rttrk.simplify", simplify_));
-    sg.addVarSetting(new IntSetting("rttrk.limitTo", limitTo_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("rttrk.inUse", inUse_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("rttrk.reverse", reverse_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("rttrk.simplify", simplify_));
+    sg.addVarSetting(std::make_unique<IntSetting>("rttrk.limitTo", limitTo_));
   }
 
-public:
-  bool simplify_, reverse_;
-  int limitTo_;
+  /* Data Members */
+
+  bool simplify_{false}, reverse_{false};
+  int limitTo_{100};
 };
 
 //------------------------------------------------------------------------
 class MiscFltFilterData: public FilterData
 {
 public:
-  MiscFltFilterData():
-    nukeRoutes_(false),
-    nukeTracks_(false),
-    nukeWaypoints_(false),
-    transform_(false),
-    del_(false),
-    swap_(false),
-    sortWpt_(false),
-    sortRte_(false),
-    sortTrk_(false),
-    transformVal_(0),
-    sortWptBy_(0),
-    sortRteBy_(0),
-    sortTrkBy_(0)
-  {
-  }
+  /* Member Functions */
 
-  QStringList makeOptionString() override;
+  QStringList makeOptionString() const override;
   void makeSettingGroup(SettingGroup& sg) override
   {
-    sg.addVarSetting(new BoolSetting("mscflt.nukeRoutes", nukeRoutes_));
-    sg.addVarSetting(new BoolSetting("mscflt.nukeTracks", nukeTracks_));
-    sg.addVarSetting(new BoolSetting("mscflt.nukeWaypoints", nukeWaypoints_));
-    sg.addVarSetting(new BoolSetting("mscflt.inUse", inUse_));
-    sg.addVarSetting(new BoolSetting("mscflt.transform", transform_));
-    sg.addVarSetting(new IntSetting("mscflt.transformVal", transformVal_));
-    sg.addVarSetting(new BoolSetting("mscflt.delete", del_));
-    sg.addVarSetting(new BoolSetting("mscflt.swap", swap_));
-    sg.addVarSetting(new BoolSetting("mscflt.sortWpt", sortWpt_));
-    sg.addVarSetting(new IntSetting("mscflt.sortWptBy", sortWptBy_));
-    sg.addVarSetting(new BoolSetting("mscflt.sortRte", sortRte_));
-    sg.addVarSetting(new IntSetting("mscflt.sortRteBy", sortRteBy_));
-    sg.addVarSetting(new BoolSetting("mscflt.sortTrk", sortTrk_));
-    sg.addVarSetting(new IntSetting("mscflt.sortTrkBy", sortTrkBy_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.nukeRoutes", nukeRoutes_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.nukeTracks", nukeTracks_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.nukeWaypoints", nukeWaypoints_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.inUse", inUse_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.transform", transform_));
+    sg.addVarSetting(std::make_unique<IntSetting>("mscflt.transformVal", transformVal_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.delete", del_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.swap", swap_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.sortWpt", sortWpt_));
+    sg.addVarSetting(std::make_unique<IntSetting>("mscflt.sortWptBy", sortWptBy_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.sortRte", sortRte_));
+    sg.addVarSetting(std::make_unique<IntSetting>("mscflt.sortRteBy", sortRteBy_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("mscflt.sortTrk", sortTrk_));
+    sg.addVarSetting(std::make_unique<IntSetting>("mscflt.sortTrkBy", sortTrkBy_));
   }
 
-public:
-  bool nukeRoutes_, nukeTracks_, nukeWaypoints_;
-  bool transform_, del_, swap_;
-  bool sortWpt_, sortRte_, sortTrk_;
-  int transformVal_;
-  int sortWptBy_, sortRteBy_, sortTrkBy_;
+  /* Member Data */
+
+  bool nukeRoutes_{false}, nukeTracks_{false}, nukeWaypoints_{false};
+  bool transform_{false}, del_{false}, swap_{false};
+  bool sortWpt_{false}, sortRte_{false}, sortTrk_{false};
+  int transformVal_{0};
+  int sortWptBy_{0}, sortRteBy_{0}, sortTrkBy_{0};
 };
 
 
@@ -254,14 +232,7 @@ public:
 class AllFiltersData
 {
 public:
-  AllFiltersData()
-  {
-    defaultAll();
-    filters << &miscFltFilterData;
-    filters << &trackFilterData;
-    filters << &wayPtsFilterData;
-    filters << &rtTrkFilterData;
-  }
+  /* Member Functions */
 
   void defaultAll()
   {
@@ -274,18 +245,18 @@ public:
   QStringList getAllFilterStrings()
   {
     QStringList args;
-    for (int i=0; i<filters.size(); i++) {
-      args << filters[i]->makeOptionString();
+    for (const auto* filter : std::as_const(filters)) {
+      args << filter->makeOptionString();
     }
     return args;
   }
+
+  /* Member Data */
 
   TrackFilterData trackFilterData;
   WayPtsFilterData wayPtsFilterData;
   RtTrkFilterData rtTrkFilterData;
   MiscFltFilterData miscFltFilterData;
-  QList<FilterData*>filters;
+  QList<FilterData*>filters{&miscFltFilterData, &trackFilterData, &wayPtsFilterData, &rtTrkFilterData};
 };
-
-
 #endif

--- a/gui/filterdata.h
+++ b/gui/filterdata.h
@@ -75,7 +75,7 @@ class TrackFilterData: public FilterData
 public:
   /* Special Member Functions */
 
-  TrackFilterData() : titleString("ACTIVE LOG #%Y%m%d")   
+  TrackFilterData() : titleString("ACTIVE LOG #%Y%m%d")
   {
     QDate today = QDate::currentDate();
     stopTime = today.endOfDay();

--- a/gui/filterwidgets.cc
+++ b/gui/filterwidgets.cc
@@ -102,42 +102,42 @@ TrackWidget::TrackWidget(QWidget* parent, TrackFilterData& tfd): FilterWidget(pa
   tfd.utc = !tfd.localTime;
 
   // Collect the data fields.
-  fopts << new BoolFilterOption(tfd.title,  ui.titleCheck);
-  fopts << new BoolFilterOption(tfd.move,   ui.moveCheck);
-  fopts << new BoolFilterOption(tfd.localTime,     ui.localTime);
-  fopts << new BoolFilterOption(tfd.utc,     ui.utc);
-  fopts << new BoolFilterOption(tfd.start,  ui.startCheck);
-  fopts << new BoolFilterOption(tfd.stop,   ui.stopCheck);
-  fopts << new BoolFilterOption(tfd.pack,   ui.packCheck);
-  fopts << new BoolFilterOption(tfd.merge,  ui.mergeCheck);
-  fopts << new BoolFilterOption(tfd.splitByDate,  ui.splitDateCheck);
-  fopts << new BoolFilterOption(tfd.splitByTime,  ui.splitTimeCheck);
-  fopts << new BoolFilterOption(tfd.splitByDistance,  ui.splitDistanceCheck);
-  fopts << new BoolFilterOption(tfd.GPSFixes,  ui.GPSFixesCheck);
-  fopts << new BoolFilterOption(tfd.course, ui.courseCheck);
-  fopts << new BoolFilterOption(tfd.speed,  ui.speedCheck);
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.title,  ui.titleCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.move,   ui.moveCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.localTime,     ui.localTime));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.utc,     ui.utc));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.start,  ui.startCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.stop,   ui.stopCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.pack,   ui.packCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.merge,  ui.mergeCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.splitByDate,  ui.splitDateCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.splitByTime,  ui.splitTimeCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.splitByDistance,  ui.splitDistanceCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.GPSFixes,  ui.GPSFixesCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.course, ui.courseCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(tfd.speed,  ui.speedCheck));
 
-  fopts << new IntSpinFilterOption(tfd.weeks,  ui.weeksSpin, ui.weeksSpin->minimum(), ui.weeksSpin->maximum());
-  fopts << new IntSpinFilterOption(tfd.days,  ui.daysSpin, ui.daysSpin->minimum(), ui.daysSpin->maximum());
-  fopts << new IntSpinFilterOption(tfd.hours, ui.hoursSpin, ui.hoursSpin->minimum(), ui.hoursSpin->maximum());
-  fopts << new IntSpinFilterOption(tfd.mins,  ui.minsSpin, ui.minsSpin->minimum(), ui.minsSpin->maximum());
-  fopts << new IntSpinFilterOption(tfd.secs,  ui.secsSpin, ui.secsSpin->minimum(), ui.secsSpin->maximum());
-  fopts << new IntSpinFilterOption(tfd.splitTime,  ui.splitTimeSpin, 0, 1000);
-  fopts << new IntSpinFilterOption(tfd.splitDist,  ui.splitDistSpin, 0, 5280);
+  addFilterOption(std::make_unique<IntSpinFilterOption>(tfd.weeks,  ui.weeksSpin, ui.weeksSpin->minimum(), ui.weeksSpin->maximum()));
+  addFilterOption(std::make_unique<IntSpinFilterOption>(tfd.days,  ui.daysSpin, ui.daysSpin->minimum(), ui.daysSpin->maximum()));
+  addFilterOption(std::make_unique<IntSpinFilterOption>(tfd.hours, ui.hoursSpin, ui.hoursSpin->minimum(), ui.hoursSpin->maximum()));
+  addFilterOption(std::make_unique<IntSpinFilterOption>(tfd.mins,  ui.minsSpin, ui.minsSpin->minimum(), ui.minsSpin->maximum()));
+  addFilterOption(std::make_unique<IntSpinFilterOption>(tfd.secs,  ui.secsSpin, ui.secsSpin->minimum(), ui.secsSpin->maximum()));
+  addFilterOption(std::make_unique<IntSpinFilterOption>(tfd.splitTime,  ui.splitTimeSpin, 0, 1000));
+  addFilterOption(std::make_unique<IntSpinFilterOption>(tfd.splitDist,  ui.splitDistSpin, 0, 5280));
 
-  fopts << new DateTimeFilterOption(tfd.startTime, ui.startEdit);
-  fopts << new DateTimeFilterOption(tfd.stopTime,  ui.stopEdit);
+  addFilterOption(std::make_unique<DateTimeFilterOption>(tfd.startTime, ui.startEdit));
+  addFilterOption(std::make_unique<DateTimeFilterOption>(tfd.stopTime,  ui.stopEdit));
 
-  fopts << new StringFilterOption(tfd.titleString, ui.titleText);
-  fopts << new ComboFilterOption(tfd.GPSFixesVal,  ui.GPSFixesCombo);
-  fopts << new ComboFilterOption(tfd.splitTimeUnit,  ui.splitTimeCombo);
-  fopts << new ComboFilterOption(tfd.splitDistUnit,  ui.splitDistCombo);
+  addFilterOption(std::make_unique<StringFilterOption>(tfd.titleString, ui.titleText));
+  addFilterOption(std::make_unique<ComboFilterOption>(tfd.GPSFixesVal,  ui.GPSFixesCombo));
+  addFilterOption(std::make_unique<ComboFilterOption>(tfd.splitTimeUnit,  ui.splitTimeCombo));
+  addFilterOption(std::make_unique<ComboFilterOption>(tfd.splitDistUnit,  ui.splitDistCombo));
   setWidgetValues();
   checkChecks();
 }
 
 //------------------------------------------------------------------------
-void TrackWidget::otherCheckX()
+void TrackWidget::otherCheckX() const
 {
   ui.localTime->setEnabled(ui.stopCheck->isChecked() || ui.startCheck->isChecked());
   ui.utc->setEnabled(ui.stopCheck->isChecked() || ui.startCheck->isChecked());
@@ -198,7 +198,7 @@ void TrackWidget::splitDistanceX()
   otherCheckX();
 }
 //------------------------------------------------------------------------
-void TrackWidget::TZX()
+void TrackWidget::TZX() const
 {
   if (ui.localTime->isChecked()) {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
@@ -238,17 +238,17 @@ WayPtsWidget::WayPtsWidget(QWidget* parent, WayPtsFilterData& wfd): FilterWidget
                   QList<QWidget*>() << ui.latLabel << ui.latText << ui.longLabel <<
                   ui.longText << ui.radiusUnitCombo << ui.radiusText);
 
-  fopts << new BoolFilterOption(wfd.duplicates, ui.duplicatesCheck);
-  fopts << new BoolFilterOption(wfd.shortNames, ui.shortNamesCheck);
-  fopts << new BoolFilterOption(wfd.locations, ui.locationsCheck);
-  fopts << new BoolFilterOption(wfd.position, ui.positionCheck);
-  fopts << new BoolFilterOption(wfd.radius, ui.radiusCheck);
-  fopts << new DoubleFilterOption(wfd.positionVal, ui.positionText, 0.0, 1.0E308);
-  fopts << new DoubleFilterOption(wfd.radiusVal, ui.radiusText, 0.0, 1.0E308);
-  fopts << new DoubleFilterOption(wfd.longVal, ui.longText, -180, 180, 7, 'f');
-  fopts << new DoubleFilterOption(wfd.latVal, ui.latText,  -90, 90, 7, 'f');
-  fopts << new ComboFilterOption(wfd.positionUnit, ui.positionUnitCombo);
-  fopts << new ComboFilterOption(wfd.radiusUnit, ui.radiusUnitCombo);
+  addFilterOption(std::make_unique<BoolFilterOption>(wfd.duplicates, ui.duplicatesCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(wfd.shortNames, ui.shortNamesCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(wfd.locations, ui.locationsCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(wfd.position, ui.positionCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(wfd.radius, ui.radiusCheck));
+  addFilterOption(std::make_unique<DoubleFilterOption>(wfd.positionVal, ui.positionText, 0.0, 1.0E308));
+  addFilterOption(std::make_unique<DoubleFilterOption>(wfd.radiusVal, ui.radiusText, 0.0, 1.0E308));
+  addFilterOption(std::make_unique<DoubleFilterOption>(wfd.longVal, ui.longText, -180, 180, 7, 'f'));
+  addFilterOption(std::make_unique<DoubleFilterOption>(wfd.latVal, ui.latText,  -90, 90, 7, 'f'));
+  addFilterOption(std::make_unique<ComboFilterOption>(wfd.positionUnit, ui.positionUnitCombo));
+  addFilterOption(std::make_unique<ComboFilterOption>(wfd.radiusUnit, ui.radiusUnitCombo));
 
   connect(ui.shortNamesCheck, &QAbstractButton::clicked, this, &WayPtsWidget::shortNamesCkX);
   connect(ui.locationsCheck, &QAbstractButton::clicked, this, &WayPtsWidget::locationsCkX);
@@ -256,14 +256,14 @@ WayPtsWidget::WayPtsWidget(QWidget* parent, WayPtsFilterData& wfd): FilterWidget
   checkChecks();
 }
 //------------------------------------------------------------------------
-void WayPtsWidget::shortNamesCkX()
+void WayPtsWidget::shortNamesCkX() const
 {
   if (!ui.shortNamesCheck->isChecked()) {
     ui.locationsCheck->setChecked(true);
   }
 }
 //------------------------------------------------------------------------
-void WayPtsWidget::locationsCkX()
+void WayPtsWidget::locationsCkX() const
 {
   if (!ui.locationsCheck->isChecked()) {
     ui.shortNamesCheck->setChecked(true);
@@ -278,9 +278,9 @@ RtTrkWidget::RtTrkWidget(QWidget* parent, RtTrkFilterData& rfd): FilterWidget(pa
   addCheckEnabler(ui.simplifyCheck,
                   QList<QWidget*>() << ui.limitToLabel << ui.limitToSpin << ui.pointLabel);
 
-  fopts << new BoolFilterOption(rfd.simplify_, ui.simplifyCheck);
-  fopts << new BoolFilterOption(rfd.reverse_, ui.reverseCheck);
-  fopts << new IntSpinFilterOption(rfd.limitTo_, ui.limitToSpin, 1, std::numeric_limits<int>::max());
+  addFilterOption(std::make_unique<BoolFilterOption>(rfd.simplify_, ui.simplifyCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(rfd.reverse_, ui.reverseCheck));
+  addFilterOption(std::make_unique<IntSpinFilterOption>(rfd.limitTo_, ui.limitToSpin, 1, std::numeric_limits<int>::max()));
   setWidgetValues();
   checkChecks();
 }
@@ -302,19 +302,19 @@ MiscFltWidget::MiscFltWidget(QWidget* parent, MiscFltFilterData& mfd): FilterWid
   addCheckEnabler(ui.sortRteCheck, ui.sortRteBy);
   addCheckEnabler(ui.sortTrkCheck, ui.sortTrkBy);
 
-  fopts << new BoolFilterOption(mfd.transform_, ui.transformCheck);
-  fopts << new BoolFilterOption(mfd.swap_, ui.swapCheck);
-  fopts << new BoolFilterOption(mfd.del_, ui.deleteCheck);
-  fopts << new BoolFilterOption(mfd.nukeTracks_, ui.nukeTracks);
-  fopts << new BoolFilterOption(mfd.nukeRoutes_, ui.nukeRoutes);
-  fopts << new BoolFilterOption(mfd.nukeWaypoints_, ui.nukeWaypoints);
-  fopts << new BoolFilterOption(mfd.sortWpt_, ui.sortWptCheck);
-  fopts << new BoolFilterOption(mfd.sortRte_, ui.sortRteCheck);
-  fopts << new BoolFilterOption(mfd.sortTrk_, ui.sortTrkCheck);
-  fopts << new ComboFilterOption(mfd.transformVal_,  ui.transformCombo);
-  fopts << new ComboFilterOption(mfd.sortWptBy_, ui.sortWptBy);
-  fopts << new ComboFilterOption(mfd.sortRteBy_, ui.sortRteBy);
-  fopts << new ComboFilterOption(mfd.sortTrkBy_, ui.sortTrkBy);
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.transform_, ui.transformCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.swap_, ui.swapCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.del_, ui.deleteCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.nukeTracks_, ui.nukeTracks));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.nukeRoutes_, ui.nukeRoutes));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.nukeWaypoints_, ui.nukeWaypoints));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.sortWpt_, ui.sortWptCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.sortRte_, ui.sortRteCheck));
+  addFilterOption(std::make_unique<BoolFilterOption>(mfd.sortTrk_, ui.sortTrkCheck));
+  addFilterOption(std::make_unique<ComboFilterOption>(mfd.transformVal_,  ui.transformCombo));
+  addFilterOption(std::make_unique<ComboFilterOption>(mfd.sortWptBy_, ui.sortWptBy));
+  addFilterOption(std::make_unique<ComboFilterOption>(mfd.sortRteBy_, ui.sortRteBy));
+  addFilterOption(std::make_unique<ComboFilterOption>(mfd.sortTrkBy_, ui.sortTrkBy));
 
   setWidgetValues();
   checkChecks();

--- a/gui/filterwidgets.h
+++ b/gui/filterwidgets.h
@@ -273,7 +273,7 @@ public:
   }
   void setWidgetValues()
   {
-    for (const auto & fopt : fopts) {
+    for (const auto& fopt : fopts) {
       fopt->setWidgetValue();
     }
   }

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -77,11 +77,6 @@
 #include "version_mismatch.h"  // for VersionMismatch
 
 
-
-const int BabelData::noType_ = -1;
-const int BabelData::fileType_ = 0;
-const int BabelData::deviceType_ = 1;
-
 //------------------------------------------------------------------------
 QString MainWindow::findBabelVersion()
 {


### PR DESCRIPTION
These tidy checks had a large impact:
cppcoreguidelines-prefer-member-initializer
modernize-use-default-member-init
modernize-use-equals-default

Some instances of other tidy issues were resolved:
clang-analyzer-optin.cplusplus.VirtualCall
cppcoreguidelines-special-member-functions
readability-inconsistent-declaration-parameter-name
readability-named-parameter
and others.

Overall we have 1334 fewer tidy checks on our code base, a
reduction of 15% of the total!

The user defined dtor for class SettingGroup was eliminated
by using std::vector<std::unique_ptr<VarSetting>> instead of a
QList of raw pointers.
The user defined dtor for class FilterWidget was eliminated
by using std::vector<std::unique_ptr<FilterOption>> instead of a
QList of raw pointers.