### PR TITLE
turn of PCH with clazy

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -89,7 +89,6 @@ jobs:
         brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
         brew list -1 | grep python
         ls -l $(brew --prefix)/bin | grep -i python
-        brew install ninja
         brew install docbook docbook-xsl fop gnu-sed
         # brew install is taking forever on macos-11, skip jing-trang and all it's dependencies.
         # jing 20241231 is failing with "Unknown XPath version 0", https://github.com/relaxng/jing-trang/issues/284

--- a/tools/build_extra_tests.sh
+++ b/tools/build_extra_tests.sh
@@ -46,7 +46,7 @@ rm -rf bld-clazy
 mkdir bld-clazy
 pushd bld-clazy
 export CLAZY_CHECKS=level0,level1,no-non-pod-global-static,no-qstring-ref
-cmake -DCMAKE_CXX_COMPILER=clazy -DCMAKE_BUILD_TYPE=Debug -G Ninja "${SOURCE_DIR}"
+cmake -DCMAKE_CXX_COMPILER=clazy -DCMAKE_BUILD_TYPE=Debug -DGPSBABEL_ENABLE_PCH=OFF -G Ninja "${SOURCE_DIR}"
 cmake --build . 2>&1 | tee clazy.log
 if grep -- '-Wclazy' clazy.log; then
   exit 1


### PR DESCRIPTION
Although we never noticed any problems with pch enabled, the clazy
recommendation is to turn off PCH when using clazy.