### PR TITLE
workaound maccos codesign issues.

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -206,9 +206,16 @@ else()
                     USES_TERMINAL)
 
   if(APPLE)
+    # avoid macdeployqt issues with -executable and -codesign QTBUG-118075
+    if(${Qt6Core_VERSION} VERSION_GREATER_EQUAL 6.7)
+      # codesign seems to be needed on M1 tahoe for builds done with 6.5.3, XCode 16.4 on macos 15.
+      # codesign doesn't seem to be needed on M1 tahoe for builds done with 6.5.3, XCode 15.4 on macos 14.
+      # In the future codesign will run by default QTBUG-138019.
+      set(_codesign -c)
+    endif()
     get_target_property(_qmake_executable Qt6::qmake IMPORTED_LOCATION)
     add_custom_target(package_app
-                      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/package_app -a $<TARGET_BUNDLE_DIR:gpsbabelfe> -q ${_qmake_executable} -g $<TARGET_FILE:gpsbabel> -s ${CMAKE_CURRENT_SOURCE_DIR}
+                      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/package_app -a $<TARGET_BUNDLE_DIR:gpsbabelfe> -q ${_qmake_executable} -g $<TARGET_FILE:gpsbabel> -s ${CMAKE_CURRENT_SOURCE_DIR} ${_codesign}
                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_BUNDLE_DIR:gpsbabelfe>/../GPSBabelFE.dmg ${CMAKE_CURRENT_BINARY_DIR}
                       DEPENDS gpsbabelfe gpsbabel gpsbabelfe_lrelease coretool_lrelease
                       VERBATIM

--- a/gui/package_app
+++ b/gui/package_app
@@ -84,14 +84,15 @@ SKIP_UPDATE_RELEASE=
 GPSBABEL=../gpsbabel
 QMAKE=qmake
 SOURCEDIR=.
-while getopts a:g:q:s: name
+while getopts a:g:q:s:c name
 do
   case $name in
     a) APPDIR="$OPTARG";;
     g) GPSBABEL="$OPTARG";;
     q) QMAKE="$OPTARG";;
     s) SOURCEDIR="$OPTARG";;
-    ?) printf "Usage: %s: [-a package_directory] [-g gpsbabel] [-q qmake] [-s source_directory]\n" "$0"
+    c) CODESIGN="-codesign=-";;
+    ?) printf "Usage: %s: [-a package_directory] [-g gpsbabel] [-q qmake] [-s source_directory] [-c]\n" "$0"
        exit 2;;
   esac
 done
@@ -131,6 +132,6 @@ else # Mac
   rm -f GPSBabelFE.dmg
   # macdeploytqt likes relative paths or else the dmg mount points get funky.
   APPBUNDLE="$(basename "$APPDIR")"
-  "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -dmg -verbose=2 -fs=APFS
+  "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -dmg -verbose=2 -fs=APFS "${CODESIGN}"
   popd
 fi


### PR DESCRIPTION
Note that madeployqt will output several "ERROR:" messages, but exit with good status.  Mostly these are because macdeployqt doesn't expect anything but exectuables in Content/MacOS.  But there are some others like "codesign verification error:" that seem to be ignorable.