### PR TITLE
add options for geojson name and description keys.

### DIFF
--- a/geojson.cc
+++ b/geojson.cc
@@ -67,10 +67,10 @@ GeoJsonFormat::geojson_waypt_pr(const Waypoint* waypoint) const
   // Build up the properties.
   QJsonObject properties;
   if (!waypoint->shortname.isEmpty()) {
-    properties[NAME] = waypoint->shortname;
+    properties[name_opt] = waypoint->shortname;
   }
   if (!waypoint->description.isEmpty()) {
-    properties[DESCRIPTION] = waypoint->description;
+    properties[desc_opt] = waypoint->description;
   }
   if (waypoint->HasUrlLink()) {
     const UrlLink& link = waypoint->GetUrlLink();
@@ -161,11 +161,11 @@ GeoJsonFormat::read()
     QString name;
     QString description;
     if (!properties.empty()) {
-      if (properties.contains(NAME)) {
-        name = properties[NAME].toString();
+      if (properties.contains(name_opt)) {
+        name = properties[name_opt].toString();
       }
-      if (properties.contains(DESCRIPTION)) {
-        description = properties[DESCRIPTION].toString();
+      if (properties.contains(desc_opt)) {
+        description = properties[desc_opt].toString();
       }
     }
 
@@ -215,6 +215,7 @@ GeoJsonFormat::read()
       for (auto&& line_string : line_strings) {
         QJsonArray coordinates = line_string.toArray();
         auto* route = new route_head;
+        route->rte_name = name;
         track_add_head(route);
         for (auto&& coordinate : coordinates) {
           auto* waypoint = waypoint_from_coordinates(coordinate.toArray());
@@ -235,7 +236,7 @@ void GeoJsonFormat::geojson_track_hdr(const route_head* track)
 
   QJsonObject properties;
   if (!track->rte_name.isEmpty()) {
-    properties[NAME] = track->rte_name;
+    properties[name_opt] = track->rte_name;
   }
   (*track_object)[PROPERTIES] = properties;
 }

--- a/geojson.h
+++ b/geojson.h
@@ -72,6 +72,8 @@ private:
   gpsbabel::File* ifd{nullptr};
   gpsbabel::File* ofd{nullptr};
   OptionBool compact_opt;
+  OptionString name_opt;
+  OptionString desc_opt;
   QJsonObject* track_object = nullptr;
   QJsonArray* track_coords = nullptr;
 
@@ -88,15 +90,21 @@ private:
   const QString COORDINATES = QStringLiteral("coordinates");
   const QString GEOMETRY = QStringLiteral("geometry");
   const QString PROPERTIES = QStringLiteral("properties");
-  const QString NAME = QStringLiteral("name");
-  const QString DESCRIPTION = QStringLiteral("description");
   const QString URL = QStringLiteral("url");
   const QString URLNAME = QStringLiteral("urlname");
 
   QVector<arglist_t> geojson_args = {
     {
-      "compact", &compact_opt, "Compact Output. Default is off.",
+      "compact", &compact_opt, "Compact Output. Default is off",
       nullptr, ARGTYPE_BOOL, ARG_NOMINMAX, nullptr
+    },
+    {
+      "name", &name_opt, "Property key to use for name",
+      "name", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
+    },
+    {
+      "desc", &desc_opt, "Property key to use for description",
+      "description", ARGTYPE_STRING, ARG_NOMINMAX, nullptr
     },
   };
 

--- a/reference/format3.txt
+++ b/reference/format3.txt
@@ -312,11 +312,11 @@ option	geo	deficon	Default icon name	string				https://www.gpsbabel.org/WEB_DOC_
 
 file	rwrwrw	geojson	json	GeoJson	geojson
 	https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html
-option	geojson	compact	Compact Output. Default is off.	boolean				https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_compact
+option	geojson	compact	Compact Output. Default is off	boolean				https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_compact
 
-option	geojson	name	Property key to use for name.	string	name			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_name
+option	geojson	name	Property key to use for name	string	name			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_name
 
-option	geojson	desc	Property key to use for description.	string	description			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_desc
+option	geojson	desc	Property key to use for description	string	description			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_desc
 
 internal	r-r---	dg-100-bin		GlobalSat DG-100/BT-335 Binary File	dg-100-bin
 	https://www.gpsbabel.org/WEB_DOC_DIR/fmt_dg-100-bin.html

--- a/reference/format3.txt
+++ b/reference/format3.txt
@@ -314,6 +314,10 @@ file	rwrwrw	geojson	json	GeoJson	geojson
 	https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html
 option	geojson	compact	Compact Output. Default is off.	boolean				https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_compact
 
+option	geojson	name	Property key to use for name.	string	name			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_name
+
+option	geojson	desc	Property key to use for description.	string	description			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_geojson.html#fmt_geojson_o_desc
+
 internal	r-r---	dg-100-bin		GlobalSat DG-100/BT-335 Binary File	dg-100-bin
 	https://www.gpsbabel.org/WEB_DOC_DIR/fmt_dg-100-bin.html
 option	dg-100-bin	erase	Erase device data after download	boolean	0			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_dg-100-bin.html#fmt_dg-100-bin_o_erase

--- a/reference/help.txt
+++ b/reference/help.txt
@@ -162,6 +162,8 @@ File Types (-i and -o options):
 	  deficon               Default icon name
 	geojson               GeoJson
 	  compact               (0/1) Compact Output. Default is off.
+	  name                  Property key to use for name.
+	  desc                  Property key to use for description.
 	dg-100                GlobalSat DG-100/BT-335 Download
 	  erase                 (0/1) Erase device data after download
 	  erase_only            (0/1) Only erase device data, do not download anything

--- a/reference/help.txt
+++ b/reference/help.txt
@@ -161,9 +161,9 @@ File Types (-i and -o options):
 	geo                   Geocaching.com .loc
 	  deficon               Default icon name
 	geojson               GeoJson
-	  compact               (0/1) Compact Output. Default is off.
-	  name                  Property key to use for name.
-	  desc                  Property key to use for description.
+	  compact               (0/1) Compact Output. Default is off
+	  name                  Property key to use for name
+	  desc                  Property key to use for description
 	dg-100                GlobalSat DG-100/BT-335 Download
 	  erase                 (0/1) Erase device data after download
 	  erase_only            (0/1) Only erase device data, do not download anything

--- a/xmldoc/formats/options/geojson-desc.xml
+++ b/xmldoc/formats/options/geojson-desc.xml
@@ -1,0 +1,3 @@
+<para>
+This option specifies the property key to associate with a waypoint, route or track description. It is case sensitive.  The default is "description".
+</para>

--- a/xmldoc/formats/options/geojson-name.xml
+++ b/xmldoc/formats/options/geojson-name.xml
@@ -1,0 +1,3 @@
+<para>
+This option specifies the property key to associate with a waypoint, route or track name. It is case sensitive.  The default is "name".
+</para>


### PR DESCRIPTION
also, name created tracks.

This allows an improved reading of the "Boulder Area Trails" from https://opendata-bouldercounty.hub.arcgis.com/search?tags=recreation with "-i geojson,name=TRAILNAME".