### PR TITLE
geojson, googletakeout: parse JSON bytes directly instead of round-tripping through QString

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# These fixtures deliberately contain a byte sequence that is not valid UTF-8,
+# and exist to prove the JSON readers reject such input rather than silently
+# substituting U+FFFD. Mark them binary so no end-of-line normalisation or
+# encoding conversion can quietly turn them back into well-formed text, which
+# would leave the tests passing while testing nothing.
+reference/geojson-badutf8.geojson   binary
+reference/googletakeout-badutf8.json binary

--- a/geojson.cc
+++ b/geojson.cc
@@ -18,7 +18,7 @@
  */
 
 #include <QByteArray>              // for QByteArray
-#include <QIODevice>               // for operator|, QIODevice, QIODevice::ReadOnly, QIODevice::Text
+#include <QIODevice>               // for QIODevice, QIODevice::ReadOnly, QIODevice::WriteOnly
 #include <QJsonArray>              // for QJsonArray
 #include <QJsonDocument>           // for QJsonDocument, QJsonDocument::Compact, QJsonDocument::Indented, QJsonDocument::JsonFormat
 #include <QJsonObject>             // for QJsonObject
@@ -36,7 +36,12 @@ void
 GeoJsonFormat::rd_init(const QString& fname)
 {
   ifd = new gpsbabel::File(fname);
-  ifd->open(QIODevice::ReadOnly | QIODevice::Text);
+  /*
+   * Deliberately not QIODevice::Text: it translates line endings on read, so
+   * the parser would not see the bytes that are actually on disk. JSON treats
+   * CR and LF alike as whitespace, so the translation gains nothing.
+   */
+  ifd->open(QIODevice::ReadOnly);
 }
 
 void
@@ -144,7 +149,7 @@ void
 GeoJsonFormat::read()
 {
   /*
-   * Hand the raw bytes to the parser. Decoding to QString and re-encoding with
+   * Hand the bytes to the parser. Decoding to QString and re-encoding with
    * toUtf8() copies the whole buffer an extra time and, worse, launders invalid
    * UTF-8: the decode substitutes U+FFFD, so a corrupt file parses
    * "successfully" and the damage lands silently in the output. Parsing the

--- a/geojson.cc
+++ b/geojson.cc
@@ -143,9 +143,15 @@ GeoJsonFormat::routes_from_polygon_coordinates(const QJsonArray& polygon)
 void
 GeoJsonFormat::read()
 {
-  QString file_content = ifd->readAll();
+  /*
+   * Hand the raw bytes to the parser. Decoding to QString and re-encoding with
+   * toUtf8() copies the whole buffer an extra time and, worse, launders invalid
+   * UTF-8: the decode substitutes U+FFFD, so a corrupt file parses
+   * "successfully" and the damage lands silently in the output. Parsing the
+   * QByteArray reports QJsonParseError::IllegalUTF8String instead.
+   */
   QJsonParseError error{};
-  QJsonDocument document = QJsonDocument::fromJson(file_content.toUtf8(), &error);
+  QJsonDocument document = QJsonDocument::fromJson(ifd->readAll(), &error);
   if (error.error != QJsonParseError::NoError) {
     gbFatal(FatalMsg().nospace() << "GeoJSON parse error in " << ifd->fileName() << ": " << error.errorString());
   }

--- a/googletakeout.cc
+++ b/googletakeout.cc
@@ -93,9 +93,14 @@ QList<QJsonObject> GoogleTakeoutFormat::GoogleTakeoutInputStream::readJson(
     Debug(2) << "Reading from JSON " << source;
   }
   auto* ifd = new gpsbabel::File(source);
-  ifd->open(QIODevice::ReadOnly | QIODevice::Text);
   /*
-   * Hand the raw bytes to the parser. Decoding to QString and re-encoding with
+   * Deliberately not QIODevice::Text: it translates line endings on read, so
+   * the parser would not see the bytes that are actually on disk. JSON treats
+   * CR and LF alike as whitespace, so the translation gains nothing.
+   */
+  ifd->open(QIODevice::ReadOnly);
+  /*
+   * Hand the bytes to the parser. Decoding to QString and re-encoding with
    * toUtf8() copies the whole buffer an extra time and, worse, launders invalid
    * UTF-8: the decode substitutes U+FFFD, so a corrupt file parses
    * "successfully" and the damage lands silently in the output. Parsing the

--- a/googletakeout.cc
+++ b/googletakeout.cc
@@ -94,9 +94,15 @@ QList<QJsonObject> GoogleTakeoutFormat::GoogleTakeoutInputStream::readJson(
   }
   auto* ifd = new gpsbabel::File(source);
   ifd->open(QIODevice::ReadOnly | QIODevice::Text);
-  const QString content = ifd->readAll();
+  /*
+   * Hand the raw bytes to the parser. Decoding to QString and re-encoding with
+   * toUtf8() copies the whole buffer an extra time and, worse, launders invalid
+   * UTF-8: the decode substitutes U+FFFD, so a corrupt file parses
+   * "successfully" and the damage lands silently in the output. Parsing the
+   * QByteArray reports QJsonParseError::IllegalUTF8String instead.
+   */
   QJsonParseError error{};
-  const QJsonDocument doc = QJsonDocument::fromJson(content.toUtf8(), &error);
+  const QJsonDocument doc = QJsonDocument::fromJson(ifd->readAll(), &error);
   if (error.error != QJsonParseError::NoError) {
     takeout_fatal(
       QString("JSON parse error in ") + ifd->fileName() + ": " +

--- a/reference/geojson-badutf8.geojson
+++ b/reference/geojson-badutf8.geojson
@@ -1,0 +1,1 @@
+{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"name":"Cafÿ Rendezvous"},"geometry":{"type":"Point","coordinates":[-122.084,37.422]}}]}

--- a/reference/googletakeout-badutf8.json
+++ b/reference/googletakeout-badutf8.json
@@ -1,0 +1,1 @@
+{"timelineObjects":[{"placeVisit":{"location":{"latitudeE7":374220000,"longitudeE7":-1220840000,"address":"1 Test Way","name":"Cafÿ Rendezvous"},"duration":{"startTimestamp":"2013-05-01T12:00:00Z"}}}]}

--- a/testo.d/geojson.test
+++ b/testo.d/geojson.test
@@ -27,9 +27,12 @@ ${VALGRIND} "${PNAME}" -i geojson -f ${REFERENCE}/geojson-badutf8.geojson -o gpx
   echo "${PNAME} succeeded! (it shouldn't have with this input...)"
   errorcount=`expr $errorcount + 1`
 }
-# The diagnostic embeds the input path, which varies with how testo was
-# invoked, so match the distinctive part instead of comparing the whole log.
-grep -q 'invalid UTF8 string' ${TMPDIR}/geojson-badutf8.log || {
+# Not a whole-log compare: the diagnostic embeds the input path, which varies
+# with how testo was invoked. Anchor on gpsbabel's own "parse error in" wording
+# plus the UTF8 token, rather than Qt's exact phrasing -- errorString() is a
+# translatable, human-readable string and pinning all of it would couple this
+# test to third-party wording.
+grep -Eq 'parse error in .*UTF8' ${TMPDIR}/geojson-badutf8.log || {
   echo "ERROR: expected an invalid UTF-8 diagnostic from geojson, got:"
   cat ${TMPDIR}/geojson-badutf8.log
   errorcount=`expr $errorcount + 1`

--- a/testo.d/geojson.test
+++ b/testo.d/geojson.test
@@ -18,3 +18,20 @@ compare ${REFERENCE}/wptsequence~gpx.json ${TMPDIR}/wptsequence~gpx.json
 gpsbabel -i geojson -f ${REFERENCE}/wptsequence~gpx.json -o gpx -F ${TMPDIR}/wptsequence~gpx~json.gpx
 compare ${REFERENCE}/wptsequence~gpx~json.gpx ${TMPDIR}/wptsequence~gpx~json.gpx
 
+# Input containing invalid UTF-8 must be rejected, not silently repaired.
+# The reader used to decode the file to a QString and re-encode it before
+# parsing, which replaced the bad byte with U+FFFD. This fixture therefore
+# converted "successfully" and emitted a waypoint with a corrupted name.
+# expecting this to fail so call directly rather than via gpsbabel function
+${VALGRIND} "${PNAME}" -i geojson -f ${REFERENCE}/geojson-badutf8.geojson -o gpx -F ${TMPDIR}/geojson-badutf8.gpx > /dev/null 2> ${TMPDIR}/geojson-badutf8.log && {
+  echo "${PNAME} succeeded! (it shouldn't have with this input...)"
+  errorcount=`expr $errorcount + 1`
+}
+# The diagnostic embeds the input path, which varies with how testo was
+# invoked, so match the distinctive part instead of comparing the whole log.
+grep -q 'invalid UTF8 string' ${TMPDIR}/geojson-badutf8.log || {
+  echo "ERROR: expected an invalid UTF-8 diagnostic from geojson, got:"
+  cat ${TMPDIR}/geojson-badutf8.log
+  errorcount=`expr $errorcount + 1`
+}
+

--- a/testo.d/googletakeout.test
+++ b/testo.d/googletakeout.test
@@ -6,3 +6,20 @@ gpsbabel \
   -F ${TMPDIR}/googletakeout.gpx
 
 compare "${TMPDIR}/googletakeout.gpx" "${REFERENCE}/googletakeout/googletakeout.gpx"
+
+# Input containing invalid UTF-8 must be rejected, not silently repaired.
+# The reader used to decode the file to a QString and re-encode it before
+# parsing, which replaced the bad byte with U+FFFD. This fixture therefore
+# converted "successfully" and emitted a waypoint with a corrupted name.
+# expecting this to fail so call directly rather than via gpsbabel function
+${VALGRIND} "${PNAME}" -i googletakeout -f ${REFERENCE}/googletakeout-badutf8.json -o gpx -F ${TMPDIR}/googletakeout-badutf8.gpx > /dev/null 2> ${TMPDIR}/googletakeout-badutf8.log && {
+  echo "${PNAME} succeeded! (it shouldn't have with this input...)"
+  errorcount=`expr $errorcount + 1`
+}
+# The diagnostic embeds the input path, which varies with how testo was
+# invoked, so match the distinctive part instead of comparing the whole log.
+grep -q 'invalid UTF8 string' ${TMPDIR}/googletakeout-badutf8.log || {
+  echo "ERROR: expected an invalid UTF-8 diagnostic from googletakeout, got:"
+  cat ${TMPDIR}/googletakeout-badutf8.log
+  errorcount=`expr $errorcount + 1`
+}

--- a/testo.d/googletakeout.test
+++ b/testo.d/googletakeout.test
@@ -16,9 +16,12 @@ ${VALGRIND} "${PNAME}" -i googletakeout -f ${REFERENCE}/googletakeout-badutf8.js
   echo "${PNAME} succeeded! (it shouldn't have with this input...)"
   errorcount=`expr $errorcount + 1`
 }
-# The diagnostic embeds the input path, which varies with how testo was
-# invoked, so match the distinctive part instead of comparing the whole log.
-grep -q 'invalid UTF8 string' ${TMPDIR}/googletakeout-badutf8.log || {
+# Not a whole-log compare: the diagnostic embeds the input path, which varies
+# with how testo was invoked. Anchor on gpsbabel's own "parse error in" wording
+# plus the UTF8 token, rather than Qt's exact phrasing -- errorString() is a
+# translatable, human-readable string and pinning all of it would couple this
+# test to third-party wording.
+grep -Eq 'parse error in .*UTF8' ${TMPDIR}/googletakeout-badutf8.log || {
   echo "ERROR: expected an invalid UTF-8 diagnostic from googletakeout, got:"
   cat ${TMPDIR}/googletakeout-badutf8.log
   errorcount=`expr $errorcount + 1`


### PR DESCRIPTION
Both readers decode the file into a `QString` and then re-encode it with `toUtf8()` before handing it to `QJsonDocument::fromJson()`.

Besides the extra full-buffer copy, the round trip launders invalid UTF-8: the decode substitutes U+FFFD, so a corrupt input parses "successfully" and the damage lands silently in the converted output. Passing the `QByteArray` from `readAll()` straight to `fromJson()` surfaces `QJsonParseError::IllegalUTF8String` instead.

Given a GeoJSON feature whose `name` property contains a lone `0xFF` byte, before:

```
$ gpsbabel -i geojson -f reference/geojson-badutf8.geojson -o gpx -F -
...
<name>Caf� Rendezvous</name>
$ echo $?
0
```

and after:

```
$ gpsbabel -i geojson -f reference/geojson-badutf8.geojson -o gpx -F -
geojson: GeoJSON parse error in "reference/geojson-badutf8.geojson": "invalid UTF8 string"
$ echo $?
1
```

### Tests

Adds a regression test per format using the existing expected-failure idiom from `mkshort.test` and `track-discard.test`. Each asserts both a non-zero exit status and an invalid-UTF-8 diagnostic. The message embeds the input path, which varies with how `testo` is invoked, so the tests match the distinctive substring rather than comparing a full reference log.

The two fixtures are marked `binary` in a new `.gitattributes`. They exist to carry a byte sequence that is not valid UTF-8, and any end-of-line or encoding normalisation would quietly turn them back into well-formed text, leaving the tests passing while testing nothing.

Confirmed the tests actually catch the regression: reverting just the two `fromJson()` calls and rebuilding gives `Total Errors: 4`; restoring them gives `Total Errors: 0`. Full `testo` suite passes.

---

Noted by @tsteven4 while reviewing #1612, which fixes the same pattern in the new `googletimeline` reader. Split out here to keep that PR scoped to the new format.
