### PR TITLE
fix autouic warnings

### DIFF
--- a/gui/advui.ui
+++ b/gui/advui.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>288</width>
-    <height>196</height>
+    <height>206</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -191,4 +191,7 @@ Higher number provides more detailed diagnostics.</string>
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="advMapPreviewButtonGroup"/>
+ </buttongroups>
 </ui>

--- a/gui/preferences.ui
+++ b/gui/preferences.ui
@@ -203,4 +203,7 @@
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="mapPreviewButtonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
```
AutoUic: advui.ui: Warning: Creating button group `advMapPreviewButtonGroup'
AutoUic: preferences.ui: Warning: Creating button group `mapPreviewButtonGroup'
```

These were fixed by opening them in Qt 6.4.2 designer on linux, assigning the selected buttons to a new button group, and renaming the new button group to match the existing group name.  It seems like the tool used to generate the buttons is out of sync with autouic and designer.