### PR TITLE
reduce archive sizes

### DIFF
--- a/tools/archive_images/Dockerfile_gpsbabel_1.10.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.10.0
@@ -69,7 +69,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
  && mkdir bld \
  && cd bld \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig .. \
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGPSBABEL_ENABLE_PCH=OFF .. \
  && cmake --build . --target package_app \
  && cmake --build . --target check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \

--- a/tools/archive_images/Dockerfile_gpsbabel_1.9.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.9.0
@@ -77,7 +77,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
  && mkdir bld \
  && cd bld \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig .. \
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGPSBABEL_ENABLE_PCH=OFF .. \
  && cmake --build . --target package_app \
  && cmake --build . --target check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \

--- a/tools/archive_images/Dockerfile_gpsbabel_dev
+++ b/tools/archive_images/Dockerfile_gpsbabel_dev
@@ -72,7 +72,7 @@ RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
  && mkdir bld \
  && cd bld \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGB.PACKAGE_RELEASE="+$(git log -1 --format=%h)" .. \
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGPSBABEL_ENABLE_PCH=OFF -DGB.PACKAGE_RELEASE="+$(git log -1 --format=%h)" .. \
  && cmake --build . --target package_app \
  && cmake --build . --target check \
  && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \


### PR DESCRIPTION
It turns out the PCH build consumes significantly more space.