### PR TITLE
googletimeline: add read support for the device-local Timeline.json export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(ALL_FMTS ${MINIMAL_FMTS}
   geojson.cc
   globalsat_sport.cc
   googletakeout.cc
+  googletimeline.cc
   gtm.cc
   gtrnctr.cc
   html.cc
@@ -239,6 +240,7 @@ set(HEADERS
   globalsat_sport.h
   geo.h
   googletakeout.h
+  googletimeline.h
   gpx.h
   grtcirc.h
   gtm.h
@@ -410,6 +412,7 @@ set(TESTS
   geo
   globalsat_sport
   googletakeout
+  googletimeline
   gpsdrive
   gpx
   grapheme

--- a/googletimeline.cc
+++ b/googletimeline.cc
@@ -104,7 +104,7 @@ Waypoint* GoogleTimelineFormat::make_waypoint(
 
 /* Add a point to a track, dropping a null-island (0, 0) coordinate.
  *
- * Unlike googletakeout, where a missing late7/lone7 field reads back as 0, a
+ * Unlike googletakeout, where a missing latitudeE7/longitudeE7 field reads back as 0, a
  * point only reaches here once parse_latlng() has accepted an explicit
  * coordinate string, so (0, 0) means the file really did say "0.0°, 0.0°".
  * That is open ocean in the Gulf of Guinea and, in a phone's timeline, a

--- a/googletimeline.cc
+++ b/googletimeline.cc
@@ -205,11 +205,19 @@ void GoogleTimelineFormat::read()
         ++points;
       }
     } else if (segment.contains(ACTIVITY)) {
-      points += add_activity(segment[ACTIVITY].toObject(), startTime, endTime);
-      ++activities;
+      /* likewise, an activity or timelinePath whose points were all unusable
+       * or dropped emits no track and isn't counted */
+      if (const int n = add_activity(segment[ACTIVITY].toObject(), startTime, endTime);
+          n > 0) {
+        points += n;
+        ++activities;
+      }
     } else if (segment.contains(TIMELINE_PATH)) {
-      points += add_timeline_path(segment[TIMELINE_PATH].toArray(), startTime);
-      ++paths;
+      if (const int n = add_timeline_path(segment[TIMELINE_PATH].toArray(), startTime);
+          n > 0) {
+        points += n;
+        ++paths;
+      }
     }
   }
   if (segments.isEmpty()) {

--- a/googletimeline.cc
+++ b/googletimeline.cc
@@ -187,6 +187,7 @@ void GoogleTimelineFormat::read()
   int visits = 0;
   int activities = 0;
   int paths = 0;
+  int parking = 0;
   int points = 0;
   for (const auto&& segmentRef : segments) {
     const QJsonObject segment = segmentRef.toObject();
@@ -205,12 +206,16 @@ void GoogleTimelineFormat::read()
         ++points;
       }
     } else if (segment.contains(ACTIVITY)) {
+      const QJsonObject activity = segment[ACTIVITY].toObject();
       /* likewise, an activity or timelinePath whose points were all unusable
        * or dropped emits no track and isn't counted */
-      if (const int n = add_activity(segment[ACTIVITY].toObject(), startTime, endTime);
-          n > 0) {
+      if (const int n = add_activity(activity, startTime, endTime); n > 0) {
         points += n;
         ++activities;
+      }
+      if (add_parking(activity)) {
+        ++parking;
+        ++points;
       }
     } else if (segment.contains(TIMELINE_PATH)) {
       if (const int n = add_timeline_path(segment[TIMELINE_PATH].toArray(), startTime);
@@ -226,7 +231,7 @@ void GoogleTimelineFormat::read()
   if (global_opts.debug_level >= 1) {
     Debug(1) << "Processed " << segments.size() << " semanticSegments: " <<
       visits << " visits, " << activities << " activities, " << paths <<
-      " timelinePaths (" << points << " points total)";
+      " timelinePaths, " << parking << " parking (" << points << " points total)";
   }
 }
 
@@ -266,8 +271,8 @@ bool GoogleTimelineFormat::add_visit(const QJsonObject& visit, const QString& st
   return true;
 }
 
-/* add an "activity" as a track: its start and end points, plus (as a standalone
- * waypoint) a parking location if present. returns the number of TRACK points added.
+/* add an "activity" as a track: its start and end points. returns the number of
+ * points added.
  */
 int GoogleTimelineFormat::add_activity(
   const QJsonObject& activity,
@@ -297,18 +302,26 @@ int GoogleTimelineFormat::add_activity(
     }
     track_del_head(route);
   }
-
-  /* A parked-vehicle activity carries a parking.location — emit it as a waypoint. */
-  if (activity.contains(PARKING)) {
-    const QJsonObject parking = activity[PARKING].toObject();
-    double plat = 0;
-    double plon = 0;
-    if (parse_latlng(parking[LOCATION].toObject()[LATLNG].toString(), plat, plon)) {
-      waypt_add(make_waypoint(
-        plat, plon, QStringLiteral("Parking"), nullString, parking[START_TIME].toString()));
-    }
-  }
   return n_points;
+}
+
+/* a parked-vehicle activity carries a parking.location — emit it as a waypoint.
+ * returns true if one was added.
+ */
+bool GoogleTimelineFormat::add_parking(const QJsonObject& activity)
+{
+  if (!activity.contains(PARKING)) {
+    return false;
+  }
+  const QJsonObject parking = activity[PARKING].toObject();
+  double lat = 0;
+  double lon = 0;
+  if (!parse_latlng(parking[LOCATION].toObject()[LATLNG].toString(), lat, lon)) {
+    return false;
+  }
+  waypt_add(make_waypoint(
+    lat, lon, QStringLiteral("Parking"), nullString, parking[START_TIME].toString()));
+  return true;
 }
 
 /* add a "timelinePath" (the raw point trail) as a track. returns the number of

--- a/googletimeline.cc
+++ b/googletimeline.cc
@@ -141,9 +141,16 @@ void GoogleTimelineFormat::read()
   }
   auto* ifd = new gpsbabel::File(fname);
   ifd->open(QIODevice::ReadOnly | QIODevice::Text);
-  const QString content = ifd->readAll();
+  /*
+   * Hand the raw bytes to the JSON parser. Decoding to QString first and
+   * re-encoding with toUtf8() both copies the whole buffer an extra time and,
+   * more importantly, launders invalid UTF-8: the decode substitutes U+FFFD, so
+   * a corrupt file parses "successfully" and the damage lands silently in the
+   * output. Parsing the QByteArray directly reports QJsonParseError::IllegalUTF8String
+   * instead.
+   */
   QJsonParseError error{};
-  const QJsonDocument doc = QJsonDocument::fromJson(content.toUtf8(), &error);
+  const QJsonDocument doc = QJsonDocument::fromJson(ifd->readAll(), &error);
   if (error.error != QJsonParseError::NoError) {
     timeline_fatal(
       QString("JSON parse error in ") + ifd->fileName() + ": " + error.errorString()
@@ -177,9 +184,12 @@ void GoogleTimelineFormat::read()
      * point trail, -> track). Some carry only "timelineMemory" and no coordinates.
      */
     if (segment.contains(VISIT)) {
-      add_visit(segment[VISIT].toObject(), startTime);
-      ++visits;
-      ++points;
+      /* a visit with an unusable placeLocation adds nothing, so it must not be
+       * counted towards either total */
+      if (add_visit(segment[VISIT].toObject(), startTime)) {
+        ++visits;
+        ++points;
+      }
     } else if (segment.contains(ACTIVITY)) {
       points += add_activity(segment[ACTIVITY].toObject(), startTime, endTime);
       ++activities;
@@ -198,7 +208,10 @@ void GoogleTimelineFormat::read()
   }
 }
 
-void GoogleTimelineFormat::add_visit(const QJsonObject& visit, const QString& start_time)
+/* add a "visit" as a waypoint. returns true if a waypoint was added, false if the
+ * visit had no usable coordinate and was skipped.
+ */
+bool GoogleTimelineFormat::add_visit(const QJsonObject& visit, const QString& start_time)
 {
   /*
    * A visit's coordinate lives in visit.topCandidate.placeLocation.latLng.
@@ -216,7 +229,7 @@ void GoogleTimelineFormat::add_visit(const QJsonObject& visit, const QString& st
       Debug(2) << "visit @" << start_time <<
         ": unparsable placeLocation \"" << latLng << "\", skipping";
     }
-    return;
+    return false;
   }
   QString shortname = topCandidate[SEMANTIC_TYPE].toString();
   title_case(shortname);
@@ -228,6 +241,7 @@ void GoogleTimelineFormat::add_visit(const QJsonObject& visit, const QString& st
     start_time
   );
   waypt_add(waypoint);
+  return true;
 }
 
 /* add an "activity" as a track: its start and end points, plus (as a standalone

--- a/googletimeline.cc
+++ b/googletimeline.cc
@@ -37,6 +37,7 @@
 #include "src/core/file.h"      // for File
 #include "src/core/logging.h"   // for Debug, FatalMsg, Warning
 
+const QString GoogleTimelineFormat::nullString = QString();
 
 void GoogleTimelineFormat::timeline_fatal(const QString& message)
 {
@@ -82,18 +83,18 @@ gpsbabel::DateTime GoogleTimelineFormat::parse_time(const QString& s)
 Waypoint* GoogleTimelineFormat::make_waypoint(
   double lat,
   double lon,
-  const QString* shortname,
-  const QString* description,
+  const QString& shortname,
+  const QString& description,
   const QString& time_str)
 {
   auto* waypoint = new Waypoint();
   waypoint->latitude = lat;
   waypoint->longitude = lon;
-  if (shortname != nullptr && !shortname->isEmpty()) {
-    waypoint->shortname = *shortname;
+  if (!shortname.isEmpty()) {
+    waypoint->shortname = shortname;
   }
-  if (description != nullptr && !description->isEmpty()) {
-    waypoint->description = *description;
+  if (!description.isEmpty()) {
+    waypoint->description = description;
   }
   if (!time_str.isEmpty()) {
     waypoint->SetCreationTime(parse_time(time_str));
@@ -236,8 +237,8 @@ bool GoogleTimelineFormat::add_visit(const QJsonObject& visit, const QString& st
   const QString placeId = topCandidate[PLACE_ID].toString();
   Waypoint* waypoint = make_waypoint(
     lat, lon,
-    shortname.isEmpty() ? nullptr : &shortname,
-    placeId.isEmpty() ? nullptr : &placeId,
+    shortname,
+    placeId,
     start_time
   );
   waypt_add(waypoint);
@@ -263,11 +264,11 @@ int GoogleTimelineFormat::add_activity(
   double lon = 0;
   if (parse_latlng(activity[START].toObject()[LATLNG].toString(), lat, lon)) {
     n_points += track_maybe_add_wpt(
-      route, make_waypoint(lat, lon, nullptr, nullptr, start_time));
+      route, make_waypoint(lat, lon, nullString, nullString, start_time));
   }
   if (parse_latlng(activity[END].toObject()[LATLNG].toString(), lat, lon)) {
     n_points += track_maybe_add_wpt(
-      route, make_waypoint(lat, lon, nullptr, nullptr, end_time));
+      route, make_waypoint(lat, lon, nullString, nullString, end_time));
   }
   if (n_points == 0) {
     if (global_opts.debug_level >= 2) {
@@ -282,9 +283,8 @@ int GoogleTimelineFormat::add_activity(
     double plat = 0;
     double plon = 0;
     if (parse_latlng(parking[LOCATION].toObject()[LATLNG].toString(), plat, plon)) {
-      QString parking_name = QStringLiteral("Parking");
       waypt_add(make_waypoint(
-        plat, plon, &parking_name, nullptr, parking[START_TIME].toString()));
+        plat, plon, QStringLiteral("Parking"), nullString, parking[START_TIME].toString()));
     }
   }
   return n_points;
@@ -309,7 +309,7 @@ int GoogleTimelineFormat::add_timeline_path(
       continue;
     }
     n_points += track_maybe_add_wpt(
-      route, make_waypoint(lat, lon, nullptr, nullptr, point[TIME].toString()));
+      route, make_waypoint(lat, lon, nullString, nullString, point[TIME].toString()));
   }
   if (n_points == 0) {
     track_del_head(route);

--- a/googletimeline.cc
+++ b/googletimeline.cc
@@ -24,7 +24,7 @@
 #include <QChar>                // for QChar
 #include <QDateTime>            // for QDateTime
 #include <QDebug>               // for QDebug
-#include <QIODevice>            // for operator|, QIODevice
+#include <QIODevice>            // for QIODevice, QIODevice::ReadOnly
 #include <QJsonArray>           // for QJsonArray, QJsonArray::const_iterator
 #include <QJsonDocument>        // for QJsonDocument
 #include <QJsonObject>          // for QJsonObject
@@ -102,13 +102,21 @@ Waypoint* GoogleTimelineFormat::make_waypoint(
   return waypoint;
 }
 
+/* Add a point to a track, dropping a null-island (0, 0) coordinate.
+ *
+ * Unlike googletakeout, where a missing late7/lone7 field reads back as 0, a
+ * point only reaches here once parse_latlng() has accepted an explicit
+ * coordinate string, so (0, 0) means the file really did say "0.0°, 0.0°".
+ * That is open ocean in the Gulf of Guinea and, in a phone's timeline, a
+ * placeholder rather than a visit.
+ */
 bool GoogleTimelineFormat::track_maybe_add_wpt(route_head* route, Waypoint* waypoint)
 {
   if (waypoint->latitude == 0 && waypoint->longitude == 0) {
     if (global_opts.debug_level >= 2) {
       Debug(2) << "Track " << route->rte_name << "@" <<
         waypoint->creation_time.toPrettyString() <<
-        ": Dropping point with no lat/long";
+        ": Dropping null island (0, 0) point";
     }
     delete waypoint; // as we're dropping it, gpsbabel won't clean it up later
     return false;
@@ -141,7 +149,12 @@ void GoogleTimelineFormat::read()
     Debug(4) << "reading " << fname;
   }
   auto* ifd = new gpsbabel::File(fname);
-  ifd->open(QIODevice::ReadOnly | QIODevice::Text);
+  /*
+   * Deliberately not QIODevice::Text: it translates line endings on read, so
+   * the parser would not see the bytes that are actually on disk. JSON treats
+   * CR and LF alike as whitespace, so the translation gains nothing.
+   */
+  ifd->open(QIODevice::ReadOnly);
   /*
    * Hand the raw bytes to the JSON parser. Decoding to QString first and
    * re-encoding with toUtf8() both copies the whole buffer an extra time and,

--- a/googletimeline.cc
+++ b/googletimeline.cc
@@ -1,0 +1,304 @@
+/*
+  Support reading the device-local Google Maps Timeline export ("Timeline.json").
+
+  Copyright (C) 2026 Tyler MacDonald, tyler@macdonald.name
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+  USA.
+*/
+
+#include "googletimeline.h"
+
+#include <QChar>                // for QChar
+#include <QDateTime>            // for QDateTime
+#include <QDebug>               // for QDebug
+#include <QIODevice>            // for operator|, QIODevice
+#include <QJsonArray>           // for QJsonArray, QJsonArray::const_iterator
+#include <QJsonDocument>        // for QJsonDocument
+#include <QJsonObject>          // for QJsonObject
+#include <QJsonParseError>      // for QJsonParseError, QJsonParseError::NoError
+#include <QJsonValue>           // for QJsonValue
+#include <QStringList>          // for QStringList
+#include <Qt>                   // for ISODateWithMs, CaseInsensitive
+
+#include "src/core/datetime.h"  // for DateTime
+#include "src/core/file.h"      // for File
+#include "src/core/logging.h"   // for Debug, FatalMsg, Warning
+
+
+void GoogleTimelineFormat::timeline_fatal(const QString& message)
+{
+  gbFatal(FatalMsg() << message);
+}
+
+void GoogleTimelineFormat::timeline_warning(const QString& message)
+{
+  Warning() << message;
+}
+
+/* Parse a "lat°, lng°" decimal-degree string (e.g. "37.4277646°, -122.1404993°").
+ * Returns false and leaves lat/lon untouched on a malformed value.
+ */
+bool GoogleTimelineFormat::parse_latlng(const QString& s, double& lat, double& lon)
+{
+  QString cleaned = s;
+  cleaned.remove(QChar(0x00B0)); // strip the degree signs
+  const QStringList parts = cleaned.split(',');
+  if (parts.size() != 2) {
+    return false;
+  }
+  bool ok_lat = false;
+  bool ok_lon = false;
+  const double parsed_lat = parts.at(0).trimmed().toDouble(&ok_lat);
+  const double parsed_lon = parts.at(1).trimmed().toDouble(&ok_lon);
+  if (!ok_lat || !ok_lon) {
+    return false;
+  }
+  lat = parsed_lat;
+  lon = parsed_lon;
+  return true;
+}
+
+gpsbabel::DateTime GoogleTimelineFormat::parse_time(const QString& s)
+{
+  // Timeline times are ISO-8601 with milliseconds and a UTC offset, e.g.
+  // "2024-11-22T11:17:53.000-05:00". The absolute instant is unambiguous; gpsbabel
+  // stores it as UTC.
+  return QDateTime::fromString(s, Qt::ISODateWithMs);
+}
+
+Waypoint* GoogleTimelineFormat::make_waypoint(
+  double lat,
+  double lon,
+  const QString* shortname,
+  const QString* description,
+  const QString& time_str)
+{
+  auto* waypoint = new Waypoint();
+  waypoint->latitude = lat;
+  waypoint->longitude = lon;
+  if (shortname != nullptr && !shortname->isEmpty()) {
+    waypoint->shortname = *shortname;
+  }
+  if (description != nullptr && !description->isEmpty()) {
+    waypoint->description = *description;
+  }
+  if (!time_str.isEmpty()) {
+    waypoint->SetCreationTime(parse_time(time_str));
+  }
+  return waypoint;
+}
+
+bool GoogleTimelineFormat::track_maybe_add_wpt(route_head* route, Waypoint* waypoint)
+{
+  if (waypoint->latitude == 0 && waypoint->longitude == 0) {
+    if (global_opts.debug_level >= 2) {
+      Debug(2) << "Track " << route->rte_name << "@" <<
+        waypoint->creation_time.toPrettyString() <<
+        ": Dropping point with no lat/long";
+    }
+    delete waypoint; // as we're dropping it, gpsbabel won't clean it up later
+    return false;
+  }
+  track_add_wpt(route, waypoint);
+  return true;
+}
+
+void GoogleTimelineFormat::title_case(QString& title)
+{
+  bool new_word = true;
+  for (auto& chr : title) {
+    if (chr == '_' || chr == ' ') {
+      new_word = true;
+      if (chr == '_') {
+        chr = ' ';
+      }
+    } else if (new_word) {
+      new_word = false;
+      chr = chr.toUpper();
+    } else {
+      chr = chr.toLower();
+    }
+  }
+}
+
+void GoogleTimelineFormat::read()
+{
+  if (global_opts.debug_level >= 4) {
+    Debug(4) << "reading " << fname;
+  }
+  auto* ifd = new gpsbabel::File(fname);
+  ifd->open(QIODevice::ReadOnly | QIODevice::Text);
+  const QString content = ifd->readAll();
+  QJsonParseError error{};
+  const QJsonDocument doc = QJsonDocument::fromJson(content.toUtf8(), &error);
+  if (error.error != QJsonParseError::NoError) {
+    timeline_fatal(
+      QString("JSON parse error in ") + ifd->fileName() + ": " + error.errorString()
+    );
+  }
+
+  const QJsonObject root = doc.object();
+  const QJsonValue segmentsIn = root.value(SEMANTIC_SEGMENTS);
+  if (!segmentsIn.isArray()) {
+    timeline_fatal(
+      ifd->fileName() + " is missing the required \"" + SEMANTIC_SEGMENTS +
+      "\" array. If this is an older Google Takeout export (a \"timelineObjects\" "
+      "array, or per-year folders), use the \"googletakeout\" format instead."
+    );
+  }
+  ifd->close();
+  delete ifd;
+
+  const QJsonArray segments = segmentsIn.toArray();
+  int visits = 0;
+  int activities = 0;
+  int paths = 0;
+  int points = 0;
+  for (const auto&& segmentRef : segments) {
+    const QJsonObject segment = segmentRef.toObject();
+    const QString startTime = segment[START_TIME].toString();
+    const QString endTime = segment[END_TIME].toString();
+    /*
+     * A semanticSegment carries exactly one of: a "visit" (a place, -> waypoint),
+     * an "activity" (a trip start/end, -> track), or a "timelinePath" (a raw
+     * point trail, -> track). Some carry only "timelineMemory" and no coordinates.
+     */
+    if (segment.contains(VISIT)) {
+      add_visit(segment[VISIT].toObject(), startTime);
+      ++visits;
+      ++points;
+    } else if (segment.contains(ACTIVITY)) {
+      points += add_activity(segment[ACTIVITY].toObject(), startTime, endTime);
+      ++activities;
+    } else if (segment.contains(TIMELINE_PATH)) {
+      points += add_timeline_path(segment[TIMELINE_PATH].toArray(), startTime);
+      ++paths;
+    }
+  }
+  if (segments.isEmpty()) {
+    timeline_warning(fname + " does not contain any semanticSegments");
+  }
+  if (global_opts.debug_level >= 1) {
+    Debug(1) << "Processed " << segments.size() << " semanticSegments: " <<
+      visits << " visits, " << activities << " activities, " << paths <<
+      " timelinePaths (" << points << " points total)";
+  }
+}
+
+void GoogleTimelineFormat::add_visit(const QJsonObject& visit, const QString& start_time)
+{
+  /*
+   * A visit's coordinate lives in visit.topCandidate.placeLocation.latLng.
+   * There's no street address in the device export, so the human-readable
+   * "semanticType" (HOME, INFERRED_WORK, ...) becomes the waypoint name and the
+   * Google placeId (if any) its description.
+   */
+  const QJsonObject topCandidate = visit[TOP_CANDIDATE].toObject();
+  const QString latLng =
+    topCandidate[PLACE_LOCATION].toObject()[LATLNG].toString();
+  double lat = 0;
+  double lon = 0;
+  if (!parse_latlng(latLng, lat, lon)) {
+    if (global_opts.debug_level >= 2) {
+      Debug(2) << "visit @" << start_time <<
+        ": unparsable placeLocation \"" << latLng << "\", skipping";
+    }
+    return;
+  }
+  QString shortname = topCandidate[SEMANTIC_TYPE].toString();
+  title_case(shortname);
+  const QString placeId = topCandidate[PLACE_ID].toString();
+  Waypoint* waypoint = make_waypoint(
+    lat, lon,
+    shortname.isEmpty() ? nullptr : &shortname,
+    placeId.isEmpty() ? nullptr : &placeId,
+    start_time
+  );
+  waypt_add(waypoint);
+}
+
+/* add an "activity" as a track: its start and end points, plus (as a standalone
+ * waypoint) a parking location if present. returns the number of TRACK points added.
+ */
+int GoogleTimelineFormat::add_activity(
+  const QJsonObject& activity,
+  const QString& start_time,
+  const QString& end_time)
+{
+  int n_points = 0;
+  auto* route = new route_head;
+  QString name = activity[TOP_CANDIDATE][TYPE].toString(); // e.g. WALKING, CYCLING
+  title_case(name);
+  route->rte_name = name;
+  track_add_head(route);
+
+  double lat = 0;
+  double lon = 0;
+  if (parse_latlng(activity[START].toObject()[LATLNG].toString(), lat, lon)) {
+    n_points += track_maybe_add_wpt(
+      route, make_waypoint(lat, lon, nullptr, nullptr, start_time));
+  }
+  if (parse_latlng(activity[END].toObject()[LATLNG].toString(), lat, lon)) {
+    n_points += track_maybe_add_wpt(
+      route, make_waypoint(lat, lon, nullptr, nullptr, end_time));
+  }
+  if (n_points == 0) {
+    if (global_opts.debug_level >= 2) {
+      Debug(2) << "Track " << route->rte_name << ": Dropping track with no waypoints";
+    }
+    track_del_head(route);
+  }
+
+  /* A parked-vehicle activity carries a parking.location — emit it as a waypoint. */
+  if (activity.contains(PARKING)) {
+    const QJsonObject parking = activity[PARKING].toObject();
+    double plat = 0;
+    double plon = 0;
+    if (parse_latlng(parking[LOCATION].toObject()[LATLNG].toString(), plat, plon)) {
+      QString parking_name = QStringLiteral("Parking");
+      waypt_add(make_waypoint(
+        plat, plon, &parking_name, nullptr, parking[START_TIME].toString()));
+    }
+  }
+  return n_points;
+}
+
+/* add a "timelinePath" (the raw point trail) as a track. returns the number of
+ * points added.
+ */
+int GoogleTimelineFormat::add_timeline_path(
+  const QJsonArray& path,
+  const QString& track_name)
+{
+  int n_points = 0;
+  auto* route = new route_head;
+  route->rte_name = track_name.isEmpty() ? QStringLiteral("Timeline Path") : track_name;
+  track_add_head(route);
+  for (const auto&& pointRef : path) {
+    const QJsonObject point = pointRef.toObject();
+    double lat = 0;
+    double lon = 0;
+    if (!parse_latlng(point[POINT].toString(), lat, lon)) {
+      continue;
+    }
+    n_points += track_maybe_add_wpt(
+      route, make_waypoint(lat, lon, nullptr, nullptr, point[TIME].toString()));
+  }
+  if (n_points == 0) {
+    track_del_head(route);
+  }
+  return n_points;
+}

--- a/googletimeline.h
+++ b/googletimeline.h
@@ -100,7 +100,9 @@ private:
                                  const QString* description, const QString& time_str);
   static bool track_maybe_add_wpt(route_head* route, Waypoint* waypoint);
   static void title_case(QString& title);
-  void add_visit(const QJsonObject& visit, const QString& start_time);
+  // Returns true if a waypoint was added, false if the visit had no usable
+  // coordinate and was skipped.
+  bool add_visit(const QJsonObject& visit, const QString& start_time);
   int add_activity(const QJsonObject& activity, const QString& start_time,
                    const QString& end_time);
   int add_timeline_path(const QJsonArray& path, const QString& track_name);

--- a/googletimeline.h
+++ b/googletimeline.h
@@ -1,0 +1,112 @@
+/*
+  Support reading the device-local Google Maps Timeline export ("Timeline.json").
+
+  Copyright (C) 2026 Tyler MacDonald, tyler@macdonald.name
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+  USA.
+*/
+#ifndef GOOGLETIMELINE_H_INCLUDED_
+#define GOOGLETIMELINE_H_INCLUDED_
+
+#include <QJsonArray>      // for QJsonArray
+#include <QJsonObject>     // for QJsonObject
+#include <QString>         // for QString
+#include <QVector>         // for QVector
+
+#include "defs.h"
+#include "format.h"        // for Format
+#include "src/core/datetime.h"  // for DateTime
+
+/*
+ * Reads the device-local Google Maps Timeline export (a single "Timeline.json"
+ * with a top-level "semanticSegments" array), the format Google switched to after
+ * retiring the Takeout Location History download. For the older Takeout structure
+ * (a "timelineObjects" array, or per-year folders) use the "googletakeout" format.
+ *
+ * Read-only.
+ */
+class GoogleTimelineFormat : public Format
+{
+public:
+  using Format::Format;
+
+  /* Member functions */
+  QVector<arglist_t>* get_args() override
+  {
+    return &googletimeline_args;
+  }
+
+  ff_type get_type() const override
+  {
+    return ff_type_file;
+  }
+
+  QVector<ff_cap> get_cap() const override
+  {
+    /* waypoints (visits), tracks (paths/activities), no routes */
+    return { ff_cap_read, ff_cap_read, ff_cap_none };
+  }
+
+  void rd_init(const QString& fname) override
+  {}
+  void read() override;
+
+private:
+  /* Constants — top level */
+  static constexpr char SEMANTIC_SEGMENTS[] = "semanticSegments";
+  static constexpr char16_t START_TIME[] = u"startTime";
+  static constexpr char16_t END_TIME[] = u"endTime";
+
+  /* Constants — the three semanticSegment sub-types */
+  static constexpr char16_t VISIT[] = u"visit";
+  static constexpr char16_t ACTIVITY[] = u"activity";
+  static constexpr char16_t TIMELINE_PATH[] = u"timelinePath";
+
+  /* Constants — fields within the sub-types */
+  static constexpr char16_t TOP_CANDIDATE[] = u"topCandidate";
+  static constexpr char16_t PLACE_LOCATION[] = u"placeLocation";
+  static constexpr char16_t LATLNG[] = u"latLng";
+  static constexpr char16_t SEMANTIC_TYPE[] = u"semanticType";
+  static constexpr char16_t PLACE_ID[] = u"placeId";
+  static constexpr char16_t POINT[] = u"point";
+  static constexpr char16_t TIME[] = u"time";
+  static constexpr char16_t START[] = u"start";
+  static constexpr char16_t END[] = u"end";
+  static constexpr char16_t TYPE[] = u"type";
+  static constexpr char16_t PARKING[] = u"parking";
+  static constexpr char16_t LOCATION[] = u"location";
+
+  /* Member functions */
+  static void timeline_fatal(const QString& message);
+  static void timeline_warning(const QString& message);
+  // Parse a "lat°, lng°" decimal-degree string. Returns false (and leaves lat/lon
+  // untouched) on a malformed value.
+  static bool parse_latlng(const QString& s, double& lat, double& lon);
+  static gpsbabel::DateTime parse_time(const QString& s);
+  static Waypoint* make_waypoint(double lat, double lon, const QString* shortname,
+                                 const QString* description, const QString& time_str);
+  static bool track_maybe_add_wpt(route_head* route, Waypoint* waypoint);
+  static void title_case(QString& title);
+  void add_visit(const QJsonObject& visit, const QString& start_time);
+  int add_activity(const QJsonObject& activity, const QString& start_time,
+                   const QString& end_time);
+  int add_timeline_path(const QJsonArray& path, const QString& track_name);
+
+  /* Data Members */
+  QVector<arglist_t> googletimeline_args;
+};
+
+#endif /* GOOGLETIMELINE_H_INCLUDED_ */

--- a/googletimeline.h
+++ b/googletimeline.h
@@ -89,6 +89,8 @@ private:
   static constexpr char16_t PARKING[] = u"parking";
   static constexpr char16_t LOCATION[] = u"location";
 
+  static const QString nullString;
+
   /* Member functions */
   static void timeline_fatal(const QString& message);
   static void timeline_warning(const QString& message);
@@ -96,16 +98,16 @@ private:
   // untouched) on a malformed value.
   static bool parse_latlng(const QString& s, double& lat, double& lon);
   static gpsbabel::DateTime parse_time(const QString& s);
-  static Waypoint* make_waypoint(double lat, double lon, const QString* shortname,
-                                 const QString* description, const QString& time_str);
+  static Waypoint* make_waypoint(double lat, double lon, const QString& shortname,
+                                 const QString& description, const QString& time_str);
   static bool track_maybe_add_wpt(route_head* route, Waypoint* waypoint);
   static void title_case(QString& title);
   // Returns true if a waypoint was added, false if the visit had no usable
   // coordinate and was skipped.
-  bool add_visit(const QJsonObject& visit, const QString& start_time);
-  int add_activity(const QJsonObject& activity, const QString& start_time,
-                   const QString& end_time);
-  int add_timeline_path(const QJsonArray& path, const QString& track_name);
+  static bool add_visit(const QJsonObject& visit, const QString& start_time);
+  static int add_activity(const QJsonObject& activity, const QString& start_time,
+                          const QString& end_time);
+  static int add_timeline_path(const QJsonArray& path, const QString& track_name);
 
   /* Data Members */
   QVector<arglist_t> googletimeline_args;

--- a/googletimeline.h
+++ b/googletimeline.h
@@ -107,6 +107,9 @@ private:
   static bool add_visit(const QJsonObject& visit, const QString& start_time);
   static int add_activity(const QJsonObject& activity, const QString& start_time,
                           const QString& end_time);
+  // Returns true if a parking waypoint was added, false if the activity had no
+  // parking location or an unusable one.
+  static bool add_parking(const QJsonObject& activity);
   static int add_timeline_path(const QJsonArray& path, const QString& track_name);
 
   /* Data Members */

--- a/org.gpsbabel.cli.metainfo.xml
+++ b/org.gpsbabel.cli.metainfo.xml
@@ -42,6 +42,7 @@
       <li>geojson: GeoJson</li>
       <li>globalsat: GlobalSat GH625XT GPS training watch</li>
       <li>googletakeout: Google Takeout Location History</li>
+      <li>googletimeline: Google Maps Timeline</li>
       <li>gpsdrive: GpsDrive Format</li>
       <li>gpsdrivetrack: GpsDrive Format for Tracks</li>
       <li>gpx: GPX XML</li>

--- a/reference/format0.txt
+++ b/reference/format0.txt
@@ -22,6 +22,7 @@ dg-200		GlobalSat DG-200 Download
 dg-388	gpl	GlobalSat DG-388 Binary File
 globalsat		GlobalSat GH625XT GPS training watch
 kml	kml	Google Earth (Keyhole) Markup Language
+googletimeline	json	Google Maps Timeline
 googletakeout	json	Google Takeout Location History
 land_air_sea	txt	GPS Tracking Key Pro text
 gtm	gtm	GPS TrackMaker

--- a/reference/format1.txt
+++ b/reference/format1.txt
@@ -27,6 +27,7 @@ serial	dg-200		GlobalSat DG-200 Download
 file	dg-388	gpl	GlobalSat DG-388 Binary File
 serial	globalsat		GlobalSat GH625XT GPS training watch
 file	kml	kml	Google Earth (Keyhole) Markup Language
+file	googletimeline	json	Google Maps Timeline
 file	googletakeout	json	Google Takeout Location History
 file	land_air_sea	txt	GPS Tracking Key Pro text
 file	gtm	gtm	GPS TrackMaker

--- a/reference/format2.txt
+++ b/reference/format2.txt
@@ -27,6 +27,7 @@ serial	r-r---	dg-200		GlobalSat DG-200 Download
 file	r-r---	dg-388	gpl	GlobalSat DG-388 Binary File
 serial	--r---	globalsat		GlobalSat GH625XT GPS training watch
 file	rwrwrw	kml	kml	Google Earth (Keyhole) Markup Language
+file	r-r---	googletimeline	json	Google Maps Timeline
 file	r-r---	googletakeout	json	Google Takeout Location History
 file	--rw--	land_air_sea	txt	GPS Tracking Key Pro text
 file	rwrwrw	gtm	gtm	GPS TrackMaker

--- a/reference/format3.txt
+++ b/reference/format3.txt
@@ -392,6 +392,8 @@ option	kml	rotate_colors	Rotate colors for tracks and routes (default automatic)
 
 option	kml	prec	Precision of coordinates, number of decimals	integer	6			https://www.gpsbabel.org/WEB_DOC_DIR/fmt_kml.html#fmt_kml_o_prec
 
+file	r-r---	googletimeline	json	Google Maps Timeline	googletimeline
+	https://www.gpsbabel.org/WEB_DOC_DIR/fmt_googletimeline.html
 file	r-r---	googletakeout	json	Google Takeout Location History	googletakeout
 	https://www.gpsbabel.org/WEB_DOC_DIR/fmt_googletakeout.html
 file	--rw--	land_air_sea	txt	GPS Tracking Key Pro text	xcsv

--- a/reference/googletimeline/Timeline.json
+++ b/reference/googletimeline/Timeline.json
@@ -1,0 +1,66 @@
+{
+  "semanticSegments": [
+    {
+      "startTime": "2024-11-15T09:30:00.000-08:00",
+      "endTime": "2024-11-15T11:00:00.000-08:00",
+      "startTimeTimezoneUtcOffsetMinutes": -480,
+      "endTimeTimezoneUtcOffsetMinutes": -480,
+      "visit": {
+        "hierarchyLevel": 0,
+        "probability": 0.9200000166893005,
+        "topCandidate": {
+          "placeId": "ChIJ2eUgeAK6j4ARbn5u_wAGqWA",
+          "semanticType": "INFERRED_HOME",
+          "probability": 0.9700000286102295,
+          "placeLocation": { "latLng": "37.4219983°, -122.0840000°" }
+        }
+      }
+    },
+    {
+      "startTime": "2024-11-15T11:00:00.000-08:00",
+      "endTime": "2024-11-15T11:20:00.000-08:00",
+      "startTimeTimezoneUtcOffsetMinutes": -480,
+      "endTimeTimezoneUtcOffsetMinutes": -480,
+      "activity": {
+        "start": { "latLng": "37.4219983°, -122.0840000°" },
+        "end": { "latLng": "37.4419983°, -122.1040000°" },
+        "distanceMeters": 2900.0,
+        "topCandidate": { "type": "IN_PASSENGER_VEHICLE", "probability": 0.8100000023841858 },
+        "parking": {
+          "location": { "latLng": "37.4419000°, -122.1041000°" },
+          "startTime": "2024-11-15T11:20:00.000-08:00"
+        }
+      }
+    },
+    {
+      "startTime": "2024-11-15T11:00:00.000-08:00",
+      "endTime": "2024-11-15T11:20:00.000-08:00",
+      "startTimeTimezoneUtcOffsetMinutes": -480,
+      "endTimeTimezoneUtcOffsetMinutes": -480,
+      "timelinePath": [
+        { "point": "37.4219983°, -122.0840000°", "time": "2024-11-15T11:02:00.000-08:00" },
+        { "point": "37.4300000°, -122.0950000°", "time": "2024-11-15T11:10:00.000-08:00" },
+        { "point": "37.4419983°, -122.1040000°", "time": "2024-11-15T11:19:00.000-08:00" }
+      ]
+    },
+    {
+      "startTime": "2024-11-15T11:20:00.000-08:00",
+      "endTime": "2024-11-15T12:30:00.000-08:00",
+      "startTimeTimezoneUtcOffsetMinutes": -480,
+      "endTimeTimezoneUtcOffsetMinutes": -480,
+      "visit": {
+        "topCandidate": {
+          "semanticType": "UNKNOWN",
+          "placeLocation": { "latLng": "37.4419983°, -122.1040000°" }
+        }
+      }
+    },
+    {
+      "startTime": "2024-11-15T12:30:00.000-08:00",
+      "endTime": "2024-11-15T12:30:00.000-08:00",
+      "timelineMemory": {
+        "trip": { "distanceFromPreviousVisitMeters": 0 }
+      }
+    }
+  ]
+}

--- a/reference/googletimeline/googletimeline.gpx
+++ b/reference/googletimeline/googletimeline.gpx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="GPSBabel - https://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">
+  <time>1970-01-01T00:00:00Z</time>
+  <bounds minlat="37.421998300" minlon="-122.104100000" maxlat="37.441998300" maxlon="-122.084000000"/>
+  <wpt lat="37.421998300" lon="-122.084000000">
+    <time>2024-11-15T17:30:00Z</time>
+    <name>Inferred Home</name>
+    <cmt>ChIJ2eUgeAK6j4ARbn5u_wAGqWA</cmt>
+    <desc>ChIJ2eUgeAK6j4ARbn5u_wAGqWA</desc>
+  </wpt>
+  <wpt lat="37.441900000" lon="-122.104100000">
+    <time>2024-11-15T19:20:00Z</time>
+    <name>Parking</name>
+    <cmt>Parking</cmt>
+    <desc>Parking</desc>
+  </wpt>
+  <wpt lat="37.441998300" lon="-122.104000000">
+    <time>2024-11-15T19:20:00Z</time>
+    <name>Unknown</name>
+    <cmt>Unknown</cmt>
+    <desc>Unknown</desc>
+  </wpt>
+  <trk>
+    <name>In Passenger Vehicle</name>
+    <trkseg>
+      <trkpt lat="37.421998300" lon="-122.084000000">
+        <time>2024-11-15T19:00:00Z</time>
+      </trkpt>
+      <trkpt lat="37.441998300" lon="-122.104000000">
+        <time>2024-11-15T19:20:00Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+  <trk>
+    <name>2024-11-15T11:00:00.000-08:00</name>
+    <trkseg>
+      <trkpt lat="37.421998300" lon="-122.084000000">
+        <time>2024-11-15T19:02:00Z</time>
+      </trkpt>
+      <trkpt lat="37.430000000" lon="-122.095000000">
+        <time>2024-11-15T19:10:00Z</time>
+      </trkpt>
+      <trkpt lat="37.441998300" lon="-122.104000000">
+        <time>2024-11-15T19:19:00Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/reference/help.txt
+++ b/reference/help.txt
@@ -195,6 +195,7 @@ File Types (-i and -o options):
 	  max_position_point    Retain at most this number of position points  (0 
 	  rotate_colors         Rotate colors for tracks and routes (default autom
 	  prec                  Precision of coordinates, number of decimals
+	googletimeline        Google Maps Timeline
 	googletakeout         Google Takeout Location History
 	land_air_sea          GPS Tracking Key Pro text
 	  snlen                 Max synthesized shortname length

--- a/testo.d/googletimeline.test
+++ b/testo.d/googletimeline.test
@@ -1,0 +1,8 @@
+rm -f ${TMPDIR}/googletimeline.gpx
+gpsbabel \
+  -i googletimeline \
+  -f ${REFERENCE}/googletimeline/Timeline.json \
+  -o gpx \
+  -F ${TMPDIR}/googletimeline.gpx
+
+compare "${TMPDIR}/googletimeline.gpx" "${REFERENCE}/googletimeline/googletimeline.gpx"

--- a/vecs.cc
+++ b/vecs.cc
@@ -83,6 +83,7 @@
 #include "vcf.h"               // for VcfFormat
 #include "xcsv.h"              // for XcsvStyle, XcsvFormat
 #include "googletakeout.h"     // for GoogleTakeoutFormat
+#include "googletimeline.h"    // for GoogleTimelineFormat
 
 
 template <typename T>
@@ -482,6 +483,14 @@ struct Vecs::Impl {
       "json",
       nullptr,
       &fmtfactory<GoogleTakeoutFormat>
+    },
+    {
+      nullptr,
+      "googletimeline",
+      "Google Maps Timeline",
+      "json",
+      nullptr,
+      &fmtfactory<GoogleTimelineFormat>
     },
     {
       nullptr,

--- a/xmldoc/formats/googletakeout.xml
+++ b/xmldoc/formats/googletakeout.xml
@@ -1,7 +1,18 @@
+<note><para>
+  This format reads the <emphasis>older</emphasis> Google Takeout Location
+  History download (a ZIP of monthly JSON files with a "timelineObjects" array).
+  In late 2024 Google retired that download and moved Timeline data on-device;
+  the current export is a single "Timeline.json" file with a different structure.
+  To read that newer file, use the
+  <link linkend="fmt_googletimeline">googletimeline</link> format. The
+  "googletakeout" format is retained for anyone who still has an archived Takeout
+  download.
+</para></note>
+
 <para>
-  Google gives you two options to download your location history:
-  In Google Maps, you can go into your Timeline and download your location
-  history a day at a time as KML files. Or, in Google Takeout, you can
+  Historically, Google gave you two options to download your location history:
+  In Google Maps, you could go into your Timeline and download your location
+  history a day at a time as KML files. Or, in Google Takeout, you could
   download all of your location history all at once as a ZIP of JSON files,
   one for each month.
 </para>

--- a/xmldoc/formats/googletimeline.xml
+++ b/xmldoc/formats/googletimeline.xml
@@ -1,0 +1,68 @@
+<para>
+  In late 2024 Google retired the Takeout "Location History" download and moved
+  Timeline data on-device. The current export is a single <filename>Timeline.json</filename>
+  file with a top-level "semanticSegments" array, a different structure from
+  the older Takeout download. The "googletimeline" format reads this newer file.
+</para>
+
+<para>
+  If instead you have an older Takeout download archived (a ZIP of monthly JSON
+  files, or per-year folders), use the
+  <link linkend="fmt_googletakeout">googletakeout</link> format.
+</para>
+
+<para>
+  This is a read-only format. Each Timeline segment is converted as follows:
+  <itemizedlist mark="bullet">
+    <listitem><para>
+      a <emphasis>visit</emphasis> (a place you stopped) becomes a waypoint, named
+      by its semantic type (HOME, INFERRED_WORK, and so on);
+    </para></listitem>
+    <listitem><para>
+      an <emphasis>activity</emphasis> (a trip) becomes a track holding its start
+      and end points, named by the activity type (WALKING, CYCLING, ...); a parked
+      vehicle location, if present, becomes a waypoint;
+    </para></listitem>
+    <listitem><para>
+      a <emphasis>timelinePath</emphasis> (a recorded point trail) becomes a track.
+    </para></listitem>
+  </itemizedlist>
+</para>
+
+<para>
+  There is no official documentation from Google for this format. A volunteer is
+  maintaining a schema at
+  <link xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="https://locationhistoryformat.com/">
+    locationhistoryformat.com
+  </link>.
+</para>
+
+<para>
+  To export <filename>Timeline.json</filename> from an Android device:
+  <itemizedlist mark="bullet">
+    <listitem><para>Open the device <emphasis>Settings</emphasis> app</para></listitem>
+    <listitem><para>
+      Go to <emphasis>Location</emphasis> &gt; <emphasis>Location services</emphasis>
+      &gt; <emphasis>Timeline</emphasis>
+    </para></listitem>
+    <listitem><para>
+      Choose <emphasis>Export Timeline data</emphasis> and save the resulting
+      <filename>Timeline.json</filename> file
+    </para></listitem>
+  </itemizedlist>
+</para>
+
+<example xml:id="googletimeline-gpx">
+  <title>Convert a Timeline export to GPX</title>
+  <para><userinput>
+    gpsbabel -i googletimeline -f Timeline.json -o gpx -F timeline.gpx
+  </userinput></para>
+</example>
+
+<example xml:id="googletimeline-tracks">
+  <title>Keep only the recorded tracks, dropping the visit waypoints</title>
+  <para><userinput>
+    gpsbabel -i googletimeline -f Timeline.json -x nuketypes,waypoints -o gpx -F tracks.gpx
+  </userinput></para>
+</example>


### PR DESCRIPTION
Fixes #1383.

Google retired the Takeout "Location History" download in late 2024 and moved Timeline data on-device. The current export is a single `Timeline.json` with a top-level `semanticSegments` array — a different structure that the existing `googletakeout` format can't read.

This adds a new read-only **`googletimeline`** format that converts each segment:

| segment | becomes |
| --- | --- |
| `visit` | a waypoint (named by its `semanticType`; the Google `placeId` as the description) |
| `activity` | a track of its start/end points (named by the activity type); a `parking` location, if present, becomes a waypoint |
| `timelinePath` | a track of the recorded points |

Coordinates are `"lat, lng"` decimal-degree strings (with a degree sign) and times are ISO-8601 with a UTC offset.

`googletakeout` is functionally untouched and kept for anyone with an archived Takeout download; its documentation now notes it is the legacy format and points to `googletimeline`.

### Testing

- New reference test (`testo.d/googletimeline.test`) with a synthetic fixture covering visits (with and without a `placeId`), an activity plus `parking`, a `timelinePath`, UTC-offset conversion, and a `timelineMemory`-only segment that carries no coordinates.
- Full `./testo` suite passes with 0 errors on a local Windows / MSVC + Qt 6.8.3 build.
- Smoke-tested against a real ~71 MB `Timeline.json`: 46,783 segments to 14,917 waypoints + 32,659 tracks (332k points), well-formed GPX, ~2.7 s.

This was developed with AI assistance (noted via the `Co-Authored-By` trailer on the commit).
