### PR TITLE
handle potential errors on open in GUI

### DIFF
--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -955,8 +955,7 @@ void MainWindow::applyActionX()
       // ftemp.fileName() may be empty so display ftemp.fileTemplate().
       QMessageBox::warning(nullptr, QString(appName),
         tr("Failed to open temporary file \"%1\" for map preview.  The error was: \"%2\".  The map preview will not be shown.")
-        .arg(ftemp.fileTemplate())
-        .arg(ftemp.errorString()));
+        .arg(ftemp.fileTemplate(), ftemp.errorString()));
     }
   }
 #endif


### PR DESCRIPTION
Like #1462, but this fixes the same error in the GUI.

If we have an error opening the temporary file to get a temporary file name for map preview, we will show a warning and continue without map preview.