### PR TITLE
only save caches from the master branch

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,7 +81,7 @@ jobs:
       id: restore-cache
       with:
         path: ~/Cache
-        key: ${{ runner.os }}-${{ matrix.QT_VERSION }}-${{ matrix.COMPILER }}-${{ matrix.CROSS_COMPILER }}-${{ secrets.CACHE_VERSION }}
+        key: ${{ runner.os }}-${{ matrix.QT_VERSION }}-${{ matrix.COMPILER }}-${{ matrix.CROSS_COMPILER }}
 
     - name: Install Qt setup(aqt)
       if: ( steps.restore-cache.outputs.cache-hit != 'true' ) && ( matrix.METHOD == 'aqt' )

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,20 +77,20 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Cache Qt
-      uses: actions/cache@v4
-      id: cache
+      uses: actions/cache/restore@v4
+      id: restore-cache
       with:
         path: ~/Cache
         key: ${{ runner.os }}-${{ matrix.QT_VERSION }}-${{ matrix.COMPILER }}-${{ matrix.CROSS_COMPILER }}-${{ secrets.CACHE_VERSION }}
 
     - name: Install Qt setup(aqt)
-      if: ( steps.cache.outputs.cache-hit != 'true' ) && ( matrix.METHOD == 'aqt' )
+      if: ( steps.restore-cache.outputs.cache-hit != 'true' ) && ( matrix.METHOD == 'aqt' )
       uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
     - name: Install Qt
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.restore-cache.outputs.cache-hit != 'true'
       env:
         CI_BUILD_DIR: ${{ github.workspace }}
         ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
@@ -169,6 +169,13 @@ jobs:
           bld/gui/GPSBabel-*-Setup-*.exe
           bld/gui/GPSBabel-*-Manifest-*.txt
         retention-days: 7
+
+    - name: Save Cache Qt
+      if: ( steps.restore-cache.outputs.cache-hit != 'true' ) && ( github.ref == 'refs/heads/master' )
+      uses: actions/cache/save@v4
+      with:
+        path: ~/Cache
+        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
   test_installer:
     name: 'Test Installer'


### PR DESCRIPTION
Caches from the default branch (master) are useable by a pull request if the key matches.
The intent here is to avoid saving caches specific to PRs, which are only of use to that PR.  These cause the cache limits to be exceeded, which can lead to some thrashing.