### PR TITLE
use x86_64h for macos targets >= 12.0

### DIFF
--- a/tools/ci_script_osx.sh
+++ b/tools/ci_script_osx.sh
@@ -17,9 +17,12 @@ if [ $# -ge 3 ]; then
     GENERATOR[1]=$3
   fi
 fi
-if version_ge "${QTVER}" 6.8.0; then
+if version_ge "${QTVER}" 6.10.0; then
+  DEPLOY_TARGET="13.0"
+  ARCHS="x86_64h;arm64"
+elif version_ge "${QTVER}" 6.8.0; then
   DEPLOY_TARGET="12.0"
-  ARCHS="x86_64;arm64"
+  ARCHS="x86_64h;arm64"
 elif version_ge "${QTVER}" 6.5.0; then
   DEPLOY_TARGET="11.0"
   ARCHS="x86_64;arm64"


### PR DESCRIPTION
I believe macOS 12.0 or later does not run on pre-Haswell Intel CPUs.  So when our minimum target is >= 12.0 we should use x86_64h instead of x86_64.