### PR TITLE
Update launchable desktop ID in metainfo file

### DIFF
--- a/gui/org.gpsbabel.gui.metainfo.xml
+++ b/gui/org.gpsbabel.gui.metainfo.xml
@@ -15,7 +15,7 @@
   </description>
   <url type="homepage">https://www.gpsbabel.org</url>
   <url type="vcs-browser">https://github.com/GPSBabel/gpsbabel</url>
-  <launchable type="desktop-id">gpsbabel.desktop</launchable>
+  <launchable type="desktop-id">gpsbabelfe.desktop</launchable>
   <provides>
     <binary>gpsbabelfe</binary>
     <modalias>usb:v091Ep0003d*</modalias>


### PR DESCRIPTION
It has been renamed in a19263055bc6c8bfb035dc06edd9de64f0cb9160.