### PR TITLE
remove unused QNetworkAccessManger from map.

### DIFF
--- a/gui/map.cc
+++ b/gui/map.cc
@@ -30,7 +30,6 @@
 #include <QLatin1String>          // for QLatin1String
 #include <QList>                  // for QList
 #include <QMessageBox>            // for QMessageBox
-#include <QNetworkAccessManager>  // for QNetworkAccessManager
 #include <QStringLiteral>         // for qMakeStringPrivate, QStringLiteral
 #include <QUrl>                   // for QUrl
 #include <QWebChannel>            // for QWebChannel
@@ -67,7 +66,6 @@ Map::Map(QWidget* parent,
   busyCursor_ = true;
   stopWatch_.start();
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  manager_ = new QNetworkAccessManager(this);
   this->logTime("Start map constructor");
 
   auto* mclicker = new MarkerClicker(this);

--- a/gui/map.h
+++ b/gui/map.h
@@ -25,7 +25,6 @@
 
 #include <QByteArray>             // for QByteArray
 #include <QElapsedTimer>          // for QElapsedTimer
-#include <QNetworkAccessManager>  // for QNetworkAccessManager
 #include <QObject>                // for QObject, emit, Q_OBJECT, signals, slots
 #include <QPlainTextEdit>         // for QPlainTextEdit
 #include <QResizeEvent>           // for QResizeEvent
@@ -107,7 +106,6 @@ private:
   QFile* dbgdata_{nullptr};
   QTextStream* dbgout_{nullptr};
 #endif
-  QNetworkAccessManager* manager_{nullptr};
   const Gpx& gpx_;
   bool mapPresent_{false};
   bool busyCursor_{false};


### PR DESCRIPTION
Alternatively this could be done only in #1498, but it is unclear at this moment if that will be in the next release.  In any event it should be merged into #1498, and the same changes applied to leafletmap.cc and .h.