### PR TITLE
use APFS for dmg

### DIFF
--- a/gui/package_app
+++ b/gui/package_app
@@ -131,6 +131,6 @@ else # Mac
   rm -f GPSBabelFE.dmg
   # macdeploytqt likes relative paths or else the dmg mount points get funky.
   APPBUNDLE="$(basename "$APPDIR")"
-  "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -dmg -verbose=2
+  "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -dmg -verbose=2 -fs=APFS
   popd
 fi


### PR DESCRIPTION
macdeployqt defaults to HFS+ to be compatible with older versions of macos, but the minimum supported platform for Qt 6.2 is 10.14.  APFS is the filesystem used in 10.13 and later.  The default in hdiutil is now APFS.