### PR TITLE
use native WoA build for release

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,14 +61,14 @@ jobs:
             COMPILER: 'msvc2022_64'
             CROSS_COMPILER: 'msvc2022_arm64'
             METHOD: 'aqt'
-            RELEASE: true
+            RELEASE: false
             os: windows-2025
           - QT_VERSION: '6.10.0'
             ARCH: 'arm64'
             HOST_ARCH: 'arm64'
             COMPILER: 'msvc2022_arm64'
             METHOD: 'aqt'
-            RELEASE: false
+            RELEASE: true
             GENERATOR: 'Ninja'
             os: windows-11-arm
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -197,19 +197,18 @@ jobs:
     - name: 'Install Artifact'
       shell: pwsh
       run: |
-        $install_path=Join-Path $(Get-Location) install
-        New-Item $install_path -type directory -Force | Out-Null
+        $install_path=Join-Path $(Get-Location) installDir
         .\download\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=download\log.txt /MERGETASKS="!vcredist"
         Start-Sleep -Seconds 60
-        Get-ChildItem install
+        Get-ChildItem $install_path
 
     - name: 'Test Artifact'
       shell: bash
       run: |
-        find ./install -type f -exec file {} \;
-        PNAME=./install/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
-        PNAME=./install/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
-        ls -l install
+        find ./installDir -type f -exec file {} \;
+        PNAME=./installDir/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
+        PNAME=./installDir/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
+        ls -l installDir
 
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -205,7 +205,7 @@ jobs:
     - name: 'Test Artifact'
       shell: bash
       run: |
-        find ./bld/gui/package -type f -exec file {} \;
+        find ./bld -type f -exec file {} \;
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
         ls -l bld

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -141,7 +141,6 @@ jobs:
       shell: bash
       if: matrix.CROSS_COMPILER == ''
       run: |
-        find ./bld/gui/package -type f -exec file {} \;
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
 
@@ -181,7 +180,15 @@ jobs:
   test_installer:
     name: 'Test Installer'
     needs: windows
-    runs-on: windows-11-arm
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-11-arm
+            installer: Windows_Installer-*,arm64,arm64,msvc2022_arm64,aqt,true,Ninja,windows-11-arm
+          - os: windows-11-arm
+            installer: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,false,windows-2025
 
     steps:
     - name: Checkout repository
@@ -191,7 +198,7 @@ jobs:
       uses: actions/download-artifact@v6
       with:
         path: download
-        pattern: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,false,windows-2025
+        pattern: ${{ matrix.installer }}
         merge-multiple: true
 
     - name: 'Install Artifact'
@@ -207,7 +214,7 @@ jobs:
       run: |
         find ./installDir -type f -exec file {} \;
         PNAME=./installDir/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
-        PNAME=./installDir/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
+        PNAME=./installDir/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
         ls -l installDir
 
     - name: 'Upload Artifacts'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -191,7 +191,7 @@ jobs:
       uses: actions/download-artifact@v6
       with:
         path: bld
-        pattern: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,true,windows-2025
+        pattern: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,false,windows-2025
         merge-multiple: true
 
     - name: 'Install Artifact'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -141,6 +141,7 @@ jobs:
       shell: bash
       if: matrix.CROSS_COMPILER == ''
       run: |
+        find ./bld/gui/package -type f -exec file {} \;
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gui/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
 
@@ -204,6 +205,7 @@ jobs:
     - name: 'Test Artifact'
       shell: bash
       run: |
+        find ./bld/gui/package -type f -exec file {} \;
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
         ls -l bld

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -187,8 +187,10 @@ jobs:
         include:
           - os: windows-11-arm
             installer: Windows_Installer-*,arm64,arm64,msvc2022_arm64,aqt,true,Ninja,windows-11-arm
+            name: WoA-native
           - os: windows-11-arm
             installer: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,false,windows-2025
+            name: WoA-cross
 
     steps:
     - name: Checkout repository
@@ -219,7 +221,7 @@ jobs:
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v5
       with:
-        name: Test_Installer
+        name: Test_Installer-${{ name }}
         path: |
           download/log.txt
         retention-days: 7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -221,7 +221,7 @@ jobs:
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v5
       with:
-        name: Test_Installer-${{ name }}
+        name: Test_Installer-${{ matrix.name }}
         path: |
           download/log.txt
         retention-days: 7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -190,31 +190,31 @@ jobs:
     - name: 'Download Artifacts'
       uses: actions/download-artifact@v6
       with:
-        path: bld
+        path: download
         pattern: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,false,windows-2025
         merge-multiple: true
 
     - name: 'Install Artifact'
       shell: pwsh
       run: |
-        $install_path=Join-Path $(Get-Location) bld
-        .\bld\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=bld\log.txt /MERGETASKS="!vcredist"
+        $install_path=Join-Path $(Get-Location) install
+        .\download\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=download\log.txt /MERGETASKS="!vcredist"
         Start-Sleep -Seconds 60
-        Get-ChildItem bld
+        Get-ChildItem install
 
     - name: 'Test Artifact'
       shell: bash
       run: |
-        find ./bld -type f -exec file {} \;
-        PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
-        PNAME=./bld/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
-        ls -l bld
+        find ./install -type f -exec file {} \;
+        PNAME=./install/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
+        PNAME=./install/package/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
+        ls -l install
 
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v5
       with:
         name: Test_Installer
         path: |
-          bld/log.txt
+          download/log.txt
         retention-days: 7
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -207,7 +207,7 @@ jobs:
         $install_path=Join-Path $(Get-Location) installDir
         .\download\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=download\log.txt /MERGETASKS="!vcredist"
         Start-Sleep -Seconds 60
-        Get-ChildItem $install_path
+        Get-ChildItem -Path $install_path -Recurse -Force
 
     - name: 'Test Artifact'
       shell: bash
@@ -215,7 +215,6 @@ jobs:
         find ./installDir -type f -exec file {} \;
         PNAME=./installDir/gpsbabel.exe GBTEMP=./gbtemp ./testo 2>&1
         PNAME=./installDir/gpsbabel.exe GBTEMP=./gbtemp ./test_encoding_utf8 2>&1
-        ls -l installDir
 
     - name: 'Upload Artifacts'
       uses: actions/upload-artifact@v5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -198,6 +198,7 @@ jobs:
       shell: pwsh
       run: |
         $install_path=Join-Path $(Get-Location) install
+        New-Item $install_path -type directory -Force | Out-Null
         .\download\GPSBabel-*-*-Setup-arm64.exe /SILENT /NORESTART /DIR="${install_path}" /LOG=download\log.txt /MERGETASKS="!vcredist"
         Start-Sleep -Seconds 60
         Get-ChildItem install


### PR DESCRIPTION
The cross compile versions deploys the x86_64 version of icuuc.dll instead of the arm64 version.