### PR TITLE
Tools update

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,6 @@
+paths-ignore:
+  - coverity_model.cc
+  - deprecated
+  - reference
+  - 'shapelib/*.html'
+  - '**/gpsbabel*.ts'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
           build-mode: autobuild
           image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_noble
           runs-on: ubuntu-latest
-        - language: action
+        - language: actions
           build-mode: autobuild
           runs-on: ubuntu-latest
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "CodeQL Advanced"
 
 on:
   push:
@@ -22,32 +22,44 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.runs-on }},${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners
-    # Consider using larger runners for possible analysis time improvements.
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ matrix.runs-on }}
     permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
       actions: read
       contents: read
-      security-events: write
     container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_noble
+      image: ${{ matrix.image || '' }}
       env:
         CMAKE_GENERATOR: Ninja
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'c-cpp' ]
-        # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
-        # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
+        include:
+        - language: c-cpp
+          build-mode: autobuild
+          image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_noble
+          runs-on: ubuntu-latest
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -57,6 +69,8 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -64,21 +78,23 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    #- run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,9 @@ jobs:
           build-mode: autobuild
           image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_noble
           runs-on: ubuntu-latest
+        - language: action
+          build-mode: autobuild
+          runs-on: ubuntu-latest
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       security-events: write
     container:
-      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_jammy
+      image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_noble
       env:
         CMAKE_GENERATOR: Ninja
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
           image: gpsbabel-docker.jfrog.io/tsteven4/gpsbabel_build_environment_noble
           runs-on: ubuntu-latest
         - language: actions
-          build-mode: autobuild
+          build-mode: none
           runs-on: ubuntu-latest
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,8 +43,8 @@ jobs:
             GENERATOR: 'Ninja'
             RELEASE: true
             os: macos-14
-          - QT_VERSION: '6.8.0'
-            XCODE_VERSION: '16.0'
+          - QT_VERSION: '6.8.1'
+            XCODE_VERSION: '16.1'
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-15

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,7 +44,7 @@ jobs:
             RELEASE: true
             os: macos-14
           - QT_VERSION: '6.8.1'
-            XCODE_VERSION: '16.1'
+            XCODE_VERSION: '16.2'
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-15

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,6 +88,10 @@ jobs:
       run: |
         ./tools/ci_install_windows.sh "${{ matrix.QT_VERSION }}" "${{ matrix.COMPILER }}" "${{ matrix.METHOD }}"
 
+    - name: Install Inno Setup
+      if: matrix.os == 'windows-2025'
+      run: choco install innosetup 
+
     - name: Build
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,7 +61,7 @@ jobs:
             METHOD: 'aqt'
             RELEASE: false
             GENERATOR: 'Ninja'
-            os: windows-latest
+            os: windows-2025
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
             RELEASE: true
             GENERATOR: 'Ninja'
             os: windows-latest
-          - QT_VERSION: '6.8.0'
+          - QT_VERSION: '6.8.1'
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2022_64'
@@ -78,7 +78,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: Install Qt
       if: steps.cache.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.16)
+if(APPLE)
+  cmake_minimum_required(VERSION 3.21.1)
+else()
+  cmake_minimum_required(VERSION 3.16)
+endif()
 
 include(CMakeDependentOption)
 include(CheckIncludeFile)

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -72,7 +72,7 @@ else
       fi
      )
   elif [ "$METHOD" = "aqt" ]; then
-    pip3 install 'aqtinstall>=3.1.19'
+    pip3 install 'aqtinstall>=3.1.20'
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -72,7 +72,7 @@ else
       fi
      )
   elif [ "$METHOD" = "aqt" ]; then
-    pip3 install aqtinstall>=3.1.19
+    pip3 install 'aqtinstall>=3.1.19'
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -72,7 +72,7 @@ else
       fi
      )
   elif [ "$METHOD" = "aqt" ]; then
-    pip3 install aqtinstall>=2.0.0
+    pip3 install aqtinstall>=3.1.19
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else

--- a/tools/ci_install_qt.sh
+++ b/tools/ci_install_qt.sh
@@ -3,9 +3,9 @@
 # install Qt
 #
 # Examples:
-# ci_install_qt.sh mac 6.2.0 clang_64 /tmp/Qt
-# ci_install_qt.sh windows 6.2.0 win64_msvc2019_64 /tmp/Qt
-# ci_install_qt.sh linux 6.2.0 gcc_64 /tmp/Qt
+# ci_install_qt.sh mac 6.8.1 clang_64 /tmp/Qt
+# ci_install_qt.sh windows 6.8.1 win64_msvc2022_64 /tmp/Qt
+# ci_install_qt.sh linux 6.8.1 linux_gcc_64 /tmp/Qt
 
 host=$1
 version=$2

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -47,7 +47,7 @@ else
   mkdir -p "${CACHEDIR}"
 
   if [ "${METHOD}" = "aqt" ]; then
-    pip3 install aqtinstall>=2.0.0
+    pip3 install aqtinstall>=3.1.19
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" windows "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt.env"
   else

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -47,7 +47,7 @@ else
   mkdir -p "${CACHEDIR}"
 
   if [ "${METHOD}" = "aqt" ]; then
-    pip3 install aqtinstall>=3.1.19
+    pip3 install 'aqtinstall>=3.1.19'
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" windows "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt.env"
   else

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -47,7 +47,7 @@ else
   mkdir -p "${CACHEDIR}"
 
   if [ "${METHOD}" = "aqt" ]; then
-    pip3 install 'aqtinstall>=3.1.19'
+    pip3 install 'aqtinstall>=3.1.20'
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" windows "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt.env"
   else


### PR DESCRIPTION
add codeql actions language.
update codeql workflow to used advanced template.
add codeql ignore file.  even though docs say it isn't used for compiled languages it does change the denominator in the stats, i.e. it knows not to count ignored files against you.
update windows and macos workflows.  push the advanced job to the latest tools, Qt LTS, image.
require aqt >= 3.1.20, as it introduces changes that allow installation of qtwebengine and qtpdf with 6.8.x.
update cmake version requirements per Qt requirements (for Apple).