### PR TITLE
add switch to bypass signing.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,7 @@ jobs:
             RELEASE: true
             os: macos-15
           - QT_VERSION: '6.10.3'
-            XCODE_VERSION: '26.2'
+            XCODE_VERSION: '26.6'
             GENERATOR: 'Ninja'
             RELEASE: false
             os: macos-26
@@ -97,6 +97,7 @@ jobs:
         #brew install jing-trang
 
     - name: Install the Apple certificate
+      if: vars.FORCE_ADHOC != 'true'
       env:
         BUILD_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE }}
         P12_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}


### PR DESCRIPTION
add capability to force macos adhoc code signing by defining a github actions variable FORCE_ADHOC and setting it to true.
Deleting the variable will return to attempting to use a certificate as defined by MACOS_CERTIFICATE and MACOS_CERTIFICATE_PWD.

This will allow macos CI jobs to have a chance to succeed.

This is a workaround due to the delinquent resolution of #1607 @robertlipe 