### PR TITLE
workaround for missing /usr/share/libdrm mount.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,6 +134,9 @@ parts:
     override-prime: |
       craftctl default
       ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
+      # Workaround inspired from Firefox for empty libdrm LP:2054887 LP:2055273
+      # https://git.launchpad.net/~mozilla-snaps/firefox-snap/+git/firefox-snap/commit/?id=00059b6a9aea8e4ce5a239bd9e649f60736dd947
+      mkdir $CRAFT_PRIME/gpu-2404
     prime:
       - bin/gpu-2404-wrapper
 


### PR DESCRIPTION
This is a workaround for a long standing issue with snapd.  There are several launchpad bugs reported including LP:2054887 LP:2055273.

A test is
snap run --shell gpsbabel -c "ls -l /usr/share/libdrm"
which should find
-rw-r--r-- 1 root root 19045 Jun 26  2024 amdgpu.ids