### PR TITLE
tweak snap libdrm workaround to match updated canonical doc.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,9 +134,8 @@ parts:
     override-prime: |
       craftctl default
       ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
-      # Workaround inspired from Firefox for empty libdrm LP:2054887 LP:2055273
-      # https://git.launchpad.net/~mozilla-snaps/firefox-snap/+git/firefox-snap/commit/?id=00059b6a9aea8e4ce5a239bd9e649f60736dd947
-      mkdir $CRAFT_PRIME/gpu-2404
+      # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
+      mkdir -p "${CRAFT_PRIME}/gpu-2404"
     prime:
       - bin/gpu-2404-wrapper
 


### PR DESCRIPTION
tweak libdrm workaround to match resolution of https://github.com/canonical/gpu-snap/issues/44