### PR TITLE
Rework archive image builds.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: 'verison to archive'
+        description: 'version to archive'
         required: false
         default: dev
         type: string
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'verison to archive'
+        description: 'version to archive'
         required: true
         type: string
       latest:
@@ -33,6 +33,29 @@ jobs:
     env:
       docker_repository: ${{ case(github.repository == 'GPSBabel/gpsbabel', 'tsteven4/gpsbabel', 'tsteven4/testing') }}
     steps:
+    - name: Compute tag
+      id: compute
+      run: |
+        if [ "${{ inputs.version }}" == "dev" ]; then
+          echo "tag=master" >> "$GITHUB_OUTPUT"
+        else
+          echo "tag=gpsbabel_$(echo ${{ inputs.version }} | tr . _)" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ steps.compute.outputs.tag }}
+        fetch-depth: 0
+    - name: Update archive_images
+      run: |
+        git checkout ${{ github.sha }} -- tools/archive_images
+    - name: Patch
+      run: |
+        patch=tools/archive_images/gpsbabel_$(echo ${{ inputs.version }} | tr . _).patch
+        if [ -e "${patch}" ]; then
+          echo "Applying patch ${patch}"
+          git apply -v "${patch}"
+        fi
     - name: Login to Docker Hub
       uses: docker/login-action@v4
       with:
@@ -40,18 +63,19 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
-    - name: Build and export to Docker
+    - name: Build and load
       uses: docker/build-push-action@v7
       with:
-        context: "{{defaultContext}}:tools/archive_images"
-        file: "Dockerfile_gpsbabel_${{ inputs.version }}"
+        context: .
+        file: ./tools/archive_images/Dockerfile_gpsbabel_${{ inputs.version }}
         load: true
         tags: "${{ env.docker_repository }}:test_${{ inputs.version }}"
     - name: Test
       run: |
         # tests failed before 1.6.0 (and repository structure was different)
         if [[ "${{ inputs.version }}" == "dev" || $(echo -e "${{ inputs.version }}\n1.6.0" | sort -V | head -n1) == "1.6.0" ]]; then
-          docker run --rm -w /home/gpsbabel/gpsbabel-build -e PNAME=/usr/local/bin/gpsbabel "${{ env.docker_repository }}:test_${{ inputs.version }}" ./testo
+          docker run --rm --volume ${{ github.workspace }}:/app "${{ env.docker_repository }}:test_${{ inputs.version }}" \
+            /bin/bash -c 'PNAME=$(which gpsbabel) ./testo'
         fi
     - name: Docker Metadata
       id: meta
@@ -65,10 +89,13 @@ jobs:
           type=raw,value=${{ inputs.version }}
           type=raw,value=${{ inputs.version }}_{{date 'YYYYMMDD[T]HHmmss[Z]' tz='UTC'}}
           type=raw,value=latest,enable=${{ inputs.latest }}
+        context: git
     - name: Build and push
       uses: docker/build-push-action@v7
       with:
-        context: "{{defaultContext}}:tools/archive_images"
-        file: "Dockerfile_gpsbabel_${{ inputs.version }}"
+        context: .
+        file: ./tools/archive_images/Dockerfile_gpsbabel_${{ inputs.version }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}

--- a/tools/archive_images/Dockerfile_gpsbabel_1.10.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.10.0
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:noble
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:noble AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -59,22 +55,59 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_10_0 \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && rm -fr shapelib \
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
- && mkdir bld \
- && cd bld \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGPSBABEL_ENABLE_PCH=OFF .. \
- && cmake --build . --target package_app \
- && cmake --build . --target check \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -B bld \
+ && cmake --build bld --target package_app \
+ && cmake --build bld --target check \
+ && mkdir -p /usr/local/cellar \
+ && cp -pr bld/gui/GPSBabelFE /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:noble
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# the trick here is finding all the packages that we, and the plugins we
+# use need.  Note we had to figure this out for  snapcraft, but it
+# changes for different flavors of ubuntu.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    libusb-1.0-0 \
+    libudev1 \
+    libshp4 \
+    zlib1g \
+    libqt6core6 \
+    libqt6core5compat6 \
+    libqt6gui6 \
+    libqt6network6 \
+    libqt6serialport6 \
+    libqt6widgets6 \
+    libqt6xml6 \
+    libqt6webenginewidgets6 \
+    libqt6webenginecore6 \
+    libqt6webenginecore6-bin \
+    qt6-translations-l10n \
+    qt6-qpa-plugins \
+    qt6-wayland \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin
+
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.0
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:focal
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:focal AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -57,21 +53,55 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_1_5_0.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_5_0 \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && cd gpsbabel \
- && git apply /home/gpsbabel/gpsbabel_1_5_0.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabel1.5.0/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabel1.5.0 /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabel1.5.0/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel1.5.0/gpsbabelfe /usr/local/bin \
+ && cp ../tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# HINTS
+# apt-cache depends gpsbabel
+# apt-cache depends gpsbabel-gui
+# focal shipped gpsbabel 1.6.0 using webengine
+# note our early builds didn't use system shapelib (delete libshp2)
+# note our early builds used webkit instead of webengine (add libqt5webkit5, delete libqt5webenginewidgets5)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5webchannel5 \
+    libqt5webkit5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    libshp2 \
+    libstdc++6 \
+    libusb-0.1-4 \
+    zlib1g \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabel*/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel*/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.1
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.1
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:focal
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:focal AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -57,21 +53,55 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_1_5_1.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_5_1 \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && cd gpsbabel \
- && git apply /home/gpsbabel/gpsbabel_1_5_1.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabel1.5.1/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabel1.5.1 /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabel1.5.1/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel1.5.1/gpsbabelfe /usr/local/bin \
+ && cp ../tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# HINTS
+# apt-cache depends gpsbabel
+# apt-cache depends gpsbabel-gui
+# focal shipped gpsbabel 1.6.0 using webengine
+# note our early builds didn't use system shapelib (delete libshp2)
+# note our early builds used webkit instead of webengine (add libqt5webkit5, delete libqt5webenginewidgets5)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5webchannel5 \
+    libqt5webkit5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    libshp2 \
+    libstdc++6 \
+    libusb-0.1-4 \
+    zlib1g \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabel*/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel*/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.2
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.2
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:focal
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:focal AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -57,23 +53,55 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_1_5_2.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_5_2 \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && cd gpsbabel \
- && git apply /home/gpsbabel/gpsbabel_1_5_2.patch \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabel1.5.2/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabel1.5.2 /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabel1.5.2/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel1.5.2/gpsbabelfe /usr/local/bin \
+ && cp ../tools/archive_images/setup_user.sh /usr/local/bin
 
-#ENTRYPOINT ["/usr/local/bin/gpsbabel"]
+FROM ubuntu:focal
 
-COPY setup_user.sh /usr/local/bin
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# HINTS
+# apt-cache depends gpsbabel
+# apt-cache depends gpsbabel-gui
+# focal shipped gpsbabel 1.6.0 using webengine
+# note our early builds didn't use system shapelib (delete libshp2)
+# note our early builds used webkit instead of webengine (add libqt5webkit5, delete libqt5webenginewidgets5)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5webchannel5 \
+    libqt5webkit5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    libshp2 \
+    libstdc++6 \
+    libusb-0.1-4 \
+    zlib1g \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabel*/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel*/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.3
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.3
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:focal
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:focal AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -57,20 +53,54 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_1_5_3.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_5_3 \
- && git apply /home/gpsbabel/gpsbabel_1_5_3.patch \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabel1.5.3/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabel1.5.3 /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabel1.5.3/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel1.5.3/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# HINTS
+# apt-cache depends gpsbabel
+# apt-cache depends gpsbabel-gui
+# focal shipped gpsbabel 1.6.0 using webengine
+# note our early builds didn't use system shapelib (delete libshp2)
+# note our early builds used webkit instead of webengine (add libqt5webkit5, delete libqt5webenginewidgets5)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5webchannel5 \
+    libqt5webkit5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    libshp2 \
+    libstdc++6 \
+    libusb-0.1-4 \
+    zlib1g \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabel*/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel*/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.5.4
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.5.4
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:focal
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:focal AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -57,20 +53,54 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_1_5_4.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_5_4 \
- && git apply /home/gpsbabel/gpsbabel_1_5_4.patch \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && autoconf -f && ./configure --with-zlib=system && make -j 10 linux-gui \
- && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabel1.5.4/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabel1.5.4 /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabel1.5.4/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel1.5.4/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# HINTS
+# apt-cache depends gpsbabel
+# apt-cache depends gpsbabel-gui
+# focal shipped gpsbabel 1.6.0 using webengine
+# note our early builds didn't use system shapelib (delete libshp2)
+# note our early builds used webkit instead of webengine (add libqt5webkit5, delete libqt5webenginewidgets5)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5webchannel5 \
+    libqt5webenginewidgets5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    libshp2 \
+    libstdc++6 \
+    libusb-0.1-4 \
+    zlib1g \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabel*/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel*/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.6.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.6.0
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:focal
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:focal AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -29,7 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
-    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -58,20 +53,54 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_1_6_0.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_6_0.1 \
- && patch < /home/gpsbabel/gpsbabel_1_6_0.patch \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && ./configure --with-zlib=system && make -j 10 linux-gui && make check \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabelFE /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:focal
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# HINTS
+# apt-cache depends gpsbabel
+# apt-cache depends gpsbabel-gui
+# focal shipped gpsbabel 1.6.0 using webengine
+# note our early builds didn't use system shapelib (delete libshp2)
+# note our early builds used webkit instead of webengine (add libqt5webkit5, delete libqt5webenginewidgets5)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5webchannel5 \
+    libqt5webenginewidgets5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    libshp2 \
+    libstdc++6 \
+    libusb-0.1-4 \
+    zlib1g \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabel*/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabel*/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.7.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.7.0
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:jammy
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:jammy AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -29,7 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     curl \
     ca-certificates \
-    patch \
  && rm -rf /var/lib/apt/lists/*
 
 # pkgs with libraries needed by gpsbabel
@@ -58,20 +53,50 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_1_7_0.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_7_0 \
- && patch < /home/gpsbabel/gpsbabel_1_7_0.patch \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && ./configure --with-zlib=system && make -j 10 linux-gui && make check \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabelFE /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:jammy
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# for hints 
+# ubuntu jammy gpsbabel (1.8.0+ds-4) dependencies
+# ubuntu jammy gpsbabel-gui (1.8.0+ds-4) dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libudev1 \
+    libusb-1.0-0 \
+    zlib1g \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5serialport5 \
+    libqt5webchannel5 \
+    libqt5webenginewidgets5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    qttranslations5-l10n \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.8.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.8.0
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:jammy
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:jammy AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -57,19 +53,53 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_8_0 \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && rm -fr shapelib \
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
  && qmake WITH_ZLIB=pkgconfig WITH_SHAPELIB=pkgconfig && make -j 10 unix-gui && make check \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+ && mkdir -p /usr/local/cellar \
+ && cp -pr gui/GPSBabelFE /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:jammy
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# for hints 
+# ubuntu jammy gpsbabel (1.8.0+ds-4) dependencies
+# ubuntu jammy gpsbabel-gui (1.8.0+ds-4) dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libshp2 \
+    libudev1 \
+    libusb-1.0-0 \
+    zlib1g \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5network5 \
+    libqt5serialport5 \
+    libqt5webchannel5 \
+    libqt5webenginewidgets5 \
+    libqt5widgets5 \
+    libqt5xml5 \
+    qttranslations5-l10n \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin
+
 RUN useradd ubuntu -m -s /bin/bash
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_1.9.0
+++ b/tools/archive_images/Dockerfile_gpsbabel_1.9.0
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:jammy
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:noble AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -40,21 +36,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pkgs with qt used by gpsbabel
 RUN apt-get update && apt-get install -y --no-install-recommends \
     qt6-base-dev \
-    libqt6core5compat6-dev \
-    libqt6opengl6-dev \
-    libqt6serialport6-dev \
-    libqt6webenginecore6-bin \
-    libgl-dev \
-    libopengl-dev \
-    libvulkan-dev \
+    qt6-5compat-dev \
+    qt6-serialport-dev \
     libx11-xcb-dev \
     libxkbcommon-dev \
-    qt6-l10n-tools \
     qt6-tools-dev \
-    qt6-tools-dev-tools \
     qt6-translations-l10n \
     qt6-webengine-dev \
-    qt6-webengine-dev-tools \
     qt6-wayland \
  && rm -rf /var/lib/apt/lists/*
 
@@ -67,23 +55,59 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git checkout gpsbabel_1_9_0 \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && rm -fr shapelib \
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
- && mkdir bld \
- && cd bld \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGPSBABEL_ENABLE_PCH=OFF .. \
- && cmake --build . --target package_app \
- && cmake --build . --target check \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -B bld \
+ && cmake --build bld --target package_app \
+ && cmake --build bld --target check \
+ && mkdir -p /usr/local/cellar \
+ && cp -pr bld/gui/GPSBabelFE /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
-RUN useradd ubuntu -m -s /bin/bash
+FROM ubuntu:noble
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# the trick here is finding all the packages that we, and the plugins we
+# use need.  Note we had to figure this out for  snapcraft, but it
+# changes for different flavors of ubuntu.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    libusb-1.0-0 \
+    libudev1 \
+    libshp4 \
+    zlib1g \
+    libqt6core6 \
+    libqt6core5compat6 \
+    libqt6gui6 \
+    libqt6network6 \
+    libqt6serialport6 \
+    libqt6widgets6 \
+    libqt6xml6 \
+    libqt6webenginewidgets6 \
+    libqt6webenginecore6 \
+    libqt6webenginecore6-bin \
+    qt6-translations-l10n \
+    qt6-qpa-plugins \
+    qt6-wayland \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin
+
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/Dockerfile_gpsbabel_dev
+++ b/tools/archive_images/Dockerfile_gpsbabel_dev
@@ -1,10 +1,6 @@
 # this file is used to build the image gpsbabel_build_environment used by travis.
 
-FROM ubuntu:noble
-
-LABEL maintainer="https://github.com/tsteven4"
-
-WORKDIR /app
+FROM ubuntu:noble AS stage
 
 # update environment.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -59,25 +55,59 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && locale-gen \
  && locale -a
 
-WORKDIR /home/gpsbabel
-
-COPY gpsbabel_dev.patch /home/gpsbabel
-
-RUN git clone https://github.com/GPSBabel/gpsbabel.git gpsbabel-build\
- && cd gpsbabel-build \
- && git apply /home/gpsbabel/gpsbabel_dev.patch \
+RUN --mount=type=bind,target=/home/gpsbabel/gpsbabel-build,rw cd /home/gpsbabel/gpsbabel-build \
  && rm -fr zlib \
  && rm -fr shapelib \
- && rm -f testo.d/serialization.test \
  && sed -i -e"/GB.SHA/i set(ENV{GITHUB_SHA} \"$(git log -1 --format=%h)\")" gbversion.cmake \
- && mkdir bld \
- && cd bld \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGPSBABEL_ENABLE_PCH=OFF -DGB.PACKAGE_RELEASE="+$(git log -1 --format=%h)" .. \
- && cmake --build . --target package_app \
- && cmake --build . --target check \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabel /usr/local/bin \
- && ln -s $(pwd)/gui/GPSBabelFE/gpsbabelfe /usr/local/bin 
+ && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DGPSBABEL_WITH_ZLIB=pkgconfig -DGPSBABEL_WITH_SHAPELIB=pkgconfig -DGB.PACKAGE_RELEASE="+$(git log -1 --format=%h)" -B bld \
+ && cmake --build bld --target package_app \
+ && cmake --build bld --target check \
+ && mkdir -p /usr/local/cellar \
+ && cp -pr bld/gui/GPSBabelFE /usr/local/cellar \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin \
+ && cp tools/archive_images/setup_user.sh /usr/local/bin
 
-COPY setup_user.sh /usr/local/bin
+FROM ubuntu:noble
+
+LABEL maintainer="https://github.com/tsteven4"
+
+# update environment.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# the trick here is finding all the packages that we, and the plugins we
+# use need.  Note we had to figure this out for  snapcraft, but it
+# changes for different flavors of ubuntu.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    libusb-1.0-0 \
+    libudev1 \
+    libshp4 \
+    zlib1g \
+    libqt6core6 \
+    libqt6core5compat6 \
+    libqt6gui6 \
+    libqt6network6 \
+    libqt6serialport6 \
+    libqt6widgets6 \
+    libqt6xml6 \
+    libqt6webenginewidgets6 \
+    libqt6webenginecore6 \
+    libqt6webenginecore6-bin \
+    qt6-translations-l10n \
+    qt6-qpa-plugins \
+    qt6-wayland \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage /usr/local/cellar /usr/local/cellar
+COPY --from=stage /usr/local/bin/setup_user.sh /usr/local/bin
+
+RUN ln -s /usr/local/cellar/GPSBabelFE/gpsbabel /usr/local/bin \
+ && ln -s /usr/local/cellar/GPSBabelFE/gpsbabelfe /usr/local/bin
+
 USER ubuntu:ubuntu
 WORKDIR /app

--- a/tools/archive_images/check_labels_annotations.sh
+++ b/tools/archive_images/check_labels_annotations.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+image=$1
+root=${image%%:*}
+
+# get manifests in image index and check them for annotations
+mapfile -t manifest < <(docker buildx imagetools inspect "${image}" --raw | jq -r .manifests[].digest)
+
+echo -e "\nChecking annotations in image manifest"
+for sha in "${manifest[@]}"
+do
+  docker buildx imagetools inspect --raw "${root}@${sha}" | jq .annotations
+done
+
+# get the image and check for labels
+docker pull -q "${image}" >/dev/null
+echo -e "\nChecking labels in image"
+docker inspect "${image}" | jq .[].Config.Labels

--- a/tools/archive_images/gpsbabel_dev.patch
+++ b/tools/archive_images/gpsbabel_dev.patch
@@ -11,3 +11,47 @@ index 50d6d1e3..4a7a5736 100644
    bool reportStatistics_{true};
    bool upgradeMenuEnabled_{true};
    bool mapPreviewEnabled_{true};
+diff --git a/testo.d/serialization.test b/testo.d/serialization.test
+deleted file mode 100644
+index 3eadff6a..00000000
+--- a/testo.d/serialization.test
++++ /dev/null
+@@ -1,38 +0,0 @@
+-# These outputs will change with any new format or changed format option.
+-# Format options should be automatically handled by the GUI.
+-# These outputs will change with any new filter or changed filter option.
+-# Filter options must be hand coded in the GUI.
+-#
+-# These are primarily meant to serialize the interface specification to
+-# the GUI and the document.
+-# We do a compare_nole as specific whitespace is part of deserialization.
+-gpsbabel -^3 > ${TMPDIR}/format3.txt
+-sed 's,https://www.gpsbabel.org/htmldoc-.[^/]*/,https://www.gpsbabel.org/WEB_DOC_DIR/,' ${TMPDIR}/format3.txt >${TMPDIR}/format3.fiddled.txt
+-compare_nole ${REFERENCE}/format3.txt ${TMPDIR}/format3.fiddled.txt
+-gpsbabel -^2 > ${TMPDIR}/format2.txt
+-compare_nole ${REFERENCE}/format2.txt ${TMPDIR}/format2.txt
+-gpsbabel -^1 > ${TMPDIR}/format1.txt
+-compare_nole ${REFERENCE}/format1.txt ${TMPDIR}/format1.txt
+-gpsbabel -^0 > ${TMPDIR}/format0.txt
+-compare_nole ${REFERENCE}/format0.txt ${TMPDIR}/format0.txt
+-gpsbabel -%1 > ${TMPDIR}/filter1.txt
+-sed 's,https://www.gpsbabel.org/htmldoc-.[^/]*/,https://www.gpsbabel.org/WEB_DOC_DIR/,' ${TMPDIR}/filter1.txt >${TMPDIR}/filter1.fiddled.txt
+-compare_nole ${REFERENCE}/filter1.txt ${TMPDIR}/filter1.fiddled.txt
+-gpsbabel -%0 > ${TMPDIR}/filter0.txt
+-compare_nole ${REFERENCE}/filter0.txt ${TMPDIR}/filter0.txt
+-
+-# These are primarily meant for a user
+-gpsbabel -h > ${TMPDIR}/help.txt
+-# ahh shucks, the executable changes based on OS, and the path can change as well.
+-sed 's/.*\[options\]/    .\/gpsbabel [options]/' ${TMPDIR}/help.txt > ${TMPDIR}/help.stripped.txt
+-compare ${REFERENCE}/help.txt ${TMPDIR}/help.stripped.txt
+-gpsbabel -h gpx > ${TMPDIR}/formatusage.txt
+-compare ${REFERENCE}/formatusage.txt ${TMPDIR}/formatusage.txt
+-gpsbabel -h radius > ${TMPDIR}/filterusage.txt
+-compare ${REFERENCE}/filterusage.txt ${TMPDIR}/filterusage.txt
+-gpsbabel > ${TMPDIR}/usage.txt << EOJ
+-
+-EOJ
+-# ahh shucks, the executable changes based on OS, and the path can change as well.
+-sed 's/.*\[options\]/    .\/gpsbabel [options]/' ${TMPDIR}/usage.txt > ${TMPDIR}/usage.stripped.txt
+-compare ${REFERENCE}/usage.txt ${TMPDIR}/usage.stripped.txt

--- a/tools/archive_images/make_docker_image_gpsbabel.sh
+++ b/tools/archive_images/make_docker_image_gpsbabel.sh
@@ -1,18 +1,58 @@
 #!/bin/bash -ex
 # you must be logged into docker for the push to succeed.
 
-versuffix=${1:+$1} # tag name must be lower case
+args=()
+while getopts "s:mpl" opt; do
+  case $opt in
+    s) versuffix="$OPTARG";;
+    m) args+=("--platform"); args+=("linux/amd64,linux/arm64");;
+    p) args+=("--push");;
+    l) args+=("--load");;
+    *) echo "Usage: $0 [-s suffix] [-m] [-p]"; exit 1;;
+  esac
+done
+shift $((OPTIND -1))
+
+if [ "${versuffix}" == "dev" ]; then
+  tag="master"
+else
+  tag="gpsbabel_$(echo "${versuffix}" | tr . _)"
+fi
+
+sourcedir=$(git rev-parse --show-toplevel)
+
+origin=$(git remote get-url origin | sed 's|.*github.com/\(.*\)|\1|;s|\.git$||')
+if [ "${origin,,}" == "GPSBabel/gpsbabel" ]; then
+  dockerrepo=tsteven4/gpsbabel
+else
+  dockerrepo=tsteven4/testing
+fi
+
 TMPDIR=$(mktemp -d)
+trap "rm -fr ${TMPDIR}" 0 1 2 3 15
+cd "${TMPDIR}"
 
-cp "Dockerfile_gpsbabel_${versuffix}" "$TMPDIR"
-cp setup_user.sh "$TMPDIR"
-cp ./*.patch "$TMPDIR"
+# get the branch we want to build
+git clone --depth 1 --branch "${tag}" https://github.com/tsteven4/gpsbabel.git
+cd gpsbabel
 
-docker build --pull --file "Dockerfile_gpsbabel_${versuffix}" \
-             --tag "tsteven4/gpsbabel:${versuffix}" \
+# override the docker build instructions with the current version.
+# note the docker build instructions may not exist in the branch,
+# or may exist and be outdated.
+mkdir -p tools
+rm -fr tools/archive_images
+cp -pr "${sourcedir}/tools/archive_images" tools
+
+# patch if necessary
+patch="tools/archive_images/gpsbabel_$(echo "${versuffix}" | tr . _).patch"
+if [ -e "${patch}" ]; then
+  git apply -v "${patch}"
+fi
+
+docker buildx build \
+             --pull \
+             --file "tools/archive_images/Dockerfile_gpsbabel_${versuffix}" \
+             "${args[@]}" \
+             --tag "${dockerrepo}:${versuffix}" \
              --progress=plain \
-             "$TMPDIR"
-
-/bin/rm -fr "$TMPDIR"
-#docker push tsteven4/gpsbabel:latest
-docker image ls
+             .

--- a/tools/archive_images/rebuild.sh
+++ b/tools/archive_images/rebuild.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -ex
-./make_docker_image_gpsbabel.sh 1.5.0
-./make_docker_image_gpsbabel.sh 1.5.1
-./make_docker_image_gpsbabel.sh 1.5.2
-./make_docker_image_gpsbabel.sh 1.5.3
-./make_docker_image_gpsbabel.sh 1.5.4
-./make_docker_image_gpsbabel.sh 1.6.0
-./make_docker_image_gpsbabel.sh 1.7.0
-./make_docker_image_gpsbabel.sh 1.8.0
-./make_docker_image_gpsbabel.sh 1.9.0
-./make_docker_image_gpsbabel.sh 1.10.0
+./make_docker_image_gpsbabel.sh -s 1.5.0
+./make_docker_image_gpsbabel.sh -s 1.5.1
+./make_docker_image_gpsbabel.sh -s 1.5.2
+./make_docker_image_gpsbabel.sh -s 1.5.3
+./make_docker_image_gpsbabel.sh -s 1.5.4
+./make_docker_image_gpsbabel.sh -s 1.6.0
+./make_docker_image_gpsbabel.sh -s 1.7.0
+./make_docker_image_gpsbabel.sh -s 1.8.0
+./make_docker_image_gpsbabel.sh -s 1.9.0
+./make_docker_image_gpsbabel.sh -s 1.10.0

--- a/tools/archive_images/test.sh
+++ b/tools/archive_images/test.sh
@@ -1,14 +1,28 @@
-#!/bin/bash -x
-SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+#!/bin/bash -ex
+# run testo on the docker images
 
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.0 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.1 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.2 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.3 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.5.4 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.6.0 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.7.0 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.8.0 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v 1.9.0 -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -- -D1
-"${SOURCE_DIR}/run_gpsbabel.sh" -v dev -- -D1
+versions=(1.5.0 1.5.1 1.5.2 1.5.3 1.5.4 1.6.0 1.7.0 1.8.0 1.9.0 1.10.0)
+for ver in "${versions[@]}"; do
+  ver_=$(echo "${ver}" | tr . _) 
+  tag=gpsbabel_${ver_}
+  TMPDIR=$(mktemp -d)
+  trap 'rm -fr ${TMPDIR}' 0 1 2 3 15
+  pushd "${TMPDIR}"
+  git clone --depth 1 --branch "${tag}" https://github.com/tsteven4/gpsbabel.git
+  cd gpsbabel
+  # early releases had testo under directory gpsbabel
+  if [ -d gpsbabel ]; then
+    cd gpsbabel
+  fi 
+  # run testo, using testo, the tests and references from the DUT.
+  # some tests failed before 1.6.0
+  if [[ "${ver}" == "dev" || $(echo -e "${ver}\n1.6.0" | sort -V | head -n1) == "1.6.0" ]]; then
+    # ver = dev, or ver >= 1.6.0
+    docker run -it --rm -v "$(pwd):/app" "tsteven4/testing:${ver}" /bin/bash -c 'PNAME=/usr/local/bin/gpsbabel ./testo'
+  else
+    # ver < 1.6.0
+    docker run -it --rm -v "$(pwd):/app" "tsteven4/testing:${ver}" /bin/bash -c 'PNAME=/usr/local/bin/gpsbabel ./testo || true'
+  fi
+  popd
+  rm -fr "${TMPDIR}"
+done


### PR DESCRIPTION
Add annotations and labels to images.
Move source tree manipulations out of docker.
Use a bind mount to access the patched source from docker. Use a multistage build to minimize the image size. Move 1.9.0 build from jammy to noble.

This dramatically reduces image size.