### PR TITLE
handle potential errors on open

### DIFF
--- a/src/core/textstream.cc
+++ b/src/core/textstream.cc
@@ -47,11 +47,11 @@ void TextStream::open(const QString& fname, QIODevice::OpenMode mode, const char
    * but autodetection may switch to a converter that is.
    */
   if (!use_stringconverter && (mode & QFile::ReadOnly)) {
-    QFile file = QFile(fname);
-    file.open(mode);
+    auto scanfile = gpsbabel::File(fname);
+    scanfile.open(mode);
     char data[4];
-    qint64 bytesread = file.read(data, 4);
-    file.close();
+    qint64 bytesread = scanfile.read(data, 4);
+    scanfile.close();
     encoding = QStringConverter::encodingForData(QByteArrayView(data, bytesread));
     if (encoding.has_value()) {
       use_stringconverter = true;


### PR DESCRIPTION
of a file for unicode scanning by gpsbabel::TextStream::open. This was found because QFile::open is nodiscard since 6.8.

Note that this didn't show up with our existing tests using 6.8.3, but it did show up with 6.10.0 and XCode 16.4.
```
/Users/runner/work/gpsbabel/gpsbabel/src/core/textstream.cc:51:5: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
   51 |     file.open(mode);
      |     ^~~~~~~~~ ~~~~
1 warning generated.
/Users/runner/work/gpsbabel/gpsbabel/src/core/textstream.cc:51:5: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
   51 |     file.open(mode);
      |     ^~~~~~~~~ ~~~~
1 warning generated.
```

There is an additional case that is not fixed:
```
/Users/runner/work/gpsbabel/gpsbabel/gui/mainwindow.cc:948:5: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
  948 |     ftemp.open();
      |     ^~~~~~~~~~
```