### PR TITLE
Set desktop file name for the application

### DIFF
--- a/gui/main.cc
+++ b/gui/main.cc
@@ -49,6 +49,7 @@ int main(int argc, char** argv)
   QApplication::setOrganizationName("GPSBabel");
   QApplication::setOrganizationDomain("gpsbabel.org");
   QApplication::setApplicationName("GPSBabel");
+  QApplication::setDesktopFileName("gpsbabelfe");
 
   MainWindow mainWindow(nullptr);
   mainWindow.show();

--- a/gui/main.cc
+++ b/gui/main.cc
@@ -37,6 +37,9 @@ int main(int argc, char** argv)
 #error this version of Qt is not supported.
 #endif
 
+  // Set desktop filename before creating QApplication, see QTBUG-149180
+  QApplication::setDesktopFileName("gpsbabelfe");
+
   QApplication app(argc, argv);
   // Don't override the window icon on macos.
   // Overriding defeats style preferences which otherwise will modify the appearance
@@ -49,7 +52,6 @@ int main(int argc, char** argv)
   QApplication::setOrganizationName("GPSBabel");
   QApplication::setOrganizationDomain("gpsbabel.org");
   QApplication::setApplicationName("GPSBabel");
-  QApplication::setDesktopFileName("gpsbabelfe");
 
   MainWindow mainWindow(nullptr);
   mainWindow.show();


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `org.gpsbabel.gpsbabelfe`, but the desktop file is called as [`gpsbabelfe`](https://github.com/GPSBabel/gpsbabel/blob/278a635eb8b3cd0625b24b8386662d622419bebe/gui/gpsbabelfe.desktop).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id