### PR TITLE
Fix recovery of macos keychain identity 

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -97,8 +97,8 @@ jobs:
 
     - name: Install the Apple certificate
       env:
-        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE }}
+        P12_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
       run: |
         ./tools/ci_load_keychain.sh
 

--- a/tools/ci_load_keychain.sh
+++ b/tools/ci_load_keychain.sh
@@ -32,5 +32,5 @@ if [ -n "${GITHUB_ENV}" ]; then
     IDENTITY="-"
   fi
   echo "Loaded identity \"$IDENTITY\" for codesigning."
-  echo IDENTITY="${IDENTITY}" >> "$GITHUB_ENV"
+  echo "IDENTITY=${IDENTITY}" >> "$GITHUB_ENV"
 fi

--- a/tools/ci_load_keychain.sh
+++ b/tools/ci_load_keychain.sh
@@ -27,6 +27,9 @@ if [ -n "${BUILD_CERTIFICATE_BASE64}" ] && \
   security list-keychain -d user -s "$KEYCHAIN_PATH"
 fi
 if [ -n "${GITHUB_ENV}" ]; then
+set -x
+security find-identity -p codesigning "$KEYCHAIN_PATH"
+set +x
   IDENTITY=$(security find-identity -p codesigning "$KEYCHAIN_PATH" | grep '1)' | cut -d '"' -f 2)
   if [ -z "${IDENTITY}" ]; then
     IDENTITY="-"

--- a/tools/ci_load_keychain.sh
+++ b/tools/ci_load_keychain.sh
@@ -27,9 +27,7 @@ if [ -n "${BUILD_CERTIFICATE_BASE64}" ] && \
   security list-keychain -d user -s "$KEYCHAIN_PATH"
 fi
 if [ -n "${GITHUB_ENV}" ]; then
-  set -x
   security find-identity -p codesigning "$KEYCHAIN_PATH"
-  set +x
   IDENTITY=$(security find-identity -p codesigning "$KEYCHAIN_PATH" | grep '1)' | head -1 | cut -d '"' -f 2)
   if [ -z "${IDENTITY}" ]; then
     IDENTITY="-"

--- a/tools/ci_load_keychain.sh
+++ b/tools/ci_load_keychain.sh
@@ -30,7 +30,7 @@ if [ -n "${GITHUB_ENV}" ]; then
 set -x
 security find-identity -p codesigning "$KEYCHAIN_PATH"
 set +x
-  IDENTITY=$(security find-identity -p codesigning "$KEYCHAIN_PATH" | grep '1)' | cut -d '"' -f 2)
+  IDENTITY=$(security find-identity -p codesigning "$KEYCHAIN_PATH" | grep '1)' | head -1 | cut -d '"' -f 2)
   if [ -z "${IDENTITY}" ]; then
     IDENTITY="-"
   fi

--- a/tools/ci_load_keychain.sh
+++ b/tools/ci_load_keychain.sh
@@ -27,9 +27,9 @@ if [ -n "${BUILD_CERTIFICATE_BASE64}" ] && \
   security list-keychain -d user -s "$KEYCHAIN_PATH"
 fi
 if [ -n "${GITHUB_ENV}" ]; then
-set -x
-security find-identity -p codesigning "$KEYCHAIN_PATH"
-set +x
+  set -x
+  security find-identity -p codesigning "$KEYCHAIN_PATH"
+  set +x
   IDENTITY=$(security find-identity -p codesigning "$KEYCHAIN_PATH" | grep '1)' | head -1 | cut -d '"' -f 2)
   if [ -z "${IDENTITY}" ]; then
     IDENTITY="-"


### PR DESCRIPTION
This also lines up with the current name of the secrets which is
MACOS_CERTIFICATE instead of BUILD_CERTIFICATE_BASE64
MACOS_CERTIFICATE_PWD instead of P12_PASSWORD

This results in signed DMGs for Qt >= 6.7 using the identity in the above secrets.   They are not hardened, timestamped or notarized and still require the user to jump through a hoop with MacOS security:
<img width="320" height="122" alt="image" src="https://github.com/user-attachments/assets/3eb4e1ef-8c72-4ab4-a8ba-53df67ed2d8e" />
