### PR TITLE
Add support to install Qt using official installer

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
           runs-on: ubuntu-latest
         - language: python
           build-mode: none
-          runs-on: ubuntu-lastest
+          runs-on: ubuntu-latest
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,6 +55,9 @@ jobs:
         - language: actions
           build-mode: none
           runs-on: ubuntu-latest
+        - language: python
+          build-mode: none
+          runs-on: ubuntu-lastest
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,6 +70,7 @@ jobs:
       if: steps.restore-cache.outputs.cache-hit != 'true'
       env:
         CI_BUILD_DIR: ${{ github.workspace }}
+        QT_INSTALLER_JWT_TOKEN: ${{secrets.QT_INSTALLER_JWT_TOKEN}}
       run: |
         ./tools/ci_install_osx.sh ${{ matrix.QT_VERSION }} qtonline
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,7 +71,7 @@ jobs:
       env:
         CI_BUILD_DIR: ${{ github.workspace }}
       run: |
-        ./tools/ci_install_osx.sh ${{ matrix.QT_VERSION }} aqt
+        ./tools/ci_install_osx.sh ${{ matrix.QT_VERSION }} qtonline
 
     - name: Brew install
       if: matrix.GENERATOR == 'Ninja'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -72,7 +72,7 @@ jobs:
         CI_BUILD_DIR: ${{ github.workspace }}
         QT_INSTALLER_JWT_TOKEN: ${{secrets.QT_INSTALLER_JWT_TOKEN}}
       run: |
-        ./tools/ci_install_osx.sh ${{ matrix.QT_VERSION }} qtonline
+        ./tools/ci_install_osx.sh ${{ matrix.QT_VERSION }} aqt
 
     - name: Brew install
       if: matrix.GENERATOR == 'Ninja'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'
             TOOLSET: 'v142,version=14.29.30133'
-            METHOD: 'aqt'
+            METHOD: 'qtonline'
             GENERATOR: 'Visual Studio 17 2022'
             RELEASE: false
             os: windows-2022
@@ -43,7 +43,7 @@ jobs:
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'
-            METHOD: 'aqt'
+            METHOD: 'qtonline'
             RELEASE: false
             GENERATOR: 'Ninja'
             os: windows-2022
@@ -51,7 +51,7 @@ jobs:
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2022_64'
-            METHOD: 'aqt'
+            METHOD: 'qtonline'
             RELEASE: true
             GENERATOR: 'Ninja'
             os: windows-2025
@@ -67,7 +67,7 @@ jobs:
             ARCH: 'arm64'
             HOST_ARCH: 'arm64'
             COMPILER: 'msvc2022_arm64'
-            METHOD: 'aqt'
+            METHOD: 'qtonline'
             RELEASE: true
             GENERATOR: 'Ninja'
             os: windows-11-arm

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2022_64'
             CROSS_COMPILER: 'msvc2022_arm64'
-            METHOD: 'aqt'
+            METHOD: 'qtonline'
             RELEASE: false
             os: windows-2025
           - QT_VERSION: '6.10.1'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -187,13 +187,13 @@ jobs:
       matrix:
         include:
           - os: windows-11-arm
-            installer: Windows_Installer-*,arm64,arm64,msvc2022_arm64,aqt,true,Ninja,windows-11-arm
+            installer: Windows_Installer-*,arm64,arm64,msvc2022_arm64,*,true,Ninja,windows-11-arm
             name: WoA-native
           - os: windows-11-arm
-            installer: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,aqt,false,windows-2025
+            installer: Windows_Installer-*,arm64,amd64,msvc2022_64,msvc2022_arm64,*,false,windows-2025
             name: WoA-cross
           - os: windows-2025
-            installer: Windows_Installer-*,amd64,amd64,msvc2022_64,aqt,true,Ninja,windows-2025
+            installer: Windows_Installer-*,amd64,amd64,msvc2022_64,*,true,Ninja,windows-2025
             name: x86_64
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,6 +96,7 @@ jobs:
         ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
         ARTIFACTORY_BASE_URL: ${{ secrets.ARTIFACTORY_BASE_URL }}
+        QT_INSTALLER_JWT_TOKEN: ${{secrets.QT_INSTALLER_JWT_TOKEN}}
       shell: bash
       run: |
         if [ -n "${{ matrix.CROSS_COMPILER }}" ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'
             TOOLSET: 'v142,version=14.29.30133'
-            METHOD: 'qtonline'
+            METHOD: 'aqt'
             GENERATOR: 'Visual Studio 17 2022'
             RELEASE: false
             os: windows-2022
@@ -43,7 +43,7 @@ jobs:
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2019_64'
-            METHOD: 'qtonline'
+            METHOD: 'aqt'
             RELEASE: false
             GENERATOR: 'Ninja'
             os: windows-2022
@@ -51,7 +51,7 @@ jobs:
             ARCH: 'amd64'
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2022_64'
-            METHOD: 'qtonline'
+            METHOD: 'aqt'
             RELEASE: true
             GENERATOR: 'Ninja'
             os: windows-2025
@@ -60,14 +60,14 @@ jobs:
             HOST_ARCH: 'amd64'
             COMPILER: 'msvc2022_64'
             CROSS_COMPILER: 'msvc2022_arm64'
-            METHOD: 'qtonline'
+            METHOD: 'aqt'
             RELEASE: false
             os: windows-2025
           - QT_VERSION: '6.10.1'
             ARCH: 'arm64'
             HOST_ARCH: 'arm64'
             COMPILER: 'msvc2022_arm64'
-            METHOD: 'qtonline'
+            METHOD: 'aqt'
             RELEASE: true
             GENERATOR: 'Ninja'
             os: windows-11-arm

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 /config.status
 /cscope.out
 /debug/
+/docbook.css
 /empty
 /gbversion.h
 /gpsbabel
@@ -43,13 +44,12 @@
 /gpsbabel.fo
 /gpsbabel.gch/
 /gpsbabel.html
+/gpsbabel.org/
 /gpsbabel.pdf
 /gpsbabel.rc
 /gpsbabel_autogen/
 /gpsbabel_coverage.xml
-/makedoc
 /makelinuxdist.sh
-/mkcapabilities
 /objects/
 /out/
 /qrc_gpsbabel.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.cbp
 *.o
 *.swo
+.DS_Store
 .ninja_deps
 .ninja_log
 .qmake.cache
@@ -21,18 +22,18 @@
 /autogen/
 /autom4te.cache/
 /babelweb/
-/bld/
 /bld-clazy/
 /bld-sanitizeaddress/
 /bld-sanitizeundefined/
 /bld-tidy/
+/bld/
 /build/
 /codacy-clang-tidy
 /compile_commands.json
-/config.tests/
 /config.h
 /config.log
 /config.status
+/config.tests/
 /cscope.out
 /debug/
 /docbook.css
@@ -59,7 +60,7 @@
 CMakeCache.txt
 CMakeFiles/
 CTestTestfile.cmake
-Testing
+Testing/
 build.ninja
 cmake_install.cmake
 rules.ninja

--- a/gui/.gitignore
+++ b/gui/.gitignore
@@ -2,6 +2,7 @@
 /GPSBabel[0-9]*.[0-9]*.[0-9]*.tar.bz2
 /GPSBabelFE/
 /GPSBabelFE.app/
+/GPSBabelFE.dmg
 /gpsbabelfe_autogen/
 /Makefile
 /objects/

--- a/gui/coretool/.gitignore
+++ b/gui/coretool/.gitignore
@@ -1,2 +1,4 @@
-/objects/
 /Makefile
+/coretool
+/gpsbabel
+/objects/

--- a/tools/.flake8
+++ b/tools/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,1 +1,1 @@
-/mkcapabilities
+/.mypy_cache/

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -70,7 +70,7 @@ else
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   elif [ "$METHOD" = "qtonline" ]; then
-    python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" --ver "${QT_VERSION}" --hostarch clang_64 --dest "${CACHEDIR}/Qt" --verbose
+    python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" --ver "${QT_VERSION}" --hostarch clang_64 --dest "${CACHEDIR}/Qt" -v -v
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -76,6 +76,7 @@ else
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   elif [ "$METHOD" = "qtonline" ]; then
+    echo -n "$QT_INSTALLER_JWT_TOKEN" | openssl dgst -sha512 | cut -d " " -f 2
     python3 ${CI_BUILD_DIR}/tools/ci_install_qt.py "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt" --verbose
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# This script is run on travis for the install stage of mac builds.
+# This script is run on github for the install stage of mac builds.
 #
 
 function version_ge() { test "$(printf "%s\n%s" "$1" "$2" | sort -rV | head -n 1)" == "$1"; }
@@ -31,14 +31,10 @@ function validate() {
 QT_VERSION=${1:-6.2.4}
 METHOD=${2:-aqt}
 
-# our expectation is that install-qt creates $QTDIR, $QTDIR/bin.
+# our expectation is that the install creates $QTDIR, $QTDIR/bin.
 CACHEDIR=${HOME}/Cache
-if [ "$METHOD" = "aqt" ] || [ "$METHOD" = "qtonline" ]; then
-  if version_ge "${QT_VERSION}" 6.1.2; then
-    QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/macos
-  else
-    QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
-  fi
+if version_ge "${QT_VERSION}" 6.1.2; then
+  QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/macos
 else
   QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/clang_64
 fi
@@ -54,13 +50,12 @@ else
       # Do not leak keys
       set +x
       if [ -z "${ARTIFACTORY_API_KEY}" ]; then
-        echo "An untrusted build cannot load cache from artifactory."
+        echo "An untrusted build cannot load cache from artifactory as it won't have access to repository secrets."
         echo "A PR from a forked repo will be an untrusted build."
         echo "The cache can be loaded from a trusted build of the default branch."
-        echo "A PR from the original repo will be trusted, but has it's own cache."
-        echo "However, when that PR is merged it will build cache for the default branch."
-        echo "Also, the cron job should rebuild the cache for the default branch, if necessary,"
-        echo "once that flavor of build in .travis.yml makes it into the default branch."
+        echo "A PR from the original repo will be trusted, but may have it's own cache."
+        echo "However, when a PR is merged the cache for the default branch will be built."
+        echo "Alternatively, building of the cache for the default branch can be triggered by a scheduled job or workflow dispatch."
         exit 1
       else
         archive=qt-${QT_VERSION}-release-macos.tar.xz
@@ -75,7 +70,6 @@ else
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   elif [ "$METHOD" = "qtonline" ]; then
-    #echo -n "$QT_INSTALLER_JWT_TOKEN" | openssl dgst -sha512 | cut -d " " -f 2
     python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" --ver "${QT_VERSION}" --hostarch clang_64 --dest "${CACHEDIR}/Qt" --verbose
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
@@ -83,6 +77,4 @@ else
     exit 1
   fi
   validate
-  # look for extra stuff left behind
-  #find "${CACHEDIR}" -maxdepth 3 -ls
 fi

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -76,7 +76,7 @@ else
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   elif [ "$METHOD" = "qtonline" ]; then
     #echo -n "$QT_INSTALLER_JWT_TOKEN" | openssl dgst -sha512 | cut -d " " -f 2
-    python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt" --verbose
+    python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" --ver "${QT_VERSION}" --hostarch clang_64 --dest "${CACHEDIR}/Qt" --verbose
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -33,7 +33,7 @@ METHOD=${2:-aqt}
 
 # our expectation is that install-qt creates $QTDIR, $QTDIR/bin.
 CACHEDIR=${HOME}/Cache
-if [ "$METHOD" = "aqt" ]; then
+if [ "$METHOD" = "aqt" ] || [ "$METHOD" = "qtonline" ]; then
   if version_ge "${QT_VERSION}" 6.1.2; then
     QTDIR=${CACHEDIR}/Qt/${QT_VERSION}/macos
   else
@@ -77,7 +77,7 @@ else
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   elif [ "$METHOD" = "qtonline" ]; then
     echo -n "$QT_INSTALLER_JWT_TOKEN" | openssl dgst -sha512 | cut -d " " -f 2
-    python3 ${CI_BUILD_DIR}/tools/ci_install_qt.py "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt" --verbose
+    python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt" --verbose
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -75,6 +75,9 @@ else
     pip3 install 'aqtinstall>=3.1.20'
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
+  elif [ "$METHOD" = "qtonline" ]; then
+    python3 ${CI_BUILD_DIR}/tools/ci_install_qt.py "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
+    echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2
     exit 1

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -83,5 +83,6 @@ else
     exit 1
   fi
   validate
-  debug "DEBUG ONLY"
+  # look for extra stuff left behind
+  #find "${CACHEDIR}" -maxdepth 3 -ls
 fi

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -48,7 +48,6 @@ if [ -d "${QTDIR}/bin" ]; then
 else
   rm -fr "${CACHEDIR}"
   mkdir -p "${CACHEDIR}"
-  pushd "${CACHEDIR}"
 
   if [ "$METHOD" = "artifactory" ]; then
     (
@@ -66,7 +65,7 @@ else
       else
         archive=qt-${QT_VERSION}-release-macos.tar.xz
         curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}" "${ARTIFACTORY_BASE_URL}/${archive}" -o "/tmp/${archive}"
-        tar -x -J -f "/tmp/${archive}"
+        tar -x -J -f "/tmp/${archive}" -C "${CACHEDIR}"
         echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
         rm -f "/tmp/${archive}"
       fi
@@ -76,13 +75,13 @@ else
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   elif [ "$METHOD" = "qtonline" ]; then
-    echo -n "$QT_INSTALLER_JWT_TOKEN" | openssl dgst -sha512 | cut -d " " -f 2
+    #echo -n "$QT_INSTALLER_JWT_TOKEN" | openssl dgst -sha512 | cut -d " " -f 2
     python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt" --verbose
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2
     exit 1
   fi
-  popd
   validate
+  debug "DEBUG ONLY"
 fi

--- a/tools/ci_install_osx.sh
+++ b/tools/ci_install_osx.sh
@@ -76,7 +76,7 @@ else
     "${CI_BUILD_DIR}/tools/ci_install_qt.sh" mac "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   elif [ "$METHOD" = "qtonline" ]; then
-    python3 ${CI_BUILD_DIR}/tools/ci_install_qt.py "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt"
+    python3 ${CI_BUILD_DIR}/tools/ci_install_qt.py "${QT_VERSION}" clang_64 "${CACHEDIR}/Qt" --verbose
     echo "export PATH=${QTDIR}/bin:\$PATH" > "${CACHEDIR}/qt-${QT_VERSION}.env"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/python3
 """
 Copyright (C) 2025 Robert Lipe, robertlipe+source@gpsbabel.org
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -69,9 +69,9 @@ def fetch_installer(verbose):
     """Fetch the appropriate Qt online installer."""
     installer = None
     if platform.system() == "Windows":
-        if platform.machine() == "x86_64":
+        if platform.machine() in ["x86_64", "AMD64"]:
             installer = "qt-online-installer-windows-x64-online.exe"
-        elif platform.machine() == "arm64":
+        elif platform.machine() in ["arm64", "ARM64"]:
             installer = "qt-online-installer-windows-arm64-online.exe"
     elif platform.system() == "Darwin":
         # note this may require rosetta is installed on arm64 macs.
@@ -79,11 +79,11 @@ def fetch_installer(verbose):
     elif platform.system() == "Linux":
         if platform.machine() == "x86_64":
             installer = "qt-online-installer-linux-x64-online.run"
-        elif platform.machine() == "arm64":
+        elif platform.machine() in ["arm64", "ARM64"]:
             installer = "qt-online-installer-linux-arm64-online.run"
     if installer is None:
         sys.exit(
-            f"Error: Unknown installer for system {platform.system} and machine {platform.machine}"
+            f"Error: Unknown installer for system {platform.system()} and machine {platform.machine()}"
         )
     try:
         url = "https://download.qt.io/official_releases/online_installers/" + installer

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -138,6 +138,7 @@ def get_available_pkgs(installer: str, ver: str, verbose: int) -> str:
     verparts = ver.split(".")
     if len(verparts) != 3:
         sys.exit(f"Error: Expected version string of the form 'major.minor.patch', got '{ver}'.")
+    print(f"Searching for packages for version {ver}.", flush=True)
     try:
         output = subprocess.run(
             [
@@ -160,8 +161,9 @@ def get_available_pkgs(installer: str, ver: str, verbose: int) -> str:
             stderr: {e.stderr}
             stdout: {e.stdout}"""
         )
-
     pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))
+    if len(pkgxml) == 0:
+        sys.exit(output.stdout)
     if verbose > 2:
         print(pkgxml)
     print(f"Fetched available packages for {ver}.", flush=True)
@@ -294,6 +296,7 @@ def main() -> None:
         "-v",
         help="verbose",
         action="count",
+        default=0,
     )
     args = parser.parse_args()
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -269,6 +269,9 @@ def main():
     )
     args = parser.parse_args()
 
+    jwt = os.getenv('QT_INSTALLER_JWT_TOKEN')
+    if jwt is None or len(jwt) == 0:
+        print("Warning: QT_INSTALLER_JWT_TOKEN not set")
     installer = fetch_installer(verbose=args.verbose)
     packagexml = get_available_pkgs(installer=installer, ver=args.ver)
     selected = select_pkgs(packagesxml=packagexml, arch=args.arch, verbose=args.verbose)

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -144,8 +144,13 @@ def get_available_pkgs(installer, ver):
         capture_output=True,
         text=True,
         encoding="UTF-8",
-        check=True,
+        check=False,
     )
+    if output.returncode != 0:
+        sys.exit(
+            f"Error: Failed to run installer {output.returncode} {output.stderr}}"
+        )
+       
     pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))
     return pkgxml
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -27,7 +27,7 @@ import stat
 import subprocess
 import sys
 import urllib.request
-import xml.etree.ElementTree as ET
+from xml.etree import ElementTree
 
 rejectlicense = [
     "qtcharts",
@@ -163,7 +163,7 @@ def select_pkgs(packagesxml, hostarch, targetarch, verbose):
     archs = [hostarch]
     if targetarch:
         archs.append(targetarch)
-    tree = ET.fromstring(packagesxml)
+    tree = ElementTree.fromstring(packagesxml)
     names = [pkg.get("name") for pkg in tree.findall("package")]
     if verbose:
         print(sorted(names))
@@ -213,7 +213,7 @@ def select_pkgs(packagesxml, hostarch, targetarch, verbose):
     if others != len(archs):
         sys.exit(f"Error: couldn't find architecture {archs}")
     print(f"Selected packages are {selected}.", flush=True)
-    return " ".join(selected)
+    return selected
 
 
 def install(installer, dest, selected):
@@ -229,7 +229,7 @@ def install(installer, dest, selected):
         "--no-force-installations",
         "install",
     ]
-    installargs.extend(selected.split())
+    installargs.extend(selected)
     subprocess.run(installargs, check=True)
 
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -189,8 +189,8 @@ def select_pkgs(
         print("\n".join(sorted(names)))
         print("")
     namebits = [name.split(".") for name in sorted(names)]
-    prevbits: Optional[List[str]] = None
-    leafs: List[List[str]] = []
+    prevbits = None
+    leafs = []
     for bits in namebits:
         if prevbits:
             plen = len(prevbits)

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -88,7 +88,9 @@ def fetch_installer(verbose):
     try:
         url = "https://download.qt.io/official_releases/online_installers/" + installer
         urllib.request.urlretrieve(url, installer)
-        print(f"Fetched installer {installer} for system {platform.system()} and machine {platform.machine()} successfully.")
+        print(
+            f"Fetched installer {installer} for system {platform.system()} and machine {platform.machine()} successfully."
+        )
     except urllib.error.URLError as e:
         sys.exit(f"Failed to download file: {e}")
     if platform.system() == "Darwin":
@@ -128,7 +130,7 @@ def fetch_installer(verbose):
 def get_available_pkgs(installer, ver):
     """Find the available packages for this Qt version."""
     verparts = ver.split(".")
-    output = subprocess.run(
+    command = (
         [
             installer,
             "se",
@@ -137,6 +139,10 @@ def get_available_pkgs(installer, ver):
             "--filter-packages",
             f"Version=^{verparts[0]}\\.{verparts[1]}\\.{verparts[2]}-",
         ],
+    )
+    print("Command is", command)
+    output = subprocess.run(
+        command,
         capture_output=True,
         text=True,
         encoding="UTF-8",

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -142,8 +142,13 @@ def get_available_pkgs(installer, ver):
         capture_output=True,
         text=True,
         encoding="UTF-8",
-        check=True,
+        check=False,
     )
+    if output.returncode != 0:
+        sys.exit(
+            f"Error: Failed to run installer {output.returncode} {output.stderr}"
+        )
+       
     pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))
     return pkgxml
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -214,18 +214,17 @@ def select_pkgs(packagesxml, arch, verbose):
 
 def install(installer, dest, selected):
     """Install the selected packages."""
-    installargs = [installer]
-    installargs.extend(["--root", dest])
-    installargs.extend(
-        [
-            "--accept-licenses",
-            "--accept-obligations",
-            "--default-answer",
-            "--confirm-command",
-            "--no-force-installations",
-        ]
-    )
-    installargs.append("install")
+    installargs = [
+        installer,
+        "--root",
+        dest,
+        "--accept-licenses",
+        "--accept-obligations",
+        "--default-answer",
+        "--confirm-command",
+        "--no-force-installations",
+        "install",
+    ]
     installargs.extend(selected.split())
     subprocess.run(installargs, check=True)
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -147,7 +147,7 @@ def get_available_pkgs(installer, ver):
         )
     except subprocess.CalledProcessError as e:
         sys.exit(
-            f"Error: Installer failed, rc: {e.returncode}\\nCommand: {e.cmd}\\nstderr: {e.stderr}\\nstdout: {e.stdout})}"
+            f"Error: Installer failed, rc: {e.returncode}\\nCommand: {e.cmd}\\nstderr: {e.stderr}\\nstdout: {e.stdout}"
         )
 
     pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -160,11 +160,9 @@ def get_available_pkgs(installer, ver):
 
 def select_pkgs(packagesxml, hostarch, targetarch, verbose):
     """Select the packages we want to install."""
-    arch = hostarch
-    numarchs = 1
+    archs = [hostarch]
     if targetarch:
-        arch.append(targetarch)
-        numarchs += 1
+        archs.append(targetarch)
     tree = ET.fromstring(packagesxml)
     names = [pkg.get("name") for pkg in tree.findall("package")]
     if verbose:
@@ -187,7 +185,7 @@ def select_pkgs(packagesxml, hostarch, targetarch, verbose):
     others = 0
     for node in leafs:
         if node[0] == "extensions":
-            if node[1] in black or node[-1] != arch:
+            if node[1] in black or node[-1] not in archs:
                 if verbose:
                     print(f"extension {node}")
             else:
@@ -204,7 +202,7 @@ def select_pkgs(packagesxml, hostarch, targetarch, verbose):
                     print(f"module {node} *")
                 selected.append(".".join(node))
         else:
-            if node[-1] == arch:
+            if node[-1] in archs:
                 if verbose:
                     print(f"other {node} *")
                 selected.append(".".join(node))
@@ -212,8 +210,8 @@ def select_pkgs(packagesxml, hostarch, targetarch, verbose):
             else:
                 if verbose:
                     print(f"other {node}")
-    if others != numarchs:
-        sys.exit(f"Error: couldn't find architecture {hostarch}/{targetarch}")
+    if others != len(archs):
+        sys.exit(f"Error: couldn't find architecture {archs}")
     print(f"Selected packages are {selected}.", flush=True)
     return " ".join(selected)
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -147,7 +147,10 @@ def get_available_pkgs(installer, ver):
         )
     except subprocess.CalledProcessError as e:
         sys.exit(
-            f"Error: Installer failed, rc: {e.returncode}\\nCommand: {e.cmd}\\nstderr: {e.stderr}\\nstdout: {e.stdout}"
+            f"""Error: Installer failed, rc: {e.returncode}
+            Command: {e.cmd}
+            stderr: {e.stderr}
+            stdout: {e.stdout}"""
         )
 
     pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -130,16 +130,14 @@ def fetch_installer(verbose):
 def get_available_pkgs(installer, ver):
     """Find the available packages for this Qt version."""
     verparts = ver.split(".")
-    command = (
-        [
-            installer,
-            "se",
-            "--type",
-            "package",
-            "--filter-packages",
-            f"Version=^{verparts[0]}\\.{verparts[1]}\\.{verparts[2]}-",
-        ],
-    )
+    command = [
+        installer,
+        "se",
+        "--type",
+        "package",
+        "--filter-packages",
+        f"Version=^{verparts[0]}\\.{verparts[1]}\\.{verparts[2]}-",
+    ]
     print("Command is", command)
     output = subprocess.run(
         command,

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -130,25 +130,26 @@ def fetch_installer(verbose):
 def get_available_pkgs(installer, ver):
     """Find the available packages for this Qt version."""
     verparts = ver.split(".")
-    output = subprocess.run(
-        [
-            installer,
-            "se",
-            "--type",
-            "package",
-            "--filter-packages",
-            f"Version=^{verparts[0]}\\.{verparts[1]}\\.{verparts[2]}-",
-        ],
-        capture_output=True,
-        text=True,
-        encoding="UTF-8",
-        check=False,
-    )
-    if output.returncode != 0:
-        sys.exit(
-            f"Error: Failed to run installer {output.returncode} {output.stderr}"
+    try:
+        output = subprocess.run(
+            [
+                installer,
+                "se",
+                "--type",
+                "package",
+                "--filter-packages",
+                f"Version=^{verparts[0]}\\.{verparts[1]}\\.{verparts[2]}-",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="UTF-8",
+            check=True,
         )
-       
+    except subprocess.CalledProcessError as e:
+        sys.exit(
+            f"Error: Installer failed, rc: {e.returncode}\\nCommand: {e.cmd}\\nstderr: {e.stderr}\\nstdout: {e.stdout})}"
+        )
+
     pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))
     return pkgxml
 

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -148,7 +148,7 @@ def get_available_pkgs(installer, ver):
     )
     if output.returncode != 0:
         sys.exit(
-            f"Error: Failed to run installer {output.returncode} {output.stderr}}"
+            f"Error: Failed to run installer {output.returncode} {output.stderr}"
         )
        
     pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -1,0 +1,265 @@
+#!/bin/python3
+"""
+Copyright (C) 2025 Robert Lipe, robertlipe+source@gpsbabel.org
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+
+rejectlicense = [
+    "qtcharts",
+    "qtdatavis3d",
+    "qtgraphs",
+    "qtgrpc",
+    "qthttpserver",
+    "qtlottie",
+    "qtnetworkauth",
+    "qtquick3d",
+    "qtquick3dphysics",
+    "qtquicktimeline",
+    "qtwebglplugin",
+    "qtshadertools",
+    "qtvirtualkeyboard",
+    "qtwaylandcompositor",
+]
+unused = [
+    "qtinsighttracker",  # extension
+    "qt3d",
+    "qtactiveqt",
+    "qtconnectivity",
+    "qtlanguageserver",
+    "qtlocation",
+    "qtmultimedia",
+    "qtquickeffectmaker",
+    "qtremoteobjects",
+    "qtscxml",
+    "qtsensors",
+    "qtspeech",
+    "qtwebsockets",
+]
+black = []
+black.extend(rejectlicense)
+black.extend(unused)
+
+
+def fetch_installer(verbose):
+    """Fetch the appropriate Qt online installer."""
+    installer = None
+    if platform.system() == "Windows":
+        if platform.machine() == "x86_64":
+            installer = "qt-online-installer-windows-x64-online.exe"
+        elif platform.machine() == "arm64":
+            installer = "qt-online-installer-windows-arm64-online.exe"
+    elif platform.system() == "Darwin":
+        # note this may require rosetta is installed on arm64 macs.
+        installer = "qt-online-installer-mac-x64-online.dmg"
+    elif platform.system() == "Linux":
+        if platform.machine() == "x86_64":
+            installer = "qt-online-installer-linux-x64-online.run"
+        elif platform.machine() == "arm64":
+            installer = "qt-online-installer-linux-arm64-online.run"
+    if installer is None:
+        sys.exit(
+            f"Error: Unknown installer for system {platform.system} and machine {platform.machine}"
+        )
+    try:
+        url = "https://download.qt.io/official_releases/online_installers/" + installer
+        urllib.request.urlretrieve(url, installer)
+        print(f"Fetched installer {installer} successfully.")
+    except urllib.error.URLError as e:
+        sys.exit(f"Failed to download file: {e}")
+    if platform.system() == "Darwin":
+        output = subprocess.run(
+            ["hdiutil", "attach", installer],
+            capture_output=True,
+            text=True,
+            encoding="UTF-8",
+            check=True,
+        )
+        volumes = re.findall(
+            r"^.*qt-online-installer.*$", output.stdout, flags=re.MULTILINE
+        )
+        if len(volumes) != 1:
+            sys.exit(f"Error: couldn't find macos volume in {volumes}")
+        volume = Path(volumes[0].split("\t")[2])
+        apps = list(volume.glob("*.app"))
+        if len(apps) != 1:
+            sys.exit(f"Error: couldn't find macos app in {apps}")
+        app = apps[0].name
+        exe = apps[0].stem
+        apppath = volume / app / "Contents" / "MacOS" / exe
+        if verbose:
+            print("vol is", volume, "app is", app, "app path is", apppath)
+        subprocess.run(["cp", "-R", apppath, app], check=True)
+        subprocess.run(["hdiutil", "detach", volume, "-quiet"], check=True)
+        return os.path.abspath(os.path.join(app, "Contents", "MacOS", exe))
+    st = os.stat(installer)
+    os.chmod(installer, st.st_mode | (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+    return os.path.abspath(installer)
+
+
+def get_available_pkgs(installer, ver):
+    """Find the available packages for this Qt version."""
+    verparts = ver.split(".")
+    output = subprocess.run(
+        [
+            installer,
+            "se",
+            "--type",
+            "package",
+            "--filter-packages",
+            f"Version=^{verparts[0]}\\.{verparts[1]}\\.{verparts[2]}-",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="UTF-8",
+        check=True,
+    )
+    pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))
+    return pkgxml
+
+
+def select_pkgs(packagesxml, arch, verbose):
+    """Select the packages we want to install."""
+    tree = ET.fromstring(packagesxml)
+    names = [pkg.get("name") for pkg in tree.findall("package")]
+    if verbose:
+        print(sorted(names))
+    namebits = [name.split(".") for name in sorted(names)]
+    prevbits = [None, None, None, None, None]
+    leafs = []
+    for bits in namebits:
+        plen = len(prevbits)
+        blen = len(bits)
+        if blen == plen + 1 and bits[0:plen] == prevbits[0:plen]:
+            if verbose:
+                print("internal node", prevbits)
+            leafs.pop()
+        leafs.append(bits)
+        prevbits = bits
+    if verbose:
+        print(f"found {len(leafs)} leafs from {len(namebits)} nodes.")
+    selected = []
+    others = 0
+    for node in leafs:
+        if node[0] == "extensions":
+            if node[1] in black or node[-1] != arch:
+                if verbose:
+                    print(f"extension {node}")
+            else:
+                if verbose:
+                    print(f"extension {node} *")
+                selected.append(".".join(node))
+        # a few modules in 6.2.4, 6.5.3 weren't in addons, e.g. qt5compat
+        elif node[-1].startswith("qt"):
+            if node[-1] in black:
+                if verbose:
+                    print(f"module {node}")
+            else:
+                if verbose:
+                    print(f"module {node} *")
+                selected.append(".".join(node))
+        else:
+            if node[-1] == arch:
+                if verbose:
+                    print(f"other {node} *")
+                selected.append(".".join(node))
+                others += 1
+            else:
+                if verbose:
+                    print(f"other {node}")
+    if others != 1:
+        sys.exit(f"Error: couldn't find architecture {arch}")
+    print(f"Selected packages are {selected}.")
+    return " ".join(selected)
+
+
+def install(installer, dest, selected):
+    """Install the selected packages."""
+    installargs = [installer]
+    installargs.extend(["--root", dest])
+    installargs.extend(
+        [
+            "--accept-licenses",
+            "--accept-obligations",
+            "--default-answer",
+            "--confirm-command",
+            "--no-force-installations",
+        ]
+    )
+    installargs.append("install")
+    installargs.extend(selected.split())
+    subprocess.run(installargs, check=True)
+
+
+def cleanup(dest, ver):
+    """Delete all the stuff we don't want that the Qt installer insists on installing."""
+    dpath = Path(dest)
+    vpath = dpath / ver
+    for entry in dpath.iterdir():
+        if not entry.samefile(vpath):
+            if entry.is_file():
+                print(f"removing file {entry}")
+                entry.unlink()
+            elif entry.is_dir():
+                shutil.rmtree(entry)
+                print(f"removing dir {entry}")
+            else:
+                print(f"unknown directory entry {entry}")
+
+
+def main():
+    """Install Qt."""
+    parser = argparse.ArgumentParser(
+        prog="ci_install_qt",
+        description="Install Qt using official online installer",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("ver", help="version, e.g. 6.10.1")
+    parser.add_argument(
+        "arch",
+        help="architecture, e.g. win64_msvc2022_64, win64_msvc2022_arm64, linux_gcc_64, clang_64",
+    )
+    parser.add_argument("dest", help="install root, e.g. C:\\Qt")
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        help="verbose",
+        action="store_const",
+        const=True,
+        default=False,
+    )
+    args = parser.parse_args()
+
+    installer = fetch_installer(verbose=args.verbose)
+    packagexml = get_available_pkgs(installer=installer, ver=args.ver)
+    selected = select_pkgs(packagesxml=packagexml, arch=args.arch, verbose=args.verbose)
+    install(installer=installer, dest=args.dest, selected=selected)
+    cleanup(dest=args.dest, ver=args.ver)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -111,11 +111,15 @@ def fetch_installer(verbose):
         app = apps[0].name
         exe = apps[0].stem
         apppath = volume / app / "Contents" / "MacOS" / exe
+        tgtpath = os.path.abspath(os.path.join(app, "Contents", "MacOS", exe))
         if verbose:
-            print("vol is", volume, "app is", app, "app path is", apppath)
+            print("Volume is", volume)
+            print("App is", app)
+            print("App path is", apppath)
+            print("Installed installer is", tgtpath)
         subprocess.run(["cp", "-R", apppath, app], check=True)
         subprocess.run(["hdiutil", "detach", volume, "-quiet"], check=True)
-        return os.path.abspath(os.path.join(app, "Contents", "MacOS", exe))
+        return tgtpath
     st = os.stat(installer)
     os.chmod(installer, st.st_mode | (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
     return os.path.abspath(installer)

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -269,7 +269,7 @@ def main():
     )
     args = parser.parse_args()
 
-    jwt = os.getenv('QT_INSTALLER_JWT_TOKEN')
+    jwt = os.getenv("QT_INSTALLER_JWT_TOKEN")
     if jwt is None or len(jwt) == 0:
         print("Warning: QT_INSTALLER_JWT_TOKEN not set")
     installer = fetch_installer(verbose=args.verbose)

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -88,7 +88,7 @@ def fetch_installer(verbose):
     try:
         url = "https://download.qt.io/official_releases/online_installers/" + installer
         urllib.request.urlretrieve(url, installer)
-        print(f"Fetched installer {installer} successfully.")
+        print(f"Fetched installer {installer} for system {platform.system()} and machine {platform.machine()} successfully.")
     except urllib.error.URLError as e:
         sys.exit(f"Failed to download file: {e}")
     if platform.system() == "Darwin":

--- a/tools/ci_install_qt.py
+++ b/tools/ci_install_qt.py
@@ -161,9 +161,11 @@ def get_available_pkgs(installer: str, ver: str, verbose: int) -> str:
             stderr: {e.stderr}
             stdout: {e.stdout}"""
         )
-    pkgxml = "\n".join(re.findall(r"^(?!\[).*$", output.stdout, flags=re.MULTILINE))
-    if len(pkgxml) == 0:
+    xmlre = r"^(?:<\?xml.*?\?>[ \t\r\n]*)?<availablepackages>.*?</availablepackages>"
+    xmlmatch = re.search(xmlre, output.stdout, flags=re.MULTILINE | re.DOTALL)
+    if not xmlmatch:
         sys.exit(output.stdout)
+    pkgxml = xmlmatch.group()
     if verbose > 2:
         print(pkgxml)
     print(f"Fetched available packages for {ver}.", flush=True)

--- a/tools/ci_install_qt.sh
+++ b/tools/ci_install_qt.sh
@@ -17,6 +17,7 @@ available=( $(aqt list-qt "$host" desktop --modules "$version" "$arch") )
 # remove commercial/GPLv3 modules, see https://doc-snapshots.qt.io/qt6-dev/qtmodules.html
 remove=( \
 debug_info \
+qtcanvaspainter \
 qtcharts \
 qtdatavis3d \
 qtgraphs \
@@ -46,6 +47,7 @@ qtremoteobjects \
 qtscxml \
 qtsensors \
 qtspeech \
+qttasktree \
 qtwebsockets \
 )
 

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -70,6 +70,8 @@ else
     if [ -n "${PACKAGE_SUFFIX_CROSS}" ]; then
       "${CI_BUILD_DIR}/tools/ci_install_qt.sh" "${HOST}" "${QT_VERSION}" "${PACKAGE_SUFFIX_CROSS}" "${CACHEDIR}/Qt"
     fi
+  elif [ "${METHOD}" = "qtonline" ]; then
+      python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2
     exit 1

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -71,7 +71,14 @@ else
       "${CI_BUILD_DIR}/tools/ci_install_qt.sh" "${HOST}" "${QT_VERSION}" "${PACKAGE_SUFFIX_CROSS}" "${CACHEDIR}/Qt"
     fi
   elif [ "${METHOD}" = "qtonline" ]; then
-      python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt" --verbose
+    args=(--ver "${QT_VERSION}")
+    args+=(--hostarch "${PACKAGE_SUFFIX}")
+    if [ -n "${PACKAGE_SUFFIX_CROSS}" ]; then
+      args+=(--targetarch "${PACKAGE_SUFFIX_CROSS}")
+    fi
+    args+=(--dest "${CACHEDIR}/Qt")
+    args+=(--verbose)
+    python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${args[@]}"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2
     exit 1

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -61,7 +61,8 @@ else
 
   if [ "${METHOD}" = "aqt" ]; then
     # we need https://github.com/miurahr/aqtinstall/pull/941 to install extensions with 6.10.0 for windows arm64.
-    # until this is merged and released use a locally generated version of aqt.
+    # we need https://github.com/miurahr/aqtinstall/pull/952 to install the cross compiler with 6.10.1.
+    # until these are merged and released we must use a locally generated version of aqt.
     #pip3 install 'aqtinstall>=3.3.0'
     archive=aqtinstall-3.3.1.dev18-py3-none-any.whl
     curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY}" "${ARTIFACTORY_BASE_URL}/${archive}" -o "/tmp/${archive}"

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -71,7 +71,7 @@ else
       "${CI_BUILD_DIR}/tools/ci_install_qt.sh" "${HOST}" "${QT_VERSION}" "${PACKAGE_SUFFIX_CROSS}" "${CACHEDIR}/Qt"
     fi
   elif [ "${METHOD}" = "qtonline" ]; then
-      python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt"
+      python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${QT_VERSION}" "${PACKAGE_SUFFIX}" "${CACHEDIR}/Qt" --verbose
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2
     exit 1

--- a/tools/ci_install_windows.sh
+++ b/tools/ci_install_windows.sh
@@ -78,7 +78,7 @@ else
       args+=(--targetarch "${PACKAGE_SUFFIX_CROSS}")
     fi
     args+=(--dest "${CACHEDIR}/Qt")
-    args+=(--verbose)
+    args+=(-v -v)
     python3 "${CI_BUILD_DIR}/tools/ci_install_qt.py" "${args[@]}"
   else
     echo "ERROR: unknown installation method ${METHOD}." >&2

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "gpsbabel-tools"
+requires-python = ">= 3.9"
+dynamic = ["version"]
+license = "GPL-2.0-or-later"
+
+[project.urls]
+Homepage = "https://www.gpsbabel.org"
+Repository = "https://github.com/GPSBabel/gpsbabel"
+
+[tool.black]
+line-length = 100
+
+# flake8 doesn't support pyproject.toml
+# configuration is in .flake8
+
+[tool.mypy]
+strict = true
+


### PR DESCRIPTION
This adds the capability to use the official Qt installer.  We are currently using a patched version of aqt to overcome difficulties installing on windows, the fixes we need have not been released.  The official Qt installer may be utilized in CI by:

1. adding a secret QT_INSTALLER_JWT_TOKEN containing a java web token.  The token can be found in your qtaccount.ini file after logging in with the installer interactively.  See https://doc.qt.io/qt-6/get-and-install-qt-cli.html.  Note this will not work from forked repositories, see https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#using-secrets-in-a-workflow.  However PRs can use the cache from the master branch.  Therefore PRs that require a different cache, for example when switching to a new version of Qt, should be from a branch in https://github.com/GPSBabel/gpsbabel.git.
2. For windows, change the METHOD to qtonline in .github/workflows/windows.yml.  For macos, change the second parameter in the call to ci_install_osx.sh to qtonline in .github/workflows/macos.yml.