### PR TITLE
trim more qt modules

### DIFF
--- a/tools/ci_install_qt.sh
+++ b/tools/ci_install_qt.sh
@@ -46,6 +46,7 @@ qtremoteobjects \
 qtscxml \
 qtsensors \
 qtspeech \
+qtwebsockets \
 )
 
 mods=()


### PR DESCRIPTION
We don't have a need for QtWebSockets.  Manifests compare.