### PR TITLE
Fix symbol names for Dog icons.

### DIFF
--- a/garmin_icon_tables.h
+++ b/garmin_icon_tables.h
@@ -344,11 +344,11 @@ static const QVector<icon_mapping_t> garmin_icon_table = {
   { 248, -1, "Water Source" },
 
   /* BaseCamp 4.8.13 */
-  { 249, -1, "Dog, running" },
-  { 250, -1, "Dog, pointing" },
-  { 251, -1, "Dog, treed" },
-  { 252, -1, "Dog, sitting" },
-  { 253, -1, "Dog, unknown" },
+  { 249, -1, "Dog Running" },
+  { 250, -1, "Dog Pointing" },
+  { 251, -1, "Dog Treed" },
+  { 252, -1, "Dog Sitting" },
+  { 253, -1, "Dog Unknown" },
   { 254, -1, "Bank, Euro" },
   { 255, -1, "Bank, Pound" },
   { 256, -1, "Bank, Yen" },

--- a/xmldoc/chapters/garmin_icons.xml
+++ b/xmldoc/chapters/garmin_icons.xml
@@ -97,11 +97,11 @@ These values are also used internally by the
     <member>Diver Down Flag 1</member>
     <member>Diver Down Flag 2</member>
     <member>Dock</member>
-    <member>Dog, pointing</member>
-    <member>Dog, running</member>
-    <member>Dog, sitting</member>
-    <member>Dog, treed</member>
-    <member>Dog, unknown</member>
+    <member>Dog Pointing</member>
+    <member>Dog Running</member>
+    <member>Dog Sitting</member>
+    <member>Dog Treed</member>
+    <member>Dog Unknown</member>
     <member>Dot, White</member>
     <member>Drinking Water</member>
     <member>Dropoff</member>


### PR DESCRIPTION
The new icons in the hunting category for dogs had the wrong description, in #1496 I had used the ones from the tooltip instead from the <sym> element in GPX file.