### PR TITLE
workaround issue with jing-trang 20241231

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,9 +92,8 @@ jobs:
         brew install ninja
         brew install docbook docbook-xsl fop gnu-sed
         # brew install is taking forever on macos-11, skip jing-trang and all it's dependencies.
-        if [ "${{ matrix.os }}" != "macos-11" ]; then
-          brew install jing-trang
-        fi
+        # jing 20241231 is failing with "Unknown XPath version 0", https://github.com/relaxng/jing-trang/issues/284
+        #brew install jing-trang
 
     - name: Script
       env:


### PR DESCRIPTION
by not running jing on macos. homebrew recently
updated from 20220510 -> 20241231.