### PR TITLE
for Qstrings and QByteArrays prefer isEmpty() over size() and length()

### DIFF
--- a/arcdist.cc
+++ b/arcdist.cc
@@ -132,7 +132,7 @@ void ArcDistanceFilter::process()
       arcpt2->latitude = arcpt2->longitude = BADVAL;
       int argsfound = sscanf(CSTR(line), "%lf %lf", &arcpt2->latitude, &arcpt2->longitude);
 
-      if ((argsfound != 2) && (line.trimmed().size() > 0)) {
+      if ((argsfound != 2) && (!line.trimmed().isEmpty())) {
         gbWarning("Warning: Arc file contains unusable vertex on line %d.\n", fileline);
       } else {
         Waypoint* arcpttmp = arcpt1;

--- a/csv_util.cc
+++ b/csv_util.cc
@@ -102,7 +102,7 @@ QString
 csv_enquote(const QString& str, const QString& enclosure)
 {
   QString retval = str;
-  if (enclosure.size() > 0) {
+  if (!enclosure.isEmpty()) {
     retval = enclosure + retval.replace(enclosure, enclosure + enclosure) + enclosure;
   }
   return retval;

--- a/exif.cc
+++ b/exif.cc
@@ -215,7 +215,7 @@ ExifFormat::exif_read_str(ExifTag* tag)
   if (auto idx = buf.indexOf('\0'); idx >= 0) {
     buf = buf.left(idx);
   }
-  while ((buf.size() > 0) && isspace(buf.back())) {
+  while ((!buf.isEmpty()) && isspace(buf.back())) {
     buf.chop(1);
   }
   return buf;

--- a/googletakeout.cc
+++ b/googletakeout.cc
@@ -59,13 +59,13 @@ Waypoint* GoogleTakeoutFormat::takeout_waypoint(
   auto* waypoint = new Waypoint();
   waypoint->latitude = lat_e7 / 1e7;
   waypoint->longitude = lon_e7 / 1e7;
-  if (shortname && shortname->length() > 0) {
+  if (shortname && !shortname->isEmpty()) {
     waypoint->shortname = *shortname;
   }
-  if (description && description->length() > 0) {
+  if (description && !description->isEmpty()) {
     waypoint->description = *description;
   }
-  if (start_str && start_str->length() > 0) {
+  if (start_str && !start_str->isEmpty()) {
     gpsbabel::DateTime start = QDateTime::fromString(*start_str, Qt::ISODate);
     waypoint->SetCreationTime(start);
   }
@@ -286,12 +286,12 @@ GoogleTakeoutFormat::add_place_visit(const QJsonObject& placeVisit)
   const QString timestamp = placeVisit[DURATION][START_TIMESTAMP].toString();
   Waypoint* waypoint;
 
-  if (loc.contains(NAME) && loc[NAME].toString().length() > 0) {
+  if (loc.contains(NAME) && !loc[NAME].toString().isEmpty()) {
     QString name = loc[NAME].toString();
     waypoint = takeout_waypoint(
       loc[LOCATION_LATE7].toInt(),
       loc[LOCATION_LONE7].toInt(),
-      name.length() > 0 ? &name : nullptr,
+      !name.isEmpty() ? &name : nullptr,
       &address,
       &timestamp
     );

--- a/gui/filterdata.cc
+++ b/gui/filterdata.cc
@@ -143,7 +143,7 @@ QStringList TrackFilterData::makeOptionString() const
     s += QString(",title=%1").arg(titleString);
   }
 
-  if (s.length() != 0) {
+  if (!s.isEmpty()) {
     args << "-x" << "track" + s;
   }
 

--- a/gui/formatload.cc
+++ b/gui/formatload.cc
@@ -87,19 +87,19 @@ bool FormatLoad::processFormat(Format& format)
     } else if (optionType == "string") {
       type = FormatOption::OPTstring;
     } else if (optionType == "integer") {
-      type = (optionMax != "" && optionMin != "") ? FormatOption::OPTboundedInt : FormatOption::OPTint;
-      if (optionMax == "") {
+      type = (!optionMax.isEmpty() && !optionMin.isEmpty()) ? FormatOption::OPTboundedInt : FormatOption::OPTint;
+      if (optionMax.isEmpty()) {
         optionMax = "2147483647";
       }
-      if (optionMin == "") {
+      if (optionMin.isEmpty()) {
         optionMin = "-2147483647";
       }
     } else if (optionType == "float") {
       type = FormatOption::OPTfloat;
-      if (optionMax == "") {
+      if (optionMax.isEmpty()) {
         optionMax = "1.0E308";
       }
-      if (optionMin == "") {
+      if (optionMin.isEmpty()) {
         optionMin = "-1.0E308";
       }
     } else if (optionType == "file") {
@@ -125,7 +125,7 @@ bool FormatLoad::processFormat(Format& format)
                   optionList,
                   optionList2, htmlPage);
 #ifndef GENERATE_CORE_STRINGS
-  if (htmlPage.length() > 0 && Format::getHtmlBase().length() == 0) {
+  if (!htmlPage.isEmpty() && Format::getHtmlBase().isEmpty()) {
     QString base = htmlPage;
     static const QRegularExpression re("/[^/]+$");
     base.replace(re, "/");

--- a/gui/gmapdlg.cc
+++ b/gui/gmapdlg.cc
@@ -82,10 +82,10 @@ void GMapDialog::appendWaypointInfo(QStandardItem* it, const GpxWaypoint& wpt)
 {
   it->appendRow(new StandardItem(tr("Lat: %1").arg(wpt.getLocation().lat(), 0, 'f', 7)));
   it->appendRow(new StandardItem(tr("Lng: %1").arg(wpt.getLocation().lng(), 0, 'f', 7)));
-  if (wpt.getDescription() != QString()) {
+  if (!wpt.getDescription().isEmpty()) {
     it->appendRow(new StandardItem(tr("Desc: %1").arg(wpt.getDescription())));
   }
-  if (wpt.getComment() != QString() && wpt.getComment() != wpt.getDescription()) {
+  if (!wpt.getComment().isEmpty() && wpt.getComment() != wpt.getDescription()) {
     it->appendRow(new StandardItem(tr("Cmt: %1").arg(wpt.getComment())));
   }
   if (wpt.getElevation() > -50000) {

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -142,7 +142,7 @@ static QString MakeOptions(const QList<FormatOption>& options)
 static QString MakeOptionsNoLeadingComma(const QList<FormatOption>& options)
 {
   QString str = MakeOptions(options);
-  return (str.length()) != 0 ? str.mid(1) : str;
+  return !str.isEmpty() ? str.mid(1) : str;
 
 }
 
@@ -461,7 +461,7 @@ QString MainWindow::filterForFormat(int idx)
 QString MainWindow::ensureExtensionPresent(const QString& name, int idx)
 {
   QString outname = name;
-  if (QFileInfo(name).suffix().length() == 0) {
+  if (QFileInfo(name).suffix().isEmpty()) {
     QStringList extensions = formatList_[idx].getExtensions();
     if (!extensions.empty() && !extensions[0].isEmpty()) {
       outname += "." + extensions[0];
@@ -524,7 +524,7 @@ void MainWindow::browseInputFile()
 void MainWindow::browseOutputFile()
 {
   int idx = currentComboFormatIndex(ui_.outputFormatCombo);
-  QString startFile = babelData_.outputFileName_.length() == 0 ? babelData_.outputBrowse_ : babelData_.outputFileName_;
+  QString startFile = babelData_.outputFileName_.isEmpty() ? babelData_.outputBrowse_ : babelData_.outputFileName_;
   QFileInfo finfo(startFile);
   if (!finfo.isDir() && (!filterForFormatIncludes(idx, finfo.suffix()))) {
     startFile = finfo.dir().absolutePath();
@@ -534,7 +534,7 @@ void MainWindow::browseOutputFile()
     QFileDialog::getSaveFileName(nullptr, tr("Output File Name"),
                                  startFile,
                                  filterForFormat(idx));
-  if (str.length() != 0) {
+  if (!str.isEmpty()) {
     str = ensureExtensionPresent(str, idx);
     babelData_.outputBrowse_ = str;
     babelData_.outputFileName_ = str;
@@ -805,7 +805,7 @@ bool MainWindow::isOkToGo()
     babelData_.inputFileNames_ << ui_.inputFileNameText->text();
   }
   if ((babelData_.outputType_ == BabelData::fileType_) &&
-      (babelData_.outputFileName_.size() == 0) &&
+      (babelData_.outputFileName_.isEmpty()) &&
       (!ui_.outputFileNameText->text().isEmpty())) {
     babelData_.outputFileName_ = ui_.outputFileNameText->text();
   }
@@ -825,7 +825,7 @@ bool MainWindow::isOkToGo()
     return false;
   }
   if (babelData_.outputType_ == BabelData::fileType_ &&
-      babelData_.outputFileName_.length() == 0) {
+      babelData_.outputFileName_.isEmpty()) {
     QMessageBox::information(nullptr, QString(appName), tr("No output file specified"));
     return false;
   }
@@ -920,7 +920,7 @@ void MainWindow::applyActionX()
 
     // output file or device option
     if (outIsFile) {
-      if (babelData_.outputFileName_ != "") {
+      if (!babelData_.outputFileName_.isEmpty()) {
         args << "-F" << babelData_.outputFileName_;
       }
     } else if (babelData_.outputType_ == BabelData::deviceType_) {

--- a/gui/optionsdlg.cc
+++ b/gui/optionsdlg.cc
@@ -60,7 +60,7 @@ FileDlgManager::FileDlgManager(QObject* parent,
 //------------------------------------------------------------------------
 QVariant getOptionValue(QList<FormatOption> opts, int k)
 {
-  if (opts[k].getValue().toString() != "") {
+  if (!opts[k].getValue().toString().isEmpty()) {
     return opts[k].getValue();
   }
   return opts[k].getDefaultValue();
@@ -80,7 +80,7 @@ void FileDlgManager::buttonClicked()
                                        le->text(),
                                        "All Files (*.*)");
   }
-  if (str != "") {
+  if (!str.isEmpty()) {
     le->setText(str);
   }
 }

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -323,7 +323,7 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
     }
   }
 
-  if (response.length() != 0) {
+  if (!response.isEmpty()) {
     QMessageBox information;
     information.setWindowTitle(tr("Upgrade"));
 

--- a/main.cc
+++ b/main.cc
@@ -340,7 +340,7 @@ run(const char* prog_name)
 
 //  we must check the length for afl input fuzzing to work.
 //    if (qargs.at(argn).at(0).toLatin1() != '-') {
-    if (qargs.at(argn).size() > 0 && qargs.at(argn).at(0).toLatin1() != '-') {
+    if (!qargs.at(argn).isEmpty() && qargs.at(argn).at(0).toLatin1() != '-') {
       break;
     }
     if (qargs.at(argn).size() > 1 && qargs.at(argn).at(1).toLatin1() == '-') {

--- a/nmea.cc
+++ b/nmea.cc
@@ -368,11 +368,11 @@ NmeaFormat::gpgll_parse(const QString& ibuf)
   double latdeg = 0;
   if (fields.size() > 1) latdeg = fields[1].toDouble();
   QChar latdir = 'N';
-  if ((fields.size() > 2) && (fields[2].size() > 0)) latdir = fields[2][0];
+  if ((fields.size() > 2) && (!fields[2].isEmpty())) latdir = fields[2][0];
   double lngdeg = 0;
   if (fields.size() > 3) lngdeg = fields[3].toDouble();
   QChar lngdir = 'E';
-  if ((fields.size() > 4) && (fields[4].size() > 0)) lngdir = fields[4][0];
+  if ((fields.size() > 4) && (!fields[4].isEmpty())) lngdir = fields[4][0];
   QTime hms;
   if (fields.size() > 5) hms = nmea_parse_hms(fields[5]);
   bool valid = false;
@@ -416,11 +416,11 @@ NmeaFormat::gpgga_parse(const QString& ibuf)
   double latdeg = 0;
   if (fields.size() > 2) latdeg = fields[2].toDouble();
   QChar latdir = 'N';
-  if ((fields.size() > 3) && (fields[3].size() > 0)) latdir = fields[3][0];
+  if ((fields.size() > 3) && (!fields[3].isEmpty())) latdir = fields[3][0];
   double lngdeg = 0;
   if (fields.size() > 4) lngdeg = fields[4].toDouble();
   QChar lngdir = 'E';
-  if ((fields.size() > 5) && (fields[5].size() > 0)) lngdir = fields[5][0];
+  if ((fields.size() > 5) && (!fields[5].isEmpty())) lngdir = fields[5][0];
   int fix = fix_unknown;
   if (fields.size() > 6) fix = fields[6].toInt();
   int nsats = 0;
@@ -430,11 +430,11 @@ NmeaFormat::gpgga_parse(const QString& ibuf)
   double alt = unknown_alt;
   if (fields.size() > 9) alt = fields[9].toDouble();
   QChar altunits ='M';
-  if ((fields.size() > 10) && (fields[10].size() > 0)) altunits = fields[10][0];
+  if ((fields.size() > 10) && (!fields[10].isEmpty())) altunits = fields[10][0];
   double geoidheight = unknown_alt;
   if (fields.size() > 11) geoidheight = fields[11].toDouble();
   QChar geoidheightunits = 'M';
-  if ((fields.size() > 12) && (fields[12].size() > 0)) geoidheightunits = fields[12][0];
+  if ((fields.size() > 12) && (!fields[12].isEmpty())) geoidheightunits = fields[12][0];
 
   /*
    * In serial mode, allow the fix with an invalid position through
@@ -503,15 +503,15 @@ NmeaFormat::gprmc_parse(const QString& ibuf)
   QTime hms;
   if (fields.size() > 1) hms = nmea_parse_hms(fields[1]);
   QChar fix = 'V'; // V == "Invalid"
-  if ((fields.size() > 2) && (fields[2].size() > 0)) fix = fields[2][0];
+  if ((fields.size() > 2) && (!fields[2].isEmpty())) fix = fields[2][0];
   double latdeg = 0;
   if (fields.size() > 3) latdeg = fields[3].toDouble();
   QChar latdir = 'N';
-  if ((fields.size() > 4) && (fields[4].size() > 0)) latdir = fields[4][0];
+  if ((fields.size() > 4) && (!fields[4].isEmpty())) latdir = fields[4][0];
   double lngdeg = 0;
   if (fields.size() > 5) lngdeg = fields[5].toDouble();
   QChar lngdir = 'E';
-  if ((fields.size() > 6) && (fields[6].size() > 0)) lngdir = fields[6][0];
+  if ((fields.size() > 6) && (!fields[6].isEmpty())) lngdir = fields[6][0];
   double speed = 0;
   if (fields.size() > 7) speed = fields[7].toDouble();
   double course = 0;
@@ -585,11 +585,11 @@ NmeaFormat::gpwpl_parse(const QString& ibuf)
   double latdeg = 0;
   if (fields.size() > 1) latdeg = fields[1].toDouble();
   QChar latdir = 'N';
-  if ((fields.size() > 2) && (fields[2].size() > 0)) latdir = fields[2][0];
+  if ((fields.size() > 2) && (!fields[2].isEmpty())) latdir = fields[2][0];
   double lngdeg = 0;
   if (fields.size() > 3) lngdeg = fields[3].toDouble();
   QChar lngdir = 'E';
-  if ((fields.size() > 4) && (fields[4].size() > 0)) lngdir = fields[4][0];
+  if ((fields.size() > 4) && (!fields[4].isEmpty())) lngdir = fields[4][0];
   QString sname;
   if (fields.size() > 5) sname = fields[5];
 
@@ -643,7 +643,7 @@ NmeaFormat::gpgsa_parse(const QString& ibuf) const
   // 0 = "GPGSA"
   // 1 = Mode. Ignored
   QChar fix;
-  if ((nfields > 2) && (fields[2].size() > 0)) {
+  if ((nfields > 2) && (!fields[2].isEmpty())) {
     fix = fields[2][0];
   }
 

--- a/polygon.cc
+++ b/polygon.cc
@@ -247,7 +247,7 @@ void PolygonFilter::process()
     lat2 = lon2 = BADVAL;
     int argsfound = sscanf(CSTR(line), "%lf %lf", &lat2, &lon2);
 
-    if ((argsfound != 2) && (line.trimmed().size() > 0)) {
+    if ((argsfound != 2) && (!line.trimmed().isEmpty())) {
       gbWarning("Warning: Polygon file contains unusable vertex on line %d.\n",
               fileline);
     } else if (lat1 != BADVAL && lon1 != BADVAL &&

--- a/unicsv.cc
+++ b/unicsv.cc
@@ -191,7 +191,7 @@ UnicsvFormat::unicsv_parse_gc_code(const QString& str)
   //
   int base;
   const QString kBase31 = "0123456789ABCDEFGHJKMNPQRTVWXYZ"; //  ILOSU are omitted.
-  if (s.size() >= 1 && s.size() <= 3) {
+  if (!s.isEmpty() && s.size() <= 3) {
     base = 16;
   } else if (s.size() == 4) {
     if (kBase31.indexOf(s[0]) < 16) {

--- a/xcsv.cc
+++ b/xcsv.cc
@@ -834,7 +834,7 @@ XcsvFormat::read()
      * is whitespace and we have leading whitespace.
      */
     // This could be hoisted out as a generic rtrim() if we need such a thing.
-    while (buff.size() > 0 && buff.at(buff.size() - 1).isSpace()) {
+    while (!buff.isEmpty() && buff.at(buff.size() - 1).isSpace()) {
       buff.chop(1);
     }
 


### PR DESCRIPTION
This applies the clang-tidy readability-container-size-empty check to QString and QByteArrays.

This check normally doesn't work because unlike QList QString and QByteArray don't have an empty() method.  By editing qstring.h and qbytearray.h an empty() method can be added.  When running clang-tidy use the export-fixes option as the fixes will use empty() instead of isEmpty().  Edit the fixes file changing the replacment text to use isEmpty() instead of empty(): 'g/ReplacementText/s/\\.empty()/.isEmpty()/g' and 'g/ReplacementText/s/->empty()/->isEmpty()/g', and then run clang-apply-replacements.

You may note some replacements where the original code didn't use size() or length(), but instead used equality comparisons to "" or QString().  These were generated by the readability-container-size-empty check, and should work fine.  I did compare the optionList generated by formatload and found it equivalent.