### PR TITLE
fix github action failures on windows of "Test Installer" job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -198,7 +198,7 @@ jobs:
       shell: pwsh
       run: |
         $install_path=Join-Path $(Get-Location) bld
-        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=bld\log.txt
+        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=bld\log.txt /MERGETASKS="!vcredist"
         Start-Sleep -Seconds 60
         Get-ChildItem bld
 

--- a/gui/setup.iss.in
+++ b/gui/setup.iss.in
@@ -82,9 +82,9 @@ Name: "{group}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"
 Name: "{commondesktop}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\vc_redist.x86.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
-Filename: "{app}\vc_redist.x64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
-Filename: "{app}\vc_redist.arm64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.x86.exe"; Parameters: "/quiet /norestart"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.x64.exe"; Parameters: "/quiet /norestart"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.arm64.exe"; Parameters: "/quiet /norestart"; Flags: skipifdoesntexist
 Filename: "{app}\gpsbabelfe.exe"; Description: "{cm:LaunchProgram,GPSBabelFE}"; Flags: nowait postinstall skipifsilent
 
 [Registry]

--- a/gui/setup.iss.in
+++ b/gui/setup.iss.in
@@ -47,7 +47,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: "vcredist"; Description: "Install Visual C++ Redistributable";
+Name: "vcredist"; Description: "Install Microsoft Visual C++ Redistributable (An appropriate Visual C++ Resdistributable is required.)";
 
 [Files]
 Source: gmapbase.html; 			DestDir: "{app}"; Flags: ignoreversion

--- a/gui/setup.iss.in
+++ b/gui/setup.iss.in
@@ -47,6 +47,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "vcredist"; Description: "Install Visual C++ Redistributable";
 
 [Files]
 Source: gmapbase.html; 			DestDir: "{app}"; Flags: ignoreversion
@@ -82,9 +83,9 @@ Name: "{group}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"
 Name: "{commondesktop}\GPSBabel"; Filename: "{app}\gpsbabelfe.exe"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\vc_redist.x86.exe"; Parameters: "/quiet /norestart"; Flags: skipifdoesntexist
-Filename: "{app}\vc_redist.x64.exe"; Parameters: "/quiet /norestart"; Flags: skipifdoesntexist
-Filename: "{app}\vc_redist.arm64.exe"; Parameters: "/quiet /norestart"; Flags: skipifdoesntexist
+Filename: "{app}\vc_redist.x86.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist; Tasks: vcredist
+Filename: "{app}\vc_redist.x64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist; Tasks: vcredist
+Filename: "{app}\vc_redist.arm64.exe"; Parameters: "/quiet"; Flags: skipifdoesntexist; Tasks: vcredist
 Filename: "{app}\gpsbabelfe.exe"; Description: "{cm:LaunchProgram,GPSBabelFE}"; Flags: nowait postinstall skipifsilent
 
 [Registry]


### PR DESCRIPTION
The "Test Installer" job has started failing.  Apparently it if failing because installation of the vc redistributable is indicating the need for a restart.  The restart can be avoided by adding the /norestart flag, which allows the test to run successfully.

However, we should consider that when users run the installer this flag will also prevent a restart.