### PR TITLE
use Qt 6.10.0 for windows arm64 builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,6 +48,11 @@ jobs:
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-15
+          - QT_VERSION: '6.10.0'
+            XCODE_VERSION: '26.0'
+            GENERATOR: 'Ninja'
+            RELEASE: false
+            os: macos-26
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,11 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - QT_VERSION: '6.2.4'
-            XCODE_VERSION: '14.3.1'
-            GENERATOR: 'Ninja'
-            RELEASE: false
-            os: macos-13
           - QT_VERSION: '6.8.3'
             XCODE_VERSION: '15.4'
             GENERATOR: 'Xcode'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,18 +33,18 @@ jobs:
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-13
-          - QT_VERSION: '6.5.3'
+          - QT_VERSION: '6.8.3'
             XCODE_VERSION: '15.4'
             GENERATOR: 'Xcode'
             RELEASE: false
             os: macos-14
-          - QT_VERSION: '6.5.3'
+          - QT_VERSION: '6.8.3'
             XCODE_VERSION: '15.4'
             GENERATOR: 'Ninja'
             RELEASE: true
             os: macos-14
-          - QT_VERSION: '6.8.3'
-            XCODE_VERSION: '16.2'
+          - QT_VERSION: '6.10.0'
+            XCODE_VERSION: '16.4'
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-15

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,23 +28,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - QT_VERSION: '6.8.3'
+          - QT_VERSION: '6.5.3'
             XCODE_VERSION: '15.4'
+            GENERATOR: 'Ninja'
+            RELEASE: false
+            os: macos-14
+          - QT_VERSION: '6.8.3'
+            XCODE_VERSION: '16.4'
             GENERATOR: 'Xcode'
             RELEASE: false
-            os: macos-14
+            os: macos-15
           - QT_VERSION: '6.8.3'
-            XCODE_VERSION: '15.4'
-            GENERATOR: 'Ninja'
-            RELEASE: true
-            os: macos-14
-          - QT_VERSION: '6.10.0'
             XCODE_VERSION: '16.4'
             GENERATOR: 'Ninja'
-            RELEASE: false
+            RELEASE: true
             os: macos-15
           - QT_VERSION: '6.10.0'
-            XCODE_VERSION: '26.0'
+            XCODE_VERSION: '26.0.1'
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-26

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,6 +79,22 @@ jobs:
             RELEASE: false
             GENERATOR: 'Ninja'
             os: windows-11-arm
+          - QT_VERSION: '6.10.0'
+            TARGET_ARCH: 'arm64'
+            HOST_ARCH: 'amd64'
+            COMPILER: 'msvc2022_64'
+            CROSS_COMPILER: 'msvc2022_arm64'
+            METHOD: 'aqt'
+            RELEASE: false
+            os: windows-2025
+          - QT_VERSION: '6.10.0'
+            ARCH: 'arm64'
+            HOST_ARCH: 'arm64'
+            COMPILER: 'msvc2022_arm64'
+            METHOD: 'aqt'
+            RELEASE: false
+            GENERATOR: 'Ninja'
+            os: windows-11-arm
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,6 +101,9 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       env:
         CI_BUILD_DIR: ${{ github.workspace }}
+        ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+        ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+        ARTIFACTORY_BASE_URL: ${{ secrets.ARTIFACTORY_BASE_URL }}
       shell: bash
       run: |
         if [ -n "${{ matrix.CROSS_COMPILER }}" ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,14 +39,6 @@ jobs:
             GENERATOR: 'Visual Studio 17 2022'
             RELEASE: false
             os: windows-2022
-          - QT_VERSION: '6.2.4'
-            ARCH: 'amd64'
-            HOST_ARCH: 'amd64'
-            COMPILER: 'msvc2019_64'
-            METHOD: 'aqt'
-            GENERATOR: 'Visual Studio 17 2022'
-            RELEASE: false
-            os: windows-2022
           - QT_VERSION: '6.5.3'
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
@@ -63,29 +55,13 @@ jobs:
             RELEASE: true
             GENERATOR: 'Ninja'
             os: windows-2025
-          - QT_VERSION: '6.8.3'
-            TARGET_ARCH: 'arm64'
-            HOST_ARCH: 'amd64'
-            COMPILER: 'msvc2022_64'
-            CROSS_COMPILER: 'msvc2022_arm64'
-            METHOD: 'aqt'
-            RELEASE: true
-            os: windows-2025
-          - QT_VERSION: '6.8.3'
-            ARCH: 'arm64'
-            HOST_ARCH: 'arm64'
-            COMPILER: 'msvc2022_arm64'
-            METHOD: 'aqt'
-            RELEASE: false
-            GENERATOR: 'Ninja'
-            os: windows-11-arm
           - QT_VERSION: '6.10.0'
             TARGET_ARCH: 'arm64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2022_64'
             CROSS_COMPILER: 'msvc2022_arm64'
             METHOD: 'aqt'
-            RELEASE: false
+            RELEASE: true
             os: windows-2025
           - QT_VERSION: '6.10.0'
             ARCH: 'arm64'

--- a/src/core/textstream.cc
+++ b/src/core/textstream.cc
@@ -47,11 +47,11 @@ void TextStream::open(const QString& fname, QIODevice::OpenMode mode, const char
    * but autodetection may switch to a converter that is.
    */
   if (!use_stringconverter && (mode & QFile::ReadOnly)) {
-    QFile file = QFile(fname);
-    file.open(mode);
+    auto scanfile = gpsbabel::File(fname);
+    scanfile.open(mode);
     char data[4];
-    qint64 bytesread = file.read(data, 4);
-    file.close();
+    qint64 bytesread = scanfile.read(data, 4);
+    scanfile.close();
     encoding = QStringConverter::encodingForData(QByteArrayView(data, bytesread));
     if (encoding.has_value()) {
       use_stringconverter = true;

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -60,7 +60,10 @@ else
   mkdir -p "${CACHEDIR}"
 
   if [ "${METHOD}" = "aqt" ]; then
-    pip3 install 'aqtinstall>=3.3.0'
+    #pip3 install 'aqtinstall>=3.3.0'
+    archive=aqtinstall-3.3.1.dev13-py3-none-any.whl
+    curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}" "${ARTIFACTORY_BASE_URL}/${archive}" -o "/tmp/${archive}"
+    pip3 install "/tmp/${archive}"
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" "${HOST}" "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt"
     if [ -n "${PACKAGE_SUFFIX_CROSS}" ]; then
       "${CI_BUILD_DIR}/tools/ci_install_qt.sh" "${HOST}" "${QT_VERSION}" "${PACKAGE_SUFFIX_CROSS}" "${CACHEDIR}/Qt"

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -60,6 +60,8 @@ else
   mkdir -p "${CACHEDIR}"
 
   if [ "${METHOD}" = "aqt" ]; then
+    # we need https://github.com/miurahr/aqtinstall/pull/941 to install extensions with 6.10.0 for windows arm64.
+    # until this is merged and released use a locally generated version of aqt.
     #pip3 install 'aqtinstall>=3.3.0'
     archive=aqtinstall-3.3.1.dev13-py3-none-any.whl
     curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}" "${ARTIFACTORY_BASE_URL}/${archive}" -o "/tmp/${archive}"

--- a/tools/ci_script_osx.sh
+++ b/tools/ci_script_osx.sh
@@ -17,7 +17,10 @@ if [ $# -ge 3 ]; then
     GENERATOR[1]=$3
   fi
 fi
-if version_ge "${QTVER}" 6.8.0; then
+if version_ge "${QTVER}" 6.10.0; then
+  DEPLOY_TARGET="13.0"
+  ARCHS="x86_64;arm64"
+elif version_ge "${QTVER}" 6.8.0; then
   DEPLOY_TARGET="12.0"
   ARCHS="x86_64;arm64"
 elif version_ge "${QTVER}" 6.5.0; then


### PR DESCRIPTION
This is the first release to support QtWebEngine for WoA.

Unfortunately our Qt installer hasn't caught up yet, so a pre-release version of aqtinstall is used on windows.