### PR TITLE
update snap build action.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -115,10 +115,19 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
-
+    - name: detect architecture
+      id: detect-arch
+      shell: bash
+      env:
+        ARCHES: '{"X86": "i386", "X64": "amd64", "ARM": "armhf", "ARM64": "arm64"}'
+      run: echo "architecture=${{ fromJSON(env.ARCHES)[runner.arch] }}" >> $GITHUB_OUTPUT
     - name: Build
-      uses: snapcore/action-build@v1
+      uses: canonical/actions/build-snap@bd56f0f0934af9edbbd49378645727d7ef7a4571 # release @ 2025.06.05
       id: build-snap
+      with:
+        architecture: ${{ steps.detect-arch.outputs.architecture }}
+        review: false
+        publish: false
 
     # Make sure the snap is installable
     - name: Test
@@ -133,7 +142,7 @@ jobs:
             sudo snap install --channel=latest/beta mesa-2404
           fi
         fi
-        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap-path }}
         snap list
         export GBTEMP=$(pwd)/gbtemp
         mkdir -p "$GBTEMP"
@@ -144,7 +153,7 @@ jobs:
       if: ${{ inputs.attestation }}
       uses: actions/attest@v4
       with:
-        subject-path: ${{ steps.build-snap.outputs.snap }}
+        subject-path: ${{ steps.build-snap.outputs.snap-path }}
 
     - name: Deploy
       # This only handles continous releases now, for other events artifacts may be saved in
@@ -154,11 +163,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NAME: Continuous-Linux
       run: |
-        ./tools/uploadtool/upload_github.sh ${{ steps.build-snap.outputs.snap }}
+        ./tools/uploadtool/upload_github.sh ${{ steps.build-snap.outputs.snap-path }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ steps.build-snap.outputs.snap }}
-        path: ${{ steps.build-snap.outputs.snap }}
+        name: ${{ steps.build-snap.outputs.snap-name }}
+        path: ${{ steps.build-snap.outputs.snap-path }}
         retention-days: 7


### PR DESCRIPTION
snapcore/action-build@v1 is stuck on node20 which no longer exists on github hosted runners, and seems abandoned.
switch to use canonical/actions/build-snap which is light on documentation and doesn't use semantic versioning.  The canonical users either pin to the release branch or an sha from the release branch.