### PR TITLE
add test for WoA installer

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -157,7 +157,7 @@ jobs:
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v4
       with:
-        name: Windows_Installer ${{ join(matrix.*) }}
+        name: Windows_Installer-${{ join(matrix.*) }}
         path: |
           bld/gui/GPSBabel-*-Setup-*.exe
           bld/gui/GPSBabel-*-Manifest-*.txt
@@ -176,7 +176,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: bld
-        pattern: GPSBabel-*-*-Setup-arm64.exe
+        pattern: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,true,windows-2025
         merge-multiple: true
 
     - name: 'Install Artifact'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -192,4 +192,5 @@ jobs:
       run: |
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
+        ls bld
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -184,6 +184,8 @@ jobs:
       run: |
         $install_path=Join-Path $(Get-Location) bld
         .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /DIR="${install_path}"
+        Start-Sleep -Seconds 30
+        dir bld
 
     - name: 'Test Artifact'
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -183,16 +183,16 @@ jobs:
       shell: powershell
       run: |
         $install_path=Join-Path $(Get-Location) bld
-        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /DIR="${install_path}" /LOG=bld\log.txt
-        Start-Sleep -Seconds 30
-        dir bld
+        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=bld\log.txt
+        Start-Sleep -Seconds 60
+        Get-ChildItem bld
 
     - name: 'Test Artifact'
       shell: bash
       run: |
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
-        ls bld
+        ls -l bld
 
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -183,7 +183,7 @@ jobs:
       shell: powershell
       run: |
         $install_path=Join-Path $(Get-Location) bld
-        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /DIR="${install_path}"
+        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /DIR="${install_path}" /LOG=bld\log.txt
         Start-Sleep -Seconds 30
         dir bld
 
@@ -193,4 +193,12 @@ jobs:
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
         ls bld
+
+    - name: 'Upload Artifacts'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test_Installer
+        path: |
+          bld/log.txt
+        retention-days: 7
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -173,9 +173,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: 'Download Artifacts'
-      uses: actions/download-artifact@v3
-      with:
-        name: Windows_Installer 6.8.3,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,true,windows-2025
+      uses: actions/download-artifact@v4
 
     - name: 'Install Artifact'
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -180,12 +180,10 @@ jobs:
         merge-multiple: true
 
     - name: 'Install Artifact'
-      shell: bash
+      shell: powershell
       run: |
-        ls
-        ls bld
-        installer=$(ls bld/GPSBabel-*-*-Setup-arm64.exe)
-        "./${installer}" /SILENT /DIR=bld
+        $install_path=Join-Path $PWD bld
+        .\bld\GPSBabel-*-Setup-arm64.exe /SILENT /DIR=$install_path
 
     - name: 'Test Artifact'
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -162,3 +162,32 @@ jobs:
           bld/gui/GPSBabel-*-Setup-*.exe
           bld/gui/GPSBabel-*-Manifest-*.txt
         retention-days: 7
+
+  test_installer:
+    name: 'Test Installer'
+    needs: windows
+    runs-on: windows-11-arm64
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: 'Download Artifacts'
+      uses: actions/download-artifact@v3
+      with:
+        name: Windows_Installer 6.8.3,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,true,windows-2025
+
+   - name: 'Install Artifact'
+     shell: bash
+     run: |
+       ls
+       mkdir bld
+       installer=$(ls "GPSBabel-*-*-Setup-arm64.exe")
+       ./${installer} /SILENT /DIR=bld
+
+   - name: 'Test Artifact'
+      shell: bash
+      run: |
+        PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
+        PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,14 +174,18 @@ jobs:
 
     - name: 'Download Artifacts'
       uses: actions/download-artifact@v4
+      with:
+        path: bld
+        pattern: GPSBabel-*-*-Setup-arm64.exe
+        merge-multiple: true
 
     - name: 'Install Artifact'
       shell: bash
       run: |
         ls
-        mkdir bld
-        installer=$(ls "GPSBabel-*-*-Setup-arm64.exe")
-        ./${installer} /SILENT /DIR=bld
+        ls bld
+        installer=$(ls "bld/GPSBabel-*-*-Setup-arm64.exe")
+        "./${installer}" /SILENT /DIR=bld
 
     - name: 'Test Artifact'
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -184,7 +184,7 @@ jobs:
       run: |
         ls
         ls bld
-        installer=$(ls "bld/GPSBabel-*-*-Setup-arm64.exe")
+        installer=$(ls bld/GPSBabel-*-*-Setup-arm64.exe)
         "./${installer}" /SILENT /DIR=bld
 
     - name: 'Test Artifact'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -182,8 +182,8 @@ jobs:
     - name: 'Install Artifact'
       shell: powershell
       run: |
-        $install_path=Join-Path $PWD bld
-        .\bld\GPSBabel-*-Setup-arm64.exe /SILENT /DIR=$install_path
+        $install_path=Join-Path $(Get-Location) bld
+        .\bld\GPSBabel-*-Setup-arm64.exe /SILENT /DIR="${install_path}"
 
     - name: 'Test Artifact'
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -166,7 +166,7 @@ jobs:
   test_installer:
     name: 'Test Installer'
     needs: windows
-    runs-on: windows-11-arm64
+    runs-on: windows-11-arm
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,5 @@
 name: "windows"
+permissions: {}
 
 on:
   push:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -183,7 +183,7 @@ jobs:
       shell: powershell
       run: |
         $install_path=Join-Path $(Get-Location) bld
-        .\bld\GPSBabel-*-Setup-arm64.exe /SILENT /DIR="${install_path}"
+        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /DIR="${install_path}"
 
     - name: 'Test Artifact'
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -177,15 +177,15 @@ jobs:
       with:
         name: Windows_Installer 6.8.3,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,true,windows-2025
 
-   - name: 'Install Artifact'
-     shell: bash
-     run: |
-       ls
-       mkdir bld
-       installer=$(ls "GPSBabel-*-*-Setup-arm64.exe")
-       ./${installer} /SILENT /DIR=bld
+    - name: 'Install Artifact'
+      shell: bash
+      run: |
+        ls
+        mkdir bld
+        installer=$(ls "GPSBabel-*-*-Setup-arm64.exe")
+        ./${installer} /SILENT /DIR=bld
 
-   - name: 'Test Artifact'
+    - name: 'Test Artifact'
       shell: bash
       run: |
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1


### PR DESCRIPTION
In order to test the cross-compiled WoA executable we need to start a job on a newly available windows-11-arm runner, run the installer, and then run regression.

We can't build on WoA yet because aqtinstall doesn't work on windows-11-arm yet due to https://codeberg.org/miurahr/pyppmd/issues/128