### PR TITLE
prepare for deprecation of windows-2019 github runner.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,9 +36,9 @@ jobs:
             COMPILER: 'msvc2019_64'
             TOOLSET: 'v142,version=14.29.30133'
             METHOD: 'aqt'
-            GENERATOR: 'Visual Studio 16 2019'
+            GENERATOR: 'Visual Studio 17 2022'
             RELEASE: false
-            os: windows-2019
+            os: windows-2022
           - QT_VERSION: '6.2.4'
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
@@ -115,6 +115,10 @@ jobs:
     - name: Install Inno Setup
       if: matrix.os == 'windows-2025'
       run: choco install innosetup 
+
+    - name: Install legacy microsoft compiler
+      if: matrix.TOOLSET == 'v142,version=14.29.30133'
+      run: choco install visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Component.VC.14.29.16.11.CLI.Support"
 
     - name: Build
       shell: pwsh


### PR DESCRIPTION
This PR allows us to continue to test our minimum supported MSVC compiler on the github actions visual studio 2022 image instead of [the github actions about to be deprecated visual studio 2019 image](https://github.com/actions/runner-images/issues/12045).  At some point we should just move up the minimum supported versions of visual studio and the MSVC compiler, but we have no need to do so currently. 