### PR TITLE
add Option methods to distinguish between defaulted and supplied option values

### DIFF
--- a/filter_vecs.cc
+++ b/filter_vecs.cc
@@ -217,9 +217,9 @@ void FilterVecs::prepare_filter(const fltinfo_t& fltdata)
         qtemp = inifile_readstr(global_opts.inifile, "Common filter settings", arg.argstring);
       }
       if (qtemp.isNull()) {
-        Vecs::assign_option(fltdata.fltname, arg, arg.defaultvalue);
+        Vecs::assign_option(fltdata.fltname, arg, arg.defaultvalue, true);
       } else {
-        Vecs::assign_option(fltdata.fltname, arg, qtemp);
+        Vecs::assign_option(fltdata.fltname, arg, qtemp, true);
       }
     }
   }
@@ -231,7 +231,7 @@ void FilterVecs::prepare_filter(const fltinfo_t& fltdata)
       for (auto& arg : *args) {
         const QString opt = Vecs::get_option(fltdata.options, arg.argstring);
         if (!opt.isNull()) {
-          Vecs::assign_option(fltdata.fltname, arg, opt);
+          Vecs::assign_option(fltdata.fltname, arg, opt, false);
         }
       }
     }

--- a/option.h
+++ b/option.h
@@ -46,6 +46,8 @@ public:
   virtual void init(const QString& id) {}
   virtual void reset() = 0;
   virtual void set(const QString& s) = 0;
+  [[nodiscard]] virtual bool getDefaulted() const = 0;
+  virtual void setDefaulted(bool defaulted) = 0;
 
   /* Data Members */
   // I.25: Prefer empty abstract classes as interfaces to class hierarchies
@@ -98,6 +100,16 @@ public:
     value_ = s;
   }
 
+  [[nodiscard]] bool getDefaulted() const override
+  {
+    return isDefaulted;
+  }
+
+  void setDefaulted(bool defaulted) override
+  {
+    isDefaulted = defaulted;
+  } 
+
 // We use overloads instead of default parameters to enable tool visibility into different usages.
   int toInt() const;
   int toInt(bool* ok) const;
@@ -109,6 +121,7 @@ public:
 private:
   QString value_;
   QString id_;
+  bool isDefaulted{true};
 };
 
 class OptionInt : public Option
@@ -146,6 +159,16 @@ public:
     return value_;
   }
 
+  [[nodiscard]] bool getDefaulted() const override
+  {
+    return isDefaulted;
+  }
+
+  void setDefaulted(bool defaulted) override
+  {
+    isDefaulted = defaulted;
+  } 
+
   void init(const QString& id) override;
   void reset() override;
   void set(const QString& s) override;
@@ -160,6 +183,7 @@ private:
   QString end_;
   bool allow_trailing_data_{false};
   int base_{10};
+  bool isDefaulted{true};
 };
 
 class OptionDouble : public Option
@@ -196,6 +220,16 @@ public:
     return value_;
   }
 
+  [[nodiscard]] bool getDefaulted() const override
+  {
+    return isDefaulted;
+  }
+
+  void setDefaulted(bool defaulted) override
+  {
+    isDefaulted = defaulted;
+  } 
+
   void init(const QString& id) override;
   void reset() override;
   void set(const QString& s) override;
@@ -209,6 +243,7 @@ private:
   double result_{};
   QString end_;
   bool allow_trailing_data_{false};
+  bool isDefaulted{true};
 };
 
 class OptionBool : public Option
@@ -251,7 +286,18 @@ public:
     value_ = s;
   }
 
+  [[nodiscard]] bool getDefaulted() const override
+  {
+    return isDefaulted;
+  }
+
+  void setDefaulted(bool defaulted) override
+  {
+    isDefaulted = defaulted;
+  } 
+
 private:
   QString value_;
+  bool isDefaulted{true};
 };
 #endif // OPTION_H_INCLUDED_

--- a/option.h
+++ b/option.h
@@ -108,7 +108,7 @@ public:
   void setDefaulted(bool defaulted) override
   {
     isDefaulted = defaulted;
-  } 
+  }
 
 // We use overloads instead of default parameters to enable tool visibility into different usages.
   int toInt() const;
@@ -167,7 +167,7 @@ public:
   void setDefaulted(bool defaulted) override
   {
     isDefaulted = defaulted;
-  } 
+  }
 
   void init(const QString& id) override;
   void reset() override;
@@ -228,7 +228,7 @@ public:
   void setDefaulted(bool defaulted) override
   {
     isDefaulted = defaulted;
-  } 
+  }
 
   void init(const QString& id) override;
   void reset() override;
@@ -294,7 +294,7 @@ public:
   void setDefaulted(bool defaulted) override
   {
     isDefaulted = defaulted;
-  } 
+  }
 
 private:
   QString value_;

--- a/option.h
+++ b/option.h
@@ -46,7 +46,7 @@ public:
   virtual void init(const QString& id) {}
   virtual void reset() = 0;
   virtual void set(const QString& s) = 0;
-  [[nodiscard]] virtual bool getDefaulted() const = 0;
+  [[nodiscard]] virtual bool isDefaulted() const = 0;
   virtual void setDefaulted(bool defaulted) = 0;
 
   /* Data Members */
@@ -100,14 +100,14 @@ public:
     value_ = s;
   }
 
-  [[nodiscard]] bool getDefaulted() const override
+  [[nodiscard]] bool isDefaulted() const override
   {
-    return isDefaulted;
+    return isDefaulted_;
   }
 
   void setDefaulted(bool defaulted) override
   {
-    isDefaulted = defaulted;
+    isDefaulted_ = defaulted;
   }
 
 // We use overloads instead of default parameters to enable tool visibility into different usages.
@@ -121,7 +121,7 @@ public:
 private:
   QString value_;
   QString id_;
-  bool isDefaulted{true};
+  bool isDefaulted_{true};
 };
 
 class OptionInt : public Option
@@ -159,14 +159,14 @@ public:
     return value_;
   }
 
-  [[nodiscard]] bool getDefaulted() const override
+  [[nodiscard]] bool isDefaulted() const override
   {
-    return isDefaulted;
+    return isDefaulted_;
   }
 
   void setDefaulted(bool defaulted) override
   {
-    isDefaulted = defaulted;
+    isDefaulted_ = defaulted;
   }
 
   void init(const QString& id) override;
@@ -183,7 +183,7 @@ private:
   QString end_;
   bool allow_trailing_data_{false};
   int base_{10};
-  bool isDefaulted{true};
+  bool isDefaulted_{true};
 };
 
 class OptionDouble : public Option
@@ -220,14 +220,14 @@ public:
     return value_;
   }
 
-  [[nodiscard]] bool getDefaulted() const override
+  [[nodiscard]] bool isDefaulted() const override
   {
-    return isDefaulted;
+    return isDefaulted_;
   }
 
   void setDefaulted(bool defaulted) override
   {
-    isDefaulted = defaulted;
+    isDefaulted_ = defaulted;
   }
 
   void init(const QString& id) override;
@@ -243,7 +243,7 @@ private:
   double result_{};
   QString end_;
   bool allow_trailing_data_{false};
-  bool isDefaulted{true};
+  bool isDefaulted_{true};
 };
 
 class OptionBool : public Option
@@ -286,18 +286,18 @@ public:
     value_ = s;
   }
 
-  [[nodiscard]] bool getDefaulted() const override
+  [[nodiscard]] bool isDefaulted() const override
   {
-    return isDefaulted;
+    return isDefaulted_;
   }
 
   void setDefaulted(bool defaulted) override
   {
-    isDefaulted = defaulted;
+    isDefaulted_ = defaulted;
   }
 
 private:
   QString value_;
-  bool isDefaulted{true};
+  bool isDefaulted_{true};
 };
 #endif // OPTION_H_INCLUDED_

--- a/vecs.cc
+++ b/vecs.cc
@@ -570,7 +570,7 @@ void Vecs::exit_vecs()
   style_list.squeeze();
 }
 
-void Vecs::assign_option(const QString& module, arglist_t& arg, const QString& val)
+void Vecs::assign_option(const QString& module, arglist_t& arg, const QString& val, bool isDefault)
 {
   QString id = QStringLiteral("%1(%2)").arg(module, arg.argstring);
 
@@ -579,6 +579,7 @@ void Vecs::assign_option(const QString& module, arglist_t& arg, const QString& v
   }
 
   arg.argval->reset();
+  arg.argval->setDefaulted(isDefault);
 
   if (val.isNull()) {
     return;
@@ -668,7 +669,7 @@ void Vecs::prepare_format(const fmtinfo_t& fmtdata)
       if (!fmtdata.options.isEmpty()) {
         const QString opt = get_option(fmtdata.options, arg.argstring);
         if (!opt.isNull()) {
-          assign_option(fmtdata.fmtname, arg, opt);
+          assign_option(fmtdata.fmtname, arg, opt, false);
           continue;
         }
       }
@@ -677,9 +678,9 @@ void Vecs::prepare_format(const fmtinfo_t& fmtdata)
         qopt = inifile_readstr(global_opts.inifile, "Common format settings", arg.argstring);
       }
       if (qopt.isNull()) {
-        assign_option(fmtdata.fmtname, arg, arg.defaultvalue);
+        assign_option(fmtdata.fmtname, arg, arg.defaultvalue, true);
       } else {
-        assign_option(fmtdata.fmtname, arg, qopt);
+        assign_option(fmtdata.fmtname, arg, qopt, true);
       }
     }
   }

--- a/vecs.h
+++ b/vecs.h
@@ -76,7 +76,7 @@ public:
   static void free_options(QVector<arglist_t>* args);
   static void exit_vec(Format* fmt);
   void exit_vecs();
-  static void assign_option(const QString& module, arglist_t& arg, const QString& val);
+  static void assign_option(const QString& module, arglist_t& arg, const QString& val, bool isDefault);
   static void disp_vec_options(const QString& vecname, const QVector<arglist_t>* args);
   static void validate_options(const QStringList& options, const QVector<arglist_t>* args, const QString& name);
   static QString get_option(const QStringList& options, const QString& argname);


### PR DESCRIPTION
This might be a better fit for Kalman::is_using_default_value().  If the use supplies an option on the command line we should respect it even if it happens to match the default value.   This PR makes a determination based on the source of the option, not a comparison of it's value.  If it comes from argdefault or the init file it is reported as defaulted, otherwise it must be on the command line and it is reproed as not defaulted.