### PR TITLE
fix bug with TrackWidget and time zones.

### DIFF
--- a/gui/filterdlg.cc
+++ b/gui/filterdlg.cc
@@ -26,8 +26,10 @@
 #include <QFrame>           // for QFrame
 #include <QHBoxLayout>      // for QHBoxLayout
 #include <QListWidget>      // for QListWidget
+#include <QLoggingCategory> // for QLoggingCategory
 #include <QMessageBox>      // for QMessageBox, operator|
 #include <QPushButton>      // for QPushButton
+#include <QTimeZone>        // for QTimeZone
 #include <Qt>               // for CheckState
 #include "appname.h"        // for appName
 #include "help.h"           // for ShowHelp
@@ -129,13 +131,23 @@ void FilterDialog::helpX()
 }
 
 //------------------------------------------------------------------------
+void FilterDialog::traceDialog(const char* state) const
+{
+  static QLoggingCategory category("gpsbabelfe.filterdialog.track");
+  qCDebug(category) << state << "start time:" << fd_.trackFilterData.startTime << "time zone:" << fd_.trackFilterData.startTime.timeZone() << "time spec:" << fd_.trackFilterData.startTime.timeSpec();
+  qCDebug(category) << state << "stop time:" << fd_.trackFilterData.stopTime << "time zone:" << fd_.trackFilterData.stopTime.timeZone() << "time spec:" << fd_.trackFilterData.stopTime.timeSpec();
+}
+
+//------------------------------------------------------------------------
 void FilterDialog::runDialog()
 {
+  traceDialog("before:");
   if (exec() != 0) {
     for (int i=0; i<pages_.size(); i++) {
       pages_[i]->getWidgetValues();
       *(usePages_[i]) = ui_.filterList->item(i)->checkState() == Qt::Checked;
     }
   }
+  traceDialog("after:");
   lastPage_ = ui_.filterList->currentRow();
 }

--- a/gui/filterdlg.h
+++ b/gui/filterdlg.h
@@ -44,6 +44,8 @@ public:
 
 
 private:
+  void traceDialog(const char* state) const;
+
   static int lastPage_;
   QList <FilterWidget*>pages_;
   QList <bool*>usePages_;

--- a/gui/filterwidgets.cc
+++ b/gui/filterwidgets.cc
@@ -79,8 +79,8 @@ TrackWidget::TrackWidget(QWidget* parent, TrackFilterData& tfd): FilterWidget(pa
   ui.stopEdit->setDisplayFormat("dd MMM yyyy hh:mm:ss AP");
 
   // setWidgetValues() will set the QDateTimeEdit dateTime property.
-  // When setting this property, e.g. with QDateTimeEdit::setDateTime,
-  // the new QDateTime is converted to the time system of the QDateTimeEdit, which thus remains unchanged.
+  // When setting this property, the new QDateTime is converted to the time
+  // system of the QDateTimeEdit, which thus remains unchanged.
   setTZ(tfd.localTime);
   tfd.utc = !tfd.localTime;
 

--- a/gui/filterwidgets.cc
+++ b/gui/filterwidgets.cc
@@ -22,18 +22,18 @@
 
 #include "filterwidgets.h"
 
-#include <cassert>       // for assert
-#include <limits>        // for numeric_limits
+#include <limits>             // for numeric_limits
 
-#include <QChar>         // for QChar
-#include <QCheckBox>     // for QCheckBox
-#include <QEvent>        // for QEvent
-#include <QLabel>        // for QLabel
-#include <QRadioButton>  // for QRadioButton
+#include <QChar>              // for QChar
+#include <QCheckBox>          // for QCheckBox
+#include <QEvent>             // for QEvent
+#include <QLabel>             // for QLabel
+#include <QRadioButton>       // for QRadioButton
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-#include <QTimeZone>     // for QTimeZone
+#include <QTimeZone>          // for QTimeZone
 #endif
-#include <Qt>            // for TimeSpec
+#include <Qt>                 // for TimeSpec
+#include <QtGlobal>           // for QT_VERSION, QT_VERSION_CHECK
 
 
 //------------------------------------------------------------------------
@@ -78,27 +78,10 @@ TrackWidget::TrackWidget(QWidget* parent, TrackFilterData& tfd): FilterWidget(pa
   ui.startEdit->setDisplayFormat("dd MMM yyyy hh:mm:ss AP");
   ui.stopEdit->setDisplayFormat("dd MMM yyyy hh:mm:ss AP");
 
-  // Qt5 QDateTimeEdit::setDateTime ignored the passed QDateTime::timeSpec.
-  // Qt6 QDateTimeEdit::setDateTime will convert the passed QDateTime if the passed
-  // QDateTime::timeSpec doesn't match QDateTimeEdit::timeSpec.
-  // If the two timeSpecs match Qt5 and Qt6 behave the same.
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-  assert(tfd.startTime.timeZone() == tfd.stopTime.timeZone());
-  assert((tfd.startTime.timeZone() == QTimeZone::UTC) || (tfd.startTime.timeZone() == QTimeZone::LocalTime));
-  ui.startEdit->setTimeZone(tfd.startTime.timeZone());
-  ui.stopEdit->setTimeZone(tfd.stopTime.timeZone());
-  // Make sure the initial state of the localTime and utc radio buttons
-  // is in agreement with the startTime::timeSpec and stopTime::timeSpec.
-  tfd.localTime = tfd.startTime.timeZone() == QTimeZone::LocalTime;
-#else
-  assert(tfd.startTime.timeSpec() == tfd.stopTime.timeSpec());
-  assert((tfd.startTime.timeSpec() == Qt::UTC) || (tfd.startTime.timeSpec() == Qt::LocalTime));
-  ui.startEdit->setTimeSpec(tfd.startTime.timeSpec());
-  ui.stopEdit->setTimeSpec(tfd.stopTime.timeSpec());
-  // Make sure the initial state of the localTime and utc radio buttons
-  // is in agreement with the startTime::timeSpec and stopTime::timeSpec.
-  tfd.localTime = tfd.startTime.timeSpec() == Qt::LocalTime;
-#endif
+  // setWidgetValues() will set the QDateTimeEdit dateTime property.
+  // When setting this property, e.g. with QDateTimeEdit::setDateTime,
+  // the new QDateTime is converted to the time system of the QDateTimeEdit, which thus remains unchanged.
+  setTZ(tfd.localTime);
   tfd.utc = !tfd.localTime;
 
   // Collect the data fields.
@@ -198,9 +181,9 @@ void TrackWidget::splitDistanceX()
   otherCheckX();
 }
 //------------------------------------------------------------------------
-void TrackWidget::TZX() const
+void TrackWidget::setTZ(bool local) const
 {
-  if (ui.localTime->isChecked()) {
+  if (local) {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
     ui.startEdit->setTimeZone(QTimeZone::LocalTime);
     ui.stopEdit->setTimeZone(QTimeZone::LocalTime);
@@ -217,6 +200,12 @@ void TrackWidget::TZX() const
     ui.stopEdit->setTimeSpec(Qt::UTC);
 #endif
   }
+
+}
+//------------------------------------------------------------------------
+void TrackWidget::TZX() const
+{
+  setTZ(ui.localTime->isChecked());
   // Force update of Edit displays, so the displayed
   // datetimes are in sync with the specified time spec.
   auto ev = QEvent(QEvent::LocaleChange);

--- a/gui/filterwidgets.h
+++ b/gui/filterwidgets.h
@@ -28,13 +28,13 @@
 #include <QDateTime>         // for QDateTime
 #include <QDateTimeEdit>     // for QDateTimeEdit
 #include <QDoubleValidator>  // for QDoubleValidator
-#include <QFunctionPointer>  // for qMax, qMin
 #include <QLineEdit>         // for QLineEdit
 #include <QList>             // for QList
 #include <QObject>           // for QObject, Q_OBJECT, slots
 #include <QSpinBox>          // for QSpinBox
 #include <QString>           // for QString
 #include <QWidget>           // for QWidget
+#include <QtGlobal>          // for qMax, qMin
 
 #include <memory>            // for unique_ptr
 #include <utility>           // for move
@@ -326,6 +326,8 @@ public:
   }
 
 private:
+  void setTZ(bool local) const;
+
   Ui_TrackWidget ui;
   TrackFilterData& tfd;
 

--- a/gui/main.cc
+++ b/gui/main.cc
@@ -22,6 +22,7 @@
 //------------------------------------------------------------------------
 #include <QApplication>  // for QApplication
 #include <QIcon>         // for QIcon
+#include <QLoggingCategory>
 #include <QString>       // for QString
 #include <QtGlobal>      // for QT_VERSION, QT_VERSION_CHECK
 
@@ -37,6 +38,7 @@ int main(int argc, char** argv)
 #error this version of Qt is not supported.
 #endif
 
+  QLoggingCategory::setFilterRules(QStringLiteral("gpsbabelfe.*=false"));
   // Set desktop filename before creating QApplication, see QTBUG-149180
   QApplication::setDesktopFileName("gpsbabelfe");
 


### PR DESCRIPTION
For Qt >= 6.7.0 the assertion about the expected tfdata start and stop time zone could be violated, which could lead to incorrect setting of the tfdata local and utc booleans.
This could occur when QDateTimeEdit::setTimeZone was called with a non lightweight timezone.
A non lightweight timezone can be created by TrackFilterData ctor.  When getWidgetValues was run after the dialog finished the non lightweight tz could make it to tfdata, causing a failure on subsequent attempts to use the dialog.

This also introduce Qt category logging to the GUI.  The category gpsbabelfe is turned off by default, but can be set with the environment variable QT_LOGGING_RULES, e.g. QT_LOGGING_RULES="gpsbabelfe.*=true".  On windows logging output goes to the debugger by default, but you can use QT_FORCE_STDERR_LOGGING=1