### PR TITLE
Fix mac codesiging

### DIFF
--- a/gui/mainwindow.cc
+++ b/gui/mainwindow.cc
@@ -253,13 +253,18 @@ void MainWindow::switchTranslator(QTranslator& translator, const QString& filena
 
   // Set a list of locations to search for the translation file.
   // 1. In the file system in the translations directory relative to the
-  //    location of the executable.
+  //    location of the executable, or on macOS in the Resources
+  //    directory relative to the location of the executable.
   // 2. In the Qt resource system under the translations path.  This is useful
   //    if the resource was compiled into the executable.
   // 3. In the translations path for Qt.  This is useful to find translations
   //    included with Qt.
   const QStringList directories = {
+#ifdef Q_OS_MACOS
+    QApplication::applicationDirPath() + "/../Resources/translations",
+#else
     QApplication::applicationDirPath() + "/translations",
+#endif
     ":/translations",
     QLibraryInfo::path(QLibraryInfo::TranslationsPath)
   };

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -78,7 +78,8 @@ Map::Map(QWidget* parent,
   connect(mclicker, &MarkerClicker::logTime, this, &Map::logTime);
 
   // We search the following locations:
-  // 1. In the file system in the same directory as the executable.
+  // 1. In the file system in the same directory as the executable, or on macOS,
+  //    in the Resources directory relative to the location of the executable.
   // 2. In the Qt resource system.  This is useful if the resource was compiled
   //    into the executable.
 #ifdef Q_OS_MACOS

--- a/gui/map.cc
+++ b/gui/map.cc
@@ -81,7 +81,11 @@ Map::Map(QWidget* parent,
   // 1. In the file system in the same directory as the executable.
   // 2. In the Qt resource system.  This is useful if the resource was compiled
   //    into the executable.
+#ifdef Q_OS_MACOS
+  QString baseFile = QApplication::applicationDirPath() + "/../Resources/gmapbase.html";
+#else
   QString baseFile = QApplication::applicationDirPath() + "/gmapbase.html";
+#endif
   QString fileName;
   QUrl baseUrl;
   if (QFile(baseFile).exists()) {

--- a/gui/package_app
+++ b/gui/package_app
@@ -129,9 +129,23 @@ else # Mac
   cp "${SOURCEDIR}/gmapbase.html" "${APPDIR}/Contents/Resources"
   cp "${SOURCEDIR}/COPYING.txt" "${APPDIR}/Contents/Resources"
   pushd "${APPDIR}/.."
-  rm -f GPSBabelFE.dmg
   # macdeploytqt likes relative paths or else the dmg mount points get funky.
   APPBUNDLE="$(basename "$APPDIR")"
-  "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -dmg -verbose=2 -fs=APFS "${CODESIGN}"
+  VOLNAME="$(basename "$APPBUNDLE" .app)"
+  DMG="${VOLNAME}.dmg"
+  rm -f "${DMG}"
+  "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -verbose=2 "${CODESIGN}"
+  if [ ! -z "${CODESIGN}" ]; then
+    set -x
+    # GPSBabelFE ends not being signed due incorrect signing order of gpsbabel in macdeployqt.
+    # but QtCore5Compat and gpsbabel are signed belatedly.
+    echo "Re-signing GPSBabelFE assuming macdeployqt failed to sign it"
+    # the options we use to resign are the same as macdeployqt defaults (no hardened runtime, timestamps, extra enttilements)
+    codesign --preserve-metadata=identifier,entitlements --force -s - "${APPBUNDLE}/Contents/MacOS/GPSBabelFE"
+    codesign --deep --verify --verbose=3 "${APPBUNDLE}"
+    set +x
+  fi
+  # because we might have had to fix codesigning we have to create the dmg instead of letting macdeployqt do it.
+  hdiutil create "${DMG}" -srcfolder "${APPBUNDLE}" -format UDZO -fs APFS -volname "${VOLNAME}"
   popd
 fi

--- a/gui/package_app
+++ b/gui/package_app
@@ -142,7 +142,7 @@ else # Mac
     echo "Re-signing GPSBabelFE assuming macdeployqt failed to sign it"
     # the options we use to resign are the same as macdeployqt defaults (no hardened runtime, timestamps, extra enttilements)
     codesign --preserve-metadata=identifier,entitlements --force -s - "${APPBUNDLE}/Contents/MacOS/GPSBabelFE"
-    codesign --deep --verify --verbose=3 "${APPBUNDLE}"
+    codesign --deep --verify --verbose=2 "${APPBUNDLE}"
   fi
   # because we might have had to fix codesigning we have to create the dmg instead of letting macdeployqt do it.
   hdiutil create "${DMG}" -srcfolder "${APPBUNDLE}" -format UDZO -fs APFS -volname "${VOLNAME}"

--- a/gui/package_app
+++ b/gui/package_app
@@ -106,7 +106,7 @@ QT_INSTALL_TRANSLATIONS="$(${QMAKE} -query QT_INSTALL_TRANSLATIONS)"
 if [ "${machine}" = "Linux" ]; then
   LANGDIR="${APPDIR}/translations"
 else
-  LANGDIR="${APPDIR}/Contents/MacOS/translations"
+  LANGDIR="${APPDIR}/Contents/Resources/translations"
 fi
 
 rm -fr "${LANGDIR}"
@@ -126,8 +126,8 @@ if [ "${machine}" = "Linux" ]; then
   cp "${SOURCEDIR}/COPYING.txt" "${APPDIR}"
 else # Mac
   cp "${GPSBABEL}" "${APPDIR}/Contents/MacOS/gpsbabel"
-  cp "${SOURCEDIR}/gmapbase.html" "${APPDIR}/Contents/MacOS"
-  cp "${SOURCEDIR}/COPYING.txt" "${APPDIR}/Contents/MacOS"
+  cp "${SOURCEDIR}/gmapbase.html" "${APPDIR}/Contents/Resources"
+  cp "${SOURCEDIR}/COPYING.txt" "${APPDIR}/Contents/Resources"
   pushd "${APPDIR}/.."
   rm -f GPSBabelFE.dmg
   # macdeploytqt likes relative paths or else the dmg mount points get funky.

--- a/gui/package_app
+++ b/gui/package_app
@@ -134,18 +134,18 @@ else # Mac
   VOLNAME="$(basename "$APPBUNDLE" .app)"
   DMG="${VOLNAME}.dmg"
   rm -f "${DMG}"
+  set -x
   "${MACDEPLOYQT}" "${APPBUNDLE}" -executable="${APPBUNDLE}/Contents/MacOS/gpsbabel" -verbose=2 "${CODESIGN}"
   if [ ! -z "${CODESIGN}" ]; then
-    set -x
     # GPSBabelFE ends not being signed due incorrect signing order of gpsbabel in macdeployqt.
     # but QtCore5Compat and gpsbabel are signed belatedly.
     echo "Re-signing GPSBabelFE assuming macdeployqt failed to sign it"
     # the options we use to resign are the same as macdeployqt defaults (no hardened runtime, timestamps, extra enttilements)
     codesign --preserve-metadata=identifier,entitlements --force -s - "${APPBUNDLE}/Contents/MacOS/GPSBabelFE"
     codesign --deep --verify --verbose=3 "${APPBUNDLE}"
-    set +x
   fi
   # because we might have had to fix codesigning we have to create the dmg instead of letting macdeployqt do it.
   hdiutil create "${DMG}" -srcfolder "${APPBUNDLE}" -format UDZO -fs APFS -volname "${VOLNAME}"
+  set +x
   popd
 fi


### PR DESCRIPTION
While #1507 allowed the bundled app to run on macOS,  errors were generated during codesigning and codesigning would fail verification.  These were due to two problems:
1) we traditionally have packaged non-executable code in Contents/MacOS (COPYING.txt, gmapbase.html and translations.)  The MacOS directory is intended for only executable code according to the Apple documentation.  Having non-executable code present caused macdeployqt to generate errors when codesigning.
2) An apparently unreported bug in macdeployqt, including release 6.10.0, exists when the -executable option is used.  The CFBundleExecutable, GPSBabelFE, needs to be signed last.  But it is signed before executables passed with the -executable option.  This results in gpsbabel and it's dependency QtCore5Compat being signed after GPSBabelFE, which results in a codesign verification error.  The actual error message is different on github and macstadium, but the underlying problem seems identical and this PR fixes the issue on both.

Issue 1) is fixed by moving the non-executable resources to the Resources directory in the bundle.  Issue 2) is worked around by resigning GPSBabelFE after macdeployqt finishes.  However, this means we can't use macdeployqt to create the disk image, we have to do that manual after the re-signing.