### PR TITLE
update upgrade for Qt6

### DIFF
--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -54,11 +54,7 @@ static const bool testing = false;
 UpgradeCheck::UpgradeCheck(QWidget* parent, QList<Format>& formatList,
                            BabelData& bd) :
   QObject(parent),
-  manager_(nullptr),
-  replyId_(nullptr),
-  upgradeUrl_(QUrl("http://www.gpsbabel.org/upgrade_check.html")),
   formatList_(formatList),
-  updateStatus_(updateUnknown),
   babelData_(bd)
 {
 }
@@ -120,31 +116,33 @@ UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
   args += "&os=" + getOsName();
   args += "&cpu=" + getCpuArchitecture();
   args += "&os_ver=" + getOsVersion();
-  args += QString("&beta_ok=%1").arg(static_cast<int>(allowBeta));
+  args += QStringLiteral("&beta_ok=%1").arg(static_cast<int>(allowBeta));
   args += "&lang=" + QLocale::languageToString(locale.language());
   args += "&last_checkin=" + lastCheckTime.toString(Qt::ISODate);
-  args += QString("&ugcb=%1").arg(babelData_.upgradeCallbacks_);
-  args += QString("&ugdec=%1").arg(babelData_.upgradeDeclines_);
-  args += QString("&ugacc=%1").arg(babelData_.upgradeAccept_);
-  args += QString("&ugoff=%1").arg(babelData_.upgradeOffers_);
-  args += QString("&ugerr=%1").arg(babelData_.upgradeErrors_);
-  args += QString("&rc=%1").arg(babelData_.runCount_);
+  args += QStringLiteral("&ugcb=%1").arg(babelData_.upgradeCallbacks_);
+  args += QStringLiteral("&ugdec=%1").arg(babelData_.upgradeDeclines_);
+  args += QStringLiteral("&ugacc=%1").arg(babelData_.upgradeAccept_);
+  args += QStringLiteral("&ugoff=%1").arg(babelData_.upgradeOffers_);
+  args += QStringLiteral("&ugerr=%1").arg(babelData_.upgradeErrors_);
+  args += QStringLiteral("&rc=%1").arg(babelData_.runCount_);
 
-  int j = 0;
+  if (babelData_.reportStatistics_) {
+    int j = 0;
 
-  for (int i = 0; i < formatList_.size(); i++) {
-    int rc = formatList_[i].getReadUseCount();
-    int wc = formatList_[i].getWriteUseCount();
-    QString formatName = formatList_[i].getName();
-    if (rc != 0) {
-      args += QString("&uc%1=rd/%2/%3").arg(j++).arg(formatName).arg(rc);
+    for (int i = 0; i < formatList_.size(); i++) {
+      int rc = formatList_[i].getReadUseCount();
+      int wc = formatList_[i].getWriteUseCount();
+      QString formatName = formatList_[i].getName();
+      if (rc != 0) {
+        args += QStringLiteral("&uc%1=rd/%2/%3").arg(j++).arg(formatName).arg(rc);
+      }
+      if (wc != 0) {
+        args += QStringLiteral("&uc%1=wr/%2/%3").arg(j++).arg(formatName).arg(wc);
+      }
     }
-    if (wc != 0) {
-      args += QString("&uc%1=wr/%2/%3").arg(j++).arg(formatName).arg(wc);
+    if (j != 0) {
+      args += QStringLiteral("&uc=%1").arg(j);
     }
-  }
-  if ((j != 0) && babelData_.reportStatistics_) {
-    args += QString("&uc=%1").arg(j);
   }
 
   if (false && testing) {
@@ -179,8 +177,8 @@ bool UpgradeCheck::suggestUpgrade(const QString& from, const QString& to)
   qsizetype fromIndex = 0;
   qsizetype toIndex = 0;
 #endif
-  QVersionNumber fromVersion  = QVersionNumber::fromString(from, &fromIndex);
-  QVersionNumber toVersion  = QVersionNumber::fromString(to, &toIndex);
+  QVersionNumber fromVersion = QVersionNumber::fromString(from, &fromIndex);
+  QVersionNumber toVersion = QVersionNumber::fromString(to, &toIndex);
 
   // We don't have to handle every possible range because the server won't
   // have more than a version or two live at any time.
@@ -223,25 +221,7 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
     return;
   }
 
-  // New post 1.4.4: Allow redirects in case a proxy server or something
-  // slightly rewrites the post.
-  // Note that adding port 80 to the url will cause a redirect, which is useful for testing.
-  // Also you use gpsbabel.org instead of www.gpsbabel.org to generate redirects.
-  QVariant attributeValue = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
-  if (!attributeValue.isNull() && attributeValue.isValid()) {
-    QUrl redirectUrl = attributeValue.toUrl();
-    if (redirectUrl.isValid()) {
-      if (testing) {
-        qDebug() << "redirect to " << redirectUrl.toString();
-      }
-      // Change the url for the next update check.
-      // TODO: kick off another update check.
-      upgradeUrl_ = redirectUrl;
-      replyId_ = nullptr;
-      reply->deleteLater();
-      return;
-    }
-  }
+  // redirection is handled by the Network Access API automatically.
 
   QVariant statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
   if (testing) {
@@ -286,30 +266,30 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
   QString upgradeText;
 
   if (testing) {
-    currentVersion_ =  "1.3.1";  // for testing
+    currentVersion_ = QStringLiteral("1.3.1");  // for testing
   }
 
   bool allowBeta = true;  // TODO: come from prefs or current version...
 
-  QDomNodeList upgrades = document.elementsByTagName("update");
+  QDomNodeList upgrades = document.elementsByTagName(QStringLiteral("update"));
   QUrl downloadUrl;
   updateStatus_ = updateCurrent;  // Current until proven guilty.
 
   for (int i = 0; i < upgrades.length(); i++) {
     QDomNode upgradeNode = upgrades.item(i);
     QDomElement upgrade = upgradeNode.toElement();
-    QString updateVersion = upgrade.attribute("version");
-    if (upgrade.attribute("downloadURL").isEmpty()) {
-      downloadUrl = "https://www.gpsbabel.org/download.html";
+    QString updateVersion = upgrade.attribute(QStringLiteral("version"));
+    if (upgrade.attribute(QStringLiteral("downloadURL")).isEmpty()) {
+      downloadUrl = QStringLiteral("https://www.gpsbabel.org/download.html");
     } else {
-      downloadUrl = upgrade.attribute("downloadURL");
+      downloadUrl = upgrade.attribute(QStringLiteral("downloadURL"));
     }
-    bool updateIsBeta  = upgrade.attribute("type") == "beta";
-    bool updateIsMajor = upgrade.attribute("type") == "major";
-    bool updateIsMinor = upgrade.attribute("type") == "minor";
+    bool updateIsBeta = upgrade.attribute(QStringLiteral("type")) == "beta";
+    bool updateIsMajor = upgrade.attribute(QStringLiteral("type")) == "major";
+    bool updateIsMinor = upgrade.attribute(QStringLiteral("type")) == "minor";
 
     bool updateCandidate = updateIsMajor || updateIsMinor || (updateIsBeta && allowBeta);
-    upgradeText = upgrade.firstChildElement("overview").text();
+    upgradeText = upgrade.firstChildElement(QStringLiteral("overview")).text();
 
     // String compare, not a numeric one.  Server will return "best first".
     if (suggestUpgrade(currentVersion_, updateVersion) && updateCandidate) {
@@ -348,7 +328,7 @@ void UpgradeCheck::httpRequestFinished(QNetworkReply* reply)
     }
   }
 
-  upgradeWarningTime_ = QDateTime(QDateTime::currentDateTime());
+  upgradeWarningTime_ = QDateTime::currentDateTime();
 
   for (int i = 0; i < formatList_.size(); i++) {
     formatList_[i].zeroUseCounts();

--- a/gui/upgrade.h
+++ b/gui/upgrade.h
@@ -52,13 +52,12 @@ public:
 
 private:
   QString currentVersion_;
-  QNetworkAccessManager* manager_;
-  QNetworkReply* replyId_;
-  QUrl upgradeUrl_;
-  QString latestVersion_;
+  QNetworkAccessManager* manager_{nullptr};
+  QNetworkReply* replyId_{nullptr};
+  QUrl upgradeUrl_{QStringLiteral("https://www.gpsbabel.org/upgrade_check.html")};
   QDateTime upgradeWarningTime_;  // invalid time if this object never issued.
   QList<Format>& formatList_;
-  updateStatus updateStatus_;
+  updateStatus updateStatus_{updateUnknown};
   BabelData& babelData_;
 
   static QString getOsName();


### PR DESCRIPTION
1. change upgrade url method to https.  In the past this caused problems on windows (#580, #587).  However, with Qt6 we are shipping plugins for native TLS libraries (windows SChannel, macos Secure Transport) as well as OpenSSL.  Qt will fall back on the native plugin if required.
2. skip all the use count statistics if the user has disabled them, i.e. babelData_.reportStatistics_ is false.
3. implement clazy QString allocation optimizations.
4. delete redundant QDateTime constructor.
5. use default initializers.
6. delete obsolete manual redirection code.
7. delete unused variable.