### PR TITLE
create preference privacy tab.

### DIFF
--- a/gui/advdlg.cc
+++ b/gui/advdlg.cc
@@ -28,6 +28,7 @@
 //------------------------------------------------------------------------
 AdvDlg::AdvDlg(QWidget* parent,
                bool& synthShortNames,
+               bool mapPreviewEnabled,
                bool& previewGmap,
                int&  debugLevel):
   QDialog(parent),
@@ -37,6 +38,10 @@ AdvDlg::AdvDlg(QWidget* parent,
 {
   ui_.setupUi(this);
   ui_.synthShortNames->setChecked(synthShortNames);
+  ui_.previewGmap->setEnabled(mapPreviewEnabled);
+  if (!mapPreviewEnabled) {
+    previewGmap = false;
+  }
   ui_.previewGmap->setChecked(previewGmap);
   ui_.debugCombo->setCurrentIndex(debugLevel+1);
 #if defined (Q_OS_WIN)

--- a/gui/advdlg.h
+++ b/gui/advdlg.h
@@ -34,9 +34,10 @@ class AdvDlg: public QDialog
 
 public:
   AdvDlg(QWidget* parent,
-         bool& synthShortNames_,
-         bool& previewGmap_,
-         int&   debugLevel_);
+         bool& synthShortNames,
+         bool mapPreviewEnabled,
+         bool& previewGmap,
+         int&   debugLevel);
   QPushButton* formatButton()
   {
     return ui_.formatButton;

--- a/gui/advui.ui
+++ b/gui/advui.ui
@@ -26,6 +26,9 @@
    </item>
    <item>
     <widget class="QCheckBox" name="previewGmap">
+     <property name="toolTip">
+      <string>Enable this is the File Menu, Preferences Item, Privacy tab.</string>
+     </property>
      <property name="text">
       <string>Preview in Google Maps</string>
      </property>

--- a/gui/babeldata.h
+++ b/gui/babeldata.h
@@ -107,6 +107,8 @@ public:
     // Global preferences.
     sg.addVarSetting(std::make_unique<BoolSetting>("app.startupVersionCheck", startupVersionCheck_));
     sg.addVarSetting(std::make_unique<BoolSetting>("app.reportStatistics", reportStatistics_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.upgradeMenuEnabled", upgradeMenuEnabled_));
+    sg.addVarSetting(std::make_unique<BoolSetting>("app.mapPreviewEnabled", mapPreviewEnabled_));
     sg.addVarSetting(std::make_unique<BoolSetting>("app.allowBetaUpgrades", allowBetaUpgrades_));
     sg.addVarSetting(std::make_unique<BoolSetting>("app.ignoreVersionMismatch", ignoreVersionMismatch_));
     sg.addVarSetting(std::make_unique<BoolSetting>("app.disableDonateDialog", disableDonateDialog_));
@@ -152,6 +154,8 @@ public:
   // Global preferences.
   bool startupVersionCheck_{true};
   bool reportStatistics_{true};
+  bool upgradeMenuEnabled_{true};
+  bool mapPreviewEnabled_{true};
   bool allowBetaUpgrades_{false};
   bool ignoreVersionMismatch_{false};
   bool disableDonateDialog_{false};

--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -1130,7 +1130,7 @@ void MainWindow::resetFormatDefaults()
 void MainWindow::moreOptionButtonClicked()
 {
   AdvDlg advDlg(nullptr, babelData_.synthShortNames_,
-                babelData_.previewGmap_, babelData_.debugLevel_);
+                babelData_.mapPreviewEnabled_, babelData_.previewGmap_, babelData_.debugLevel_);
   connect(advDlg.formatButton(), &QAbstractButton::clicked,
           this, &MainWindow::resetFormatDefaults);
   advDlg.exec();
@@ -1162,7 +1162,10 @@ void MainWindow::preferencesActionX()
   Preferences preferences(nullptr, formatList_, babelData_);
   preferences.exec();
 
-  // We may have changed the list of displayed formats.  Resynchronize.
+  // The user may have changed the list of displayed formats, and/or
+  // enabled or disabled the upgrade menu item.
+  // Resynchronize.
+
   setWidgetValues();
 }
 
@@ -1195,6 +1198,7 @@ void MainWindow::updateFilterStatus()
 //------------------------------------------------------------------------
 void MainWindow::setWidgetValues()
 {
+  ui_.actionUpgradeCheck->setEnabled(babelData_.upgradeMenuEnabled_);
   if (babelData_.inputType_ == BabelData::fileType_) {
     ui_.inputFileOptBtn->setChecked(true);
     inputFileOptBtnClicked();

--- a/gui/mainwinui.ui
+++ b/gui/mainwinui.ui
@@ -674,7 +674,7 @@
      <x>0</x>
      <y>0</y>
      <width>675</width>
-     <height>26</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -687,6 +687,9 @@
    <widget class="QMenu" name="menuHelp">
     <property name="title">
      <string>Help</string>
+    </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
     </property>
     <addaction name="actionHelp"/>
     <addaction name="separator"/>
@@ -723,6 +726,9 @@
   <action name="actionUpgradeCheck">
    <property name="text">
     <string>Check for Upgrade</string>
+   </property>
+   <property name="toolTip">
+    <string>Enable this is the File Menu, Preferences Item, Privacy tab.</string>
    </property>
   </action>
   <action name="actionVisit_Website">

--- a/gui/notices.txt
+++ b/gui/notices.txt
@@ -1,0 +1,18 @@
+Privacy
+
+The command line interface program, gpsbabel.exe, will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.
+
+The graphical user interface program, GPSBabelFE.exe, may transfer information to other networked systems.
+  - If enabled, the automatic upgrade check transmits information about your installation and computer environment, such as the Installation ID, GPSBabel GUI and CLI versions, CPU architecture, operating system name and version, and language, to gpsbabel.org.
+  - If enabled, anonymous usage data is sent to gpsbabel.org. This helps us understand what features of the program are being used.
+  - If enabled and selected, the "Check for Upgrade" item in the "Help" menu sends the same information as the automatic upgrade check to gpsbabel.org.
+  - If enabled and selected, the "Preview in Google Maps" item in the "More Options" dialog uses the Google Maps API(s) per Google's Terms of Service (http://www.google.com/intl/en/policies/terms) and the Google Privacy Policy (http://www.google.com/policies/privacy).
+All of these items can be controlled through the Privacy tab reached through the Preferences item of the File menu.
+
+Third Party Content
+
+GPSBabel uses:
+  - libusb (https://libusb.info/)
+  - Qt (https://www.qt.io/download-open-source).
+  - Shapelib (http://shapelib.maptools.org/).
+  - zlib (https://zlib.net/)

--- a/gui/notices.txt
+++ b/gui/notices.txt
@@ -3,11 +3,11 @@ Privacy
 The command line interface program, gpsbabel.exe, will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.
 
 The graphical user interface program, GPSBabelFE.exe, may transfer information to other networked systems.
-  - If enabled, the automatic upgrade check transmits information about your installation and computer environment, such as the Installation ID, GPSBabel GUI and CLI versions, CPU architecture, operating system name and version, and language, to gpsbabel.org.
-  - If enabled, anonymous usage data is sent to gpsbabel.org. This helps us understand what features of the program are being used.
-  - If enabled and selected, the "Check for Upgrade" item in the "Help" menu sends the same information as the automatic upgrade check to gpsbabel.org.
-  - If enabled and selected, the "Preview in Google Maps" item in the "More Options" dialog uses the Google Maps API(s) per Google's Terms of Service (http://www.google.com/intl/en/policies/terms) and the Google Privacy Policy (http://www.google.com/policies/privacy).
-All of these items can be controlled through the Privacy tab reached through the Preferences item of the File menu.
+  - If enabled, the automatic upgrade check transmits information about your installation and computer environment, such as the Installation ID, GPSBabel GUI and CLI versions, CPU architecture, operating system name and version, and language, to gpsbabel.org. This never includes any data from user files or devices.
+  - If enabled, anonymous usage data is sent to gpsbabel.org. This helps the developers at gpsbabel.org understand what features of the program are being used. This never includes any data from user files or devices.
+  - If enabled, selecting the "Check for Upgrade" item in the "Help" menu sends the same information as the automatic upgrade check to gpsbabel.org.
+  - If enabled, checking the "Preview in Google Maps" item in the "More Options" dialog uses the Google Maps API(s) per Google's Terms of Service (http://www.google.com/intl/en/policies/terms) and the Google Privacy Policy (http://www.google.com/policies/privacy).
+All of these items can be enabled or disabled through the "Privacy" tab reached through the "Preferences" item of the "File" menu.
 
 Third Party Content
 

--- a/gui/preferences.cc
+++ b/gui/preferences.cc
@@ -49,6 +49,8 @@ Preferences::Preferences(QWidget* parent, QList<Format>& formatList,
 
   ui_.startupCheck->setChecked(babelData_.startupVersionCheck_);
   ui_.reportStatisticsCheck->setChecked(babelData_.reportStatistics_);
+  ui_.upgradeMenuCheck->setChecked(babelData_.upgradeMenuEnabled_);
+  ui_.mapPreviewCheck->setChecked(babelData_.mapPreviewEnabled_);
   ui_.ignoreVersionMismatchCheck->setChecked(babelData_.ignoreVersionMismatch_);
 
   connect(ui_.buttonBox, &QDialogButtonBox::accepted, this, &Preferences::acceptClicked);
@@ -89,6 +91,8 @@ void Preferences::acceptClicked()
 
   babelData_.startupVersionCheck_ = ui_.startupCheck->isChecked();
   babelData_.reportStatistics_ = ui_.reportStatisticsCheck->isChecked();
+  babelData_.upgradeMenuEnabled_ = ui_.upgradeMenuCheck->isChecked();
+  babelData_.mapPreviewEnabled_ = ui_.mapPreviewCheck->isChecked();
   babelData_.ignoreVersionMismatch_ = ui_.ignoreVersionMismatchCheck->isChecked();
   accept();
 }

--- a/gui/preferences.cc
+++ b/gui/preferences.cc
@@ -53,6 +53,10 @@ Preferences::Preferences(QWidget* parent, QList<Format>& formatList,
   ui_.mapPreviewCheck->setChecked(babelData_.mapPreviewEnabled_);
   ui_.ignoreVersionMismatchCheck->setChecked(babelData_.ignoreVersionMismatch_);
 
+#ifdef DISABLE_MAPPREVIEW
+  ui_.mapPreviewCheck->hide();
+#endif
+
   connect(ui_.buttonBox, &QDialogButtonBox::accepted, this, &Preferences::acceptClicked);
   connect(ui_.buttonBox, &QDialogButtonBox::rejected, this, &Preferences::rejectClicked);
 

--- a/gui/preferences.ui
+++ b/gui/preferences.ui
@@ -31,20 +31,6 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QCheckBox" name="startupCheck">
-         <property name="text">
-          <string>Check for newer version on start.</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="reportStatisticsCheck">
-         <property name="text">
-          <string>Anonymously report usage data.</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="ignoreVersionMismatchCheck">
          <property name="text">
           <string>Ignore mismatch between command line and GUI version.</string>
@@ -53,6 +39,66 @@
        </item>
        <item>
         <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="privacy_tab">
+      <attribute name="title">
+       <string>Privacy</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QCheckBox" name="startupCheck">
+         <property name="toolTip">
+          <string>&lt;html&gt;The check transmits information about your installation and computer environment, such as the Installation ID, GPSBabel GUI and CLI versions, CPU architecture, operating system name and version, and language, to gpsbabel.org.&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Check for newer version on start.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="reportStatisticsCheck">
+         <property name="toolTip">
+          <string>&lt;html&gt;Anonymous usage data is sent to gpsbabel.org. This helps us understand what features of the program are being used.&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Anonymously report usage data.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="upgradeMenuCheck">
+         <property name="toolTip">
+          <string>&lt;html&gt;When selected, this menu item sends the same information as &quot;Check for newer version on start.&quot; to gpsbabel.org.&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Enable upgrade check menu item.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="mapPreviewCheck">
+         <property name="toolTip">
+          <string>&lt;html&gt;When selected, this feature uses the Google Maps API(s) per &lt;a href=&quot;http://www.google.com/intl/en/policies/terms&quot;&gt;Google’s Terms of Service&lt;/a&gt; and the &lt;a href=&quot;http://www.google.com/policies/privacy&quot;&gt;Google Privacy Policy&lt;/a&gt;.&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Enable map preview feature.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/gui/preferences.ui
+++ b/gui/preferences.ui
@@ -60,7 +60,7 @@
        <item>
         <widget class="QCheckBox" name="startupCheck">
          <property name="toolTip">
-          <string>&lt;html&gt;The check transmits information about your installation and computer environment, such as the Installation ID, GPSBabel GUI and CLI versions, CPU architecture, operating system name and version, and language, to gpsbabel.org.&lt;/html&gt;</string>
+          <string>&lt;html&gt;The check transmits information about your installation and computer environment, such as the Installation ID, GPSBabel GUI and CLI versions, CPU architecture, operating system name and version, and language, to gpsbabel.org. This never includes any data from user files or devices.&lt;/html&gt;</string>
          </property>
          <property name="text">
           <string>Check for newer version on start.</string>
@@ -70,7 +70,7 @@
        <item>
         <widget class="QCheckBox" name="reportStatisticsCheck">
          <property name="toolTip">
-          <string>&lt;html&gt;Anonymous usage data is sent to gpsbabel.org. This helps us understand what features of the program are being used.&lt;/html&gt;</string>
+          <string>&lt;html&gt;Anonymous usage data is sent to gpsbabel.org. This helps the developers at gpsbabel.org understand what features of the program are being used. This never includes any data from user files or devices.&lt;/html&gt;</string>
          </property>
          <property name="text">
           <string>Anonymously report usage data.</string>

--- a/gui/setup.iss.in
+++ b/gui/setup.iss.in
@@ -37,6 +37,7 @@ Compression=lzma
 SolidCompression=yes
 SourceDir="{#source_dir}"
 LicenseFile=COPYING.txt
+InfoAfterFile=notices.txt
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/gui/upgrade.cc
+++ b/gui/upgrade.cc
@@ -124,9 +124,10 @@ UpgradeCheck::updateStatus UpgradeCheck::checkForUpgrade(
   args += QStringLiteral("&ugacc=%1").arg(babelData_.upgradeAccept_);
   args += QStringLiteral("&ugoff=%1").arg(babelData_.upgradeOffers_);
   args += QStringLiteral("&ugerr=%1").arg(babelData_.upgradeErrors_);
-  args += QStringLiteral("&rc=%1").arg(babelData_.runCount_);
 
   if (babelData_.reportStatistics_) {
+    args += QStringLiteral("&rc=%1").arg(babelData_.runCount_);
+
     int j = 0;
 
     for (int i = 0; i < formatList_.size(); i++) {


### PR DESCRIPTION
1. create a privacy tab on the file menu preferences item. This includes the old preferences for
   - Check for newer version on start.
   - Anonymously report usage data. and new items for
   - Enable upgrade check menu item.
   - Enable map preview feature. Tool tips are added describing the related data and/or policies.
2. enable or disable the upgrade check menu item and the map preview feature based on the preferences.
3. Add tool tip for the map preview checkbox and the Help "Check for Upgrade" action that describes how to enable these items.
4. Only report the run count if reporting of usage data is allowed.